### PR TITLE
fix: page d'accueil pour utilisateurs sans rôle + variables env NextAuth v5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 DATABASE_URL=mysql://planningcenter:planningcenter@localhost:3306/planningcenter
-NEXTAUTH_SECRET=your-secret
-NEXTAUTH_URL=http://localhost:3000
+AUTH_SECRET=your-secret
+AUTH_URL=http://localhost:3000
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 SUPER_ADMIN_EMAILS=admin@example.com

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Concue pour ICC Bretagne, adaptable a toute eglise structuree en ministeres et d
 ```bash
 git clone https://github.com/iccbretagne/planningcenter.git
 cd planningcenter
-cp .env.example .env          # configurer Google OAuth + NEXTAUTH_SECRET
+cp .env.example .env          # configurer Google OAuth + AUTH_SECRET
 docker-compose up -d           # MariaDB
 npm install
 npm run db:push                # schema

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,8 +164,8 @@ Un indicateur visuel affiche l'etat : sauvegarde en cours, modifications non sau
 | Variable | Description | Exemple |
 |---|---|---|
 | `DATABASE_URL` | URL de connexion MariaDB | `mysql://planningcenter:planningcenter@localhost:3306/planningcenter` |
-| `NEXTAUTH_SECRET` | Secret de chiffrement des sessions | `openssl rand -base64 32` |
-| `NEXTAUTH_URL` | URL publique de l'application | `http://localhost:3000` |
+| `AUTH_SECRET` | Secret de chiffrement des sessions | `openssl rand -base64 32` |
+| `AUTH_URL` | URL publique de l'application | `http://localhost:3000` |
 | `GOOGLE_CLIENT_ID` | Client ID Google OAuth | |
 | `GOOGLE_CLIENT_SECRET` | Client Secret Google OAuth | |
 | `SUPER_ADMIN_EMAILS` | Emails auto-promus Super Admin (virgule) | `admin@example.com,other@example.com` |

--- a/docs/production.md
+++ b/docs/production.md
@@ -44,8 +44,8 @@ Creer le fichier `/opt/planning/shared/.env` :
 
 ```bash
 DATABASE_URL=mysql://planning:MOT_DE_PASSE@localhost:3306/planning
-NEXTAUTH_SECRET=GENERER_AVEC_OPENSSL
-NEXTAUTH_URL=https://votre-domaine.com
+AUTH_SECRET=GENERER_AVEC_OPENSSL
+AUTH_URL=https://votre-domaine.com
 AUTH_TRUST_HOST=true
 PORT=3000
 GOOGLE_CLIENT_ID=votre-google-client-id
@@ -336,11 +336,11 @@ gh release upload guide-assets guide-*.png
 ## Checklist de production
 
 - [ ] Variables d'environnement configurees dans `shared/.env`
-- [ ] `NEXTAUTH_SECRET` genere avec `openssl rand -base64 32`
+- [ ] `AUTH_SECRET` genere avec `openssl rand -base64 32`
 - [ ] `CRON_SECRET` genere avec `openssl rand -base64 32`
 - [ ] Webcron configure (crontab ou service externe) pour appeler `/api/cron/reminders` quotidiennement
 - [ ] `AUTH_TRUST_HOST=true` present
-- [ ] `NEXTAUTH_URL` pointe vers le domaine de production (HTTPS)
+- [ ] `AUTH_URL` pointe vers le domaine de production (HTTPS)
 - [ ] Base de donnees creee avec utilisateur dedie
 - [ ] Schema applique (`npm run db:push`)
 - [ ] Application construite (`npm run build`)

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -30,6 +30,11 @@ export default async function AuthLayout({
   }
 
   const churchRoles = session.user.churchRoles;
+
+  if (!session.user.isSuperAdmin && churchRoles.length === 0) {
+    redirect("/no-access");
+  }
+
   const currentChurchId = await getCurrentChurchId(session);
   const currentChurch = churchRoles.find((r) => r.churchId === currentChurchId);
   const churchName = currentChurch?.church?.name || "Église";

--- a/src/app/no-access/page.tsx
+++ b/src/app/no-access/page.tsx
@@ -1,0 +1,72 @@
+import { auth, signOut } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+export default async function NoAccessPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/");
+  }
+
+  // Si l'utilisateur a des rôles entre-temps, rediriger vers le dashboard
+  if (session.user.isSuperAdmin || session.user.churchRoles.length > 0) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="max-w-md w-full bg-white rounded-lg border-2 border-gray-200 p-8 text-center">
+        <div className="w-16 h-16 bg-icc-violet/10 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg
+            className="w-8 h-8 text-icc-violet"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+            />
+          </svg>
+        </div>
+
+        <h1 className="text-xl font-bold text-gray-900 mb-2">
+          Accès en attente
+        </h1>
+
+        <p className="text-gray-600 mb-1">
+          Connecté en tant que{" "}
+          <span className="font-medium text-gray-800">
+            {session.user.name || session.user.email}
+          </span>
+        </p>
+
+        <p className="text-sm text-gray-500 mb-6">
+          {session.user.email}
+        </p>
+
+        <p className="text-gray-600 mb-8">
+          Votre compte n&apos;a pas encore été configuré. Contactez un{" "}
+          <strong>administrateur</strong> ou le <strong>secrétariat</strong>{" "}
+          pour demander un accès en fonction de votre rôle dans l&apos;église.
+        </p>
+
+        <form
+          action={async () => {
+            "use server";
+            await signOut({ redirectTo: "/" });
+          }}
+        >
+          <button
+            type="submit"
+            className="w-full px-4 py-2 text-sm font-medium text-white bg-icc-violet rounded-lg hover:bg-icc-violet/90 transition-colors"
+          >
+            Se déconnecter
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé

- Correction du bug `InvalidCheck: pkceCodeVerifier` en production : la variable `NEXTAUTH_SECRET` (NextAuth v4) était utilisée à la place de `AUTH_SECRET` (NextAuth v5), empêchant la connexion OAuth
- Ajout d'une page `/no-access` pour les utilisateurs authentifiés sans rôle configuré

## Changements

### Fix auth (PKCE crash)
- `.env.example`, `docs/production.md`, `docs/architecture.md`, `README.md` : `NEXTAUTH_SECRET` → `AUTH_SECRET`, `NEXTAUTH_URL` → `AUTH_URL`

### Page sans rôle
- `src/app/(auth)/layout.tsx` : redirect vers `/no-access` si `churchRoles` vide et non super admin
- `src/app/no-access/page.tsx` : page dédiée hors route group `(auth)` affichant le nom/email de l'utilisateur, un message pour contacter un admin ou le secrétariat, et un bouton de déconnexion. Renvoie vers `/dashboard` si des rôles ont été accordés entre-temps.

## Test

- [ ] Connexion Google avec un compte sans rôle → redirection vers `/no-access`
- [ ] La page `/no-access` affiche le nom/email de l'utilisateur connecté
- [ ] Le bouton "Se déconnecter" renvoie vers la page de connexion
- [ ] Connexion Google avec un compte configuré → accès normal au dashboard
- [ ] Super admin sans rôle explicite → accès normal (pas de redirect)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)