### PR TITLE
chore: correction warnings ESLint (img, set-state-in-effect)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,11 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: __dirname,
   },
+  images: {
+    remotePatterns: [
+      { hostname: "lh3.googleusercontent.com" },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(auth)/admin/users/UsersClient.tsx
+++ b/src/app/(auth)/admin/users/UsersClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import Select from "@/components/ui/Select";
@@ -395,10 +396,12 @@ export default function UsersClient({
             <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
               <div className="flex items-center gap-3 min-w-0">
                 {user.image && (
-                  <img
+                  <Image
                     src={user.image}
                     alt=""
-                    className="w-8 h-8 rounded-full shrink-0"
+                    width={32}
+                    height={32}
+                    className="rounded-full shrink-0"
                   />
                 )}
                 <div className="min-w-0">

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,5 +1,6 @@
 import pkg from "@/../package.json";
 import { redirect } from "next/navigation";
+import Image from "next/image";
 import { auth, signOut, getCurrentChurchId } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
@@ -132,10 +133,12 @@ export default async function AuthLayout({
         </a>
         <NotificationBell />
         {session.user.image && (
-          <img
+          <Image
             src={session.user.image}
             alt={session.user.name || ""}
-            className="w-8 h-8 rounded-full"
+            width={32}
+            height={32}
+            className="rounded-full"
           />
         )}
         <span className="hidden sm:inline text-sm text-white">{session.user.name}</span>

--- a/src/components/AuthLayoutShell.tsx
+++ b/src/components/AuthLayoutShell.tsx
@@ -51,6 +51,7 @@ export default function AuthLayoutShell({
 
   // Close sidebar on route change (mobile)
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSidebarOpen(false);
   }, [pathname]);
 

--- a/src/components/GuideContent.tsx
+++ b/src/components/GuideContent.tsx
@@ -203,6 +203,7 @@ export default function GuideContent({ defaultRole }: GuideContentProps) {
                     onClick={() => setZoomedImage({ src: `${GUIDE_ASSETS_BASE}/${feature.screenshotFile}`, alt: feature.screenshotTitle })}
                     className="w-full aspect-video bg-gray-50 rounded-lg border border-gray-200 overflow-hidden cursor-zoom-in group"
                   >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={`${GUIDE_ASSETS_BASE}/${feature.screenshotFile}`}
                       alt={feature.screenshotTitle}
@@ -233,6 +234,7 @@ export default function GuideContent({ defaultRole }: GuideContentProps) {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={zoomedImage.src}
             alt={zoomedImage.alt}

--- a/src/components/GuidedTour.tsx
+++ b/src/components/GuidedTour.tsx
@@ -66,6 +66,7 @@ function TourOverlay({
   // Find and measure target element
   useEffect(() => {
     if (!step || isCentered) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setTargetRect(null);
       return;
     }
@@ -97,6 +98,7 @@ function TourOverlay({
   // Position tooltip
   useEffect(() => {
     if (isCentered || !targetRect || !tooltipRef.current) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setTooltipPos(null);
       return;
     }
@@ -366,6 +368,7 @@ function GuidedTourInner({ userRole }: GuidedTourProps) {
   const finishedRef = useRef(false);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsMobile(window.innerWidth < 768);
     setMounted(true);
   }, []);

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -33,6 +33,7 @@ export default function NotificationBell() {
   }, []);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchNotifications();
     const interval = setInterval(fetchNotifications, 60000);
     return () => clearInterval(interval);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -127,6 +127,7 @@ function MinistryGroupedDepartments({
   // Open the ministry containing the active department when it changes
   useEffect(() => {
     if (activeMinistry !== null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setOpenMinistry(activeMinistry);
     }
   }, [activeMinistry]);


### PR DESCRIPTION
## Résumé

Suppression des 10 warnings ESLint (`npm run lint` → 0 warnings, 0 erreurs).

## Changements

### `<img>` → `<Image>` (optimisation LCP)
- `next.config.ts` : ajout `remotePatterns` pour `lh3.googleusercontent.com` (avatars Google)
- `src/app/(auth)/layout.tsx` : avatar header converti en `<Image width={32} height={32}>`
- `src/app/(auth)/admin/users/UsersClient.tsx` : idem
- `src/components/GuideContent.tsx` : `eslint-disable` pour les captures du guide (dimensions inconnues, URL dynamiques GitHub releases)

### `react-hooks/set-state-in-effect`
`eslint-disable-next-line` ciblés sur des patterns valides :
- `AuthLayoutShell.tsx` : fermeture sidebar au changement de route (UX mobile)
- `Sidebar.tsx` : sync du ministère ouvert depuis le ministère actif
- `NotificationBell.tsx` : déclenchement du polling initial dans l'effet
- `GuidedTour.tsx` : initialisations au mount (`window.innerWidth`, `setTargetRect(null)`, `setTooltipPos(null)`)

## Test

- [ ] `npm run lint` → 0 warnings, 0 erreurs
- [ ] `npm run typecheck` → OK
- [ ] Les avatars Google s'affichent correctement dans le header et la liste utilisateurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)