### PR TITLE
chore: prepare release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v0.2.1] - 2026-03-01
+
+### Corrige
+
+- Bus error au build : import dynamique de `cookies` dans `getCurrentChurchId()` (evite le chargement de `next/headers` au niveau module)
+
 ## [v0.2.0] - 2026-03-01
 
 ### Ajoute

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planningcenter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.1
- Fix Bus error au build (import dynamique cookies)

## Test plan
- [x] `npm run build` passe localement

🤖 Generated with [Claude Code](https://claude.com/claude-code)