### PR TITLE
feat: responsive mobile R3 — vues métier adaptées

### DIFF
--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -51,12 +51,12 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
 
   return (
     <div>
-      <div className="mb-6 flex items-center justify-between">
+      <div className="mb-4 md:mb-6">
         <DashboardActions />
       </div>
 
       {view === "event" && (
-        <div className="mb-6">
+        <div className="mb-4 md:mb-6">
           <EventSelector
             events={events.map((e) => ({
               id: e.id,

--- a/src/app/(auth)/events/[eventId]/star-view/StarViewClient.tsx
+++ b/src/app/(auth)/events/[eventId]/star-view/StarViewClient.tsx
@@ -148,10 +148,10 @@ export default function StarViewClient({ eventId }: Props) {
   return (
     <div>
       {/* Action bar - hidden on print */}
-      <div className="mb-6 flex items-center gap-3 print:hidden">
+      <div className="mb-6 flex flex-wrap items-center gap-2 md:gap-3 print:hidden">
         <button
           onClick={() => router.back()}
-          className="p-2 rounded-md text-gray-500 hover:bg-gray-100 transition-colors mr-1"
+          className="p-2 rounded-md text-gray-500 hover:bg-gray-100 transition-colors"
           title="Retour"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -168,13 +168,13 @@ export default function StarViewClient({ eventId }: Props) {
       </div>
 
       {/* Printable zone */}
-      <div ref={printRef} className="bg-white rounded-lg shadow p-6 print:shadow-none">
+      <div ref={printRef} className="bg-white rounded-lg shadow p-4 md:p-6 print:shadow-none">
         {/* Header */}
-        <div className="flex items-center justify-between mb-6 pb-4 border-b border-gray-200">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-2 mb-6 pb-4 border-b border-gray-200">
           <div className="text-sm text-gray-600 capitalize">
             {formatDate(data.event.date)}
           </div>
-          <h1 className="text-xl font-bold text-icc-violet uppercase tracking-wider">
+          <h1 className="text-lg md:text-xl font-bold text-icc-violet uppercase tracking-wider">
             STAR EN SERVICE
           </h1>
           <div className="text-lg font-bold text-icc-violet">
@@ -191,7 +191,7 @@ export default function StarViewClient({ eventId }: Props) {
         </div>
 
         {/* Department grid */}
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3 md:gap-4">
           {data.departments.map((dept) => (
             <div
               key={dept.id}

--- a/src/components/DashboardActions.tsx
+++ b/src/components/DashboardActions.tsx
@@ -16,10 +16,10 @@ export default function DashboardActions() {
   }
 
   return (
-    <div className="flex gap-3">
+    <div className="flex flex-wrap gap-2 md:gap-3">
       <Link
         href={buildHref("event")}
-        className={`inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border transition-colors ${
+        className={`inline-flex items-center gap-2 px-3 py-2 md:px-4 text-sm font-medium rounded-lg border transition-colors ${
           currentView === "event"
             ? "bg-icc-violet text-white border-icc-violet"
             : "bg-white text-gray-600 border-gray-200 hover:bg-gray-50"
@@ -32,7 +32,7 @@ export default function DashboardActions() {
       </Link>
       <Link
         href={buildHref("month")}
-        className={`inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border transition-colors ${
+        className={`inline-flex items-center gap-2 px-3 py-2 md:px-4 text-sm font-medium rounded-lg border transition-colors ${
           currentView === "month"
             ? "bg-icc-violet text-white border-icc-violet"
             : "bg-white text-gray-600 border-gray-200 hover:bg-gray-50"

--- a/src/components/EventSelector.tsx
+++ b/src/components/EventSelector.tsx
@@ -48,7 +48,7 @@ export default function EventSelector({
       <select
         value={selectedEventId || ""}
         onChange={(e) => handleChange(e.target.value)}
-        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="w-full px-3 py-2.5 md:py-2 text-base md:text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-icc-violet"
       >
         <option value="" disabled>
           Choisir un evenement

--- a/src/components/PlanningGrid.tsx
+++ b/src/components/PlanningGrid.tsx
@@ -144,7 +144,7 @@ export default function PlanningGrid({
 
   return (
     <div>
-      <div className="flex items-center gap-4 mb-4 text-sm">
+      <div className="flex flex-wrap items-center gap-2 md:gap-4 mb-4 text-sm">
         <span className="text-green-700">
           En service : {enService}/{members.length}
         </span>
@@ -163,7 +163,42 @@ export default function PlanningGrid({
         )}
       </div>
 
-      <div className="overflow-x-auto border border-gray-200 rounded-lg">
+      {/* Mobile: card view */}
+      <div className="md:hidden space-y-2">
+        {members.map((member) => {
+          const current = STATUS_OPTIONS.find((o) => o.value === member.status) || STATUS_OPTIONS[0];
+          return (
+            <div
+              key={member.id}
+              className={`flex items-center justify-between gap-3 p-3 rounded-lg border border-gray-200 ${current.color}`}
+            >
+              <span className="text-sm font-medium truncate">
+                {member.firstName} {member.lastName}
+              </span>
+              {readOnly ? (
+                <span className="text-xs font-semibold shrink-0">{current.label}</span>
+              ) : (
+                <select
+                  value={member.status || ""}
+                  onChange={(e) =>
+                    handleStatusChange(member.id, e.target.value || null)
+                  }
+                  className="text-sm border border-gray-300 rounded-md px-2 py-1.5 bg-white shrink-0"
+                >
+                  {STATUS_OPTIONS.map((option) => (
+                    <option key={option.value || "none"} value={option.value || ""}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Desktop: table view */}
+      <div className="hidden md:block overflow-x-auto border border-gray-200 rounded-lg">
         <table className="w-full">
           <thead>
             <tr className="bg-gray-50">


### PR DESCRIPTION
## Summary

- **PlanningGrid** : vue carte par membre avec `<select>` statut sur mobile, tableau avec boutons sur desktop
- **StarView** : header empilé verticalement sur mobile, grille 1 colonne, action bar qui wrap
- **Dashboard** : boutons d'actions wrap sur petit écran, EventSelector avec text-base (évite zoom iOS)

## Fichiers modifiés

- `src/components/PlanningGrid.tsx` — vue carte mobile + tableau desktop
- `src/app/(auth)/events/[eventId]/star-view/StarViewClient.tsx` — layout responsive
- `src/app/(auth)/dashboard/page.tsx` — espacements adaptés
- `src/components/DashboardActions.tsx` — boutons wrap
- `src/components/EventSelector.tsx` — select responsive

## Test plan

- [ ] Mobile : PlanningGrid affiche des cartes avec select de statut
- [ ] Mobile : changer un statut via le select fonctionne (auto-save)
- [ ] Mobile : StarView header empilé, départements en 1 colonne
- [ ] Mobile : StarView action bar wrap correctement
- [ ] Mobile : Dashboard boutons Planification/Vue planning wrap
- [ ] Desktop : aucune régression sur toutes les vues

🤖 Generated with [Claude Code](https://claude.com/claude-code)