### PR TITLE
fix(mobile): select statut STAR toujours visible sur mobile

### DIFF
--- a/src/components/PlanningGrid.tsx
+++ b/src/components/PlanningGrid.tsx
@@ -214,7 +214,7 @@ export default function PlanningGrid({
               key={member.id}
               className={`flex items-center justify-between gap-3 p-3 rounded-lg border border-gray-200 ${current.color}`}
             >
-              <span className="text-sm font-medium truncate">
+              <span className="text-sm font-medium truncate min-w-0">
                 {member.firstName} {member.lastName}
               </span>
               {isReadOnly ? (


### PR DESCRIPTION
## Summary

- Ajout de `min-w-0` sur le span du nom STAR dans la vue carte mobile (`PlanningGrid`)
- Sans `min-w-0`, `truncate` n'est pas appliqué dans un conteneur flex : le nom long peut déborder et pousser le `<select>` de statut hors du viewport
- Le select avec les 5 options de statut est maintenant toujours visible, quelle que soit la longueur du nom

Closes #43

## Test plan

- [ ] Sur mobile (< 768px), ouvrir le planning d'un département avec des membres aux noms longs
- [ ] Vérifier que le select de statut est bien visible à droite de chaque ligne
- [ ] Vérifier que le nom est tronqué avec `...` si trop long
- [ ] Changer un statut depuis le select → sauvegarde automatique

🤖 Generated with [Claude Code](https://claude.com/claude-code)