### PR TITLE
feat: zoom images guide + fix tour guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v0.7.3] - 2026-03-06
+
+### Ajoute
+
+- Guide : zoom plein ecran au clic sur les captures d'ecran (modale avec fond sombre)
+
+### Corrige
+
+- Tour guide : correction du bouton "Terminer" qui ne desactivait pas le tour au premier clic
+
 ## [v0.7.2] - 2026-03-06
 
 ### Ameliore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planningcenter",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/GuidedTour.tsx
+++ b/src/components/GuidedTour.tsx
@@ -363,6 +363,7 @@ function GuidedTourInner({ userRole }: GuidedTourProps) {
   const [active, setActive] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const finishedRef = useRef(false);
 
   useEffect(() => {
     setIsMobile(window.innerWidth < 768);
@@ -370,7 +371,7 @@ function GuidedTourInner({ userRole }: GuidedTourProps) {
   }, []);
 
   useEffect(() => {
-    if (!mounted) return;
+    if (!mounted || finishedRef.current) return;
     if (searchParams.get("tour") === "1") {
       const timer = setTimeout(() => setActive(true), 800);
       return () => clearTimeout(timer);
@@ -378,6 +379,7 @@ function GuidedTourInner({ userRole }: GuidedTourProps) {
   }, [searchParams, mounted]);
 
   const handleFinish = useCallback(() => {
+    finishedRef.current = true;
     setActive(false);
     // Mark tour as seen (fire-and-forget)
     fetch("/api/user/tour-seen", { method: "PATCH" }).catch(() => {});


### PR DESCRIPTION
## Summary
- Ajout d'une modale plein écran au clic sur les captures d'écran du guide (hover scale + cursor zoom-in)
- Fix du bouton "Terminer" du tour guide qui ne désactivait pas le tour au premier clic (race condition `router.replace` / `useSearchParams`)
- Bump version 0.7.3 + CHANGELOG

## Test plan
- [ ] Page `/guide` : cliquer sur une image → modale zoom plein écran
- [ ] Fermer la modale (croix ou clic fond)
- [ ] Lancer le tour guide → cliquer "Terminer" → le tour se ferme immédiatement

🤖 Generated with [Claude Code](https://claude.com/claude-code)