### PR TITLE
fix: supprimer la migration isDeputy dupliquée

### DIFF
--- a/prisma/migrations/20260321000003_user_department_is_deputy/migration.sql
+++ b/prisma/migrations/20260321000003_user_department_is_deputy/migration.sql
@@ -1,2 +1,0 @@
--- Ajout du flag isDeputy pour distinguer responsable principal et adjoint
-ALTER TABLE `user_departments` ADD COLUMN `isDeputy` BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- Supprime la migration `20260321000003_user_department_is_deputy` qui fait doublon avec `20260321000003_reporter_role_is_deputy`
- La première migration utilise `ADD COLUMN IF NOT EXISTS`, la seconde non — ce qui cause un échec `P3018` (Duplicate column name 'isDeputy') en production

## Test plan
- [ ] `npx prisma migrate deploy` passe sans erreur sur une base vierge
- [ ] `npx prisma migrate deploy` passe sans erreur sur la base de production

🤖 Generated with [Claude Code](https://claude.com/claude-code)