### PR TITLE
feat: module discipolat — scope FD, département système, création membre

### DIFF
--- a/prisma/migrations/20260320000001_add_is_system_ministry_department/migration.sql
+++ b/prisma/migrations/20260320000001_add_is_system_ministry_department/migration.sql
@@ -1,0 +1,24 @@
+-- AlterTable: add isSystem to ministries
+ALTER TABLE `ministries` ADD COLUMN `isSystem` BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable: add isSystem to departments
+ALTER TABLE `departments` ADD COLUMN `isSystem` BOOLEAN NOT NULL DEFAULT false;
+
+-- Insert system ministry + department for each existing church
+INSERT INTO `ministries` (`id`, `name`, `churchId`, `isSystem`, `createdAt`)
+SELECT
+  CONCAT('sys-min-', `id`),
+  'Système',
+  `id`,
+  true,
+  NOW()
+FROM `churches`;
+
+INSERT INTO `departments` (`id`, `name`, `ministryId`, `isSystem`, `createdAt`)
+SELECT
+  CONCAT('sys-dept-', c.`id`),
+  'Sans département',
+  CONCAT('sys-min-', c.`id`),
+  true,
+  NOW()
+FROM `churches` c;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,6 +136,7 @@ model Ministry {
   id              String           @id @default(cuid())
   name            String
   churchId        String
+  isSystem        Boolean          @default(false)
   church          Church           @relation(fields: [churchId], references: [id])
   departments     Department[]
   userRoles       UserChurchRole[]
@@ -156,6 +157,7 @@ model Department {
   id                      String             @id @default(cuid())
   name                    String
   ministryId              String
+  isSystem                Boolean            @default(false)
   function                DepartmentFunction?
   ministry                Ministry           @relation(fields: [ministryId], references: [id])
   members                 Member[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -35,6 +35,22 @@ async function main() {
 
   console.log(`Church created: ${church.name}`);
 
+  // Create system ministry + department (non-modifiable, non-deletable except by superAdmin)
+  const systemMinistry = await prisma.ministry.create({
+    data: {
+      name: "Système",
+      churchId: church.id,
+      isSystem: true,
+      departments: {
+        create: {
+          name: "Sans département",
+          isSystem: true,
+        },
+      },
+    },
+  });
+  console.log(`  System ministry: ${systemMinistry.name}`);
+
   for (const [ministryName, departments] of Object.entries(
     MINISTRIES_AND_DEPARTMENTS
   )) {

--- a/src/app/(auth)/admin/departments/DepartmentsClient.tsx
+++ b/src/app/(auth)/admin/departments/DepartmentsClient.tsx
@@ -11,6 +11,7 @@ import BulkActionBar from "@/components/ui/BulkActionBar";
 interface Department {
   id: string;
   name: string;
+  isSystem: boolean;
   ministry: { id: string; name: string; churchId: string };
   _count: { members: number };
 }
@@ -18,11 +19,13 @@ interface Department {
 interface Props {
   initialDepartments: Department[];
   ministries: { id: string; name: string; churchName: string }[];
+  isSuperAdmin?: boolean;
 }
 
 export default function DepartmentsClient({
   initialDepartments,
   ministries,
+  isSuperAdmin,
 }: Props) {
   const [departments, setDepartments] = useState(initialDepartments);
   const [modalOpen, setModalOpen] = useState(false);
@@ -213,16 +216,26 @@ export default function DepartmentsClient({
           selectable
           selectedIds={selectedIds}
           onSelectionChange={setSelectedIds}
-          actions={(d) => (
-            <div className="flex gap-2 justify-end">
-              <Button variant="secondary" onClick={() => openEdit(d)}>
-                Modifier
-              </Button>
-              <Button variant="danger" onClick={() => handleDelete(d)}>
-                Supprimer
-              </Button>
-            </div>
-          )}
+          actions={(d) => {
+            const locked = d.isSystem && !isSuperAdmin;
+            return (
+              <div className="flex items-center gap-2 justify-end">
+                {d.isSystem && (
+                  <span title="Département système" className="text-gray-400">
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                    </svg>
+                  </span>
+                )}
+                <Button variant="secondary" onClick={() => openEdit(d)} disabled={locked}>
+                  Modifier
+                </Button>
+                <Button variant="danger" onClick={() => handleDelete(d)} disabled={locked}>
+                  Supprimer
+                </Button>
+              </div>
+            );
+          }}
         />
       </div>
 

--- a/src/app/(auth)/admin/departments/page.tsx
+++ b/src/app/(auth)/admin/departments/page.tsx
@@ -52,6 +52,7 @@ export default async function DepartmentsPage() {
           name: m.name,
           churchName: m.church.name,
         }))}
+        isSuperAdmin={isSuperAdmin}
       />
     </div>
   );

--- a/src/app/(auth)/admin/discipleship/DiscipleshipClient.tsx
+++ b/src/app/(auth)/admin/discipleship/DiscipleshipClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import Button from "@/components/ui/Button";
 import Select from "@/components/ui/Select";
 import Modal from "@/components/ui/Modal";
@@ -108,6 +108,154 @@ export default function DiscipleshipClient({ churchId, members, allAssignedDisci
   );
 }
 
+// ─── Combobox disciple ────────────────────────────────────────────────────────
+
+function DiscipleCombobox({
+  options,
+  value,
+  onChange,
+}: {
+  options: MemberOption[];
+  value: string | { firstName: string; lastName: string } | null;
+  onChange: (v: string | { firstName: string; lastName: string } | null) => void;
+}) {
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const isSelected = value !== null;
+  const selectedMember = typeof value === "string" ? options.find((o) => o.id === value) : null;
+  const isNew = value !== null && typeof value === "object";
+
+  function norm(s: string) {
+    return s.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+  }
+
+  // Filter by both fields, accent-insensitive
+  const qFirst = norm(firstName);
+  const qLast = norm(lastName);
+  const hasInput = firstName.trim().length > 0 || lastName.trim().length > 0;
+  const filtered = hasInput
+    ? options.filter((m) => {
+        const mFirst = norm(m.firstName);
+        const mLast = norm(m.lastName);
+        // both fields filled → must match both
+        if (qFirst && qLast) return mFirst.includes(qFirst) && mLast.includes(qLast);
+        // single field → match either first or last name
+        const q = qFirst || qLast;
+        return mFirst.includes(q) || mLast.includes(q) ||
+          `${mFirst} ${mLast}`.includes(q) || `${mLast} ${mFirst}`.includes(q);
+      })
+    : options;
+
+  const noMatch = hasInput && filtered.length === 0;
+
+  function selectMember(m: MemberOption) {
+    onChange(m.id);
+    setFirstName(m.firstName);
+    setLastName(m.lastName);
+  }
+
+  function confirmNew() {
+    onChange({ firstName: firstName.trim(), lastName: lastName.trim() });
+  }
+
+  function handleClear() {
+    onChange(null);
+    setFirstName("");
+    setLastName("");
+  }
+
+  function handleFieldChange(field: "firstName" | "lastName", val: string) {
+    if (field === "firstName") setFirstName(val);
+    else setLastName(val);
+    if (value !== null) onChange(null); // reset on edit
+  }
+
+  return (
+    <div ref={containerRef} className="space-y-2">
+      {/* Selected chip */}
+      {isSelected && (
+        <div className="flex items-center gap-2 px-3 py-2 bg-icc-violet/10 border-2 border-icc-violet/30 rounded-lg text-sm">
+          <svg className="w-4 h-4 text-icc-violet shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+          <span className="flex-1 font-medium text-gray-900">
+            {isNew
+              ? `${(value as {firstName:string;lastName:string}).firstName} ${(value as {firstName:string;lastName:string}).lastName}`.trim()
+              : `${selectedMember?.firstName} ${selectedMember?.lastName}`}
+          </span>
+          {selectedMember && (
+            <span className="text-xs text-gray-400">{selectedMember.department.ministry.name} / {selectedMember.department.name}</span>
+          )}
+          {isNew && <span className="text-xs text-icc-violet">nouveau</span>}
+          <button type="button" onClick={handleClear} className="text-gray-400 hover:text-gray-600 ml-1">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      )}
+
+      {/* Input fields */}
+      {!isSelected && (
+        <>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={firstName}
+              onChange={(e) => handleFieldChange("firstName", e.target.value)}
+              placeholder="Prénom"
+              className="flex-1 border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+            />
+            <input
+              type="text"
+              value={lastName}
+              onChange={(e) => handleFieldChange("lastName", e.target.value)}
+              placeholder="Nom"
+              className="flex-1 border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+            />
+          </div>
+
+          {/* Suggestions */}
+          {hasInput && filtered.length > 0 && (
+            <ul className="border-2 border-gray-200 rounded-lg overflow-hidden text-sm max-h-48 overflow-y-auto">
+              {filtered.map((m) => (
+                <li key={m.id}>
+                  <button
+                    type="button"
+                    onMouseDown={(e) => { e.preventDefault(); selectMember(m); }}
+                    className="w-full text-left px-3 py-2 hover:bg-icc-violet/5 transition-colors border-b border-gray-100 last:border-0"
+                  >
+                    <span className="font-medium text-gray-900">{m.firstName} {m.lastName}</span>
+                    <span className="ml-2 text-xs text-gray-400">{m.department.ministry.name} / {m.department.name}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* Create option */}
+          {noMatch && (
+            <div className="flex items-center gap-3 px-3 py-2 border-2 border-dashed border-gray-200 rounded-lg text-sm">
+              <span className="flex-1 text-gray-500">
+                Aucun résultat pour «&nbsp;{[firstName, lastName].filter(Boolean).join(" ")}&nbsp;»
+              </span>
+              <button
+                type="button"
+                onMouseDown={(e) => { e.preventDefault(); confirmNew(); }}
+                className="text-icc-violet font-medium hover:underline whitespace-nowrap"
+              >
+                + Créer ce membre
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 // ─── Tab: Relations ───────────────────────────────────────────────────────────
 
 function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, isFD, linkedMemberId }: { churchId: string; members: MemberOption[]; allAssignedDiscipleIds: string[]; canManage: boolean; isFD: boolean; linkedMemberId: string | null }) {
@@ -117,7 +265,8 @@ function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, is
 
   // Modal: nouvelle relation
   const [createModal, setCreateModal] = useState(false);
-  const [newDiscipleId, setNewDiscipleId] = useState(members[0]?.id ?? "");
+  // discipleSelection: existing member id OR { firstName, lastName } for a new member
+  const [discipleSelection, setDiscipleSelection] = useState<string | { firstName: string; lastName: string } | null>(null);
   const [newMakerId, setNewMakerId] = useState(linkedMemberId ?? members[0]?.id ?? "");
   const [createError, setCreateError] = useState<string | null>(null);
   const [createLoading, setCreateLoading] = useState(false);
@@ -154,18 +303,18 @@ function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, is
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
+    if (!discipleSelection) { setCreateError("Sélectionnez ou créez un disciple"); return; }
     const makerId = isFD ? (linkedMemberId ?? newMakerId) : newMakerId;
-    if (newDiscipleId === makerId) {
-      setCreateError("Un STAR ne peut pas être son propre FD");
-      return;
-    }
     setCreateLoading(true);
     setCreateError(null);
     try {
+      const body = typeof discipleSelection === "string"
+        ? { discipleId: discipleSelection, discipleMakerId: makerId, churchId }
+        : { newMember: discipleSelection, discipleMakerId: makerId, churchId };
       const res = await fetch("/api/discipleships", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ discipleId: newDiscipleId, discipleMakerId: makerId, churchId }),
+        body: JSON.stringify(body),
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error ?? "Erreur");
@@ -229,7 +378,7 @@ function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, is
     <>
       {canManage && (
         <div className="mb-4">
-          <Button onClick={() => { setCreateModal(true); setCreateError(null); setNewDiscipleId(members[0]?.id ?? ""); setNewMakerId(members[0]?.id ?? ""); }}>
+          <Button onClick={() => { setCreateModal(true); setCreateError(null); setDiscipleSelection(null); setNewMakerId(linkedMemberId ?? members[0]?.id ?? ""); }}>
             Nouvelle relation
           </Button>
         </div>
@@ -294,12 +443,20 @@ function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, is
       {/* Modal: nouvelle relation */}
       <Modal open={createModal} onClose={() => setCreateModal(false)} title="Nouvelle relation de discipolat">
         <form onSubmit={handleCreate} className="space-y-4">
-          <Select
-            label="Disciple"
-            value={newDiscipleId}
-            onChange={(e) => setNewDiscipleId(e.target.value)}
-            options={availableDisciples.map((m) => ({ value: m.id, label: memberLabel(m) }))}
-          />
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Disciple</label>
+            <DiscipleCombobox
+              options={availableDisciples}
+              value={discipleSelection}
+              onChange={setDiscipleSelection}
+            />
+            {discipleSelection && typeof discipleSelection === "object" && (
+              <p className="mt-1 text-xs text-gray-400">
+                Nouveau membre — sera ajouté dans «&nbsp;Sans département&nbsp;».
+              </p>
+            )}
+          </div>
+
           {!isFD && (
             <Select
               label="Faiseur de disciples (FD)"
@@ -313,7 +470,7 @@ function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, is
             <Button variant="secondary" type="button" onClick={() => setCreateModal(false)}>
               Annuler
             </Button>
-            <Button type="submit" disabled={createLoading}>
+            <Button type="submit" disabled={createLoading || !discipleSelection}>
               {createLoading ? "Enregistrement..." : "Créer"}
             </Button>
           </div>

--- a/src/app/(auth)/admin/discipleship/DiscipleshipClient.tsx
+++ b/src/app/(auth)/admin/discipleship/DiscipleshipClient.tsx
@@ -41,6 +41,8 @@ interface Props {
   members: MemberOption[];
   canManage: boolean;
   canExport: boolean;
+  isFD?: boolean;
+  linkedMemberId?: string | null;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -64,7 +66,7 @@ function firstDayOfMonthISO() {
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 
-export default function DiscipleshipClient({ churchId, members, canManage, canExport }: Props) {
+export default function DiscipleshipClient({ churchId, members, canManage, canExport, isFD = false, linkedMemberId = null }: Props) {
   const [activeTab, setActiveTab] = useState<"relations" | "appel" | "stats">("relations");
 
   const TAB_LABELS: Record<typeof activeTab, string> = {
@@ -93,7 +95,7 @@ export default function DiscipleshipClient({ churchId, members, canManage, canEx
       </div>
 
       {activeTab === "relations" && (
-        <RelationsTab churchId={churchId} members={members} canManage={canManage} />
+        <RelationsTab churchId={churchId} members={members} canManage={canManage} isFD={isFD} linkedMemberId={linkedMemberId} />
       )}
       {activeTab === "appel" && (
         <AppelTab churchId={churchId} canManage={canManage} />
@@ -107,7 +109,7 @@ export default function DiscipleshipClient({ churchId, members, canManage, canEx
 
 // ─── Tab: Relations ───────────────────────────────────────────────────────────
 
-function RelationsTab({ churchId, members, canManage }: { churchId: string; members: MemberOption[]; canManage: boolean }) {
+function RelationsTab({ churchId, members, canManage, isFD, linkedMemberId }: { churchId: string; members: MemberOption[]; canManage: boolean; isFD: boolean; linkedMemberId: string | null }) {
   const [rows, setRows] = useState<DiscipleshipRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -115,7 +117,7 @@ function RelationsTab({ churchId, members, canManage }: { churchId: string; memb
   // Modal: nouvelle relation
   const [createModal, setCreateModal] = useState(false);
   const [newDiscipleId, setNewDiscipleId] = useState(members[0]?.id ?? "");
-  const [newMakerId, setNewMakerId] = useState(members[0]?.id ?? "");
+  const [newMakerId, setNewMakerId] = useState(linkedMemberId ?? members[0]?.id ?? "");
   const [createError, setCreateError] = useState<string | null>(null);
   const [createLoading, setCreateLoading] = useState(false);
 
@@ -142,9 +144,14 @@ function RelationsTab({ churchId, members, canManage }: { churchId: string; memb
 
   useEffect(() => { fetchRows(); }, [fetchRows]);
 
+  // Membres déjà pris comme disciple (pour filtrer le sélecteur)
+  const assignedDiscipleIds = new Set(rows.map((r) => r.discipleId));
+  const availableDisciples = members.filter((m) => !assignedDiscipleIds.has(m.id));
+
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
-    if (newDiscipleId === newMakerId) {
+    const makerId = isFD ? (linkedMemberId ?? newMakerId) : newMakerId;
+    if (newDiscipleId === makerId) {
       setCreateError("Un STAR ne peut pas être son propre FD");
       return;
     }
@@ -154,7 +161,7 @@ function RelationsTab({ churchId, members, canManage }: { churchId: string; memb
       const res = await fetch("/api/discipleships", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ discipleId: newDiscipleId, discipleMakerId: newMakerId, churchId }),
+        body: JSON.stringify({ discipleId: newDiscipleId, discipleMakerId: makerId, churchId }),
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error ?? "Erreur");
@@ -260,11 +267,13 @@ function RelationsTab({ churchId, members, canManage }: { churchId: string; memb
                       {canManage && (
                         <td className="px-4 py-3">
                           <div className="flex gap-2 justify-end">
-                            <Button variant="secondary" size="sm" onClick={() => openChangeFD(row)}>
-                              Changer FD
-                            </Button>
+                            {!isFD && (
+                              <Button variant="secondary" size="sm" onClick={() => openChangeFD(row)}>
+                                Changer FD
+                              </Button>
+                            )}
                             <Button variant="danger" size="sm" onClick={() => handleDelete(row)}>
-                              Supprimer
+                              {isFD ? "Détacher" : "Supprimer"}
                             </Button>
                           </div>
                         </td>
@@ -285,14 +294,16 @@ function RelationsTab({ churchId, members, canManage }: { churchId: string; memb
             label="Disciple"
             value={newDiscipleId}
             onChange={(e) => setNewDiscipleId(e.target.value)}
-            options={members.map((m) => ({ value: m.id, label: memberLabel(m) }))}
+            options={availableDisciples.map((m) => ({ value: m.id, label: memberLabel(m) }))}
           />
-          <Select
-            label="Faiseur de disciples (FD)"
-            value={newMakerId}
-            onChange={(e) => setNewMakerId(e.target.value)}
-            options={members.map((m) => ({ value: m.id, label: memberLabel(m) }))}
-          />
+          {!isFD && (
+            <Select
+              label="Faiseur de disciples (FD)"
+              value={newMakerId}
+              onChange={(e) => setNewMakerId(e.target.value)}
+              options={members.map((m) => ({ value: m.id, label: memberLabel(m) }))}
+            />
+          )}
           {createError && <p className="text-sm text-icc-rouge">{createError}</p>}
           <div className="flex justify-end gap-2">
             <Button variant="secondary" type="button" onClick={() => setCreateModal(false)}>

--- a/src/app/(auth)/admin/discipleship/DiscipleshipClient.tsx
+++ b/src/app/(auth)/admin/discipleship/DiscipleshipClient.tsx
@@ -39,6 +39,7 @@ interface StatRow {
 interface Props {
   churchId: string;
   members: MemberOption[];
+  allAssignedDiscipleIds: string[];
   canManage: boolean;
   canExport: boolean;
   isFD?: boolean;
@@ -66,7 +67,7 @@ function firstDayOfMonthISO() {
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 
-export default function DiscipleshipClient({ churchId, members, canManage, canExport, isFD = false, linkedMemberId = null }: Props) {
+export default function DiscipleshipClient({ churchId, members, allAssignedDiscipleIds, canManage, canExport, isFD = false, linkedMemberId = null }: Props) {
   const [activeTab, setActiveTab] = useState<"relations" | "appel" | "stats">("relations");
 
   const TAB_LABELS: Record<typeof activeTab, string> = {
@@ -95,7 +96,7 @@ export default function DiscipleshipClient({ churchId, members, canManage, canEx
       </div>
 
       {activeTab === "relations" && (
-        <RelationsTab churchId={churchId} members={members} canManage={canManage} isFD={isFD} linkedMemberId={linkedMemberId} />
+        <RelationsTab churchId={churchId} members={members} allAssignedDiscipleIds={allAssignedDiscipleIds} canManage={canManage} isFD={isFD} linkedMemberId={linkedMemberId} />
       )}
       {activeTab === "appel" && (
         <AppelTab churchId={churchId} canManage={canManage} />
@@ -109,7 +110,7 @@ export default function DiscipleshipClient({ churchId, members, canManage, canEx
 
 // ─── Tab: Relations ───────────────────────────────────────────────────────────
 
-function RelationsTab({ churchId, members, canManage, isFD, linkedMemberId }: { churchId: string; members: MemberOption[]; canManage: boolean; isFD: boolean; linkedMemberId: string | null }) {
+function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, isFD, linkedMemberId }: { churchId: string; members: MemberOption[]; allAssignedDiscipleIds: string[]; canManage: boolean; isFD: boolean; linkedMemberId: string | null }) {
   const [rows, setRows] = useState<DiscipleshipRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -144,8 +145,11 @@ function RelationsTab({ churchId, members, canManage, isFD, linkedMemberId }: { 
 
   useEffect(() => { fetchRows(); }, [fetchRows]);
 
-  // Membres déjà pris comme disciple (pour filtrer le sélecteur)
-  const assignedDiscipleIds = new Set(rows.map((r) => r.discipleId));
+  // Membres déjà pris comme disciple (liste complète de l'église + nouvelles relations ajoutées en session)
+  const assignedDiscipleIds = new Set([
+    ...allAssignedDiscipleIds,
+    ...rows.map((r) => r.discipleId),
+  ]);
   const availableDisciples = members.filter((m) => !assignedDiscipleIds.has(m.id));
 
   async function handleCreate(e: React.FormEvent) {

--- a/src/app/(auth)/admin/discipleship/page.tsx
+++ b/src/app/(auth)/admin/discipleship/page.tsx
@@ -12,6 +12,7 @@ export default async function DiscipleshipPage() {
 
   const canManage = userPermissions.has("discipleship:manage");
   const canExport = userPermissions.has("discipleship:export");
+  const isFD = session.user.churchRoles.some((r) => r.role === "DISCIPLE_MAKER") && !session.user.isSuperAdmin;
 
   const churchId = await getCurrentChurchId(session);
   if (!churchId) {
@@ -22,6 +23,14 @@ export default async function DiscipleshipPage() {
       </div>
     );
   }
+
+  // Pour un FD, résoudre le membre lié pour pré-remplir le formulaire
+  const linkedMemberId = isFD
+    ? (await prisma.memberUserLink.findUnique({
+        where: { userId_churchId: { userId: session.user.id, churchId } },
+        select: { memberId: true },
+      }))?.memberId ?? null
+    : null;
 
   const members = await prisma.member.findMany({
     where: { department: { ministry: { churchId } } },
@@ -42,6 +51,8 @@ export default async function DiscipleshipPage() {
         members={members}
         canManage={canManage}
         canExport={canExport}
+        isFD={isFD}
+        linkedMemberId={linkedMemberId}
       />
     </div>
   );

--- a/src/app/(auth)/admin/discipleship/page.tsx
+++ b/src/app/(auth)/admin/discipleship/page.tsx
@@ -32,16 +32,23 @@ export default async function DiscipleshipPage() {
       }))?.memberId ?? null
     : null;
 
-  const members = await prisma.member.findMany({
-    where: { department: { ministry: { churchId } } },
-    select: {
-      id: true,
-      firstName: true,
-      lastName: true,
-      department: { select: { name: true, ministry: { select: { name: true } } } },
-    },
-    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
-  });
+  const [members, allAssignedDiscipleIds] = await Promise.all([
+    prisma.member.findMany({
+      where: { department: { ministry: { churchId } } },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        department: { select: { name: true, ministry: { select: { name: true } } } },
+      },
+      orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    }),
+    // Tous les disciples déjà assignés dans l'église (toutes relations confondues)
+    prisma.discipleship.findMany({
+      where: { churchId },
+      select: { discipleId: true },
+    }).then((rows) => rows.map((r) => r.discipleId)),
+  ]);
 
   return (
     <div>
@@ -49,6 +56,7 @@ export default async function DiscipleshipPage() {
       <DiscipleshipClient
         churchId={churchId}
         members={members}
+        allAssignedDiscipleIds={allAssignedDiscipleIds}
         canManage={canManage}
         canExport={canExport}
         isFD={isFD}

--- a/src/app/(auth)/admin/layout.tsx
+++ b/src/app/(auth)/admin/layout.tsx
@@ -11,7 +11,8 @@ export default async function AdminLayout({
     "church:manage",
     "users:manage",
     "departments:manage",
-    "events:manage"
+    "events:manage",
+    "discipleship:view"
   );
 
   return <div className="p-6">{children}</div>;

--- a/src/app/(auth)/admin/ministries/MinistriesClient.tsx
+++ b/src/app/(auth)/admin/ministries/MinistriesClient.tsx
@@ -11,6 +11,7 @@ import BulkActionBar from "@/components/ui/BulkActionBar";
 interface Ministry {
   id: string;
   name: string;
+  isSystem: boolean;
   church: { id: string; name: string };
 }
 
@@ -18,12 +19,14 @@ interface Props {
   initialMinistries: Ministry[];
   churches: { id: string; name: string }[];
   readOnly?: boolean;
+  isSuperAdmin?: boolean;
 }
 
 export default function MinistriesClient({
   initialMinistries,
   churches,
   readOnly,
+  isSuperAdmin,
 }: Props) {
   const [ministries, setMinistries] = useState(initialMinistries);
   const [modalOpen, setModalOpen] = useState(false);
@@ -200,16 +203,26 @@ export default function MinistriesClient({
           selectable={!readOnly}
           selectedIds={selectedIds}
           onSelectionChange={setSelectedIds}
-          actions={readOnly ? undefined : (m) => (
-            <div className="flex gap-2 justify-end">
-              <Button variant="secondary" onClick={() => openEdit(m)}>
-                Modifier
-              </Button>
-              <Button variant="danger" onClick={() => handleDelete(m)}>
-                Supprimer
-              </Button>
-            </div>
-          )}
+          actions={readOnly ? undefined : (m) => {
+            const locked = m.isSystem && !isSuperAdmin;
+            return (
+              <div className="flex items-center gap-2 justify-end">
+                {m.isSystem && (
+                  <span title="Ministère système" className="text-gray-400">
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                    </svg>
+                  </span>
+                )}
+                <Button variant="secondary" onClick={() => openEdit(m)} disabled={locked}>
+                  Modifier
+                </Button>
+                <Button variant="danger" onClick={() => handleDelete(m)} disabled={locked}>
+                  Supprimer
+                </Button>
+              </div>
+            );
+          }}
         />
       </div>
 

--- a/src/app/(auth)/admin/ministries/page.tsx
+++ b/src/app/(auth)/admin/ministries/page.tsx
@@ -34,6 +34,7 @@ export default async function MinistriesPage() {
         initialMinistries={ministries}
         churches={uniqueChurches.map((c) => ({ id: c.id, name: c.name }))}
         readOnly={isMinisterOnly}
+        isSuperAdmin={isSuperAdmin}
       />
     </div>
   );

--- a/src/app/(auth)/admin/users/UsersClient.tsx
+++ b/src/app/(auth)/admin/users/UsersClient.tsx
@@ -14,6 +14,7 @@ const ROLES = [
   { value: "SECRETARY", label: "Secrétaire" },
   { value: "MINISTER", label: "Ministre" },
   { value: "DEPARTMENT_HEAD", label: "Responsable de département" },
+  { value: "DISCIPLE_MAKER", label: "Faiseur de Disciples" },
 ];
 
 const ROLE_LABELS: Record<string, string> = Object.fromEntries(

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -180,6 +180,7 @@ export default async function AuthLayout({
 
   const hasDiscipleship = userPermissions.has("discipleship:view");
   const hasEventsAccess = userPermissions.has("events:view");
+  const hasPlanningAccess = userPermissions.has("planning:view");
 
   // Determine the user's primary role for the current church
   const currentRole = churchRoles.find((r) => r.churchId === currentChurchId)?.role ?? "DEPARTMENT_HEAD";
@@ -191,6 +192,7 @@ export default async function AuthLayout({
       serviceLinks={serviceLinks}
       hasDiscipleship={hasDiscipleship}
       hasEventsAccess={hasEventsAccess}
+      hasPlanningAccess={hasPlanningAccess}
       hasAdminAccess={visibleAdminLinks.length > 0}
       userRole={currentRole as "SUPER_ADMIN" | "ADMIN" | "SECRETARY" | "MINISTER" | "DEPARTMENT_HEAD" | "DISCIPLE_MAKER"}
       header={headerContent}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -63,7 +63,7 @@ export default async function AuthLayout({
   let allDepartments = departments;
   if (isAdmin && currentChurchId) {
     const depts = await prisma.department.findMany({
-      where: { ministry: { churchId: currentChurchId } },
+      where: { ministry: { churchId: currentChurchId }, isSystem: false },
       include: { ministry: true },
       orderBy: [{ ministry: { name: "asc" } }, { name: "asc" }],
     });

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -179,6 +179,7 @@ export default async function AuthLayout({
   );
 
   const hasDiscipleship = userPermissions.has("discipleship:view");
+  const hasEventsAccess = userPermissions.has("events:view");
 
   // Determine the user's primary role for the current church
   const currentRole = churchRoles.find((r) => r.churchId === currentChurchId)?.role ?? "DEPARTMENT_HEAD";
@@ -189,6 +190,7 @@ export default async function AuthLayout({
       adminLinks={visibleAdminLinks}
       serviceLinks={serviceLinks}
       hasDiscipleship={hasDiscipleship}
+      hasEventsAccess={hasEventsAccess}
       hasAdminAccess={visibleAdminLinks.length > 0}
       userRole={currentRole as "SUPER_ADMIN" | "ADMIN" | "SECRETARY" | "MINISTER" | "DEPARTMENT_HEAD" | "DISCIPLE_MAKER"}
       header={headerContent}

--- a/src/app/api/departments/[departmentId]/route.ts
+++ b/src/app/api/departments/[departmentId]/route.ts
@@ -38,6 +38,13 @@ export async function PUT(
   try {
     const session = await requirePermission("departments:manage");
     const { departmentId } = await params;
+
+    const deptCheck = await prisma.department.findUnique({ where: { id: departmentId }, select: { isSystem: true } });
+    if (!deptCheck) throw new ApiError(404, "Département introuvable");
+    if (deptCheck.isSystem && !session.user.isSuperAdmin) {
+      throw new ApiError(403, "Ce département système ne peut pas être modifié");
+    }
+
     await checkDepartmentScope(session, departmentId);
     const body = await request.json();
     const data = updateSchema.parse(body);
@@ -70,16 +77,19 @@ export async function PATCH(
   { params }: { params: Promise<{ departmentId: string }> }
 ) {
   try {
-    await requirePermission("events:manage");
+    const session = await requirePermission("events:manage");
     const { departmentId } = await params;
     const body = await request.json();
     const data = patchFunctionSchema.parse(body);
 
     const dept = await prisma.department.findUnique({
       where: { id: departmentId },
-      select: { id: true, ministry: { select: { churchId: true } } },
+      select: { id: true, isSystem: true, ministry: { select: { churchId: true } } },
     });
     if (!dept) throw new ApiError(404, "Département introuvable");
+    if (dept.isSystem && !session.user.isSuperAdmin) {
+      throw new ApiError(403, "Ce département système ne peut pas être modifié");
+    }
 
     // Clear existing dept with same function in the same church before assigning
     if (data.function !== null) {
@@ -121,6 +131,10 @@ export async function DELETE(
 
     if (!department) {
       throw new ApiError(404, "Département introuvable");
+    }
+
+    if (department.isSystem && !session.user.isSuperAdmin) {
+      throw new ApiError(403, "Ce département système ne peut pas être supprimé");
     }
 
     if (department.members.length > 0) {

--- a/src/app/api/discipleships/[id]/route.ts
+++ b/src/app/api/discipleships/[id]/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requirePermission } from "@/lib/auth";
+import { requirePermission, getDiscipleshipScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
 
@@ -59,6 +59,12 @@ export async function DELETE(
 
     const existing = await prisma.discipleship.findUnique({ where: { id } });
     if (!existing) throw new ApiError(404, "Relation de discipolat introuvable");
+
+    // DISCIPLE_MAKER ne peut détacher que ses propres disciples
+    const scope = await getDiscipleshipScope(session, existing.churchId);
+    if (scope.scoped && existing.discipleMakerId !== scope.memberId) {
+      throw new ApiError(403, "Vous ne pouvez détacher que vos propres disciples");
+    }
 
     await prisma.discipleship.delete({ where: { id } });
 

--- a/src/app/api/discipleships/attendance/route.ts
+++ b/src/app/api/discipleships/attendance/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requirePermission } from "@/lib/auth";
+import { requirePermission, getDiscipleshipScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
 
@@ -9,10 +9,10 @@ const schema = z.object({
   presentMemberIds: z.array(z.string()),
 });
 
-// Enregistre la liste des présents pour un événement (remplace les enregistrements existants)
+// Enregistre la liste des présents pour un événement
 export async function PUT(request: Request) {
   try {
-    await requirePermission("discipleship:manage");
+    const session = await requirePermission("discipleship:manage");
 
     const { eventId, presentMemberIds } = schema.parse(await request.json());
 
@@ -23,23 +23,45 @@ export async function PUT(request: Request) {
     if (!event) throw new ApiError(404, "Événement introuvable");
     if (!event.trackedForDiscipleship) throw new ApiError(400, "Cet événement n'est pas suivi pour le discipolat");
 
-    // Tous les disciples de l'église pour cet événement
-    const discipleships = await prisma.discipleship.findMany({
-      where: { churchId: event.churchId },
-      select: { discipleId: true },
-    });
-    const allDiscipleIds = discipleships.map((d) => d.discipleId);
+    const scope = await getDiscipleshipScope(session, event.churchId);
 
-    await prisma.$transaction([
-      prisma.discipleshipAttendance.deleteMany({ where: { eventId } }),
-      prisma.discipleshipAttendance.createMany({
-        data: allDiscipleIds.map((memberId) => ({
-          memberId,
-          eventId,
-          present: presentMemberIds.includes(memberId),
-        })),
-      }),
-    ]);
+    if (scope.scoped) {
+      // DISCIPLE_MAKER : ne met à jour que ses propres disciples
+      const ownDiscipleships = await prisma.discipleship.findMany({
+        where: { churchId: event.churchId, discipleMakerId: scope.memberId ?? "" },
+        select: { discipleId: true },
+      });
+      const ownDiscipleIds = ownDiscipleships.map((d) => d.discipleId);
+
+      await prisma.$transaction(
+        ownDiscipleIds.map((memberId) =>
+          prisma.discipleshipAttendance.upsert({
+            where: { memberId_eventId: { memberId, eventId } },
+            update: { present: presentMemberIds.includes(memberId) },
+            create: { memberId, eventId, present: presentMemberIds.includes(memberId) },
+          })
+        )
+      );
+    } else {
+      // Admin / Secrétaire : remplace toutes les présences de l'événement
+      const allDiscipleIds = (
+        await prisma.discipleship.findMany({
+          where: { churchId: event.churchId },
+          select: { discipleId: true },
+        })
+      ).map((d) => d.discipleId);
+
+      await prisma.$transaction([
+        prisma.discipleshipAttendance.deleteMany({ where: { eventId } }),
+        prisma.discipleshipAttendance.createMany({
+          data: allDiscipleIds.map((memberId) => ({
+            memberId,
+            eventId,
+            present: presentMemberIds.includes(memberId),
+          })),
+        }),
+      ]);
+    }
 
     return successResponse({ saved: true });
   } catch (error) {
@@ -49,14 +71,34 @@ export async function PUT(request: Request) {
 
 export async function GET(request: Request) {
   try {
-    await requirePermission("discipleship:view");
+    const session = await requirePermission("discipleship:view");
 
     const { searchParams } = new URL(request.url);
     const eventId = searchParams.get("eventId");
     if (!eventId) throw new ApiError(400, "eventId requis");
 
+    // Résoudre l'église via l'événement pour appliquer le scope
+    const event = await prisma.event.findUnique({
+      where: { id: eventId },
+      select: { churchId: true },
+    });
+    if (!event) throw new ApiError(404, "Événement introuvable");
+
+    const scope = await getDiscipleshipScope(session, event.churchId);
+
+    let whereScope = {};
+    if (scope.scoped) {
+      const ownDiscipleIds = (
+        await prisma.discipleship.findMany({
+          where: { churchId: event.churchId, discipleMakerId: scope.memberId ?? "" },
+          select: { discipleId: true },
+        })
+      ).map((d) => d.discipleId);
+      whereScope = { memberId: { in: ownDiscipleIds } };
+    }
+
     const attendances = await prisma.discipleshipAttendance.findMany({
-      where: { eventId },
+      where: { eventId, ...whereScope },
       select: { memberId: true, present: true },
     });
 

--- a/src/app/api/discipleships/route.ts
+++ b/src/app/api/discipleships/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requirePermission } from "@/lib/auth";
+import { requirePermission, getDiscipleshipScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
 
@@ -12,14 +12,19 @@ const createSchema = z.object({
 
 export async function GET(request: Request) {
   try {
-    await requirePermission("discipleship:view");
+    const session = await requirePermission("discipleship:view");
 
     const { searchParams } = new URL(request.url);
     const churchId = searchParams.get("churchId");
     if (!churchId) throw new ApiError(400, "churchId requis");
 
+    const scope = await getDiscipleshipScope(session, churchId);
+    const whereScope = scope.scoped
+      ? { discipleMakerId: scope.memberId ?? "" }
+      : {};
+
     const discipleships = await prisma.discipleship.findMany({
-      where: { churchId },
+      where: { churchId, ...whereScope },
       include: {
         disciple: { select: { id: true, firstName: true, lastName: true, department: { select: { name: true, ministry: { select: { name: true } } } } } },
         discipleMaker: { select: { id: true, firstName: true, lastName: true } },
@@ -42,6 +47,12 @@ export async function POST(request: Request) {
 
     if (discipleId === discipleMakerId) {
       throw new ApiError(400, "Un STAR ne peut pas être son propre FD");
+    }
+
+    // DISCIPLE_MAKER ne peut créer que des relations dont il est le FD
+    const scope = await getDiscipleshipScope(session, churchId);
+    if (scope.scoped && discipleMakerId !== scope.memberId) {
+      throw new ApiError(403, "Vous ne pouvez créer des relations que pour vous-même");
     }
 
     // Vérifier qu'il n'y a pas déjà un lien de discipolat dans cette église

--- a/src/app/api/discipleships/route.ts
+++ b/src/app/api/discipleships/route.ts
@@ -3,12 +3,23 @@ import { requirePermission, getDiscipleshipScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
 
-const createSchema = z.object({
-  discipleId: z.string(),
-  discipleMakerId: z.string(),
-  churchId: z.string(),
-  firstMakerId: z.string().optional(), // si omis, = discipleMakerId
-});
+const createSchema = z.union([
+  z.object({
+    discipleId: z.string(),
+    discipleMakerId: z.string(),
+    churchId: z.string(),
+    firstMakerId: z.string().optional(),
+  }),
+  z.object({
+    newMember: z.object({
+      firstName: z.string().min(1, "Le prénom est requis"),
+      lastName: z.string().min(1, "Le nom est requis"),
+    }),
+    discipleMakerId: z.string(),
+    churchId: z.string(),
+    firstMakerId: z.string().optional(),
+  }),
+]);
 
 export async function GET(request: Request) {
   try {
@@ -43,16 +54,35 @@ export async function POST(request: Request) {
   try {
     const session = await requirePermission("discipleship:manage");
     const body = await request.json();
-    const { discipleId, discipleMakerId, churchId, firstMakerId } = createSchema.parse(body);
+    const parsed = createSchema.parse(body);
 
-    if (discipleId === discipleMakerId) {
-      throw new ApiError(400, "Un STAR ne peut pas être son propre FD");
-    }
+    const { discipleMakerId, churchId, firstMakerId } = parsed;
 
     // DISCIPLE_MAKER ne peut créer que des relations dont il est le FD
     const scope = await getDiscipleshipScope(session, churchId);
     if (scope.scoped && discipleMakerId !== scope.memberId) {
       throw new ApiError(403, "Vous ne pouvez créer des relations que pour vous-même");
+    }
+
+    // Résoudre ou créer le disciple
+    let discipleId: string;
+    if ("newMember" in parsed) {
+      const sysDept = await prisma.department.findFirst({
+        where: { isSystem: true, ministry: { churchId } },
+        select: { id: true },
+      });
+      if (!sysDept) throw new ApiError(500, "Département système introuvable pour cette église");
+
+      const created = await prisma.member.create({
+        data: { firstName: parsed.newMember.firstName, lastName: parsed.newMember.lastName, departmentId: sysDept.id },
+      });
+      discipleId = created.id;
+    } else {
+      discipleId = parsed.discipleId;
+    }
+
+    if (discipleId === discipleMakerId) {
+      throw new ApiError(400, "Un STAR ne peut pas être son propre FD");
     }
 
     // Vérifier qu'il n'y a pas déjà un lien de discipolat dans cette église

--- a/src/app/api/discipleships/stats/route.ts
+++ b/src/app/api/discipleships/stats/route.ts
@@ -1,11 +1,11 @@
 import { prisma } from "@/lib/prisma";
-import { requirePermission } from "@/lib/auth";
+import { requirePermission, getDiscipleshipScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 
 // Stats de participation aux événements trackés sur une période glissante
 export async function GET(request: Request) {
   try {
-    await requirePermission("discipleship:view");
+    const session = await requirePermission("discipleship:view");
 
     const { searchParams } = new URL(request.url);
     const churchId = searchParams.get("churchId");
@@ -20,6 +20,11 @@ export async function GET(request: Request) {
     const from = searchParams.get("from") ? new Date(searchParams.get("from")!) : defaultFrom;
     const to = searchParams.get("to") ? new Date(searchParams.get("to")!) : defaultTo;
 
+    const scope = await getDiscipleshipScope(session, churchId);
+    const whereScope = scope.scoped
+      ? { discipleMakerId: scope.memberId ?? "" }
+      : {};
+
     // Événements trackés sur la période
     const trackedEvents = await prisma.event.findMany({
       where: {
@@ -33,9 +38,9 @@ export async function GET(request: Request) {
 
     const eventIds = trackedEvents.map((e) => e.id);
 
-    // Tous les disciples de l'église
+    // Disciples selon la portée
     const discipleships = await prisma.discipleship.findMany({
-      where: { churchId },
+      where: { churchId, ...whereScope },
       select: {
         id: true,
         discipleId: true,

--- a/src/app/api/discipleships/tree/route.ts
+++ b/src/app/api/discipleships/tree/route.ts
@@ -1,20 +1,23 @@
 import { prisma } from "@/lib/prisma";
-import { requirePermission } from "@/lib/auth";
+import { requirePermission, getDiscipleshipScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 
 // Arbre de lignée récursif à profondeur illimitée via WITH RECURSIVE
 export async function GET(request: Request) {
   try {
-    await requirePermission("discipleship:view");
+    const session = await requirePermission("discipleship:view");
 
     const { searchParams } = new URL(request.url);
     const churchId = searchParams.get("churchId");
-    const rootId = searchParams.get("rootId");
     // mode: "primary" = traversal via firstMakerId (lignée d'origine)
     //       "current"  = traversal via discipleMakerId (structure actuelle)
     const mode = searchParams.get("mode") === "current" ? "current" : "primary";
 
     if (!churchId) throw new ApiError(400, "churchId requis");
+
+    // DISCIPLE_MAKER : l'arbre est ancré sur son propre nœud (ignore rootId du client)
+    const scope = await getDiscipleshipScope(session, churchId);
+    const rootId = scope.scoped ? scope.memberId : searchParams.get("rootId");
 
     type TreeRow = {
       id: string;

--- a/src/app/api/ministries/[ministryId]/route.ts
+++ b/src/app/api/ministries/[ministryId]/route.ts
@@ -12,8 +12,15 @@ export async function PUT(
   { params }: { params: Promise<{ ministryId: string }> }
 ) {
   try {
-    await requirePermission("departments:manage");
+    const session = await requirePermission("departments:manage");
     const { ministryId } = await params;
+
+    const existing = await prisma.ministry.findUnique({ where: { id: ministryId }, select: { isSystem: true } });
+    if (!existing) throw new ApiError(404, "Ministère introuvable");
+    if (existing.isSystem && !session.user.isSuperAdmin) {
+      throw new ApiError(403, "Ce ministère système ne peut pas être modifié");
+    }
+
     const body = await request.json();
     const data = updateSchema.parse(body);
 
@@ -34,7 +41,7 @@ export async function DELETE(
   { params }: { params: Promise<{ ministryId: string }> }
 ) {
   try {
-    await requirePermission("departments:manage");
+    const session = await requirePermission("departments:manage");
     const { ministryId } = await params;
 
     const ministry = await prisma.ministry.findUnique({
@@ -44,6 +51,10 @@ export async function DELETE(
 
     if (!ministry) {
       throw new ApiError(404, "Ministère introuvable");
+    }
+
+    if (ministry.isSystem && !session.user.isSuperAdmin) {
+      throw new ApiError(403, "Ce ministère système ne peut pas être supprimé");
     }
 
     if (ministry.departments.length > 0) {

--- a/src/app/api/users/[userId]/roles/route.ts
+++ b/src/app/api/users/[userId]/roles/route.ts
@@ -11,6 +11,7 @@ const roleSchema = z.object({
     "SECRETARY",
     "MINISTER",
     "DEPARTMENT_HEAD",
+    "DISCIPLE_MAKER",
   ]),
   ministryId: z.string().optional(),
   departmentIds: z.array(z.string()).optional(),

--- a/src/components/AuthLayoutShell.tsx
+++ b/src/components/AuthLayoutShell.tsx
@@ -14,6 +14,7 @@ interface AuthLayoutShellProps {
   adminLinks: { href: string; label: string }[];
   serviceLinks: { href: string; label: string }[];
   hasDiscipleship: boolean;
+  hasEventsAccess: boolean;
   hasAdminAccess: boolean;
   userRole: RoleKey;
   header: React.ReactNode;
@@ -42,6 +43,7 @@ export default function AuthLayoutShell({
   adminLinks,
   serviceLinks,
   hasDiscipleship,
+  hasEventsAccess,
   hasAdminAccess,
   userRole,
   header,
@@ -105,6 +107,7 @@ export default function AuthLayoutShell({
               adminLinks={adminLinks}
               serviceLinks={serviceLinks}
               hasDiscipleship={hasDiscipleship}
+              hasEventsAccess={hasEventsAccess}
               onClose={closeSidebar}
             />
           </div>

--- a/src/components/AuthLayoutShell.tsx
+++ b/src/components/AuthLayoutShell.tsx
@@ -15,6 +15,7 @@ interface AuthLayoutShellProps {
   serviceLinks: { href: string; label: string }[];
   hasDiscipleship: boolean;
   hasEventsAccess: boolean;
+  hasPlanningAccess: boolean;
   hasAdminAccess: boolean;
   userRole: RoleKey;
   header: React.ReactNode;
@@ -44,6 +45,7 @@ export default function AuthLayoutShell({
   serviceLinks,
   hasDiscipleship,
   hasEventsAccess,
+  hasPlanningAccess,
   hasAdminAccess,
   userRole,
   header,
@@ -108,6 +110,7 @@ export default function AuthLayoutShell({
               serviceLinks={serviceLinks}
               hasDiscipleship={hasDiscipleship}
               hasEventsAccess={hasEventsAccess}
+              hasPlanningAccess={hasPlanningAccess}
               onClose={closeSidebar}
             />
           </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ interface SidebarProps {
   adminLinks: { href: string; label: string }[];
   serviceLinks: { href: string; label: string }[];
   hasDiscipleship?: boolean;
+  hasEventsAccess?: boolean;
   onClose?: () => void;
 }
 
@@ -218,6 +219,7 @@ export default function Sidebar({
   adminLinks,
   serviceLinks,
   hasDiscipleship = false,
+  hasEventsAccess = true,
   onClose,
 }: SidebarProps) {
   const searchParams = useSearchParams();
@@ -271,7 +273,7 @@ export default function Sidebar({
       </AccordionSection>
 
       {/* Evenements */}
-      <AccordionSection
+      {hasEventsAccess && <AccordionSection
         title="Evenements"
         icon={<IconCalendar className="w-4 h-4" />}
         isActive={isEventsActive}
@@ -302,7 +304,7 @@ export default function Sidebar({
             Calendrier
           </Link>
         </nav>
-      </AccordionSection>
+      </AccordionSection>}
 
       {/* Annonces & Demandes */}
       {serviceLinks.length > 0 && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ interface SidebarProps {
   serviceLinks: { href: string; label: string }[];
   hasDiscipleship?: boolean;
   hasEventsAccess?: boolean;
+  hasPlanningAccess?: boolean;
   onClose?: () => void;
 }
 
@@ -220,6 +221,7 @@ export default function Sidebar({
   serviceLinks,
   hasDiscipleship = false,
   hasEventsAccess = true,
+  hasPlanningAccess = true,
   onClose,
 }: SidebarProps) {
   const searchParams = useSearchParams();
@@ -235,7 +237,7 @@ export default function Sidebar({
   return (
     <aside className="w-64 min-h-0 md:min-h-[calc(100vh-73px)] bg-white border-r border-gray-200 p-4 pb-20 md:pb-4 space-y-1 overflow-y-auto">
       {/* Départements */}
-      <AccordionSection
+      {hasPlanningAccess && <AccordionSection
         title="Départements"
         icon={<IconDepartments className="w-4 h-4" />}
         defaultOpen
@@ -270,7 +272,7 @@ export default function Sidebar({
             ))}
           </nav>
         )}
-      </AccordionSection>
+      </AccordionSection>}
 
       {/* Evenements */}
       {hasEventsAccess && <AccordionSection

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -194,6 +194,34 @@ type DepartmentScope =
 
 const GLOBAL_ROLES: Role[] = ["SUPER_ADMIN", "ADMIN", "SECRETARY"];
 
+export type DiscipleshipScope =
+  | { scoped: false }
+  | { scoped: true; memberId: string | null };
+
+/**
+ * Retourne la portée discipolat de l'utilisateur connecté pour une église donnée.
+ * - DISCIPLE_MAKER → scoped : ne voit que ses propres disciples (filtre discipleMakerId)
+ * - Tous les autres rôles → non scoped : vue complète de l'église
+ */
+export async function getDiscipleshipScope(
+  session: Session,
+  churchId: string
+): Promise<DiscipleshipScope> {
+  if (session.user.isSuperAdmin) return { scoped: false };
+
+  const hasGlobalRole = session.user.churchRoles.some(
+    (r) => r.churchId === churchId && (r.role as Role) !== "DISCIPLE_MAKER"
+  );
+  if (hasGlobalRole) return { scoped: false };
+
+  // DISCIPLE_MAKER : résoudre le membre lié au compte
+  const link = await prisma.memberUserLink.findUnique({
+    where: { userId_churchId: { userId: session.user.id, churchId } },
+    select: { memberId: true },
+  });
+  return { scoped: true, memberId: link?.memberId ?? null };
+}
+
 export function getUserDepartmentScope(session: Session): DepartmentScope {
   const hasGlobalRole = session.user.churchRoles.some((r) =>
     GLOBAL_ROLES.includes(r.role)

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -57,9 +57,6 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "discipleship:view",
   ],
   DISCIPLE_MAKER: [
-    "planning:view",
-    "members:view",
-    "events:view",
     "discipleship:view",
     "discipleship:manage",
   ],


### PR DESCRIPTION
## Summary

- **Filtrage par FD** : un DISCIPLE_MAKER ne voit et gère que ses propres disciples (scope API sur toutes les routes discipleships)
- **Rôle Faiseur de Disciples** : assignable depuis l'admin utilisateurs, accès restreint au seul onglet discipolat
- **Protection attributions** : un FD ne peut pas s'affecter un disciple déjà pris par un autre FD ; bouton «Détacher» dédié
- **Département système «Sans département»** : non-supprimable/modifiable (sauf superAdmin), créé automatiquement pour chaque église, invisible dans la sidebar/planning
- **Création membre inline** : combobox 2 champs (Prénom + Nom) avec recherche accent-insensitive et option «Créer ce membre» si aucun résultat — le nouveau membre est placé dans «Sans département»

## Test plan

- [ ] DISCIPLE_MAKER : voit uniquement ses disciples dans les 3 onglets (relations, appel, stats)
- [ ] DISCIPLE_MAKER : ne peut pas s'affecter un disciple déjà assigné à un autre FD
- [ ] DISCIPLE_MAKER : bouton «Détacher» fonctionne, «Changer FD» masqué
- [ ] DISCIPLE_MAKER : n'a pas accès aux onglets planning/événements
- [ ] Admin : ministère «Système» et département «Sans département» affichent le cadenas, boutons désactivés
- [ ] SuperAdmin : peut modifier/supprimer les entités système
- [ ] Création disciple : taper un nom sans résultat → «+ Créer ce membre» → membre créé dans «Sans département»
- [ ] Recherche accent-insensitive : «elie» trouve «Élie», «prenom» trouve «Prénom»
- [ ] Migration : colonne `isSystem` présente sur `ministries` et `departments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)