### PR TITLE
feat: changement de ministère lors de l'édition d'un département

### DIFF
--- a/src/app/(auth)/admin/departments/DepartmentsClient.tsx
+++ b/src/app/(auth)/admin/departments/DepartmentsClient.tsx
@@ -64,7 +64,7 @@ export default function DepartmentsClient({
         ? `/api/departments/${editing.id}`
         : "/api/departments";
       const method = editing ? "PUT" : "POST";
-      const body = editing ? { name } : { name, ministryId };
+      const body = { name, ministryId };
 
       const res = await fetch(url, {
         method,
@@ -245,17 +245,15 @@ export default function DepartmentsClient({
             onChange={(e) => setName(e.target.value)}
             required
           />
-          {!editing && (
-            <Select
-              label="Ministère"
-              value={ministryId}
-              onChange={(e) => setMinistryId(e.target.value)}
-              options={ministries.map((m) => ({
-                value: m.id,
-                label: `${m.name} (${m.churchName})`,
-              }))}
-            />
-          )}
+          <Select
+            label="Ministère"
+            value={ministryId}
+            onChange={(e) => setMinistryId(e.target.value)}
+            options={ministries.map((m) => ({
+              value: m.id,
+              label: `${m.name} (${m.churchName})`,
+            }))}
+          />
           {error && <p className="text-sm text-red-600">{error}</p>}
           <div className="flex justify-end gap-2">
             <Button

--- a/src/app/api/departments/[departmentId]/route.ts
+++ b/src/app/api/departments/[departmentId]/route.ts
@@ -28,6 +28,7 @@ async function checkDepartmentScope(session: Session, departmentId: string) {
 
 const updateSchema = z.object({
   name: z.string().min(1, "Le nom est requis"),
+  ministryId: z.string().min(1, "Le ministère est requis"),
 });
 
 export async function PUT(
@@ -40,6 +41,11 @@ export async function PUT(
     await checkDepartmentScope(session, departmentId);
     const body = await request.json();
     const data = updateSchema.parse(body);
+
+    const allowedMinistries = getMinisterMinistryIds(session);
+    if (allowedMinistries !== null && !allowedMinistries.includes(data.ministryId)) {
+      throw new ApiError(403, "Vous ne pouvez déplacer un département que vers votre ministère");
+    }
 
     const department = await prisma.department.update({
       where: { id: departmentId },


### PR DESCRIPTION
## Summary
- Affichage du Select ministère en mode édition (était masqué)
- Envoi du `ministryId` dans le PUT API
- Validation du scope ministre sur le ministère cible

## Test plan
- [ ] Modifier un département et changer son ministère
- [ ] Vérifier qu'un Ministre ne peut déplacer que vers son propre ministère

🤖 Generated with [Claude Code](https://claude.com/claude-code)