### PR TITLE
ui: rendre la checkbox série plus visible

### DIFF
--- a/src/app/(auth)/admin/events/[eventId]/EventDetailClient.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/EventDetailClient.tsx
@@ -79,15 +79,18 @@ export default function EventDetailClient({ eventId, isRecurring, departments }:
       </h2>
 
       {isRecurring && (
-        <label className="flex items-center gap-2 mb-4 text-sm text-gray-700">
-          <input
-            type="checkbox"
-            checked={applyToSeries}
-            onChange={(e) => setApplyToSeries(e.target.checked)}
-            className="h-4 w-4 rounded border-gray-300 text-icc-violet focus:ring-icc-violet"
-          />
-          Appliquer aux futurs événements de la série
-        </label>
+        <div className="mb-4 flex items-center gap-3 p-3 bg-icc-violet/5 border border-icc-violet/20 rounded-lg">
+          <span className="text-icc-violet text-lg">↻</span>
+          <label className="flex items-center gap-2 text-sm font-medium text-gray-700 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={applyToSeries}
+              onChange={(e) => setApplyToSeries(e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-icc-violet focus:ring-icc-violet"
+            />
+            Appliquer aux futurs événements de la série
+          </label>
+        </div>
       )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary
- Remplace le simple label checkbox par un bandeau violet clair avec icône de récurrence ↻
- Améliore la visibilité de l'option "Appliquer aux futurs événements de la série" sur la page `/admin/events/[eventId]`

## Test plan
- [ ] Ouvrir un événement récurrent dans l'admin et vérifier que le bandeau violet apparaît
- [ ] Vérifier que la checkbox fonctionne toujours (cocher/décocher)
- [ ] Vérifier que le bandeau n'apparaît pas pour les événements non récurrents

🤖 Generated with [Claude Code](https://claude.com/claude-code)