### PR TITLE
release: v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v0.8.1] - 2026-03-18
+
+### Corrige
+
+- Motif de refus (`reviewNotes`) desormais visible par le demandeur dans "Mes annonces"
+- `tsconfig.tsbuildinfo` desindexe de git (etait deja dans `.gitignore`)
+
+### Ameliore
+
+- ESLint configure (`eslint-config-next`) avec script `npm run lint`
+- TypeScript : activation `noUnusedLocals` + `noUnusedParameters`
+- `PlanningGrid` : etats d'erreur visibles (`fetchError` / `saveError`) en remplacement des `console.error` silencieux
+- CI : `npm run lint` ajoute dans le pipeline
+- Dependances : `@types/node` 25.3.5 → 25.5.0, `vitest` + `@vitest/coverage-v8` 4.0.18 → 4.1.0
+
 ## [v0.8.0] - 2026-03-18
 
 ### Ajoute

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,6 +204,25 @@ Les demandes `VISUEL` sont liees a leur demande parente (`DIFFUSION_INTERNE` ou 
 
 Les deux cascades s'executent dans des transactions Prisma atomiques.
 
+**Motif de refus** : le champ `reviewNotes` de chaque `ServiceRequest` est visible par le demandeur dans `/announcements` (vue "Mes annonces"), sous le badge de statut `ANNULE`.
+
+### Synchronisation du statut d'annonce
+
+Le statut de l'`Announcement` est recalcule automatiquement apres chaque changement de statut d'une SR parente :
+
+| Statuts des SR parentes | Statut annonce |
+|---|---|
+| Toutes `ANNULE` | `ANNULEE` |
+| Toutes `LIVRE` ou (`LIVRE` + `ANNULE`) | `TRAITEE` |
+| Au moins une `EN_COURS` ou `LIVRE` | `EN_COURS` |
+| Sinon | `EN_ATTENTE` |
+
+### Qualite du code
+
+- **ESLint** : configure via `eslint.config.mjs` (`eslint-config-next`), script `npm run lint`
+- **TypeScript strict** : `noUnusedLocals` + `noUnusedParameters` actives dans `tsconfig.json`
+- **CI** : typecheck + lint + tests sur chaque PR
+
 ## Multi-tenant
 
 Chaque eglise (`Church`) est un tenant isole. Les donnees (ministeres, departements, membres, evenements, annonces) sont rattachees a une eglise via `churchId`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planningcenter",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

- Motif de refus visible par le demandeur dans "Mes annonces"
- ESLint configuré + `noUnusedLocals`/`noUnusedParameters` TypeScript
- `PlanningGrid` : feedback utilisateur sur erreur fetch/save
- CI : `npm run lint` dans le pipeline
- `tsconfig.tsbuildinfo` désindexé de git
- Dépendances bumped (vitest 4.1, @types/node 25.5)

## Test plan
- [ ] `npm run typecheck` → 0 erreurs
- [ ] `npm run lint` → 0 erreurs
- [ ] `npm run test` → tests passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)