### PR TITLE
release: v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v0.10.0] - 2026-03-21
+
+### Modifie
+
+- Renommage de l'application PlanningCenter en **Koinonia** (grec : communion, partage)
+- Repo GitHub renomme en `iccbretagne/koinonia`
+- Mise a jour de tous les fichiers : package.json, metadata, UI, PWA, emails, deploiement, documentation
+- Utilisateur systeme et dossier de deploiement renommes (`planning` → `koinonia`)
+- README reecrit pour refleter la vision elargie de l'application
+
 ## [v0.9.0] - 2026-03-21
 
 ### Ajoute

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koinonia",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koinonia",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@auth/prisma-adapter": "^2.7.4",
         "@prisma/client": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- Bump version 0.9.0 → 0.10.0
- CHANGELOG : section v0.10.0 (renommage PlanningCenter → Koinonia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)