### PR TITLE
fix: corrections affichage mobile (issue #39)

### DIFF
--- a/src/app/(auth)/admin/users/UsersClient.tsx
+++ b/src/app/(auth)/admin/users/UsersClient.tsx
@@ -392,26 +392,26 @@ export default function UsersClient({
       <div className="space-y-4">
         {filteredUsers.map((user) => (
           <div key={user.id} className="bg-white rounded-lg shadow p-4">
-            <div className="flex items-center justify-between mb-3">
-              <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+              <div className="flex items-center gap-3 min-w-0">
                 {user.image && (
                   <img
                     src={user.image}
                     alt=""
-                    className="w-8 h-8 rounded-full"
+                    className="w-8 h-8 rounded-full shrink-0"
                   />
                 )}
-                <div>
-                  <p className="font-medium text-gray-900">
+                <div className="min-w-0">
+                  <p className="font-medium text-gray-900 truncate">
                     {user.displayName || user.name || "Sans nom"}
                     {user.displayName && user.name && user.displayName !== user.name && (
                       <span className="text-sm text-gray-400 ml-1">({user.name})</span>
                     )}
                   </p>
-                  <p className="text-sm text-gray-500">{user.email}</p>
+                  <p className="text-sm text-gray-500 truncate">{user.email}</p>
                 </div>
               </div>
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
                 {canManageRoles && (
                   <>
                     <Button variant="secondary" onClick={() => openEditDisplayName(user)}>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -208,7 +208,7 @@ export default function Sidebar({
   const isAdminActive = pathname.startsWith("/admin");
 
   return (
-    <aside className="w-64 min-h-0 md:min-h-[calc(100vh-73px)] bg-white border-r border-gray-200 p-4 space-y-1 overflow-y-auto">
+    <aside className="w-64 min-h-0 md:min-h-[calc(100vh-73px)] bg-white border-r border-gray-200 p-4 pb-20 md:pb-4 space-y-1 overflow-y-auto">
       {/* Départements */}
       <AccordionSection
         title="Départements"


### PR DESCRIPTION
## Problèmes corrigés

**1. Débordement des boutons sur `/admin/users` (mobile)**
- Ajout de `flex-wrap` sur le conteneur info/boutons de chaque carte utilisateur
- Les boutons "Nom d'affichage" et "Ajouter un rôle" passent à la ligne si l'espace manque
- Ajout de `min-w-0` + `truncate` sur les textes pour éviter tout débordement horizontal

**2. Sidebar tronquée par la BottomNav (mobile)**
- Ajout de `pb-20` sur mobile (`md:pb-4` sur desktop) dans le `<aside>` de la Sidebar
- Le dernier item de la sidebar est désormais accessible au-dessus de la BottomNav (`h-14`)

Closes #39

## Test plan

- [ ] `/admin/users` sur mobile : vérifier que les boutons ne débordent pas
- [ ] Ouvrir la sidebar sur mobile avec de nombreux départements : vérifier que le dernier item est accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)