### PR TITLE
feat: profil disciple, liaison compte, CR événement

### DIFF
--- a/prisma/migrations/20260321000001_add_event_report/migration.sql
+++ b/prisma/migrations/20260321000001_add_event_report/migration.sql
@@ -1,0 +1,45 @@
+-- AlterTable: add report flags to events
+ALTER TABLE `events`
+  ADD COLUMN `reportEnabled` BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN `statsEnabled` BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable: event_reports
+CREATE TABLE `event_reports` (
+  `id`        VARCHAR(191) NOT NULL,
+  `eventId`   VARCHAR(191) NOT NULL,
+  `churchId`  VARCHAR(191) NOT NULL,
+  `notes`     TEXT,
+  `decisions` TEXT,
+  `authorId`  VARCHAR(191),
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL,
+
+  UNIQUE INDEX `event_reports_eventId_key`(`eventId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable: event_report_sections
+CREATE TABLE `event_report_sections` (
+  `id`           VARCHAR(191) NOT NULL,
+  `reportId`     VARCHAR(191) NOT NULL,
+  `departmentId` VARCHAR(191),
+  `label`        VARCHAR(191) NOT NULL,
+  `position`     INTEGER NOT NULL DEFAULT 0,
+  `present`      INTEGER,
+  `absent`       INTEGER,
+  `newcomers`    INTEGER,
+  `notes`        TEXT,
+
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `event_reports`
+  ADD CONSTRAINT `event_reports_eventId_fkey`  FOREIGN KEY (`eventId`)  REFERENCES `events`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT `event_reports_churchId_fkey` FOREIGN KEY (`churchId`) REFERENCES `churches`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT `event_reports_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `event_report_sections`
+  ADD CONSTRAINT `event_report_sections_reportId_fkey`     FOREIGN KEY (`reportId`)     REFERENCES `event_reports`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `event_report_sections_departmentId_fkey` FOREIGN KEY (`departmentId`) REFERENCES `departments`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,7 @@ model Church {
   memberUserLinks    MemberUserLink[]
   memberLinkRequests MemberLinkRequest[]
   discipleships      Discipleship[]
+  eventReports       EventReport[]
 
   @@map("churches")
 }
@@ -102,6 +103,7 @@ model User {
   validatedLinks          MemberUserLink[]    @relation("LinkValidator")
   memberLinkRequests      MemberLinkRequest[] @relation("LinkRequester")
   reviewedLinkRequests    MemberLinkRequest[] @relation("LinkRequestReviewer")
+  eventReports            EventReport[]       @relation("ReportAuthor")
 
   @@map("users")
 }
@@ -165,9 +167,10 @@ model Department {
   userDepts               UserDepartment[]
   tasks                   Task[]
   createdAt               DateTime           @default(now())
-  announcements           Announcement[]     @relation("AnnouncementDepartment")
-  submittedServiceRequests ServiceRequest[]  @relation("ServiceRequestDepartment")
-  assignedServiceRequests ServiceRequest[]   @relation("ServiceRequestAssigned")
+  announcements            Announcement[]     @relation("AnnouncementDepartment")
+  submittedServiceRequests ServiceRequest[]   @relation("ServiceRequestDepartment")
+  assignedServiceRequests  ServiceRequest[]   @relation("ServiceRequestAssigned")
+  reportSections           EventReportSection[]
 
   @@map("departments")
 }
@@ -289,9 +292,47 @@ model Event {
   createdAt          DateTime            @default(now())
   announcementTargets        AnnouncementEvent[]
   trackedForDiscipleship     Boolean                  @default(false)
+  reportEnabled              Boolean                  @default(false)
+  statsEnabled               Boolean                  @default(false)
   discipleshipAttendances    DiscipleshipAttendance[]
+  report                     EventReport?
 
   @@map("events")
+}
+
+model EventReport {
+  id        String   @id @default(cuid())
+  eventId   String   @unique
+  churchId  String
+  notes     String?  @db.Text
+  decisions String?  @db.Text
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  authorId  String?
+
+  event    Event                @relation(fields: [eventId],   references: [id])
+  church   Church               @relation(fields: [churchId],  references: [id])
+  author   User?                @relation("ReportAuthor", fields: [authorId],  references: [id])
+  sections EventReportSection[]
+
+  @@map("event_reports")
+}
+
+model EventReportSection {
+  id           String  @id @default(cuid())
+  reportId     String
+  departmentId String?
+  label        String
+  position     Int     @default(0)
+  present      Int?
+  absent       Int?
+  newcomers    Int?
+  notes        String? @db.Text
+
+  report     EventReport @relation(fields: [reportId],     references: [id], onDelete: Cascade)
+  department Department? @relation(fields: [departmentId], references: [id])
+
+  @@map("event_report_sections")
 }
 
 model EventDepartment {

--- a/src/app/(auth)/admin/discipleship/DiscipleshipClient.tsx
+++ b/src/app/(auth)/admin/discipleship/DiscipleshipClient.tsx
@@ -19,7 +19,7 @@ interface DiscipleshipRow {
   discipleId: string;
   discipleMakerId: string;
   firstMakerId: string;
-  disciple: { id: string; firstName: string; lastName: string; department: { name: string; ministry: { name: string } } };
+  disciple: { id: string; firstName: string; lastName: string; email?: string | null; phone?: string | null; department: { name: string; ministry: { name: string } } };
   discipleMaker: { id: string; firstName: string; lastName: string };
   firstMaker: { id: string; firstName: string; lastName: string };
   startedAt?: string;
@@ -271,6 +271,15 @@ function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, is
   const [createError, setCreateError] = useState<string | null>(null);
   const [createLoading, setCreateLoading] = useState(false);
 
+  // Modal: éditer profil disciple
+  const [editProfileRow, setEditProfileRow] = useState<DiscipleshipRow | null>(null);
+  const [editFirstName, setEditFirstName] = useState("");
+  const [editLastName, setEditLastName] = useState("");
+  const [editEmail, setEditEmail] = useState("");
+  const [editPhone, setEditPhone] = useState("");
+  const [editProfileError, setEditProfileError] = useState<string | null>(null);
+  const [editProfileLoading, setEditProfileLoading] = useState(false);
+
   // Modal: changer FD
   const [changeFDRow, setChangeFDRow] = useState<DiscipleshipRow | null>(null);
   const [newFDId, setNewFDId] = useState("");
@@ -324,6 +333,47 @@ function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, is
       setCreateError(e instanceof Error ? e.message : "Erreur");
     } finally {
       setCreateLoading(false);
+    }
+  }
+
+  function openEditProfile(row: DiscipleshipRow) {
+    setEditProfileRow(row);
+    setEditFirstName(row.disciple.firstName);
+    setEditLastName(row.disciple.lastName);
+    setEditEmail(row.disciple.email ?? "");
+    setEditPhone(row.disciple.phone ?? "");
+    setEditProfileError(null);
+  }
+
+  async function handleEditProfile(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editProfileRow) return;
+    setEditProfileLoading(true);
+    setEditProfileError(null);
+    try {
+      const res = await fetch(`/api/discipleships/${editProfileRow.id}/member`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          firstName: editFirstName.trim(),
+          lastName: editLastName.trim(),
+          email: editEmail.trim() || null,
+          phone: editPhone.trim() || null,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Erreur");
+      // Mettre à jour la ligne localement
+      setRows((prev) => prev.map((r) =>
+        r.id === editProfileRow.id
+          ? { ...r, disciple: { ...r.disciple, firstName: json.firstName, lastName: json.lastName } }
+          : r
+      ));
+      setEditProfileRow(null);
+    } catch (e) {
+      setEditProfileError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setEditProfileLoading(false);
     }
   }
 
@@ -420,6 +470,9 @@ function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, is
                       {canManage && (
                         <td className="px-4 py-3">
                           <div className="flex gap-2 justify-end">
+                            <Button variant="secondary" size="sm" onClick={() => openEditProfile(row)}>
+                              Éditer
+                            </Button>
                             {!isFD && (
                               <Button variant="secondary" size="sm" onClick={() => openChangeFD(row)}>
                                 Changer FD
@@ -475,6 +528,65 @@ function RelationsTab({ churchId, members, allAssignedDiscipleIds, canManage, is
             </Button>
           </div>
         </form>
+      </Modal>
+
+      {/* Modal: éditer profil disciple */}
+      <Modal open={!!editProfileRow} onClose={() => setEditProfileRow(null)} title="Modifier le profil du disciple">
+        {editProfileRow && (
+          <form onSubmit={handleEditProfile} className="space-y-4">
+            <div className="flex gap-3">
+              <div className="flex-1">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Prénom</label>
+                <input
+                  type="text"
+                  value={editFirstName}
+                  onChange={(e) => setEditFirstName(e.target.value)}
+                  required
+                  className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+                />
+              </div>
+              <div className="flex-1">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Nom</label>
+                <input
+                  type="text"
+                  value={editLastName}
+                  onChange={(e) => setEditLastName(e.target.value)}
+                  required
+                  className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Email <span className="text-gray-400 font-normal">(optionnel)</span></label>
+              <input
+                type="email"
+                value={editEmail}
+                onChange={(e) => setEditEmail(e.target.value)}
+                placeholder="prenom.nom@email.com"
+                className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Téléphone <span className="text-gray-400 font-normal">(optionnel)</span></label>
+              <input
+                type="tel"
+                value={editPhone}
+                onChange={(e) => setEditPhone(e.target.value)}
+                placeholder="+33 6 00 00 00 00"
+                className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+              />
+            </div>
+            {editProfileError && <p className="text-sm text-icc-rouge">{editProfileError}</p>}
+            <div className="flex justify-end gap-2">
+              <Button variant="secondary" type="button" onClick={() => setEditProfileRow(null)}>
+                Annuler
+              </Button>
+              <Button type="submit" disabled={editProfileLoading}>
+                {editProfileLoading ? "Enregistrement..." : "Enregistrer"}
+              </Button>
+            </div>
+          </form>
+        )}
       </Modal>
 
       {/* Modal: changer FD */}

--- a/src/app/(auth)/admin/events/[eventId]/EventDetailClient.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/EventDetailClient.tsx
@@ -16,10 +16,12 @@ interface Props {
   isRecurring?: boolean;
   allowAnnouncements: boolean;
   trackedForDiscipleship: boolean;
+  reportEnabled: boolean;
+  statsEnabled: boolean;
   departments: Department[];
 }
 
-export default function EventDetailClient({ eventId, isRecurring, allowAnnouncements: initialAllowAnnouncements, trackedForDiscipleship: initialTrackedForDiscipleship, departments }: Props) {
+export default function EventDetailClient({ eventId, isRecurring, allowAnnouncements: initialAllowAnnouncements, trackedForDiscipleship: initialTrackedForDiscipleship, reportEnabled: initialReportEnabled, statsEnabled: initialStatsEnabled, departments }: Props) {
   const [depts, setDepts] = useState(departments);
   const [loading, setLoading] = useState<string | null>(null);
   const [applyToSeries, setApplyToSeries] = useState(false);
@@ -27,6 +29,10 @@ export default function EventDetailClient({ eventId, isRecurring, allowAnnouncem
   const [savingAnnouncements, setSavingAnnouncements] = useState(false);
   const [trackedForDiscipleship, setTrackedForDiscipleship] = useState(initialTrackedForDiscipleship);
   const [savingDiscipleship, setSavingDiscipleship] = useState(false);
+  const [reportEnabled, setReportEnabled] = useState(initialReportEnabled);
+  const [savingReport, setSavingReport] = useState(false);
+  const [statsEnabled, setStatsEnabled] = useState(initialStatsEnabled);
+  const [savingStats, setSavingStats] = useState(false);
 
   async function toggleAllowAnnouncements() {
     setSavingAnnouncements(true);
@@ -68,6 +74,32 @@ export default function EventDetailClient({ eventId, isRecurring, allowAnnouncem
     } finally {
       setSavingDiscipleship(false);
     }
+  }
+
+  async function toggleReportEnabled() {
+    setSavingReport(true);
+    try {
+      const res = await fetch(`/api/events/${eventId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reportEnabled: !reportEnabled }),
+      });
+      if (!res.ok) { const data = await res.json(); alert(data.error || "Erreur"); return; }
+      setReportEnabled((v) => !v);
+    } catch { alert("Erreur"); } finally { setSavingReport(false); }
+  }
+
+  async function toggleStatsEnabled() {
+    setSavingStats(true);
+    try {
+      const res = await fetch(`/api/events/${eventId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ statsEnabled: !statsEnabled }),
+      });
+      if (!res.ok) { const data = await res.json(); alert(data.error || "Erreur"); return; }
+      setStatsEnabled((v) => !v);
+    } catch { alert("Erreur"); } finally { setSavingStats(false); }
   }
 
   async function toggleDepartment(dept: Department) {
@@ -205,6 +237,51 @@ export default function EventDetailClient({ eventId, isRecurring, allowAnnouncem
           Si activé, cet événement apparaîtra dans le module discipolat pour
           l&apos;enregistrement des présences des disciples.
         </p>
+      </div>
+
+      <div className="mb-6 p-4 bg-white rounded-lg shadow">
+        <h2 className="text-lg font-semibold text-gray-900 mb-3">Compte rendu</h2>
+        <div className="space-y-3">
+          <label className="flex items-center gap-3 cursor-pointer">
+            <button
+              role="switch"
+              aria-checked={reportEnabled}
+              onClick={toggleReportEnabled}
+              disabled={savingReport}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-icc-violet focus:ring-offset-2 disabled:opacity-50 ${reportEnabled ? "bg-icc-violet" : "bg-gray-200"}`}
+            >
+              <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${reportEnabled ? "translate-x-6" : "translate-x-1"}`} />
+            </button>
+            <span className="text-sm font-medium text-gray-700">Activer le compte rendu</span>
+            {reportEnabled && <span className="text-xs bg-icc-violet/10 text-icc-violet px-2 py-0.5 rounded-full font-medium">Actif</span>}
+          </label>
+          <label className="flex items-center gap-3 cursor-pointer">
+            <button
+              role="switch"
+              aria-checked={statsEnabled}
+              onClick={toggleStatsEnabled}
+              disabled={savingStats}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-icc-violet focus:ring-offset-2 disabled:opacity-50 ${statsEnabled ? "bg-icc-violet" : "bg-gray-200"}`}
+            >
+              <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${statsEnabled ? "translate-x-6" : "translate-x-1"}`} />
+            </button>
+            <span className="text-sm font-medium text-gray-700">Activer les statistiques</span>
+            {statsEnabled && <span className="text-xs bg-icc-violet/10 text-icc-violet px-2 py-0.5 rounded-full font-medium">Actif</span>}
+          </label>
+        </div>
+        {reportEnabled && (
+          <div className="mt-4">
+            <Link
+              href={`/admin/events/${eventId}/report`}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-icc-violet rounded-lg hover:bg-icc-violet/90 transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              Saisir / voir le compte rendu
+            </Link>
+          </div>
+        )}
       </div>
 
       <h2 className="text-lg font-semibold text-gray-900 mb-4">

--- a/src/app/(auth)/admin/events/[eventId]/page.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/page.tsx
@@ -49,6 +49,8 @@ export default async function EventDetailPage({
         isRecurring={event.isRecurrenceParent || !!event.seriesId}
         allowAnnouncements={event.allowAnnouncements}
         trackedForDiscipleship={event.trackedForDiscipleship}
+        reportEnabled={event.reportEnabled}
+        statsEnabled={event.statsEnabled}
         departments={allDepartments.map((d) => ({
           id: d.id,
           name: d.name,

--- a/src/app/(auth)/admin/events/[eventId]/report/EventReportClient.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/report/EventReportClient.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import Button from "@/components/ui/Button";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+interface Dept { id: string; name: string; ministryName: string }
+
+interface Section {
+  id?: string;
+  departmentId: string | null;
+  label: string;
+  position: number;
+  present: number | null;
+  absent: number | null;
+  newcomers: number | null;
+  notes: string | null;
+  department?: { id: string; name: string; ministry: { name: string } } | null;
+}
+
+interface ExistingReport {
+  id: string;
+  notes: string | null;
+  decisions: string | null;
+  sections: Section[];
+  author: { id: string; name: string | null } | null;
+  updatedAt?: string | Date;
+}
+
+interface Props {
+  eventId: string;
+  statsEnabled: boolean;
+  existingReport: ExistingReport | null;
+  eventDepts: Dept[];
+}
+
+function emptySection(dept: Dept, position: number): Section {
+  return { departmentId: dept.id, label: dept.name, position, present: null, absent: null, newcomers: null, notes: "" };
+}
+
+export default function EventReportClient({ eventId, statsEnabled, existingReport, eventDepts }: Props) {
+  const params = useParams<{ eventId: string }>();
+  const id = params?.eventId ?? eventId;
+
+  const initSections = (): Section[] => {
+    if (existingReport?.sections.length) {
+      return existingReport.sections.map((s) => ({ ...s }));
+    }
+    // Pré-remplir avec les départements liés
+    return eventDepts.map((d, i) => emptySection(d, i));
+  };
+
+  const [notes, setNotes] = useState(existingReport?.notes ?? "");
+  const [decisions, setDecisions] = useState(existingReport?.decisions ?? "");
+  const [sections, setSections] = useState<Section[]>(initSections);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function updateSection(index: number, field: keyof Section, value: string | number | null) {
+    setSections((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], [field]: value };
+      return next;
+    });
+    setSaved(false);
+  }
+
+  function addSection() {
+    setSections((prev) => [
+      ...prev,
+      { departmentId: null, label: "Section libre", position: prev.length, present: null, absent: null, newcomers: null, notes: "" },
+    ]);
+  }
+
+  function removeSection(index: number) {
+    setSections((prev) => prev.filter((_, i) => i !== index).map((s, i) => ({ ...s, position: i })));
+    setSaved(false);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      const res = await fetch(`/api/events/${id}/report`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: notes || null, decisions: decisions || null, sections }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Erreur");
+      setSaved(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const totalPresent = statsEnabled ? sections.reduce((s, r) => s + (r.present ?? 0), 0) : null;
+  const totalAbsent = statsEnabled ? sections.reduce((s, r) => s + (r.absent ?? 0), 0) : null;
+
+  return (
+    <div className="space-y-6">
+      {/* Récap stats globales */}
+      {statsEnabled && (totalPresent !== null || totalAbsent !== null) && (
+        <div className="grid grid-cols-3 gap-4">
+          {[
+            { label: "Présents", value: totalPresent, color: "text-green-600 bg-green-50" },
+            { label: "Absents", value: totalAbsent, color: "text-red-600 bg-red-50" },
+            { label: "Taux de présence", value: (totalPresent ?? 0) + (totalAbsent ?? 0) > 0 ? `${Math.round(((totalPresent ?? 0) / ((totalPresent ?? 0) + (totalAbsent ?? 0))) * 100)}%` : "—", color: "text-icc-violet bg-icc-violet/5" },
+          ].map((stat) => (
+            <div key={stat.label} className={`rounded-lg border-2 border-gray-100 p-4 text-center ${stat.color}`}>
+              <div className="text-2xl font-bold">{stat.value ?? 0}</div>
+              <div className="text-xs font-medium mt-1 opacity-70">{stat.label}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Sections par département */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">Sections</h2>
+          <Button variant="secondary" onClick={addSection}>+ Section libre</Button>
+        </div>
+
+        {sections.map((section, i) => (
+          <div key={i} className="bg-white rounded-lg border-2 border-gray-100 p-4">
+            <div className="flex items-center gap-3 mb-3">
+              <input
+                type="text"
+                value={section.label}
+                onChange={(e) => updateSection(i, "label", e.target.value)}
+                className="flex-1 text-sm font-semibold text-gray-800 border-0 border-b-2 border-gray-200 focus:border-icc-violet focus:outline-none bg-transparent pb-1"
+              />
+              {section.department && (
+                <span className="text-xs text-gray-400">{section.department.ministry.name}</span>
+              )}
+              <button
+                type="button"
+                onClick={() => removeSection(i)}
+                className="text-gray-300 hover:text-icc-rouge transition-colors"
+                title="Supprimer la section"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {statsEnabled && (
+              <div className="grid grid-cols-3 gap-3 mb-3">
+                {[
+                  { field: "present" as const, label: "Présents", color: "border-green-200 focus:border-green-400" },
+                  { field: "absent" as const, label: "Absents", color: "border-red-200 focus:border-red-400" },
+                  { field: "newcomers" as const, label: "Visiteurs", color: "border-icc-bleu/40 focus:border-icc-bleu" },
+                ].map(({ field, label, color }) => (
+                  <div key={field}>
+                    <label className="block text-xs text-gray-500 mb-1">{label}</label>
+                    <input
+                      type="number"
+                      min={0}
+                      value={section[field] ?? ""}
+                      onChange={(e) => updateSection(i, field, e.target.value === "" ? null : parseInt(e.target.value, 10))}
+                      placeholder="—"
+                      className={`w-full border-2 ${color} rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-offset-0`}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">Observations</label>
+              <textarea
+                value={section.notes ?? ""}
+                onChange={(e) => updateSection(i, "notes", e.target.value || null)}
+                rows={2}
+                placeholder="Remarques, points de vigilance..."
+                className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent resize-none"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Champs globaux */}
+      <div className="bg-white rounded-lg border-2 border-gray-100 p-4 space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Observations générales</label>
+          <textarea
+            value={notes}
+            onChange={(e) => { setNotes(e.target.value); setSaved(false); }}
+            rows={3}
+            placeholder="Bilan global de l'événement..."
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent resize-none"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Décisions / Actions</label>
+          <textarea
+            value={decisions}
+            onChange={(e) => { setDecisions(e.target.value); setSaved(false); }}
+            rows={3}
+            placeholder="Décisions prises, actions à mener..."
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent resize-none"
+          />
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-icc-rouge">{error}</p>}
+
+      <div className="flex items-center gap-4">
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? "Enregistrement..." : "Enregistrer le CR"}
+        </Button>
+        {saved && <span className="text-sm text-green-600 font-medium">CR enregistré ✓</span>}
+        <Link href={`/admin/events/${id}`} className="ml-auto text-sm text-gray-500 hover:text-gray-700">
+          ← Retour à l&apos;événement
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/admin/events/[eventId]/report/page.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/report/page.tsx
@@ -1,0 +1,72 @@
+import { requirePermission } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { notFound } from "next/navigation";
+import EventReportClient from "./EventReportClient";
+
+export default async function EventReportPage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  await requirePermission("events:manage");
+  const { eventId } = await params;
+
+  const event = await prisma.event.findUnique({
+    where: { id: eventId },
+    select: {
+      id: true,
+      title: true,
+      date: true,
+      type: true,
+      churchId: true,
+      reportEnabled: true,
+      statsEnabled: true,
+      report: {
+        include: {
+          sections: {
+            include: { department: { select: { id: true, name: true, ministry: { select: { name: true } } } } },
+            orderBy: { position: "asc" },
+          },
+          author: { select: { id: true, name: true } },
+        },
+      },
+    },
+  });
+
+  if (!event) notFound();
+  if (!event.reportEnabled) notFound();
+
+  // Départements liés à l'événement pour pré-remplir les sections
+  const eventDepts = await prisma.eventDepartment.findMany({
+    where: { eventId },
+    include: { department: { select: { id: true, name: true, ministry: { select: { name: true } } } } },
+    orderBy: [{ department: { ministry: { name: "asc" } } }, { department: { name: "asc" } }],
+  });
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Compte rendu</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          {event.title} &mdash;{" "}
+          {new Date(event.date).toLocaleDateString("fr-FR", {
+            day: "2-digit",
+            month: "long",
+            year: "numeric",
+          })}
+        </p>
+      </div>
+
+      <EventReportClient
+        eventId={event.id}
+        statsEnabled={event.statsEnabled}
+        existingReport={event.report}
+        eventDepts={eventDepts.map((ed) => ({
+          id: ed.department.id,
+          name: ed.department.name,
+          ministryName: ed.department.ministry.name,
+        }))}
+      />
+    </div>
+  );
+}

--- a/src/app/(auth)/profile/page.tsx
+++ b/src/app/(auth)/profile/page.tsx
@@ -90,6 +90,11 @@ export default async function ProfilePage() {
                   <p className="text-xs text-gray-500">
                     {l.member.department.ministry.name} / {l.member.department.name}
                   </p>
+                  {l.member.department.name === "Sans département" && (
+                    <p className="text-xs text-amber-600 mt-0.5">
+                      Profil incomplet — contactez un administrateur pour être rattaché à un département.
+                    </p>
+                  )}
                 </div>
                 <span className="text-xs text-gray-400">{l.church.name}</span>
               </div>

--- a/src/app/api/discipleships/[id]/member/route.ts
+++ b/src/app/api/discipleships/[id]/member/route.ts
@@ -1,0 +1,60 @@
+import { prisma } from "@/lib/prisma";
+import { requirePermission, getDiscipleshipScope } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { z } from "zod";
+
+const updateSchema = z.object({
+  firstName: z.string().min(1, "Le prénom est requis"),
+  lastName: z.string().min(1, "Le nom est requis"),
+  email: z.string().email("Email invalide").nullable().optional(),
+  phone: z.string().nullable().optional(),
+});
+
+// PATCH /api/discipleships/[id]/member — mise à jour du profil du disciple
+// Accessible au FD (discipleship:manage) pour ses propres disciples
+// et aux admins (members:manage)
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await requirePermission("discipleship:manage");
+    const { id } = await params;
+
+    const discipleship = await prisma.discipleship.findUnique({
+      where: { id },
+      select: { discipleId: true, discipleMakerId: true, churchId: true },
+    });
+    if (!discipleship) throw new ApiError(404, "Relation de discipolat introuvable");
+
+    // DISCIPLE_MAKER ne peut modifier que ses propres disciples
+    const scope = await getDiscipleshipScope(session, discipleship.churchId);
+    if (scope.scoped && discipleship.discipleMakerId !== scope.memberId) {
+      throw new ApiError(403, "Vous ne pouvez modifier que vos propres disciples");
+    }
+
+    const data = updateSchema.parse(await request.json());
+
+    const member = await prisma.member.update({
+      where: { id: discipleship.discipleId },
+      data: {
+        firstName: data.firstName,
+        lastName: data.lastName,
+        ...(data.email !== undefined ? { email: data.email } : {}),
+        ...(data.phone !== undefined ? { phone: data.phone } : {}),
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+        phone: true,
+        department: { select: { name: true, ministry: { select: { name: true } } } },
+      },
+    });
+
+    return successResponse(member);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/events/[eventId]/report/route.ts
+++ b/src/app/api/events/[eventId]/report/route.ts
@@ -1,0 +1,116 @@
+import { prisma } from "@/lib/prisma";
+import { requirePermission } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { z } from "zod";
+
+const sectionSchema = z.object({
+  id: z.string().optional(),          // présent si mise à jour d'une section existante
+  departmentId: z.string().nullable().optional(),
+  label: z.string().min(1),
+  position: z.number().int().default(0),
+  present: z.number().int().nullable().optional(),
+  absent: z.number().int().nullable().optional(),
+  newcomers: z.number().int().nullable().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+const upsertSchema = z.object({
+  notes: z.string().nullable().optional(),
+  decisions: z.string().nullable().optional(),
+  sections: z.array(sectionSchema),
+});
+
+// GET /api/events/[eventId]/report
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ eventId: string }> }
+) {
+  try {
+    await requirePermission("events:view");
+    const { eventId } = await params;
+
+    const report = await prisma.eventReport.findUnique({
+      where: { eventId },
+      include: {
+        sections: {
+          include: { department: { select: { id: true, name: true, ministry: { select: { name: true } } } } },
+          orderBy: { position: "asc" },
+        },
+        author: { select: { id: true, name: true } },
+      },
+    });
+
+    return successResponse(report ?? null);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+// PUT /api/events/[eventId]/report — crée ou remplace le rapport complet
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ eventId: string }> }
+) {
+  try {
+    const session = await requirePermission("events:manage");
+    const { eventId } = await params;
+
+    const event = await prisma.event.findUnique({
+      where: { id: eventId },
+      select: { id: true, churchId: true, reportEnabled: true },
+    });
+    if (!event) throw new ApiError(404, "Événement introuvable");
+    if (!event.reportEnabled) throw new ApiError(403, "Les comptes rendus ne sont pas activés pour cet événement");
+
+    const { notes, decisions, sections } = upsertSchema.parse(await request.json());
+
+    const report = await prisma.eventReport.upsert({
+      where: { eventId },
+      create: {
+        eventId,
+        churchId: event.churchId,
+        authorId: session.user.id,
+        notes: notes ?? null,
+        decisions: decisions ?? null,
+        sections: {
+          create: sections.map((s, i) => ({
+            departmentId: s.departmentId ?? null,
+            label: s.label,
+            position: s.position ?? i,
+            present: s.present ?? null,
+            absent: s.absent ?? null,
+            newcomers: s.newcomers ?? null,
+            notes: s.notes ?? null,
+          })),
+        },
+      },
+      update: {
+        notes: notes ?? null,
+        decisions: decisions ?? null,
+        sections: {
+          deleteMany: {},
+          create: sections.map((s, i) => ({
+            departmentId: s.departmentId ?? null,
+            label: s.label,
+            position: s.position ?? i,
+            present: s.present ?? null,
+            absent: s.absent ?? null,
+            newcomers: s.newcomers ?? null,
+            notes: s.notes ?? null,
+          })),
+        },
+      },
+      include: {
+        sections: {
+          include: { department: { select: { id: true, name: true, ministry: { select: { name: true } } } } },
+          orderBy: { position: "asc" },
+        },
+        author: { select: { id: true, name: true } },
+      },
+    });
+
+    return successResponse(report);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/events/[eventId]/route.ts
+++ b/src/app/api/events/[eventId]/route.ts
@@ -160,6 +160,8 @@ export async function PUT(
 const patchSchema = z.object({
   allowAnnouncements: z.boolean().optional(),
   trackedForDiscipleship: z.boolean().optional(),
+  reportEnabled: z.boolean().optional(),
+  statsEnabled: z.boolean().optional(),
   applyToSeries: z.boolean().optional(),
 });
 
@@ -176,6 +178,8 @@ export async function PATCH(
     const updateData = {
       ...(rest.allowAnnouncements !== undefined && { allowAnnouncements: rest.allowAnnouncements }),
       ...(rest.trackedForDiscipleship !== undefined && { trackedForDiscipleship: rest.trackedForDiscipleship }),
+      ...(rest.reportEnabled !== undefined && { reportEnabled: rest.reportEnabled }),
+      ...(rest.statsEnabled !== undefined && { statsEnabled: rest.statsEnabled }),
     };
 
     if (applyToSeries) {
@@ -201,7 +205,7 @@ export async function PATCH(
     const event = await prisma.event.update({
       where: { id: eventId },
       data: updateData,
-      select: { id: true, allowAnnouncements: true, trackedForDiscipleship: true },
+      select: { id: true, allowAnnouncements: true, trackedForDiscipleship: true, reportEnabled: true, statsEnabled: true },
     });
 
     return successResponse(event);

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -7,6 +7,8 @@ const updateSchema = z.object({
   firstName: z.string().min(1, "Le prénom est requis"),
   lastName: z.string().min(1, "Le nom est requis"),
   departmentId: z.string().min(1, "Le département est requis"),
+  email: z.string().email("Email invalide").nullable().optional(),
+  phone: z.string().nullable().optional(),
 });
 
 export async function PUT(


### PR DESCRIPTION
## Summary

### P1 — Profil disciple éditable
- `PATCH /api/discipleships/[id]/member` : un FD peut modifier prénom, nom, email et téléphone de ses disciples sans permission `members:manage`
- `PUT /api/members/[memberId]` : email et téléphone ajoutés au schéma admin
- DiscipleshipClient : bouton «Éditer» sur chaque ligne → modal pré-rempli

### P2 — Liaison compte / Sans département
- Les membres «Sans département» sont déjà trouvables via la recherche de lien STAR (aucune modification nécessaire)
- Page profil : badge d'avertissement ambré quand la fiche liée est dans «Sans département», invitant à contacter un admin

### P3 — Compte rendu d'événement
- Schema : `reportEnabled` + `statsEnabled` sur `Event`, nouveaux modèles `EventReport` et `EventReportSection`
- Migration SQL
- `PATCH /api/events/[eventId]` : toggles `reportEnabled`/`statsEnabled`
- `GET + PUT /api/events/[eventId]/report` : lecture et sauvegarde complète du CR
- Page de configuration événement : section «Compte rendu» avec les deux toggles + lien direct vers la saisie
- Page `/admin/events/[eventId]/report` : sections pré-remplies avec les départements liés, champs numériques (présents/absents/visiteurs), observations par section, observations générales et décisions, récapitulatif stats global

## Test plan

- [ ] Bouton «Éditer» sur un disciple → modal avec prénom/nom/email/téléphone → enregistrement OK
- [ ] FD ne peut pas éditer les disciples d'un autre FD (403)
- [ ] Profil : badge «Sans département» visible quand applicable
- [ ] Lien STAR : un membre «Sans département» est trouvable via la recherche
- [ ] Admin événement : toggles reportEnabled/statsEnabled fonctionnent
- [ ] Avec reportEnabled actif : lien «Saisir / voir le compte rendu» visible
- [ ] Page CR : sections pré-remplies avec les depts de l'événement
- [ ] Ajout section libre, suppression section, sauvegarde
- [ ] Stats globales visibles si statsEnabled actif

🤖 Generated with [Claude Code](https://claude.com/claude-code)