### PR TITLE
feat: déploiement automatisé via SSH sur push de tag v*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
     tags: ["v*"]
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,69 @@
+name: Deploy
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: ci
+    timeout-minutes: 10
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: VERSION,DEPLOY_PATH
+          script: |
+            set -e
+            DEPLOY_PATH="${DEPLOY_PATH:-/opt/planning}"
+
+            echo "Deploying v${VERSION}..."
+
+            cd "$DEPLOY_PATH/releases"
+
+            # 1. Telecharger la release
+            curl -L -o "planningcenter-${VERSION}.tar.gz" \
+              "https://github.com/iccbretagne/planningcenter/archive/refs/tags/v${VERSION}.tar.gz"
+
+            # 2. Decompresser
+            tar xzf "planningcenter-${VERSION}.tar.gz"
+            rm "planningcenter-${VERSION}.tar.gz"
+
+            # 3. Lier le fichier .env
+            ln -s "$DEPLOY_PATH/shared/.env" "$DEPLOY_PATH/releases/planningcenter-${VERSION}/.env"
+
+            # 4. Installer les dependances et construire
+            cd "$DEPLOY_PATH/releases/planningcenter-${VERSION}"
+            npm install --production=false
+            npx prisma migrate deploy
+            npm run build
+
+            # 5. Activer la release
+            ln -sfn "$DEPLOY_PATH/releases/planningcenter-${VERSION}" "$DEPLOY_PATH/current"
+
+            # 6. Redemarrer le service
+            sudo systemctl restart planning
+
+            # 7. Nettoyage : garder les 3 dernieres releases
+            cd "$DEPLOY_PATH/releases"
+            ls -1dt planningcenter-*/ | tail -n +4 | xargs rm -rf || true
+
+            echo "Deploy v${VERSION} OK"

--- a/docs/production.md
+++ b/docs/production.md
@@ -212,6 +212,54 @@ Dans la [console Google Cloud](https://console.cloud.google.com/apis/credentials
 https://votre-domaine.com/api/auth/callback/google
 ```
 
+## Deploiement automatise (CD)
+
+Le deploiement est automatise via GitHub Actions. Un push de tag `v*` declenche le workflow de deploiement apres validation du CI.
+
+### Prerequis serveur
+
+1. **Cle SSH dediee** : generer une paire Ed25519 pour l'utilisateur `planning` :
+
+```bash
+sudo -u planning ssh-keygen -t ed25519 -C "deploy@planningcenter" -f /home/planning/.ssh/id_deploy
+```
+
+2. **Autoriser la cle** : ajouter la cle publique dans `/home/planning/.ssh/authorized_keys` :
+
+```bash
+sudo -u planning bash -c 'cat /home/planning/.ssh/id_deploy.pub >> /home/planning/.ssh/authorized_keys'
+```
+
+3. **Sudo restreint** : creer `/etc/sudoers.d/planning` :
+
+```
+planning ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart planning
+```
+
+### GitHub Secrets a configurer
+
+| Secret | Description |
+|--------|-------------|
+| `DEPLOY_SSH_KEY` | Cle privee Ed25519 (`/home/planning/.ssh/id_deploy`) |
+| `DEPLOY_HOST` | Adresse IP ou domaine du serveur |
+| `DEPLOY_PORT` | Port SSH personnalise |
+| `DEPLOY_USER` | `planning` |
+| `DEPLOY_PATH` | `/opt/planning` |
+
+### Fonctionnement
+
+1. Push d'un tag `v*` (ex: `git tag v0.6.0 && git push origin v0.6.0`)
+2. Le CI s'execute (typecheck, tests, verification version)
+3. Si le CI passe, le workflow deploy se connecte en SSH au serveur
+4. Le script telecharge la release, installe les dependances, construit, migre la BDD, bascule le symlink et redemarre le service
+5. Les anciennes releases sont nettoyees (3 dernieres conservees)
+
+Un script `scripts/deploy.sh` est egalement disponible pour les deploiements manuels depuis le serveur :
+
+```bash
+DEPLOY_PATH=/opt/planning bash scripts/deploy.sh 0.6.0
+```
+
 ## Checklist de production
 
 - [ ] Variables d'environnement configurees dans `shared/.env`

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+DEPLOY_PATH="${DEPLOY_PATH:-/opt/planning}"
+VERSION="$1"
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: deploy.sh <version>"
+  exit 1
+fi
+
+echo "Deploying v${VERSION}..."
+
+cd "$DEPLOY_PATH/releases"
+
+# 1. Telecharger la release depuis le tag GitHub
+curl -L -o "planningcenter-${VERSION}.tar.gz" \
+  "https://github.com/iccbretagne/planningcenter/archive/refs/tags/v${VERSION}.tar.gz"
+
+# 2. Decompresser
+tar xzf "planningcenter-${VERSION}.tar.gz"
+rm "planningcenter-${VERSION}.tar.gz"
+
+# 3. Lier le fichier .env
+ln -s "$DEPLOY_PATH/shared/.env" "$DEPLOY_PATH/releases/planningcenter-${VERSION}/.env"
+
+# 4. Installer les dependances et construire
+cd "$DEPLOY_PATH/releases/planningcenter-${VERSION}"
+npm install --production=false
+npx prisma migrate deploy
+npm run build
+
+# 5. Activer la release (basculer le symlink)
+ln -sfn "$DEPLOY_PATH/releases/planningcenter-${VERSION}" "$DEPLOY_PATH/current"
+
+# 6. Redemarrer le service
+sudo systemctl restart planning
+
+# 7. Nettoyage : garder les 3 dernieres releases
+cd "$DEPLOY_PATH/releases"
+ls -1dt planningcenter-*/ | tail -n +4 | xargs rm -rf || true
+
+echo "Deploy v${VERSION} OK"


### PR DESCRIPTION
## Summary

- Ajoute un workflow CD (`.github/workflows/deploy.yml`) déclenché sur les tags `v*`
- Le deploy attend la validation CI (typecheck, tests, version check) avant d'exécuter le déploiement SSH
- Ajoute `workflow_call` au CI pour le rendre réutilisable par le workflow deploy
- Script `scripts/deploy.sh` pour les déploiements manuels depuis le serveur
- Documentation mise à jour dans `docs/production.md` (prérequis SSH, GitHub Secrets, fonctionnement)

## GitHub Secrets à configurer

| Secret | Description |
|--------|-------------|
| `DEPLOY_SSH_KEY` | Clé privée Ed25519 |
| `DEPLOY_HOST` | Adresse IP ou domaine du serveur |
| `DEPLOY_PORT` | Port SSH personnalisé |
| `DEPLOY_USER` | `planning` |
| `DEPLOY_PATH` | `/opt/planning` |

## Test plan

- [ ] Vérifier que le workflow deploy apparaît dans l'onglet Actions
- [ ] Vérifier qu'il ne se déclenche que sur les tags `v*` (pas sur push main ou PR)
- [ ] Configurer les GitHub Secrets et les prérequis serveur (clé SSH, sudoers)
- [ ] Tester avec un tag : `git tag v0.5.1 && git push origin v0.5.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)