### PR TITLE
fix: Bus error au build — import dynamique cookies

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,6 @@
 import NextAuth, { type Session } from "next-auth";
 import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
-import { cookies } from "next/headers";
 import { prisma } from "./prisma";
 import type { Role } from "@prisma/client";
 
@@ -165,6 +164,7 @@ export function getUserDepartmentScope(session: Session): DepartmentScope {
 export async function getCurrentChurchId(
   session: Session
 ): Promise<string | undefined> {
+  const { cookies } = await import("next/headers");
   const cookieStore = await cookies();
   const preferred = cookieStore.get("current-church")?.value;
 


### PR DESCRIPTION
## Summary
- L'import top-level de `cookies` from `next/headers` dans `auth.ts` causait un "Bus error" lors du `next build` en production
- Remplacé par un import dynamique dans `getCurrentChurchId()` pour éviter le chargement au niveau module

## Test plan
- [x] `npm run build` passe localement
- [ ] `npm run build` passe sur le serveur de production

🤖 Generated with [Claude Code](https://claude.com/claude-code)