### PR TITLE
feat: SUPER_ADMIN bootstrap, church switcher & auto-slug

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,6 +19,7 @@
 - [x] Gestion des membres (ajout, modification, suppression, transfert entre departements)
 - [x] Gestion des evenements (creation, modification, suppression, types personnalises)
 - [x] Association departements-evenements depuis l'interface
+- [ ] Schema dedie Super Admin (role global independant des eglises)
 
 ## Planning
 

--- a/src/app/(auth)/admin/churches/ChurchesClient.tsx
+++ b/src/app/(auth)/admin/churches/ChurchesClient.tsx
@@ -24,6 +24,7 @@ export default function ChurchesClient({ initialChurches }: Props) {
   const [modalOpen, setModalOpen] = useState(false);
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
+  const [slugTouched, setSlugTouched] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -33,11 +34,28 @@ export default function ChurchesClient({ initialChurches }: Props) {
   const [bulkError, setBulkError] = useState("");
   const [bulkLoading, setBulkLoading] = useState(false);
 
+  function toSlug(value: string): string {
+    return value
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  }
+
   function openCreate() {
     setName("");
     setSlug("");
+    setSlugTouched(false);
     setError("");
     setModalOpen(true);
+  }
+
+  function handleNameChange(value: string) {
+    setName(value);
+    if (!slugTouched) {
+      setSlug(toSlug(value));
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -210,15 +228,18 @@ export default function ChurchesClient({ initialChurches }: Props) {
           <Input
             label="Nom"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => handleNameChange(e.target.value)}
             required
           />
           <Input
             label="Slug"
             value={slug}
-            onChange={(e) => setSlug(e.target.value)}
+            onChange={(e) => {
+              setSlugTouched(true);
+              setSlug(e.target.value);
+            }}
             required
-            placeholder="ex: mon-église"
+            placeholder="généré automatiquement"
           />
           {error && <p className="text-sm text-red-600">{error}</p>}
           <div className="flex justify-end gap-2">

--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@/lib/auth";
+import { auth, getCurrentChurchId } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
@@ -21,7 +21,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
     view = "event",
   } = await searchParams;
 
-  const currentChurchId = session.user.churchRoles[0]?.churchId;
+  const currentChurchId = await getCurrentChurchId(session);
   const userPermissions = new Set(
     session.user.churchRoles.flatMap((r) => hasPermission(r.role))
   );

--- a/src/app/(auth)/events/page.tsx
+++ b/src/app/(auth)/events/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@/lib/auth";
+import { auth, getCurrentChurchId } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import EventsPageClient from "./EventsPageClient";
 
@@ -6,7 +6,7 @@ export default async function EventsPage() {
   const session = await auth();
   if (!session?.user) redirect("/");
 
-  const currentChurchId = session.user.churchRoles[0]?.churchId;
+  const currentChurchId = await getCurrentChurchId(session);
 
   if (!currentChurchId) {
     return (

--- a/src/app/api/current-church/route.ts
+++ b/src/app/api/current-church/route.ts
@@ -1,0 +1,35 @@
+import { requireAuth } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { cookies } from "next/headers";
+import { z } from "zod";
+
+const schema = z.object({
+  churchId: z.string().min(1, "L'ID de l'église est requis"),
+});
+
+export async function POST(request: Request) {
+  try {
+    const session = await requireAuth();
+    const body = await request.json();
+    const { churchId } = schema.parse(body);
+
+    const hasAccess = session.user.churchRoles.some(
+      (r) => r.churchId === churchId
+    );
+    if (!hasAccess) {
+      throw new ApiError(403, "Vous n'avez pas accès à cette église");
+    }
+
+    const cookieStore = await cookies();
+    cookieStore.set("current-church", churchId, {
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: 30 * 24 * 60 * 60, // 30 days
+      path: "/",
+    });
+
+    return successResponse({ churchId });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/components/ChurchSwitcher.tsx
+++ b/src/components/ChurchSwitcher.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+interface Church {
+  id: string;
+  name: string;
+}
+
+interface ChurchSwitcherProps {
+  churches: Church[];
+  currentChurchId: string;
+}
+
+export default function ChurchSwitcher({
+  churches,
+  currentChurchId,
+}: ChurchSwitcherProps) {
+  const router = useRouter();
+
+  if (churches.length <= 1) return null;
+
+  async function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const churchId = e.target.value;
+    await fetch("/api/current-church", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ churchId }),
+    });
+    router.refresh();
+  }
+
+  return (
+    <select
+      value={currentChurchId}
+      onChange={handleChange}
+      className="bg-white/10 text-white text-sm border border-white/30 rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-white/50"
+    >
+      {churches.map((c) => (
+        <option key={c.id} value={c.id} className="text-gray-900">
+          {c.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,18 @@
 import NextAuth, { type Session } from "next-auth";
 import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
+import { cookies } from "next/headers";
 import { prisma } from "./prisma";
 import type { Role } from "@prisma/client";
+
+const SUPER_ADMIN_EMAILS = (process.env.SUPER_ADMIN_EMAILS || "")
+  .split(",")
+  .map((e) => e.trim().toLowerCase())
+  .filter(Boolean);
+
+export function isSuperAdmin(email: string): boolean {
+  return SUPER_ADMIN_EMAILS.includes(email.toLowerCase());
+}
 
 declare module "next-auth" {
   interface Session {
@@ -39,12 +49,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     async signIn({ user }) {
       if (!user.email || !user.id) return true;
 
-      const superAdminEmails = (process.env.SUPER_ADMIN_EMAILS || "")
-        .split(",")
-        .map((e) => e.trim().toLowerCase())
-        .filter(Boolean);
-
-      if (superAdminEmails.includes(user.email.toLowerCase())) {
+      if (isSuperAdmin(user.email)) {
         const churches = await prisma.church.findMany();
         for (const church of churches) {
           await prisma.userChurchRole.upsert({
@@ -155,4 +160,20 @@ export function getUserDepartmentScope(session: Session): DepartmentScope {
   );
 
   return { scoped: true, departmentIds };
+}
+
+export async function getCurrentChurchId(
+  session: Session
+): Promise<string | undefined> {
+  const cookieStore = await cookies();
+  const preferred = cookieStore.get("current-church")?.value;
+
+  if (preferred) {
+    const hasAccess = session.user.churchRoles.some(
+      (r) => r.churchId === preferred
+    );
+    if (hasAccess) return preferred;
+  }
+
+  return session.user.churchRoles[0]?.churchId;
 }


### PR DESCRIPTION
## Summary
- **Bootstrap** : les SUPER_ADMIN (par email) peuvent créer la première église sans `UserChurchRole` existant
- **Auto-promotion** : à la création d'une église, tous les SUPER_ADMIN existants y sont automatiquement assignés
- **Sélecteur d'église** : dropdown dans le header pour les utilisateurs multi-églises, persistance via cookie `current-church`
- **Auto-slug** : le slug de l'église est généré automatiquement depuis le nom (avec possibilité de modifier manuellement)
- **Refactoring** : extraction de `isSuperAdmin()` et `getCurrentChurchId()` dans `auth.ts`
- **Roadmap** : ajout item "Schéma dédié Super Admin"

## Changements
| Fichier | Description |
|---|---|
| `src/lib/auth.ts` | Helpers `isSuperAdmin()`, `getCurrentChurchId()`, refactor signIn |
| `src/app/api/churches/route.ts` | Bootstrap + auto-promotion + auto-slug |
| `src/app/api/current-church/route.ts` | **Nouveau** — POST pour changer d'église (cookie) |
| `src/components/ChurchSwitcher.tsx` | **Nouveau** — Dropdown sélecteur d'église |
| `src/app/(auth)/layout.tsx` | Intégration `getCurrentChurchId` + `ChurchSwitcher` |
| `src/app/(auth)/dashboard/page.tsx` | Utilise `getCurrentChurchId` |
| `src/app/(auth)/events/page.tsx` | Utilise `getCurrentChurchId` |
| `src/app/(auth)/admin/churches/ChurchesClient.tsx` | Auto-slug à la saisie du nom |
| `docs/roadmap.md` | Item "Schéma dédié Super Admin" |

## Test plan
- [ ] Email SUPER_ADMIN sans église → peut créer une première église → rôle SUPER_ADMIN créé
- [ ] Créer une 2e église → les SUPER_ADMIN existants y sont assignés automatiquement
- [ ] Utilisateur multi-églises → dropdown visible dans le header, sélection persistée
- [ ] Utilisateur mono-église → pas de dropdown, nom affiché normalement
- [ ] Création d'église → le slug se génère automatiquement depuis le nom
- [ ] Modification manuelle du slug → l'auto-génération s'arrête
- [ ] Sign-in non-SUPER_ADMIN → comportement inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)