### PR TITLE
feat: export CR (PDF + WhatsApp) et filtres liste CR

### DIFF
--- a/src/app/(auth)/admin/events/[eventId]/report/EventReportClient.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/report/EventReportClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import Button from "@/components/ui/Button";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { formatReportWhatsApp, generateReportPDF, type ReportExportData } from "@/lib/report-export";
 
 interface Dept { id: string; name: string; ministryName: string }
 
@@ -33,6 +33,9 @@ interface ExistingReport {
 
 interface Props {
   eventId: string;
+  eventTitle: string;
+  eventDate: string;
+  eventType: string;
   statsEnabled: boolean;
   existingReport: ExistingReport | null;
   eventDepts: Dept[];
@@ -113,7 +116,7 @@ function SaveIndicator({ status, error }: { status: SaveStatus; error: string | 
 
 const AUTOSAVE_DELAY = 1500; // ms
 
-export default function EventReportClient({ eventId, statsEnabled, existingReport, eventDepts }: Props) {
+export default function EventReportClient({ eventId, eventTitle, eventDate, eventType, statsEnabled, existingReport, eventDepts }: Props) {
   const params = useParams<{ eventId: string }>();
   const id = params?.eventId ?? eventId;
 
@@ -129,6 +132,7 @@ export default function EventReportClient({ eventId, statsEnabled, existingRepor
   const [sections, setSections] = useState<Section[]>(initSections);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   // Refs pour accéder aux valeurs les plus récentes dans le callback debounced
   const notesRef = useRef(notes);
@@ -221,6 +225,33 @@ export default function EventReportClient({ eventId, statsEnabled, existingRepor
     scheduleSave();
   }
 
+  // ── Export helpers ─────────────────────────────────────────────────────────
+  function buildExportData(): ReportExportData {
+    return {
+      event: { title: eventTitle, date: eventDate, type: eventType },
+      notes: notes || null,
+      decisions: decisions || null,
+      sections: sections.map((s) => ({
+        label: s.label,
+        position: s.position,
+        stats: s.stats,
+        notes: s.notes,
+      })),
+      author: existingReport?.author?.name ?? null,
+    };
+  }
+
+  async function handleCopyWhatsApp() {
+    const text = formatReportWhatsApp(buildExportData());
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2500);
+  }
+
+  function handleExportPDF() {
+    generateReportPDF(buildExportData());
+  }
+
   // Stats globales Accueil
   const accueilSection = sections.find((s) => getDeptType(s.label) === "accueil");
   const totalAdultes = accueilSection
@@ -250,11 +281,51 @@ export default function EventReportClient({ eventId, statsEnabled, existingRepor
         </div>
       )}
 
+      {/* Navigation + export */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <Link href="/admin/reports" className="mr-auto">
+          <button type="button" className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-icc-violet bg-icc-violet/5 border-2 border-icc-violet/20 rounded-lg hover:bg-icc-violet/10 transition-colors">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Retour
+          </button>
+        </Link>
+        <button
+          type="button"
+          onClick={handleExportPDF}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-icc-bleu bg-icc-bleu/5 border-2 border-icc-bleu/20 rounded-lg hover:bg-icc-bleu/10 transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          PDF
+        </button>
+        <button
+          type="button"
+          onClick={handleCopyWhatsApp}
+          className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border-2 transition-colors ${
+            copied
+              ? "text-green-700 bg-green-50 border-green-200"
+              : "text-green-700 bg-green-50 border-green-200 hover:bg-green-100"
+          }`}
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            {copied ? (
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            ) : (
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+            )}
+          </svg>
+          {copied ? "Copié !" : "WhatsApp"}
+        </button>
+      </div>
+
       {/* Sections */}
       <div className="space-y-4">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold text-gray-900">Sections</h2>
-          <Button variant="secondary" onClick={addSection}>+ Section libre</Button>
+          <button type="button" onClick={addSection} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-icc-violet bg-icc-violet/5 border-2 border-icc-violet/20 rounded-lg hover:bg-icc-violet/10 transition-colors">+ Section libre</button>
         </div>
 
         {sections.map((section, i) => {
@@ -355,16 +426,21 @@ export default function EventReportClient({ eventId, statsEnabled, existingRepor
       {/* Barre de bas de page : statut + sauvegarde manuelle + retour */}
       <div className="flex items-center gap-4 py-2">
         <SaveIndicator status={saveStatus} error={saveError} />
-        <Button
-          variant="secondary"
+        <button
+          type="button"
           onClick={performSave}
           disabled={saveStatus === "saving"}
-          className="ml-auto"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-icc-bleu bg-icc-bleu/5 border-2 border-icc-bleu/20 rounded-lg hover:bg-icc-bleu/10 transition-colors disabled:opacity-50 ml-auto"
         >
           {saveStatus === "saving" ? "Sauvegarde…" : "Enregistrer maintenant"}
-        </Button>
-        <Link href={`/admin/events/${id}`} className="text-sm text-gray-500 hover:text-gray-700">
-          ← Événement
+        </button>
+        <Link href="/admin/reports">
+          <button type="button" className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-icc-violet bg-icc-violet/5 border-2 border-icc-violet/20 rounded-lg hover:bg-icc-violet/10 transition-colors">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Retour
+          </button>
         </Link>
       </div>
     </div>

--- a/src/app/(auth)/admin/events/[eventId]/report/page.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/report/page.tsx
@@ -59,6 +59,9 @@ export default async function EventReportPage({
 
       <EventReportClient
         eventId={event.id}
+        eventTitle={event.title}
+        eventDate={event.date.toISOString()}
+        eventType={event.type}
         statsEnabled={event.statsEnabled}
         existingReport={event.report}
         eventDepts={eventDepts.map((ed) => ({

--- a/src/app/(auth)/admin/reports/ReportsClient.tsx
+++ b/src/app/(auth)/admin/reports/ReportsClient.tsx
@@ -72,12 +72,50 @@ type Tab = "list" | "stats";
 export default function ReportsClient({ events }: Props) {
   const [tab, setTab] = useState<Tab>("list");
   const [monthFilter, setMonthFilter] = useState<string>("all");
+  const [listMonthFilter, setListMonthFilter] = useState<string>(() => {
+    // Default to current month
+    const now = new Date();
+    const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+    // Use current month if events exist for it, otherwise "all"
+    return events.some((e) => e.date.startsWith(currentMonth)) ? currentMonth : "all";
+  });
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [searchQuery, setSearchQuery] = useState("");
 
   // Mois disponibles (YYYY-MM)
   const availableMonths = useMemo(() => {
     const months = new Set(events.map((e) => e.date.slice(0, 7)));
     return Array.from(months).sort().reverse();
   }, [events]);
+
+  // Types d'événements disponibles
+  const availableTypes = useMemo(() => {
+    const types = new Set(events.map((e) => e.type));
+    return Array.from(types).sort();
+  }, [events]);
+
+  // Événements filtrés (onglet liste)
+  const filteredListEvents = useMemo(() => {
+    let filtered = events;
+    if (listMonthFilter !== "all") {
+      filtered = filtered.filter((e) => e.date.startsWith(listMonthFilter));
+    }
+    if (typeFilter !== "all") {
+      filtered = filtered.filter((e) => e.type === typeFilter);
+    }
+    if (statusFilter !== "all") {
+      filtered = filtered.filter((e) => {
+        const status = !e.report ? "none" : e.report.hasContent ? "done" : "empty";
+        return status === statusFilter;
+      });
+    }
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      filtered = filtered.filter((e) => e.title.toLowerCase().includes(q));
+    }
+    return filtered;
+  }, [events, listMonthFilter, typeFilter, statusFilter, searchQuery]);
 
   // Événements filtrés (onglet stats)
   const filteredEvents = useMemo(() => {
@@ -139,61 +177,117 @@ export default function ReportsClient({ events }: Props) {
 
       {/* ── Onglet Liste ──────────────────────────────────────────────────── */}
       {tab === "list" && (
-        <div className="space-y-3">
-          {events.length === 0 && (
-            <p className="text-center text-gray-400 py-12">
-              Aucun événement avec compte rendu activé.
-            </p>
-          )}
-          {events.map((event) => {
-            const status = !event.report
-              ? "none"
-              : event.report.hasContent
-              ? "done"
-              : "empty";
+        <div className="space-y-4">
+          {/* Filtres */}
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="relative flex-1 min-w-[200px] max-w-xs">
+              <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Rechercher un événement..."
+                className="w-full pl-9 pr-3 py-1.5 border-2 border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+              />
+            </div>
+            <select
+              value={listMonthFilter}
+              onChange={(e) => setListMonthFilter(e.target.value)}
+              className="border-2 border-gray-200 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+            >
+              <option value="all">Tous les mois</option>
+              {availableMonths.map((m) => (
+                <option key={m} value={m}>
+                  {new Date(m + "-01").toLocaleDateString("fr-FR", { month: "long", year: "numeric" })}
+                </option>
+              ))}
+            </select>
+            <select
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value)}
+              className="border-2 border-gray-200 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+            >
+              <option value="all">Tous les types</option>
+              {availableTypes.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              className="border-2 border-gray-200 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+            >
+              <option value="all">Tous les statuts</option>
+              <option value="done">Complété</option>
+              <option value="empty">Vide</option>
+              <option value="none">Aucun CR</option>
+            </select>
+            <span className="text-xs text-gray-400 ml-auto">
+              {filteredListEvents.length}/{events.length} événement{events.length > 1 ? "s" : ""}
+            </span>
+          </div>
 
-            const accueil = event.report ? getAccueilStats(event.report.sections) : null;
+          {/* Liste */}
+          <div className="space-y-3">
+            {filteredListEvents.map((event) => {
+              const status = !event.report
+                ? "none"
+                : event.report.hasContent
+                ? "done"
+                : "empty";
 
-            return (
-              <div key={event.id} className="bg-white rounded-lg border border-gray-100 shadow-sm px-5 py-4 flex items-center gap-4 flex-wrap">
-                {/* Statut */}
-                <span className={`shrink-0 w-2 h-2 rounded-full ${status === "done" ? "bg-green-500" : status === "empty" ? "bg-amber-400" : "bg-gray-200"}`} />
+              const accueil = event.report ? getAccueilStats(event.report.sections) : null;
 
-                {/* Infos événement */}
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-semibold text-gray-900 truncate">{event.title}</p>
-                  <p className="text-xs text-gray-400">
-                    {fmtDate(event.date)} · {event.type}
-                    {event.report && (
-                      <span className="ml-2 text-gray-300">· Modifié {fmtDateTime(event.report.updatedAt)}</span>
-                    )}
-                  </p>
-                </div>
+              return (
+                <div key={event.id} className="bg-white rounded-lg border border-gray-100 shadow-sm px-5 py-4 flex items-center gap-4 flex-wrap">
+                  {/* Statut */}
+                  <span className={`shrink-0 w-2 h-2 rounded-full ${status === "done" ? "bg-green-500" : status === "empty" ? "bg-amber-400" : "bg-gray-200"}`} />
 
-                {/* Mini stats Accueil si disponibles */}
-                {accueil && (
-                  <div className="flex gap-3 text-xs text-gray-500 shrink-0">
-                    <span className="text-blue-600 font-medium">{accueil.hommes}H</span>
-                    <span className="text-pink-600 font-medium">{accueil.femmes}F</span>
-                    <span className="font-semibold text-gray-700">{accueil.total} total</span>
+                  {/* Infos événement */}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-gray-900 truncate">{event.title}</p>
+                    <p className="text-xs text-gray-400">
+                      {fmtDate(event.date)} · {event.type}
+                      {event.report && (
+                        <span className="ml-2 text-gray-300">· Modifié {fmtDateTime(event.report.updatedAt)}</span>
+                      )}
+                    </p>
                   </div>
-                )}
 
-                {/* Badge + action */}
-                <div className="flex items-center gap-2 shrink-0">
-                  {status === "done" && <span className="text-xs bg-green-50 text-green-700 border border-green-200 px-2 py-0.5 rounded-full font-medium">Complété</span>}
-                  {status === "empty" && <span className="text-xs bg-amber-50 text-amber-700 border border-amber-200 px-2 py-0.5 rounded-full font-medium">Vide</span>}
-                  {status === "none" && <span className="text-xs bg-gray-50 text-gray-500 border border-gray-200 px-2 py-0.5 rounded-full font-medium">Aucun CR</span>}
-                  <Link
-                    href={`/admin/events/${event.id}/report`}
-                    className="text-xs font-medium text-icc-violet hover:underline"
-                  >
-                    {status === "none" ? "Saisir →" : "Voir / Modifier →"}
-                  </Link>
+                  {/* Mini stats Accueil si disponibles */}
+                  {accueil && (
+                    <div className="flex gap-3 text-xs text-gray-500 shrink-0">
+                      <span className="text-blue-600 font-medium">{accueil.hommes}H</span>
+                      <span className="text-pink-600 font-medium">{accueil.femmes}F</span>
+                      <span className="font-semibold text-gray-700">{accueil.total} total</span>
+                    </div>
+                  )}
+
+                  {/* Badge + action */}
+                  <div className="flex items-center gap-2 shrink-0">
+                    {status === "done" && <span className="text-xs bg-green-50 text-green-700 border border-green-200 px-2 py-0.5 rounded-full font-medium">Complété</span>}
+                    {status === "empty" && <span className="text-xs bg-amber-50 text-amber-700 border border-amber-200 px-2 py-0.5 rounded-full font-medium">Vide</span>}
+                    {status === "none" && <span className="text-xs bg-gray-50 text-gray-500 border border-gray-200 px-2 py-0.5 rounded-full font-medium">Aucun CR</span>}
+                    <Link
+                      href={`/admin/events/${event.id}/report`}
+                      className="text-xs font-medium text-icc-violet hover:underline"
+                    >
+                      {status === "none" ? "Saisir →" : "Voir / Modifier →"}
+                    </Link>
+                  </div>
                 </div>
-              </div>
-            );
-          })}
+              );
+            })}
+            {filteredListEvents.length === 0 && (
+              <p className="text-center text-gray-400 py-12">
+                {events.length === 0
+                  ? "Aucun événement avec compte rendu activé."
+                  : "Aucun événement ne correspond aux filtres sélectionnés."}
+              </p>
+            )}
+          </div>
         </div>
       )}
 

--- a/src/lib/report-export.ts
+++ b/src/lib/report-export.ts
@@ -1,0 +1,341 @@
+import { jsPDF } from "jspdf";
+
+// ─── Data interface ───────────────────────────────────────────────────────────
+
+export interface ReportExportData {
+  event: {
+    title: string;
+    date: string; // ISO date string
+    type: string;
+  };
+  notes: string | null;
+  decisions: string | null;
+  sections: Array<{
+    label: string;
+    position: number;
+    stats: Record<string, number | null> | null;
+    notes: string | null;
+  }>;
+  author?: string | null;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+type DeptType = "accueil" | "sainte-cene" | "integration" | null;
+
+function normalizeDeptName(s: string): string {
+  return s
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+function getDeptType(label: string): DeptType {
+  const n = normalizeDeptName(label);
+  if (n === "accueil") return "accueil";
+  if (n.includes("sainte") && n.includes("cene")) return "sainte-cene";
+  if (n === "integration" || n.startsWith("integration")) return "integration";
+  return null;
+}
+
+function formatDateFR(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString("fr-FR", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function statDisplay(value: number | null): string {
+  return value === null ? "-" : String(value);
+}
+
+function sortedSections(sections: ReportExportData["sections"]) {
+  return [...sections].sort((a, b) => a.position - b.position);
+}
+
+// ─── WhatsApp export ─────────────────────────────────────────────────────────
+
+export function formatReportWhatsApp(data: ReportExportData): string {
+  const lines: string[] = [];
+
+  lines.push(`*📋 Compte rendu — ${data.event.title}*`);
+  lines.push(`📅 ${formatDateFR(data.event.date)}`);
+
+  for (const section of sortedSections(data.sections)) {
+    const deptType = getDeptType(section.label);
+    const hasStats = section.stats !== null && Object.keys(section.stats).length > 0;
+    const hasNotes = section.notes !== null && section.notes.trim() !== "";
+
+    // Skip completely empty sections
+    if (!hasStats && !hasNotes) continue;
+
+    lines.push("");
+
+    if (hasStats && deptType === "accueil") {
+      const h = section.stats!["hommes"] ?? null;
+      const f = section.stats!["femmes"] ?? null;
+      const e = section.stats!["enfants"] ?? null;
+      const totalAdultes = h !== null && f !== null ? h + f : null;
+      const totalGeneral = totalAdultes !== null && e !== null ? totalAdultes + e : null;
+
+      lines.push(`*📊 ${section.label}*`);
+      lines.push(
+        `👨 Hommes : ${statDisplay(h)} | 👩 Femmes : ${statDisplay(f)} | 👶 Enfants : ${statDisplay(e)}`
+      );
+      lines.push(
+        `📊 Total adultes : ${statDisplay(totalAdultes)} | Total général : ${statDisplay(totalGeneral)}`
+      );
+      if (hasNotes) lines.push(`💬 ${section.notes}`);
+    } else if (hasStats && deptType === "sainte-cene") {
+      const used = section.stats!["supportsUtilises"] ?? null;
+      const remaining = section.stats!["supportsRestants"] ?? null;
+
+      lines.push(`*📊 ${section.label}*`);
+      lines.push(
+        `🍞 Supports utilisés : ${statDisplay(used)} | 📦 Restants : ${statDisplay(remaining)}`
+      );
+      if (hasNotes) lines.push(`💬 ${section.notes}`);
+    } else if (hasStats && deptType === "integration") {
+      const h = section.stats!["hommes"] ?? null;
+      const f = section.stats!["femmes"] ?? null;
+      const passage = section.stats!["passage"] ?? null;
+      const convertis = section.stats!["convertis"] ?? null;
+      const voeux = section.stats!["voeux"] ?? null;
+
+      lines.push(`*📊 ${section.label}*`);
+      lines.push(`👨 Hommes : ${statDisplay(h)} | 👩 Femmes : ${statDisplay(f)}`);
+      lines.push(
+        `🚶 Passage : ${statDisplay(passage)} | ✝️ Convertis : ${statDisplay(convertis)} | 🙏 Vœux : ${statDisplay(voeux)}`
+      );
+      if (hasNotes) lines.push(`💬 ${section.notes}`);
+    } else if (!hasStats && hasNotes) {
+      // No stats but has notes
+      lines.push(`*📝 ${section.label}*`);
+      lines.push(`💬 ${section.notes}`);
+    } else if (hasStats) {
+      // Has stats but no recognized type — generic display
+      lines.push(`*📊 ${section.label}*`);
+      for (const [key, value] of Object.entries(section.stats!)) {
+        lines.push(`${key} : ${statDisplay(value)}`);
+      }
+      if (hasNotes) lines.push(`💬 ${section.notes}`);
+    }
+  }
+
+  if (data.notes && data.notes.trim() !== "") {
+    lines.push("");
+    lines.push(`*📌 Observations générales*`);
+    lines.push(data.notes);
+  }
+
+  if (data.decisions && data.decisions.trim() !== "") {
+    lines.push("");
+    lines.push(`*✅ Décisions / Actions*`);
+    lines.push(data.decisions);
+  }
+
+  return lines.join("\n");
+}
+
+// ─── PDF export ───────────────────────────────────────────────────────────────
+
+const ICC_VIOLET = "#5E17EB";
+const PAGE_WIDTH = 210;
+const PAGE_HEIGHT = 297;
+const MARGIN = 20;
+const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
+
+export function generateReportPDF(data: ReportExportData): void {
+  const doc = new jsPDF({ unit: "mm", format: "a4" });
+
+  let y = MARGIN;
+
+  // ── Utility helpers ──────────────────────────────────────────────────────
+
+  function checkPageBreak(needed = 10): void {
+    if (y + needed > PAGE_HEIGHT - MARGIN) {
+      doc.addPage();
+      y = MARGIN;
+    }
+  }
+
+  function addSectionTitle(label: string): void {
+    checkPageBreak(12);
+    y += 4;
+    doc.setFontSize(14);
+    doc.setFont("helvetica", "bold");
+    const [r, g, b] = hexToRgb(ICC_VIOLET);
+    doc.setTextColor(r, g, b);
+    doc.text(label, MARGIN, y);
+    y += 6;
+    // Underline
+    doc.setDrawColor(r, g, b);
+    doc.setLineWidth(0.4);
+    doc.line(MARGIN, y, MARGIN + CONTENT_WIDTH, y);
+    y += 4;
+  }
+
+  function addKeyValue(key: string, value: string): void {
+    checkPageBreak(7);
+    doc.setFontSize(10);
+    doc.setFont("helvetica", "bold");
+    doc.setTextColor(80, 80, 80);
+    doc.text(`${key} :`, MARGIN + 2, y);
+    const keyWidth = doc.getTextWidth(`${key} : `);
+    doc.setFont("helvetica", "normal");
+    doc.setTextColor(30, 30, 30);
+    const wrapped = doc.splitTextToSize(value, CONTENT_WIDTH - keyWidth - 4) as string[];
+    doc.text(wrapped, MARGIN + 2 + keyWidth, y);
+    y += wrapped.length * 4 + 2;
+  }
+
+  function addNotes(text: string): void {
+    checkPageBreak(10);
+    doc.setFontSize(10);
+    doc.setFont("helvetica", "italic");
+    doc.setTextColor(80, 80, 80);
+    const wrapped = doc.splitTextToSize(text, CONTENT_WIDTH - 4) as string[];
+    checkPageBreak(wrapped.length * 4 + 4);
+    doc.text(wrapped, MARGIN + 2, y);
+    y += wrapped.length * 4 + 3;
+  }
+
+  // ── Document title ───────────────────────────────────────────────────────
+
+  doc.setFontSize(18);
+  doc.setFont("helvetica", "bold");
+  const [vr, vg, vb] = hexToRgb(ICC_VIOLET);
+  doc.setTextColor(vr, vg, vb);
+  const titleLines = doc.splitTextToSize(
+    `Compte rendu — ${data.event.title}`,
+    CONTENT_WIDTH
+  ) as string[];
+  doc.text(titleLines, MARGIN, y);
+  y += titleLines.length * 7 + 2;
+
+  // Subtitle: date
+  doc.setFontSize(14);
+  doc.setFont("helvetica", "normal");
+  doc.setTextColor(100, 100, 100);
+  doc.text(formatDateFR(data.event.date), MARGIN, y);
+  y += 8;
+
+  // Separator
+  doc.setDrawColor(200, 200, 200);
+  doc.setLineWidth(0.3);
+  doc.line(MARGIN, y, MARGIN + CONTENT_WIDTH, y);
+  y += 6;
+
+  // ── Sections ─────────────────────────────────────────────────────────────
+
+  for (const section of sortedSections(data.sections)) {
+    const deptType = getDeptType(section.label);
+    const hasStats = section.stats !== null && Object.keys(section.stats).length > 0;
+    const hasNotes = section.notes !== null && section.notes.trim() !== "";
+
+    if (!hasStats && !hasNotes) continue;
+
+    addSectionTitle(section.label);
+
+    if (hasStats && deptType === "accueil") {
+      const h = section.stats!["hommes"] ?? null;
+      const f = section.stats!["femmes"] ?? null;
+      const e = section.stats!["enfants"] ?? null;
+      const totalAdultes = h !== null && f !== null ? h + f : null;
+      const totalGeneral = totalAdultes !== null && e !== null ? totalAdultes + e : null;
+
+      addKeyValue("Hommes", statDisplay(h));
+      addKeyValue("Femmes", statDisplay(f));
+      addKeyValue("Enfants", statDisplay(e));
+      addKeyValue("Total adultes", statDisplay(totalAdultes));
+      addKeyValue("Total général", statDisplay(totalGeneral));
+    } else if (hasStats && deptType === "sainte-cene") {
+      const used = section.stats!["supportsUtilises"] ?? null;
+      const remaining = section.stats!["supportsRestants"] ?? null;
+
+      addKeyValue("Supports utilisés", statDisplay(used));
+      addKeyValue("Supports restants", statDisplay(remaining));
+    } else if (hasStats && deptType === "integration") {
+      const h = section.stats!["hommes"] ?? null;
+      const f = section.stats!["femmes"] ?? null;
+      const passage = section.stats!["passage"] ?? null;
+      const convertis = section.stats!["convertis"] ?? null;
+      const voeux = section.stats!["voeux"] ?? null;
+
+      addKeyValue("Hommes", statDisplay(h));
+      addKeyValue("Femmes", statDisplay(f));
+      addKeyValue("De passage", statDisplay(passage));
+      addKeyValue("Nouveaux convertis", statDisplay(convertis));
+      addKeyValue("Renouvellement de vœux", statDisplay(voeux));
+    } else if (hasStats) {
+      // Generic stats display
+      for (const [key, value] of Object.entries(section.stats!)) {
+        addKeyValue(key, statDisplay(value));
+      }
+    }
+
+    if (hasNotes) {
+      checkPageBreak(8);
+      doc.setFontSize(9);
+      doc.setFont("helvetica", "bold");
+      doc.setTextColor(100, 100, 100);
+      doc.text("Observations :", MARGIN + 2, y);
+      y += 4;
+      addNotes(section.notes!);
+    }
+  }
+
+  // ── Global notes ─────────────────────────────────────────────────────────
+
+  if (data.notes && data.notes.trim() !== "") {
+    addSectionTitle("Observations générales");
+    addNotes(data.notes);
+  }
+
+  // ── Decisions ────────────────────────────────────────────────────────────
+
+  if (data.decisions && data.decisions.trim() !== "") {
+    addSectionTitle("Décisions / Actions");
+    addNotes(data.decisions);
+  }
+
+  // ── Footer ───────────────────────────────────────────────────────────────
+
+  const pageCount = doc.getNumberOfPages();
+  const generatedDate = new Date().toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  });
+  const footerText = data.author
+    ? `Généré le ${generatedDate} par ${data.author}`
+    : `Généré le ${generatedDate}`;
+
+  for (let i = 1; i <= pageCount; i++) {
+    doc.setPage(i);
+    doc.setFontSize(8);
+    doc.setFont("helvetica", "normal");
+    doc.setTextColor(160, 160, 160);
+    doc.text(footerText, MARGIN, PAGE_HEIGHT - 10);
+    doc.text(`${i} / ${pageCount}`, PAGE_WIDTH - MARGIN, PAGE_HEIGHT - 10, { align: "right" });
+  }
+
+  // ── Save ─────────────────────────────────────────────────────────────────
+
+  const dateStr = new Date(data.event.date).toISOString().slice(0, 10);
+  const safeTitle = data.event.title.replace(/[/\\?%*:|"<>]/g, "-");
+  doc.save(`CR-${safeTitle}-${dateStr}.pdf`);
+}
+
+// ─── Color helper ─────────────────────────────────────────────────────────────
+
+function hexToRgb(hex: string): [number, number, number] {
+  const clean = hex.replace("#", "");
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  return [r, g, b];
+}


### PR DESCRIPTION
## Summary
- Export PDF des comptes rendus (jsPDF) avec stats par département, pagination et footer
- Copie message WhatsApp formaté (gras, emojis, stats typés par département)
- Filtres sur la liste des CR : mois, type d'événement, statut, recherche textuelle
- Boutons Retour en haut/bas de page, cohérence couleurs charte ICC

## Test plan
- [ ] Ouvrir un CR existant avec stats → vérifier export PDF (mise en page, sections, footer)
- [ ] Cliquer "WhatsApp" → vérifier que le texte copié est bien formaté dans le presse-papiers
- [ ] Vérifier les filtres sur `/admin/reports` (mois, type, statut, recherche)
- [ ] Vérifier les boutons Retour (haut et bas) ramènent à `/admin/reports`

🤖 Generated with [Claude Code](https://claude.com/claude-code)