### PR TITLE
docs: mise à jour guide et documentation v0.9.0

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 Toutes les routes API sont des [Next.js Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) dans `src/app/api/`.
 
-Toutes les routes (sauf `/api/auth/*`) necessitent une session NextAuth valide.
+Toutes les routes (sauf `/api/auth/*` et `/api/cron/*`) necessitent une session NextAuth valide.
 
 ## Format des reponses
 
@@ -13,7 +13,7 @@ Toutes les routes (sauf `/api/auth/*`) necessitent une session NextAuth valide.
 { "error": "Message d'erreur" }
 ```
 
-Codes HTTP utilises : `200`, `400`, `401`, `403`, `404`, `500`.
+Codes HTTP utilises : `200`, `201`, `400`, `401`, `403`, `404`, `409`, `500`.
 
 ---
 
@@ -30,7 +30,179 @@ Gere par NextAuth. Inclut :
 
 ---
 
+## Eglises
+
+### `GET /api/churches`
+
+Liste toutes les eglises avec le nombre d'utilisateurs, de ministeres et d'evenements.
+
+**Permission requise** : `church:manage` (ou Super Admin)
+
+**Reponse** : tableau d'eglises avec `_count.users`, `_count.ministries`, `_count.events`.
+
+### `POST /api/churches`
+
+Cree une nouvelle eglise. Assigne automatiquement le role `SUPER_ADMIN` a tous les super admins existants sur cette eglise.
+
+**Permission requise** : `church:manage` (ou Super Admin)
+
+**Body** :
+```json
+{
+  "name": "ICC Rennes",
+  "slug": "icc-rennes"
+}
+```
+
+- `slug` : optionnel, genere automatiquement depuis le nom si absent
+
+**Reponse** : `201` avec l'eglise creee.
+
+### `PATCH /api/churches`
+
+Actions bulk sur plusieurs eglises (suppression ou mise a jour).
+
+**Permission requise** : `church:manage` (ou Super Admin)
+
+**Body** :
+```json
+{
+  "ids": ["clx...", "clx..."],
+  "action": "delete"
+}
+```
+
+ou pour une mise a jour :
+```json
+{
+  "ids": ["clx...", "clx..."],
+  "action": "update",
+  "data": { "name": "Nouveau nom" }
+}
+```
+
+**Reponse** : `{ "deleted": 2 }` ou `{ "updated": 2 }`.
+
+### `PUT /api/churches/[churchId]`
+
+Met a jour le nom et le slug d'une eglise.
+
+**Permission requise** : `church:manage`
+
+**Body** :
+```json
+{
+  "name": "ICC Rennes",
+  "slug": "icc-rennes"
+}
+```
+
+**Reponse** : l'eglise mise a jour.
+
+### `DELETE /api/churches/[churchId]`
+
+Supprime une eglise. Bloquee si l'eglise contient des utilisateurs, ministeres ou evenements.
+
+**Permission requise** : `church:manage`
+
+**Reponse** : `{ "success": true }`.
+
+**Erreurs** :
+- `404` si l'eglise est introuvable
+- `400` si l'eglise contient des donnees
+
+### `POST /api/churches/onboard`
+
+Cree une nouvelle eglise avec un flux d'onboarding complet : cree l'eglise, assigne optionnellement un admin, et ajoute le super admin courant.
+
+**Permission requise** : `church:manage`
+
+**Body** (valide par Zod) :
+```json
+{
+  "name": "ICC Brest",
+  "slug": "icc-brest",
+  "adminEmail": "admin@iccbrest.fr"
+}
+```
+
+- `slug` : doit correspondre au pattern `[a-z0-9-]+`
+- `adminEmail` : optionnel ; si fourni, cree ou trouve l'utilisateur et lui assigne le role `ADMIN`
+
+**Reponse** : `201` avec l'eglise creee.
+
+**Erreur** : `409` si le slug est deja utilise.
+
+---
+
 ## Evenements
+
+### `GET /api/events`
+
+Liste les evenements avec filtres.
+
+**Permission requise** : `events:view`
+
+**Query params** :
+- `churchId` (optionnel) — filtre par eglise
+- `trackedForDiscipleship=true` (optionnel) — filtre les evenements suivis pour le discipolat (tries par date croissante)
+- `from` (optionnel) — date ISO minimale
+
+**Reponse** : tableau d'evenements avec `church` et `eventDepts[].department`.
+
+### `POST /api/events`
+
+Cree un evenement (ponctuel ou serie recurrente).
+
+**Permission requise** : `events:manage`
+
+**Body** (valide par Zod) :
+```json
+{
+  "title": "Culte du dimanche",
+  "type": "CULTE",
+  "date": "2026-03-01T10:00:00.000Z",
+  "churchId": "clx...",
+  "planningDeadline": "2026-02-28T00:00:00.000Z",
+  "deadlineOffset": "2d",
+  "recurrenceRule": "weekly",
+  "recurrenceEnd": "2026-06-30T00:00:00.000Z"
+}
+```
+
+- `planningDeadline` : date limite absolue (optionnel)
+- `deadlineOffset` : offset relatif avant l'evenement, format `{n}h` ou `{n}d` (optionnel, ignore si `planningDeadline` est fourni)
+- `recurrenceRule` : `"weekly"`, `"biweekly"` ou `"monthly"` (optionnel)
+- `recurrenceEnd` : date de fin de la serie (requis si `recurrenceRule` est fourni)
+
+**Logique de recurrence** : l'evenement principal est marque `isRecurrenceParent: true`, les evenements enfants sont lies via `seriesId`.
+
+**Reponse** : `201` avec l'evenement cree (ou l'evenement parent + `childrenCreated: N`).
+
+### `PATCH /api/events`
+
+Actions bulk sur plusieurs evenements.
+
+**Permission requise** : `events:manage`
+
+**Body** :
+```json
+{
+  "ids": ["clx...", "clx..."],
+  "action": "delete"
+}
+```
+
+ou pour une mise a jour :
+```json
+{
+  "ids": ["clx...", "clx..."],
+  "action": "update",
+  "data": { "title": "Nouveau titre", "date": "2026-04-01T10:00:00.000Z" }
+}
+```
+
+**Reponse** : `{ "deleted": 2 }` ou `{ "updated": 2 }`.
 
 ### `GET /api/churches/[churchId]/events`
 
@@ -97,6 +269,172 @@ Detail d'un evenement avec ses departements et ministeres.
 
 **Erreur** : `404` si l'evenement n'existe pas.
 
+### `PATCH /api/events/[eventId]`
+
+Active ou desactive les annonces pour un evenement.
+
+**Permission requise** : `events:manage`
+
+**Body** :
+```json
+{
+  "allowAnnouncements": true
+}
+```
+
+**Reponse** : `{ "id": "clx...", "allowAnnouncements": true }`.
+
+### `POST /api/events/[eventId]/departments`
+
+Lie un departement a un evenement. Supporte l'application a toute une serie recurrente.
+
+**Permission requise** : `events:manage`
+
+**Body** :
+```json
+{
+  "departmentId": "clx...",
+  "applyToSeries": false
+}
+```
+
+- `applyToSeries` : si `true`, applique a tous les evenements futurs de la serie (y compris le courant)
+
+**Reponse** : `201` avec le lien `eventDept` cree (ou `{ "created": N }` si serie).
+
+### `DELETE /api/events/[eventId]/departments`
+
+Retire le lien entre un departement et un evenement. Supprime les plannings associes en cascade. Supporte la serie.
+
+**Permission requise** : `events:manage`
+
+**Body** :
+```json
+{
+  "departmentId": "clx...",
+  "applyToSeries": false
+}
+```
+
+**Reponse** : `{ "success": true }`.
+
+### `GET /api/events/[eventId]/star-view`
+
+Vue publique d'un evenement avec tous les membres en service (statuts `EN_SERVICE`, `EN_SERVICE_DEBRIEF`, `REMPLACANT`), regroupes par departement.
+
+**Authentification** : session valide uniquement (pas de permission specifique)
+
+**Reponse** :
+```json
+{
+  "event": {
+    "id": "clx...",
+    "title": "Culte du 02/03/2026",
+    "date": "2026-03-02T10:00:00.000Z",
+    "church": { "name": "ICC Rennes" }
+  },
+  "departments": [
+    {
+      "id": "clx...",
+      "name": "Choristes",
+      "ministryName": "Louange",
+      "members": [
+        { "id": "clx...", "firstName": "Marie", "lastName": "Dupont", "status": "EN_SERVICE" }
+      ]
+    }
+  ],
+  "totalStars": 12
+}
+```
+
+### `POST /api/events/[eventId]/duplicate-planning`
+
+Duplique le planning d'un evenement source vers un evenement cible. Seuls les departements communs aux deux evenements sont copies.
+
+**Permission requise** : `planning:edit`
+
+**Body** :
+```json
+{
+  "targetEventId": "clx..."
+}
+```
+
+**Reponse** : `{ "copied": 15, "departments": 3 }`.
+
+**Erreurs** :
+- `400` si source et cible sont identiques
+- `404` si l'evenement source n'a pas de departements
+
+### `GET /api/events/[eventId]/report`
+
+Recupere le compte rendu d'un evenement. Retourne `null` si aucun CR n'existe encore.
+
+**Permission requise** : `events:manage` ou `reports:view`
+
+**Reponse** :
+```json
+{
+  "id": "clx...",
+  "eventId": "clx...",
+  "churchId": "clx...",
+  "notes": "Bonne participation generale.",
+  "decisions": "Revoir la disposition des chaises.",
+  "author": { "id": "clx...", "name": "Jean Dupont" },
+  "sections": [
+    {
+      "id": "clx...",
+      "label": "Louange",
+      "position": 0,
+      "departmentId": "clx...",
+      "department": { "id": "clx...", "name": "Choristes", "ministry": { "name": "Louange" } },
+      "stats": { "EN_SERVICE": 8, "INDISPONIBLE": 2 },
+      "notes": "Bonne energie ce matin."
+    }
+  ]
+}
+```
+
+**Erreur** : `403` si les comptes rendus ne sont pas actives pour cet evenement.
+
+### `PUT /api/events/[eventId]/report`
+
+Cree ou remplace entierement le compte rendu d'un evenement. Les sections existantes sont supprimees et recrées a chaque appel.
+
+**Permission requise** : `events:manage` ou `reports:edit`
+
+**Body** (valide par Zod) :
+```json
+{
+  "notes": "Bonne participation generale.",
+  "decisions": "Revoir la disposition des chaises.",
+  "sections": [
+    {
+      "label": "Louange",
+      "position": 0,
+      "departmentId": "clx...",
+      "stats": { "EN_SERVICE": 8, "INDISPONIBLE": 2 },
+      "notes": "Bonne energie ce matin."
+    }
+  ]
+}
+```
+
+- `notes` : notes generales du CR (optionnel)
+- `decisions` : decisions prises lors de l'evenement (optionnel)
+- `sections` : tableau de sections (peut etre vide)
+  - `label` : intitule de la section (requis)
+  - `position` : ordre d'affichage (defaut : index dans le tableau)
+  - `departmentId` : ID du departement associe (optionnel)
+  - `stats` : objet cle/valeur de statistiques numeriques (optionnel)
+  - `notes` : notes specifiques a la section (optionnel)
+
+**Reponse** : le CR complet avec ses sections.
+
+**Erreurs** :
+- `404` si l'evenement est introuvable
+- `403` si les comptes rendus ne sont pas actives pour cet evenement
+
 ---
 
 ## Departements
@@ -118,6 +456,129 @@ Liste les membres d'un departement, tries par nom.
     "createdAt": "..."
   }
 ]
+```
+
+### `PATCH /api/departments/[departmentId]`
+
+Assigne ou retire la fonction speciale d'un departement (`DepartmentFunction`).
+
+**Permission requise** : `events:manage` (et non `departments:manage`)
+
+**Body** :
+```json
+{
+  "function": "SECRETARIAT"
+}
+```
+
+Valeurs possibles : `"SECRETARIAT"`, `"COMMUNICATION"`, `"PRODUCTION_MEDIA"`, `null` (pour retirer la fonction).
+
+**Regle metier** : une seule fonction par type est autorisee par eglise. Si un autre departement de la meme eglise possede deja cette fonction, elle lui est retiree automatiquement.
+
+**Reponse** : `{ "id": "clx...", "name": "Secretariat Rennes", "function": "SECRETARIAT" }`.
+
+### `GET /api/departments/[departmentId]/stats`
+
+Statistiques de service d'un departement sur une periode glissante.
+
+**Permission requise** : `planning:view`
+
+**Query params** :
+- `months` (optionnel, defaut : `6`) — nombre de mois en arriere
+
+**Reponse** :
+```json
+{
+  "department": { "id": "clx...", "name": "Choristes" },
+  "totalEvents": 12,
+  "months": 6,
+  "members": [
+    {
+      "id": "clx...",
+      "name": "Marie Dupont",
+      "services": 10,
+      "indisponible": 1,
+      "rate": 83
+    }
+  ],
+  "trend": [
+    { "month": "2026-01", "enService": 8, "totalSlots": 10 }
+  ]
+}
+```
+
+**Erreur** : `404` si le departement est introuvable.
+
+### `GET /api/departments/[departmentId]/tasks`
+
+Liste les taches configurees pour un departement.
+
+**Permission requise** : `planning:view`
+
+**Reponse** : tableau de taches `{ id, name, description, departmentId, createdAt }`.
+
+### `POST /api/departments/[departmentId]/tasks`
+
+Cree une nouvelle tache pour un departement.
+
+**Permission requise** : `planning:edit`
+
+**Body** :
+```json
+{
+  "name": "Régisseur son",
+  "description": "Responsable de la console de mixage"
+}
+```
+
+**Reponse** : `201` avec la tache creee.
+
+**Erreur** : `409` si une tache avec ce nom existe deja dans ce departement.
+
+### `DELETE /api/departments/[departmentId]/tasks`
+
+Supprime une tache d'un departement.
+
+**Permission requise** : `planning:edit`
+
+**Body** :
+```json
+{
+  "taskId": "clx..."
+}
+```
+
+**Reponse** : `{ "success": true }`.
+
+### `GET /api/departments/[departmentId]/monthly-planning`
+
+Vue mensuelle du planning d'un departement (membres en service et leurs taches).
+
+**Authentification** : session valide uniquement (pas de permission specifique)
+
+**Query params** :
+- `month` (optionnel) — mois au format `YYYY-MM` (defaut : mois courant)
+
+**Reponse** :
+```json
+{
+  "events": [
+    {
+      "id": "clx...",
+      "title": "Culte du 02/03/2026",
+      "date": "2026-03-02T10:00:00.000Z",
+      "members": [
+        {
+          "id": "clx...",
+          "firstName": "Marie",
+          "lastName": "Dupont",
+          "status": "EN_SERVICE",
+          "tasks": ["Régisseur son"]
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ---
@@ -196,13 +657,75 @@ Valeurs possibles pour `status` : `"EN_SERVICE"`, `"EN_SERVICE_DEBRIEF"`, `"INDI
 - `400` si plus d'un `EN_SERVICE_DEBRIEF`
 - `400` si le body ne passe pas la validation Zod
 
+### `GET /api/events/[eventId]/departments/[deptId]/tasks`
+
+Liste les taches du departement pour un evenement avec leurs assignations.
+
+**Permission requise** : `planning:view`
+
+**Reponse** : tableau de taches avec `assignments[].member` (membres assignes pour cet evenement).
+
+### `PUT /api/events/[eventId]/departments/[deptId]/tasks`
+
+Assigne des membres a une tache pour un evenement. Remplace les assignations existantes.
+
+**Permission requise** : `planning:edit`
+
+**Body** :
+```json
+{
+  "taskId": "clx...",
+  "memberIds": ["clx...", "clx..."]
+}
+```
+
+**Regle metier** : seuls les membres avec le statut `EN_SERVICE` ou `EN_SERVICE_DEBRIEF` pour cet evenement peuvent etre assignes.
+
+**Reponse** : la tache mise a jour avec ses assignations.
+
+**Erreurs** :
+- `400` si un membre n'est pas en service pour cet evenement
+- `404` si la tache ou le lien evenement-departement est introuvable
+
 ---
 
 ## Utilisateurs et roles
 
+### `GET /api/users`
+
+Liste les utilisateurs avec leurs roles par eglise.
+
+**Permission requise** : `members:manage`
+
+**Query params** :
+- `churchId` (optionnel) — filtre par eglise
+
+**Reponse** : tableau d'utilisateurs avec `churchRoles[].church`.
+
+### `GET /api/users/search`
+
+Recherche d'utilisateurs par nom pour l'autocomplete (non documente separement, utilise dans la gestion des roles).
+
+### `PATCH /api/users/[userId]/profile`
+
+Met a jour le nom d'affichage d'un utilisateur.
+
+**Autorisation** : l'utilisateur peut modifier son propre profil ; les roles `SUPER_ADMIN`, `ADMIN` et `SECRETARY` peuvent modifier n'importe quel profil.
+
+**Body** :
+```json
+{
+  "displayName": "Marie Dupont"
+}
+```
+
+**Reponse** : `{ "id": "clx...", "displayName": "Marie Dupont" }`.
+
 ### `POST /api/users/[userId]/roles`
 
-Ajoute un role a un utilisateur.
+Ajoute un role a un utilisateur dans une eglise.
+
+**Permission requise** : `users:manage` ou `departments:manage`
 
 **Body** :
 ```json
@@ -210,12 +733,20 @@ Ajoute un role a un utilisateur.
   "churchId": "clx...",
   "role": "MINISTER",
   "ministryId": "clx...",
-  "departmentIds": ["clx...", "clx..."]
+  "departmentIds": ["clx...", "clx..."],
+  "departments": [
+    { "id": "clx...", "isDeputy": false },
+    { "id": "clx...", "isDeputy": true }
+  ]
 }
 ```
 
-- `ministryId` : optionnel, utilise si `role` = `MINISTER`
-- `departmentIds` : optionnel, utilise si `role` = `DEPARTMENT_HEAD`
+- `role` : valeurs possibles : `"SUPER_ADMIN"`, `"ADMIN"`, `"SECRETARY"`, `"MINISTER"`, `"DEPARTMENT_HEAD"`, `"DISCIPLE_MAKER"`, `"REPORTER"`
+- `ministryId` : optionnel, utilise si `role` = `"MINISTER"`
+- `departments` : format enrichi `{ id, isDeputy }[]` pour `DEPARTMENT_HEAD` — distingue responsable principal (`isDeputy: false`) et adjoint (`isDeputy: true`)
+- `departmentIds` : format legacy `string[]`, equivalent a `departments` avec `isDeputy: false` pour tous
+
+Les roles privilegies (`SUPER_ADMIN`, `ADMIN`, `SECRETARY`) ne peuvent etre assignes que par un `SUPER_ADMIN`.
 
 **Reponse** : `201` avec le role cree (inclut `church`, `ministry`, `departments`).
 
@@ -223,17 +754,22 @@ Ajoute un role a un utilisateur.
 
 Modifie l'affectation d'un role existant (ministere ou departements).
 
+**Permission requise** : `users:manage` ou `departments:manage`
+
 **Body** :
 ```json
 {
   "roleId": "clx...",
   "ministryId": "clx...",
-  "departmentIds": ["clx...", "clx..."]
+  "departmentIds": ["clx...", "clx..."],
+  "departments": [
+    { "id": "clx...", "isDeputy": false }
+  ]
 }
 ```
 
 - `ministryId` : `string | null` pour MINISTER
-- `departmentIds` : `string[]` pour DEPARTMENT_HEAD (remplace les assignations existantes)
+- `departments` / `departmentIds` : meme logique que pour POST (remplace les assignations existantes)
 
 **Reponse** : `200` avec le role mis a jour.
 
@@ -242,6 +778,8 @@ Modifie l'affectation d'un role existant (ministere ou departements).
 ### `DELETE /api/users/[userId]/roles`
 
 Supprime un role d'un utilisateur. Supprime en cascade les `UserDepartment` associes.
+
+**Permission requise** : `users:manage` ou `departments:manage`
 
 **Body** :
 ```json
@@ -252,6 +790,125 @@ Supprime un role d'un utilisateur. Supprime en cascade les `UserDepartment` asso
 ```
 
 **Reponse** : `200` avec `{ "success": true }`.
+
+---
+
+## Membres (STAR)
+
+### `GET /api/members/search`
+
+Recherche de STAR par nom pour l'autocomplete (utilisee depuis la page de liaison de compte). Retourne uniquement les membres sans lien utilisateur existant.
+
+**Authentification** : session valide uniquement (pas de permission specifique)
+
+**Query params** :
+- `q` (requis) — terme de recherche (minimum 2 caracteres)
+- `churchId` (requis) — ID de l'eglise
+
+**Reponse** : tableau de membres `{ id, firstName, lastName }` (max 10 resultats).
+
+---
+
+## Liaison compte utilisateur / STAR
+
+### `POST /api/member-user-links`
+
+Cree un lien direct entre un utilisateur et un STAR (sans workflow de validation). Met a jour le nom d'affichage de l'utilisateur avec le nom du STAR.
+
+**Permission requise** : `members:manage`
+
+**Body** :
+```json
+{
+  "memberId": "clx...",
+  "userId": "clx...",
+  "churchId": "clx..."
+}
+```
+
+**Reponse** : `201` avec le lien cree.
+
+**Erreurs** :
+- `404` si le STAR ou l'utilisateur est introuvable
+- `409` si le STAR est deja lie a un compte ou si l'utilisateur est deja lie a un STAR dans cette eglise
+
+### `POST /api/member-link-requests`
+
+Soumet une demande de liaison d'un compte utilisateur a un STAR (workflow de validation par un admin). Deux modes : liaison a un STAR existant ou creation d'un nouveau STAR.
+
+**Authentification** : session valide uniquement (tout utilisateur authentifie peut soumettre)
+
+**Body — mode lien vers STAR existant** :
+```json
+{
+  "type": "existing",
+  "memberId": "clx...",
+  "churchId": "clx..."
+}
+```
+
+**Body — mode creation de nouveau STAR** :
+```json
+{
+  "type": "new",
+  "firstName": "Marie",
+  "lastName": "Dupont",
+  "phone": "+33 6 00 00 00 00",
+  "churchId": "clx..."
+}
+```
+
+**Reponse** : `201` avec la demande creee.
+
+**Erreurs** :
+- `409` si une demande `PENDING` existe deja pour cet utilisateur
+- `409` si l'utilisateur est deja lie a un STAR dans cette eglise
+- `409` si le STAR vise est deja lie a un autre compte
+
+### `GET /api/member-link-requests`
+
+Liste les demandes de liaison, filtrees par statut.
+
+**Permission requise** : `members:manage`
+
+**Query params** :
+- `churchId` (optionnel) — filtre par eglise
+- `status` (optionnel, defaut : `"PENDING"`) — `"PENDING"`, `"APPROVED"` ou `"REJECTED"`
+
+**Reponse** : tableau de demandes avec `user`, `member` (si existant) et `church`.
+
+### `PATCH /api/member-link-requests/[id]`
+
+Approuve ou rejette une demande de liaison.
+
+**Permission requise** : `members:manage`
+
+**Body** :
+```json
+{
+  "action": "approve",
+  "departmentId": "clx..."
+}
+```
+
+ou pour un rejet :
+```json
+{
+  "action": "reject",
+  "rejectReason": "STAR introuvable dans notre base"
+}
+```
+
+- `departmentId` : requis uniquement si `action` = `"approve"` et la demande est de type `"new"` (creation d'un nouveau STAR)
+
+**Logique d'approbation** :
+- Si le STAR existait : cree le lien `MemberUserLink` directement
+- Si c'est une nouvelle demande : cree le STAR dans le departement specifie, puis cree le lien
+- Met a jour le `displayName` de l'utilisateur avec le nom du STAR dans tous les cas
+
+**Reponse** : `{ "approved": true }` ou la demande mise a jour (si rejet).
+
+**Erreur** : `409` si la demande a deja ete traitee.
 
 ---
 
@@ -403,42 +1060,368 @@ Lors d'un changement de statut, `reviewedById` et `reviewedAt` sont automatiquem
 
 ---
 
-## Evenements (complement)
+## Discipolat
 
-### `PATCH /api/events/[eventId]`
+Les endpoints de discipolat utilisent deux permissions specifiques :
+- `discipleship:view` — lecture des relations et statistiques
+- `discipleship:manage` — creation, modification, suppression
+- `discipleship:export` — export Excel
 
-Active ou desactive les annonces pour un evenement.
+Le perimetre est controle par `getDiscipleshipScope()` : les roles `DISCIPLE_MAKER` voient et gerent uniquement leurs propres disciples ; les admins ont acces a tout.
 
-**Permission requise** : `events:manage`
+### `GET /api/discipleships`
+
+Liste les relations de discipolat d'une eglise.
+
+**Permission requise** : `discipleship:view`
+
+**Query params** :
+- `churchId` (requis) — ID de l'eglise
+
+**Reponse** : tableau de relations avec `disciple`, `discipleMaker` et `firstMaker`.
+
+```json
+[
+  {
+    "id": "clx...",
+    "discipleId": "clx...",
+    "discipleMakerId": "clx...",
+    "firstMakerId": "clx...",
+    "churchId": "clx...",
+    "disciple": {
+      "id": "clx...",
+      "firstName": "Paul",
+      "lastName": "Leroy",
+      "department": { "name": "Choristes", "ministry": { "name": "Louange" } }
+    },
+    "discipleMaker": { "id": "clx...", "firstName": "Jean", "lastName": "Dupont" },
+    "firstMaker": { "id": "clx...", "firstName": "Jean", "lastName": "Dupont" }
+  }
+]
+```
+
+### `POST /api/discipleships`
+
+Cree une nouvelle relation de discipolat. Supporte deux modes : liaison a un STAR existant ou creation d'un nouveau STAR (place dans le departement systeme).
+
+**Permission requise** : `discipleship:manage`
+
+**Body — mode STAR existant** :
+```json
+{
+  "discipleId": "clx...",
+  "discipleMakerId": "clx...",
+  "churchId": "clx...",
+  "firstMakerId": "clx..."
+}
+```
+
+**Body — mode nouveau STAR** :
+```json
+{
+  "newMember": { "firstName": "Paul", "lastName": "Leroy" },
+  "discipleMakerId": "clx...",
+  "churchId": "clx...",
+  "firstMakerId": "clx..."
+}
+```
+
+- `firstMakerId` : optionnel ; si absent, prend la valeur de `discipleMakerId`
+- Un `DISCIPLE_MAKER` ne peut creer des relations que pour lui-meme
+
+**Reponse** : `201` avec la relation creee.
+
+**Erreurs** :
+- `400` si le disciple et le FD sont la meme personne
+- `409` si le STAR a deja un FD dans cette eglise
+
+### `PATCH /api/discipleships/[id]`
+
+Change le FD courant d'une relation de discipolat en conservant le `firstMakerId` d'origine. Remet `startedAt` a la date courante.
+
+**Permission requise** : `discipleship:manage`
 
 **Body** :
 ```json
 {
-  "allowAnnouncements": true
+  "discipleMakerId": "clx..."
 }
 ```
 
-**Reponse** : `{ "id": "clx...", "allowAnnouncements": true }`.
+**Reponse** : la relation mise a jour avec `disciple` et `discipleMaker`.
+
+**Erreur** : `400` si le nouveau FD est le disciple lui-meme.
+
+### `DELETE /api/discipleships/[id]`
+
+Supprime une relation de discipolat. Un `DISCIPLE_MAKER` ne peut supprimer que ses propres relations.
+
+**Permission requise** : `discipleship:manage`
+
+**Reponse** : `{ "deleted": true }`.
+
+### `PATCH /api/discipleships/[id]/member`
+
+Met a jour le profil (nom, email, telephone) du disciple d'une relation. Un `DISCIPLE_MAKER` ne peut modifier que ses propres disciples.
+
+**Permission requise** : `discipleship:manage`
+
+**Body** :
+```json
+{
+  "firstName": "Paul",
+  "lastName": "Leroy",
+  "email": "paul.leroy@example.com",
+  "phone": "+33 6 00 00 00 00"
+}
+```
+
+**Reponse** : le membre mis a jour avec son departement et ministere.
+
+### `GET /api/discipleships/attendance`
+
+Liste les presences enregistrees pour un evenement suivi.
+
+**Permission requise** : `discipleship:view`
+
+**Query params** :
+- `eventId` (requis) — ID de l'evenement
+
+**Reponse** : tableau `{ memberId, present }`.
+
+### `PUT /api/discipleships/attendance`
+
+Enregistre les presences pour un evenement suivi. Remplace les presences existantes.
+
+**Permission requise** : `discipleship:manage`
+
+**Comportement selon le perimetre** :
+- `DISCIPLE_MAKER` : met a jour uniquement les presences de ses propres disciples
+- Admin/Secretaire : remplace toutes les presences de l'evenement
+
+**Body** :
+```json
+{
+  "eventId": "clx...",
+  "presentMemberIds": ["clx...", "clx..."]
+}
+```
+
+Les membres absents de `presentMemberIds` sont automatiquement marques absents.
+
+**Reponse** : `{ "saved": true }`.
+
+**Erreurs** :
+- `404` si l'evenement est introuvable
+- `400` si l'evenement n'est pas suivi pour le discipolat (`trackedForDiscipleship: false`)
+
+### `GET /api/discipleships/stats`
+
+Statistiques de participation aux evenements de discipolat sur une periode glissante.
+
+**Permission requise** : `discipleship:view`
+
+**Query params** :
+- `churchId` (requis) — ID de l'eglise
+- `from` (optionnel) — debut de periode ISO (defaut : 1er du mois courant)
+- `to` (optionnel) — fin de periode ISO (defaut : dernier jour du mois courant)
+
+**Reponse** :
+```json
+{
+  "period": { "from": "2026-03-01T00:00:00.000Z", "to": "2026-03-31T23:59:59.000Z" },
+  "trackedEvents": [
+    { "id": "clx...", "title": "Reunion disciples", "date": "2026-03-15T10:00:00.000Z" }
+  ],
+  "stats": [
+    {
+      "discipleshipId": "clx...",
+      "disciple": { "id": "clx...", "firstName": "Paul", "lastName": "Leroy", "department": { "name": "Choristes", "ministry": { "name": "Louange" } } },
+      "discipleMaker": { "id": "clx...", "firstName": "Jean", "lastName": "Dupont" },
+      "firstMaker": { "id": "clx...", "firstName": "Jean", "lastName": "Dupont" },
+      "stats": { "totalEvents": 3, "present": 2, "absent": 1, "rate": 67 }
+    }
+  ]
+}
+```
+
+### `GET /api/discipleships/tree`
+
+Arbre de lignee recursif (profondeur illimitee) via requete SQL `WITH RECURSIVE`.
+
+**Permission requise** : `discipleship:view`
+
+**Query params** :
+- `churchId` (requis) — ID de l'eglise
+- `mode` (optionnel) — `"primary"` (lignee via `firstMakerId`, defaut) ou `"current"` (structure actuelle via `discipleMakerId`)
+- `rootId` (optionnel) — ID du membre racine ; si absent, part des racines naturelles de l'arbre. Ignore pour les `DISCIPLE_MAKER` (ancre sur leur propre noeud)
+
+**Reponse** : tableau de noeuds enrichis, tries par profondeur :
+```json
+[
+  {
+    "id": "clx...",
+    "discipleId": "clx...",
+    "discipleMakerId": "clx...",
+    "firstMakerId": "clx...",
+    "depth": 0,
+    "path": "clx-disciple-id",
+    "disciple": { "id": "clx...", "firstName": "Paul", "lastName": "Leroy", "department": { "name": "Choristes", "ministry": { "name": "Louange" } } },
+    "discipleMaker": { "id": "clx...", "firstName": "Jean", "lastName": "Dupont" },
+    "firstMaker": { "id": "clx...", "firstName": "Jean", "lastName": "Dupont" }
+  }
+]
+```
+
+### `GET /api/discipleships/export`
+
+Exporte les statistiques de discipolat au format Excel (`.xlsx`) avec deux feuilles : statistiques par disciple et detail des presences par evenement.
+
+**Permission requise** : `discipleship:export`
+
+**Query params** :
+- `churchId` (requis) — ID de l'eglise
+- `from` (optionnel) — debut de periode ISO (defaut : 1er du mois courant)
+- `to` (optionnel) — fin de periode ISO (defaut : dernier jour du mois courant)
+
+**Reponse** : fichier `.xlsx` avec les headers `Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` et `Content-Disposition: attachment; filename="discipolat-{mois}-{annee}.xlsx"`.
 
 ---
 
-## Departements (complement)
+## Notifications
 
-### `PATCH /api/departments/[departmentId]`
+### `GET /api/notifications`
 
-Assigne ou retire la fonction speciale d'un departement (`DepartmentFunction`).
+Liste les 20 dernieres notifications de l'utilisateur courant avec le nombre de non-lues.
 
-**Permission requise** : `events:manage` (et non `departments:manage`)
+**Authentification** : session valide uniquement
+
+**Reponse** :
+```json
+{
+  "notifications": [
+    {
+      "id": "clx...",
+      "type": "PLANNING_REMINDER",
+      "title": "Rappel : Culte du dimanche",
+      "message": "Marie Dupont est en service pour Choristes demain",
+      "link": "/dashboard?dept=clx...&event=clx...",
+      "read": false,
+      "createdAt": "2026-03-01T08:00:00.000Z"
+    }
+  ],
+  "unreadCount": 3
+}
+```
+
+### `PATCH /api/notifications`
+
+Marque des notifications comme lues.
+
+**Authentification** : session valide uniquement
+
+**Body** — marquer des notifications specifiques :
+```json
+{
+  "ids": ["clx...", "clx..."]
+}
+```
+
+**Body** — marquer toutes les notifications comme lues :
+```json
+{
+  "all": true
+}
+```
+
+**Reponse** : `{ "success": true }`.
+
+---
+
+## Journaux d'audit
+
+### `GET /api/audit-logs`
+
+Liste les journaux d'audit de l'eglise courante, pagines.
+
+**Permission requise** : `church:manage`
+
+**Query params** :
+- `page` (optionnel, defaut : `1`) — numero de page
+- `limit` (optionnel, defaut : `50`, max : `100`) — nombre de resultats par page
+
+**Reponse** :
+```json
+{
+  "logs": [
+    {
+      "id": "clx...",
+      "action": "CREATE_DISCIPLESHIP",
+      "entityType": "Discipleship",
+      "entityId": "clx...",
+      "churchId": "clx...",
+      "createdAt": "2026-03-01T10:00:00.000Z",
+      "user": { "id": "clx...", "name": "Jean Dupont", "displayName": "Jean Dupont", "email": "jean@example.com" }
+    }
+  ],
+  "total": 145,
+  "page": 1,
+  "totalPages": 3
+}
+```
+
+---
+
+## Eglise courante
+
+### `POST /api/current-church`
+
+Definit l'eglise active de l'utilisateur via un cookie HTTP-only (duree : 30 jours).
+
+**Authentification** : session valide uniquement
 
 **Body** :
 ```json
 {
-  "function": "SECRETARIAT"
+  "churchId": "clx..."
 }
 ```
 
-Valeurs possibles : `"SECRETARIAT"`, `"COMMUNICATION"`, `"PRODUCTION_MEDIA"`, `null` (pour retirer la fonction).
+**Reponse** : `{ "churchId": "clx..." }`.
 
-**Regle metier** : une seule fonction par type est autorisee par eglise. Si un autre departement de la meme eglise possede deja cette fonction, elle lui est retiree automatiquement.
+**Erreur** : `403` si l'utilisateur n'a pas acces a cette eglise.
 
-**Reponse** : `{ "id": "clx...", "name": "Secretariat Rennes", "function": "SECRETARIAT" }`.
+---
+
+## Taches CRON
+
+### `POST /api/cron/reminders`
+
+Envoie les rappels de service (emails + notifications in-app) pour les evenements a J-1 et J-3.
+
+**Authentification** : token secret via header `Authorization: Bearer {CRON_SECRET}`
+
+**Comportement** :
+- Identifie les evenements ayant lieu dans 1 ou 3 jours
+- Pour chaque membre en service (`EN_SERVICE` ou `EN_SERVICE_DEBRIEF`) : envoie un email si SMTP est configure et si le membre a une adresse email
+- Pour chaque responsable de departement concerne : cree une notification in-app
+
+**Reponse** :
+```json
+{
+  "emailsSent": 5,
+  "notificationsCreated": 8
+}
+```
+
+---
+
+## Utilisateur — preferences
+
+### `PATCH /api/user/tour-seen`
+
+Marque le tutoriel de decouverte comme vu pour l'utilisateur courant.
+
+**Authentification** : session valide uniquement
+
+**Reponse** : `{ "hasSeenTour": true }`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,11 @@ planningcenter/
 │   │   ├── (auth)/                # Route group : pages authentifiees
 │   │   │   ├── layout.tsx         # Auth guard, header, sidebar, footer version
 │   │   │   ├── dashboard/         # Vue planning par departement
+│   │   │   │   └── stats/         # Statistiques par departement
 │   │   │   ├── events/            # Gestion des evenements
+│   │   │   │   ├── calendar/      # Vue calendrier des evenements
+│   │   │   │   └── [eventId]/     # Detail evenement
+│   │   │   ├── profile/           # Profil utilisateur et liaison compte STAR
 │   │   │   ├── announcements/     # Soumission et suivi des annonces
 │   │   │   │   ├── page.tsx       # Liste des annonces du referent
 │   │   │   │   └── new/           # Formulaire de soumission d'annonce
@@ -47,28 +51,48 @@ planningcenter/
 │   │   │       ├── layout.tsx     # Guard multi-permissions
 │   │   │       ├── churches/      # CRUD eglises
 │   │   │       ├── users/         # Gestion utilisateurs et roles
+│   │   │       ├── access/        # Gestion des acces et roles (AccessClient.tsx)
 │   │   │       ├── ministries/    # CRUD ministeres
 │   │   │       ├── departments/   # CRUD departements
 │   │   │       │   └── functions/ # Config fonctions departementales
 │   │   │       ├── members/       # CRUD membres
-│   │   │       └── events/        # CRUD evenements
+│   │   │       ├── events/        # CRUD evenements
+│   │   │       │   └── [eventId]/
+│   │   │       │       └── report/ # Edition du CR d'evenement (EventReportClient.tsx)
+│   │   │       ├── reports/       # Dashboard rapports (ReportsClient.tsx)
+│   │   │       ├── discipleship/  # Dashboard discipolat (DiscipleshipClient.tsx)
+│   │   │       └── audit-logs/    # Journal des actions
 │   │   └── api/                   # Route handlers (API REST)
 │   │       ├── auth/[...nextauth]/
 │   │       ├── announcements/     # GET/POST + [id] GET/PATCH/DELETE
 │   │       ├── service-requests/  # GET/POST + [id] GET/PATCH
 │   │       ├── churches/
 │   │       ├── departments/
+│   │       ├── discipleships/     # GET/POST + gestion discipolat
 │   │       ├── events/
+│   │       │   └── [eventId]/
+│   │       │       └── report/    # GET/PATCH CR d'evenement
+│   │       ├── member-link-requests/ # Demandes de liaison membre-utilisateur
+│   │       ├── member-user-links/ # Liaisons membre-compte utilisateur
 │   │       ├── members/
 │   │       ├── ministries/
+│   │       ├── notifications/
 │   │       └── users/
 │   ├── components/
-│   │   ├── Sidebar.tsx            # Sidebar unifiee (3 sections accordion)
+│   │   ├── AuthLayoutShell.tsx    # Shell layout authentifie (header, sidebar)
+│   │   ├── BottomNav.tsx          # Navigation mobile bas d'ecran
+│   │   ├── Sidebar.tsx            # Sidebar unifiee (6 sections : Planning, Événements (Liste, Calendrier, Gestion, CR), Membres, Annonces, Discipolat, Configuration)
 │   │   ├── PlanningGrid.tsx       # Grille planning interactive (auto-save)
 │   │   ├── EventSelector.tsx      # Selecteur d'evenement
 │   │   ├── MonthlyPlanningView.tsx
 │   │   ├── ViewToggle.tsx
 │   │   ├── DashboardActions.tsx
+│   │   ├── NotificationBell.tsx   # Cloche de notifications
+│   │   ├── ChurchSwitcher.tsx     # Selecteur d'eglise multi-tenant
+│   │   ├── EventReportClient.tsx  # Edition du CR d'evenement
+│   │   ├── ReportsClient.tsx      # Dashboard rapports
+│   │   ├── AccessClient.tsx       # Gestion des acces et roles
+│   │   ├── DiscipleshipClient.tsx # Dashboard discipolat
 │   │   └── ui/                    # Composants UI reutilisables
 │   │       ├── Button.tsx
 │   │       ├── Input.tsx
@@ -81,7 +105,7 @@ planningcenter/
 │   │   ├── prisma.ts              # Singleton Prisma (globalThis pattern)
 │   │   ├── auth.ts                # Config NextAuth + helpers
 │   │   ├── api-utils.ts           # ApiError, successResponse, errorResponse
-│   │   └── permissions.ts         # Matrice roles-permissions RBAC
+│   │   └── permissions.ts         # Matrice roles-permissions RBAC (7 roles : SUPER_ADMIN, ADMIN, SECRETARY, MINISTER, DEPARTMENT_HEAD, DISCIPLE_MAKER, REPORTER)
 │   └── middleware.ts              # Edge middleware (protection routes)
 ├── docker-compose.yml             # MariaDB locale
 ├── next.config.ts

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -64,6 +64,8 @@ session.user.churchRoles = [
 | Secretariat | `SECRETARY` | Une eglise |
 | Ministre | `MINISTER` | Un ministere d'une eglise |
 | Responsable departement | `DEPARTMENT_HEAD` | Un ou plusieurs departements |
+| Accompagnateur discipolat | `DISCIPLE_MAKER` | Suivi des relations de discipolat et gestion des presences |
+| Rapporteur | `REPORTER` | Acces en lecture/ecriture aux comptes rendus d'evenements |
 
 Un utilisateur peut avoir **plusieurs roles** dans **plusieurs eglises** via la table `user_church_roles`.
 
@@ -71,6 +73,7 @@ Un utilisateur peut avoir **plusieurs roles** dans **plusieurs eglises** via la 
 
 - **Super Admin** : automatique a la premiere connexion si l'email est dans `SUPER_ADMIN_EMAILS`
 - **Autres roles** : via l'interface admin (`/admin/users`), avec affectation optionnelle de ministere (MINISTER) ou departements (DEPARTMENT_HEAD)
+- **isDeputy** : la table `user_departments` (liaison `DEPARTMENT_HEAD` ↔ departements) dispose d'un flag `isDeputy` pour distinguer le responsable principal du responsable adjoint (deputy)
 
 ---
 
@@ -78,24 +81,35 @@ Un utilisateur peut avoir **plusieurs roles** dans **plusieurs eglises** via la 
 
 Matrice role-permissions definie dans `src/lib/permissions.ts` :
 
-| Permission | Super Admin | Admin | Secrétaire | Ministre | Resp. département |
-|---|---|---|---|---|---|
-| `planning:view` | x | x | x | x | x |
-| `planning:edit` | x | x | | x | x |
-| `members:view` | x | x | x | x | x |
-| `members:manage` | x | x | | x | x |
-| `events:view` | x | x | x | x | x |
-| `events:manage` | x | x | x | | |
-| `departments:view` | x | x | x | x | x |
-| `departments:manage` | x | x | | | |
-| `church:manage` | x | | | | |
-| `users:manage` | x | | | | |
+| Permission | Super Admin | Admin | Secrétaire | Ministre | Resp. département | Disciple Maker | Reporter |
+|---|---|---|---|---|---|---|---|
+| `planning:view` | x | x | x | x | x | | |
+| `planning:edit` | x | x | | x | x | | |
+| `members:view` | x | x | x | x | x | | |
+| `members:manage` | x | x | | x | x | | |
+| `events:view` | x | x | x | x | x | | x |
+| `events:manage` | x | x | x | | | | |
+| `departments:view` | x | x | x | x | x | | |
+| `departments:manage` | x | x | | | | | |
+| `church:manage` | x | | | | | | |
+| `users:manage` | x | | | | | | |
+| `discipleship:view` | x | x | x | | x | x | |
+| `discipleship:manage` | x | x | | | | x | |
+| `discipleship:export` | x | | x | | | | |
+| `reports:view` | x | x | x | | | | x |
+| `reports:edit` | x | x | x | | | | x |
 
 **Spécificités du Secrétaire** :
 - Voit tous les départements de son église (même périmètre que Admin)
 - Planning en lecture seule (pas de `planning:edit`)
 - Membres en lecture seule dans l'admin (pas de `members:manage`)
 - Peut gérer les événements (`events:manage`)
+- Peut exporter les données discipolat (`discipleship:export`)
+- Accès en lecture/écriture aux comptes rendus (`reports:view` + `reports:edit`)
+
+**Spécificités du Reporter** :
+- Accès aux événements en lecture (`events:view`) et aux comptes rendus (`reports:view` + `reports:edit`)
+- Pas d'accès au planning, aux membres, au discipolat ni à la section admin
 
 ### Utilisation dans le code
 
@@ -122,5 +136,7 @@ L'endpoint `PATCH /api/departments/[departmentId]` qui assigne une `DepartmentFu
 - **Super Admin / Admin / Secrétaire** : voient tous les départements de leur église (lecture globale)
 - **Ministre** : voit les départements du ministère qui lui est assigné
 - **Responsable de département** : voit uniquement les départements qui lui sont assignés via `user_departments`
+- **Disciple Maker** : pas d'accès au planning ni à la grille des départements ; périmètre limité au module discipolat
+- **Reporter** : pas d'accès au planning, aux membres ni à la section admin ; voit uniquement les événements et les comptes rendus qui lui sont accessibles
 
 Cette logique est implémentée dans `src/app/(auth)/layout.tsx` et `getUserDepartmentScope()` dans `src/lib/auth.ts`.

--- a/docs/database.md
+++ b/docs/database.md
@@ -26,13 +26,27 @@ Tous les IDs sont des `String @default(cuid())`.
 │     ├──► ministries ──► departments ◄────┘                          │
 │     │                       │                                        │
 │     │                       ├──► members ──► plannings               │
-│     │                       │                    ▲                    │
+│     │                       │        │           ▲                   │
+│     │                       │        ├──► member_user_links          │
+│     │                       │        ├──► member_link_requests       │
+│     │                       │        ├──► discipleships              │
+│     │                       │        └──► discipleship_attendances   │
+│     │                       ├──► tasks ──► task_assignments          │
+│     │                       └──► event_report_sections               │
+│     │                                    ▲                           │
 │     ├──► events ──► event_departments ───► plannings                │
-│     │        │                                                       │
-│     │        └──► announcement_events ◄── announcements             │
+│     │        │           │                                           │
+│     │        │           └──► task_assignments                       │
+│     │        ├──► announcement_events ◄── announcements             │
+│     │        ├──► discipleship_attendances                          │
+│     │        └──► event_reports ──► event_report_sections           │
 │     │                                          │                     │
 │     ├──► announcements ──► service_requests ───┘                    │
-│     └──► service_requests                                            │
+│     ├──► service_requests                                            │
+│     ├──► member_user_links                                           │
+│     ├──► member_link_requests                                        │
+│     ├──► discipleships                                               │
+│     └──► event_reports                                               │
 │                                                                      │
 └──────────────────────────────────────────────────────────────────────┘
 ```
@@ -69,9 +83,14 @@ Utilisateurs de l'application. Crees automatiquement a la premiere connexion Goo
 |---|---|---|
 | `id` | String (cuid) | Identifiant unique |
 | `email` | String (unique) | Adresse email |
-| `name` | String? | Nom affiche |
+| `name` | String? | Nom affiche (fourni par Google) |
+| `displayName` | String? | Nom d'affichage personnalise (defini par l'utilisateur) |
 | `image` | String? | URL avatar Google |
 | `emailVerified` | DateTime? | Date de verification (NextAuth) |
+| `isSuperAdmin` | Boolean | Super administrateur global (default: false) |
+| `hasSeenTour` | Boolean | Indique si l'utilisateur a vu la visite guidee (default: false) |
+| `createdAt` | DateTime | Date de creation |
+| `updatedAt` | DateTime | Derniere modification |
 
 #### `user_church_roles`
 
@@ -82,7 +101,7 @@ Association utilisateur-eglise-role. Un utilisateur peut avoir plusieurs roles d
 | `id` | String (cuid) | Identifiant unique |
 | `userId` | String | Ref vers `users` |
 | `churchId` | String | Ref vers `churches` |
-| `role` | Role (enum) | `SUPER_ADMIN`, `ADMIN`, `SECRETARY`, `MINISTER`, `DEPARTMENT_HEAD` |
+| `role` | Role (enum) | `SUPER_ADMIN`, `ADMIN`, `SECRETARY`, `MINISTER`, `DEPARTMENT_HEAD`, `DISCIPLE_MAKER`, `REPORTER` |
 | `ministryId` | String? | Ref vers `ministries` (pour MINISTER) |
 
 Contrainte unique : `[userId, churchId, role]`
@@ -93,8 +112,10 @@ Departements assignes a un role utilisateur-eglise.
 
 | Champ | Type | Description |
 |---|---|---|
+| `id` | String (cuid) | Identifiant unique |
 | `userChurchRoleId` | String | Ref vers `user_church_roles` |
 | `departmentId` | String | Ref vers `departments` |
+| `isDeputy` | Boolean | `true` = responsable adjoint, `false` = responsable principal (default: false) |
 
 Contrainte unique : `[userChurchRoleId, departmentId]`
 
@@ -119,13 +140,51 @@ Departements d'un ministere (Choristes, Musiciens, Son...).
 
 #### `members`
 
-Membres d'un departement (les personnes planifiees).
+Membres d'un departement (les personnes planifiees). Appeles **STAR** (Serviteur Travaillant Activement pour le Royaume).
 
 | Champ | Type | Description |
 |---|---|---|
+| `id` | String (cuid) | Identifiant unique |
 | `firstName` | String | Prenom |
 | `lastName` | String | Nom |
+| `email` | String? | Adresse email (optionnel) |
+| `phone` | String? | Numero de telephone (optionnel) |
 | `departmentId` | String | Ref vers `departments` |
+| `createdAt` | DateTime | Date de creation |
+
+#### `member_user_links`
+
+Liaison entre un membre (STAR) et un compte utilisateur. Permet au membre de se connecter et d'acceder a son planning personnel.
+
+| Champ | Type | Description |
+|---|---|---|
+| `id` | String (cuid) | Identifiant unique |
+| `memberId` | String (unique) | Ref vers `members` (un membre ne peut avoir qu'un seul lien) |
+| `userId` | String | Ref vers `users` |
+| `churchId` | String | Ref vers `churches` |
+| `validatedAt` | DateTime? | Date de validation de la liaison (null = en attente) |
+| `validatedById` | String? | Ref vers `users` (administrateur validateur) |
+
+Contraintes : `memberId` unique ; `[userId, churchId]` unique (un utilisateur ne peut etre lie qu'a un seul membre par eglise).
+
+#### `member_link_requests`
+
+Demandes de liaison entre un compte utilisateur et un profil membre. Soumises par l'utilisateur, validees par un administrateur.
+
+| Champ | Type | Description |
+|---|---|---|
+| `id` | String (cuid) | Identifiant unique |
+| `userId` | String | Ref vers `users` (demandeur) |
+| `memberId` | String? | Ref vers `members` (membre selectionne, nullable si inconnu) |
+| `firstName` | String? | Prenom saisi manuellement (si memberId absent) |
+| `lastName` | String? | Nom saisi manuellement (si memberId absent) |
+| `phone` | String? | Telephone saisi manuellement (si memberId absent) |
+| `churchId` | String | Ref vers `churches` |
+| `status` | MemberLinkRequestStatus | `PENDING`, `APPROVED`, `REJECTED` (default: `PENDING`) |
+| `rejectReason` | String? | Motif de rejet (renseigné si `REJECTED`) |
+| `createdAt` | DateTime | Date de soumission |
+| `reviewedAt` | DateTime? | Date de traitement |
+| `reviewedById` | String? | Ref vers `users` (administrateur traitant) |
 
 #### `events`
 
@@ -142,6 +201,9 @@ Evenements d'une eglise.
 | `recurrenceRule` | String? | Regle de recurrence (format iCal RRULE) |
 | `seriesId` | String? | ID de l'evenement parent de la serie |
 | `isRecurrenceParent` | Boolean | Indique si cet evenement est le parent d'une serie |
+| `trackedForDiscipleship` | Boolean | Evenement suivi pour la presences discipolat (default: false) |
+| `reportEnabled` | Boolean | Activation du compte-rendu pour cet evenement (default: false) |
+| `statsEnabled` | Boolean | Activation des stats departementales dans le CR (default: false) |
 
 #### `event_departments`
 
@@ -166,6 +228,91 @@ Statut d'un membre pour un departement a un evenement donne.
 | `updatedAt` | DateTime | Derniere modification |
 
 Contrainte unique : `[eventDepartmentId, memberId]`
+
+#### `tasks`
+
+Taches definies par departement (ex : "Animation debrief", "Accueil enfants"). Servent a structurer les responsabilites lors d'un evenement.
+
+| Champ | Type | Description |
+|---|---|---|
+| `id` | String (cuid) | Identifiant unique |
+| `departmentId` | String | Ref vers `departments` |
+| `name` | String | Nom de la tache |
+| `description` | String? (Text) | Description detaillee (optionnel) |
+| `createdAt` | DateTime | Date de creation |
+
+Contrainte unique : `[departmentId, name]`
+
+#### `task_assignments`
+
+Affectation d'un membre a une tache pour un evenement donne.
+
+| Champ | Type | Description |
+|---|---|---|
+| `id` | String (cuid) | Identifiant unique |
+| `taskId` | String | Ref vers `tasks` (cascade delete) |
+| `memberId` | String | Ref vers `members` |
+| `eventId` | String | Ref vers `events` |
+| `assignedAt` | DateTime | Date d'affectation |
+
+Contrainte unique : `[taskId, eventId, memberId]`
+
+#### `discipleships`
+
+Relation de discipolat entre deux membres (disciple et faiseur de disciples). Un seul enregistrement actif par disciple par eglise.
+
+| Champ | Type | Description |
+|---|---|---|
+| `id` | String (cuid) | Identifiant unique |
+| `discipleId` | String | Ref vers `members` (le disciple) |
+| `discipleMakerId` | String | Ref vers `members` (le faiseur de disciples courant) |
+| `firstMakerId` | String | Ref vers `members` (premier faiseur de disciples — ne change jamais, sert pour la lignee) |
+| `churchId` | String | Ref vers `churches` |
+| `startedAt` | DateTime | Date de debut de la relation (default: now) |
+
+Contrainte unique : `[discipleId, churchId]` — un seul FD courant par disciple par eglise.
+
+#### `discipleship_attendances`
+
+Presences des membres suivis pour le discipolat lors des evenements traces (`trackedForDiscipleship = true`).
+
+| Champ | Type | Description |
+|---|---|---|
+| `id` | String (cuid) | Identifiant unique |
+| `memberId` | String | Ref vers `members` |
+| `eventId` | String | Ref vers `events` |
+| `present` | Boolean | Presence effective (default: true) |
+
+Contrainte unique : `[memberId, eventId]`
+
+#### `event_reports`
+
+Compte-rendu d'un evenement. Un seul CR par evenement.
+
+| Champ | Type | Description |
+|---|---|---|
+| `id` | String (cuid) | Identifiant unique |
+| `eventId` | String (unique) | Ref vers `events` (un seul CR par evenement) |
+| `churchId` | String | Ref vers `churches` |
+| `notes` | String? (Text) | Notes generales du CR |
+| `decisions` | String? (Text) | Decisions prises lors de l'evenement |
+| `authorId` | String? | Ref vers `users` (auteur du CR, nullable) |
+| `createdAt` | DateTime | Date de creation |
+| `updatedAt` | DateTime | Derniere modification |
+
+#### `event_report_sections`
+
+Sections d'un compte-rendu, organisees par departement ou libres. Chaque section peut contenir des statistiques JSON et des notes texte.
+
+| Champ | Type | Description |
+|---|---|---|
+| `id` | String (cuid) | Identifiant unique |
+| `reportId` | String | Ref vers `event_reports` (cascade delete) |
+| `departmentId` | String? | Ref vers `departments` (null = section libre) |
+| `label` | String | Libelle de la section |
+| `position` | Int | Ordre d'affichage (default: 0) |
+| `stats` | Json? | Statistiques specifiques au departement (structure libre) |
+| `notes` | String? (Text) | Notes texte de la section |
 
 #### `announcements`
 
@@ -241,6 +388,8 @@ ADMIN            # Admin d'une eglise
 SECRETARY        # Secretariat d'une eglise
 MINISTER         # Responsable d'un ministere
 DEPARTMENT_HEAD  # Responsable d'un ou plusieurs departements
+DISCIPLE_MAKER   # Faiseur de disciples (acces aux fonctionnalites de discipolat)
+REPORTER         # Rapporteur (acces a la saisie des comptes-rendus)
 ```
 
 #### `ServiceStatus`
@@ -261,6 +410,14 @@ PRODUCTION_MEDIA  # Departement traitant les demandes de visuels
 ```
 
 Un seul departement par fonction et par eglise. Assigne via `PATCH /api/departments/[id]`.
+
+#### `MemberLinkRequestStatus`
+
+```
+PENDING   # Demande en attente de traitement
+APPROVED  # Demande approuvee — lien cree
+REJECTED  # Demande rejetee (motif dans rejectReason)
+```
 
 #### `AnnouncementStatus`
 

--- a/src/app/(auth)/guide/page.tsx
+++ b/src/app/(auth)/guide/page.tsx
@@ -6,11 +6,9 @@ export default async function GuidePage() {
   const session = await requireAuth();
   const currentChurchId = await getCurrentChurchId(session);
 
-  const rawRole: Role = session.user.churchRoles.find(
+  const currentRole: Role = session.user.churchRoles.find(
     (r) => r.churchId === currentChurchId
   )?.role ?? "DEPARTMENT_HEAD";
-  // REPORTER has no dedicated guide tab — fall back to DEPARTMENT_HEAD
-  const currentRole = rawRole === "REPORTER" ? "DEPARTMENT_HEAD" : rawRole;
 
   return (
     <div className="max-w-5xl mx-auto">

--- a/src/components/GuideContent.tsx
+++ b/src/components/GuideContent.tsx
@@ -21,10 +21,10 @@ const ROLE_LABELS: Record<RoleKey, string> = {
 
 const ROLE_DESCRIPTIONS: Record<RoleKey, string> = {
   SUPER_ADMIN: "Accès complet à toutes les fonctionnalités et toutes les églises.",
-  ADMIN: "Gestion complète d'une église : planning, membres, départements et événements.",
-  SECRETARY: "Vision globale en lecture avec gestion des événements.",
+  ADMIN: "Gestion complète d'une église : planning, membres, événements, discipolat et comptes rendus.",
+  SECRETARY: "Vision globale en lecture avec gestion des événements, discipolat et comptes rendus.",
   MINISTER: "Gestion du planning et des membres pour les départements de son ministère.",
-  DEPARTMENT_HEAD: "Gestion du planning et des membres pour ses départements assignés.",
+  DEPARTMENT_HEAD: "Gestion du planning et des membres pour ses départements assignés. Accès au discipolat.",
   DISCIPLE_MAKER: "Suivi des disciples et de leur arbre de lignée.",
   REPORTER: "Accès en lecture et écriture aux comptes rendus d'événements et statistiques.",
 };
@@ -90,7 +90,7 @@ const FEATURES: Feature[] = [
     category: "Événements",
     screenshotTitle: "Gestion des événements",
     screenshotFile: "guide-events-manage.png",
-    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "edit", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "read" },
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "edit", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none" },
   },
   {
     name: "Gérer les départements",
@@ -115,6 +115,38 @@ const FEATURES: Feature[] = [
     screenshotTitle: "Gestion des utilisateurs",
     screenshotFile: "guide-admin-users.png",
     access: { SUPER_ADMIN: "edit", ADMIN: "none", SECRETARY: "none", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none" },
+  },
+  {
+    name: "Comptes rendus",
+    description: "Saisie et consultation des comptes rendus d'événements avec statistiques par département.",
+    category: "Événements",
+    screenshotTitle: "Comptes rendus",
+    screenshotFile: "guide-reports.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "edit", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "edit" },
+  },
+  {
+    name: "Annonces",
+    description: "Soumission d'annonces et suivi des demandes de service (secrétariat, visuels, communication).",
+    category: "Annonces",
+    screenshotTitle: "Mes annonces",
+    screenshotFile: "guide-announcements.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "edit", MINISTER: "edit", DEPARTMENT_HEAD: "edit", DISCIPLE_MAKER: "none", REPORTER: "none" },
+  },
+  {
+    name: "Discipolat",
+    description: "Suivi des relations de discipolat, appel de présence et statistiques.",
+    category: "Discipolat",
+    screenshotTitle: "Tableau de bord discipolat",
+    screenshotFile: "guide-discipleship.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "read", MINISTER: "none", DEPARTMENT_HEAD: "read", DISCIPLE_MAKER: "edit", REPORTER: "none" },
+  },
+  {
+    name: "Accès & rôles",
+    description: "Attribution des ministres, responsables de département (principal/adjoint) et accès aux comptes rendus.",
+    category: "Administration",
+    screenshotTitle: "Accès & rôles",
+    screenshotFile: "guide-access-roles.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "none", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none" },
   },
 ];
 


### PR DESCRIPTION
## Summary
- **Guide utilisateur** : +4 features (CR, Annonces, Discipolat, Accès & rôles), fix matrice REPORTER, descriptions rôles, suppression fallback REPORTER
- **database.md** : +6 modèles, +3 enums, isDeputy, champs Event manquants
- **auth.md** : +2 rôles (DISCIPLE_MAKER, REPORTER), +5 permissions, matrice 7 colonnes
- **architecture.md** : structure fichiers à jour, sidebar 6 sections, +8 composants
- **api.md** : de ~25 à ~66 endpoints documentés (reports, discipleships, member-links, etc.)

## Test plan
- [ ] Vérifier que la page `/guide` affiche les 13 features et 7 onglets de rôle
- [ ] Relire les 4 docs pour vérifier la cohérence avec le code

🤖 Generated with [Claude Code](https://claude.com/claude-code)