### PR TITLE
feat: déclenchement manuel du workflow deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,12 @@ name: Deploy
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version a deployer (ex: 0.5.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,9 +22,14 @@ jobs:
     needs: ci
     timeout-minutes: 10
     steps:
-      - name: Extract version from tag
+      - name: Determine version
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1


### PR DESCRIPTION
## Summary

- Ajoute `workflow_dispatch` au workflow deploy avec un input `version`
- Permet de redéployer une version existante depuis l'onglet Actions sans pousser un nouveau tag

## Test plan

- [ ] Vérifier que le bouton "Run workflow" apparaît dans Actions > Deploy
- [ ] Tester un déploiement manuel en saisissant une version (ex: `0.5.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)