### PR TITLE
fix: afficher le motif de refus au demandeur

### DIFF
--- a/src/app/(auth)/announcements/AnnouncementsList.tsx
+++ b/src/app/(auth)/announcements/AnnouncementsList.tsx
@@ -8,6 +8,7 @@ interface ChildRequest {
   type: ServiceRequestType;
   status: ServiceRequestStatus;
   deliveryLink: string | null;
+  reviewNotes: string | null;
   assignedDept: { id: string; name: string } | null;
 }
 
@@ -15,6 +16,7 @@ interface ServiceRequest {
   id: string;
   type: ServiceRequestType;
   status: ServiceRequestStatus;
+  reviewNotes: string | null;
   assignedDept: { id: string; name: string } | null;
   childRequests: ChildRequest[];
 }
@@ -196,24 +198,36 @@ export default function AnnouncementsList({ announcements: initial }: Props) {
                       <span className="text-xs text-gray-400">→ {sr.assignedDept.name}</span>
                     )}
                   </div>
+                  {sr.status === "ANNULE" && sr.reviewNotes && (
+                    <p className="mt-1 text-xs text-gray-500 italic pl-1">
+                      Motif : {sr.reviewNotes}
+                    </p>
+                  )}
                   {sr.childRequests.map((child) => (
-                    <div key={child.id} className="flex items-center gap-2 flex-wrap pl-4 mt-1">
-                      <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${SR_STATUS_BADGE[child.status]}`}>
-                        {SR_STATUS_DOT[child.status]} {SR_STATUS_LABEL[child.status]}
-                      </span>
-                      <span className="text-xs text-gray-500">{SR_TYPE_LABEL[child.type]}</span>
-                      {child.assignedDept && (
-                        <span className="text-xs text-gray-400">→ {child.assignedDept.name}</span>
-                      )}
-                      {child.deliveryLink && child.status === "LIVRE" && (
-                        <a
-                          href={child.deliveryLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-xs text-icc-violet underline font-medium"
-                        >
-                          Voir le visuel →
-                        </a>
+                    <div key={child.id} className="pl-4 mt-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${SR_STATUS_BADGE[child.status]}`}>
+                          {SR_STATUS_DOT[child.status]} {SR_STATUS_LABEL[child.status]}
+                        </span>
+                        <span className="text-xs text-gray-500">{SR_TYPE_LABEL[child.type]}</span>
+                        {child.assignedDept && (
+                          <span className="text-xs text-gray-400">→ {child.assignedDept.name}</span>
+                        )}
+                        {child.deliveryLink && child.status === "LIVRE" && (
+                          <a
+                            href={child.deliveryLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs text-icc-violet underline font-medium"
+                          >
+                            Voir le visuel →
+                          </a>
+                        )}
+                      </div>
+                      {child.status === "ANNULE" && child.reviewNotes && (
+                        <p className="mt-1 text-xs text-gray-500 italic">
+                          Motif : {child.reviewNotes}
+                        </p>
                       )}
                     </div>
                   ))}

--- a/src/app/(auth)/announcements/page.tsx
+++ b/src/app/(auth)/announcements/page.tsx
@@ -27,6 +27,7 @@ export default async function AnnouncementsPage() {
               type: true,
               status: true,
               deliveryLink: true,
+              reviewNotes: true,
               assignedDept: { select: { id: true, name: true } },
             },
           },


### PR DESCRIPTION
## Summary

- Ajout de `reviewNotes` dans la requête Prisma de `/announcements`
- Affichage du motif sous le badge statut pour les SR `ANNULE` (et leurs enfants VISUEL)

## Test plan
- [ ] Refuser une demande avec une note depuis le dashboard Secrétariat/Communication/Média
- [ ] Vérifier que le motif apparaît dans "Mes annonces" sous la demande concernée

🤖 Generated with [Claude Code](https://claude.com/claude-code)