### PR TITLE
feat: activate rate limiting on auth and mutation routes

### DIFF
--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { hasPermission } from "@/lib/permissions";
+import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { DepartmentFunction } from "@prisma/client";
 import { z } from "zod";
 
@@ -97,6 +98,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const data = createSchema.parse(body);
     const session = await requireChurchPermission("planning:view", data.churchId);
+    requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
     const eventDate = data.eventDate ? new Date(data.eventDate) : null;
     const saveTheDate = eventDate ? computeIsSaveTheDate(eventDate) : false;

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,17 @@
 import { handlers } from "@/lib/auth";
+import { requireRateLimit, RATE_LIMIT_AUTH } from "@/lib/rate-limit";
+import { errorResponse } from "@/lib/api-utils";
+import type { NextRequest } from "next/server";
 
-export const { GET, POST } = handlers;
+export const { GET } = handlers;
+
+const { POST: nextAuthPost } = handlers;
+
+export async function POST(request: NextRequest) {
+  try {
+    requireRateLimit(request, RATE_LIMIT_AUTH);
+    return nextAuthPost(request);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/churches/onboard/route.ts
+++ b/src/app/api/churches/onboard/route.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
+import { requireRateLimit, RATE_LIMIT_SENSITIVE } from "@/lib/rate-limit";
 import { z } from "zod";
 
 const onboardSchema = z.object({
@@ -16,6 +17,7 @@ const onboardSchema = z.object({
 export async function POST(request: Request) {
   try {
     const session = await requirePermission("church:manage");
+    requireRateLimit(request, { prefix: `onboard:${session.user.id}`, ...RATE_LIMIT_SENSITIVE });
     const body = await request.json();
     const { name, slug, adminEmail } = onboardSchema.parse(body);
 

--- a/src/app/api/departments/route.ts
+++ b/src/app/api/departments/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
 import type { Session } from "next-auth";
 
@@ -123,6 +124,7 @@ export async function POST(request: Request) {
     const { resolveChurchId } = await import("@/lib/auth");
     const ministryChurchId = await resolveChurchId("ministry", data.ministryId);
     const session = await requireChurchPermission("departments:manage", ministryChurchId);
+    requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
     const allowedMinistries = getMinisterMinistryIds(session, ministryChurchId);
     if (allowedMinistries !== null && !allowedMinistries.includes(data.ministryId)) {

--- a/src/app/api/discipleships/route.ts
+++ b/src/app/api/discipleships/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, getDiscipleshipScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
 
 const createSchema = z.union([
@@ -57,6 +58,7 @@ export async function POST(request: Request) {
 
     const { discipleMakerId, churchId, firstMakerId } = parsed;
     const session = await requireChurchPermission("discipleship:manage", churchId);
+    requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
     // DISCIPLE_MAKER ne peut créer que des relations dont il est le FD
     const scope = await getDiscipleshipScope(session, churchId);

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
+import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
 
 export async function GET(request: Request) {
@@ -146,6 +147,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const data = createSchema.parse(body);
     const session = await requireChurchPermission("events:manage", data.churchId);
+    requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
     const useOffset = data.deadlineOffset && !data.planningDeadline;
     const deadline = useOffset

--- a/src/app/api/member-link-requests/route.ts
+++ b/src/app/api/member-link-requests/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { auth, requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireRateLimit, RATE_LIMIT_SENSITIVE } from "@/lib/rate-limit";
 import { z } from "zod";
 
 const createSchema = z.discriminatedUnion("type", [
@@ -22,6 +23,7 @@ export async function POST(request: Request) {
   try {
     const session = await auth();
     if (!session?.user) throw new ApiError(401, "Non authentifié");
+    requireRateLimit(request, { prefix: `linkreq:${session.user.id}`, ...RATE_LIMIT_SENSITIVE });
 
     const body = await request.json();
     const data = createSchema.parse(body);

--- a/src/app/api/member-user-links/route.ts
+++ b/src/app/api/member-user-links/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireRateLimit, RATE_LIMIT_SENSITIVE } from "@/lib/rate-limit";
 import { z } from "zod";
 
 const schema = z.object({
@@ -14,6 +15,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const { memberId, userId, churchId } = schema.parse(body);
     const session = await requireChurchPermission("members:manage", churchId);
+    requireRateLimit(request, { prefix: `link:${session.user.id}`, ...RATE_LIMIT_SENSITIVE });
 
     // Vérifier que le member et l'user appartiennent bien à l'église concernée
     const member = await prisma.member.findFirst({

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
 
 export async function GET(request: Request) {
@@ -73,6 +74,7 @@ export async function PATCH(request: Request) {
       return resolveChurchId("member", ids[0]);
     })();
     const session = await requireChurchPermission("members:manage", firstMemberChurchId);
+    requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
     // Scope par département dans cette église
     const churchRoles = session.user.churchRoles.filter((r) => r.churchId === firstMemberChurchId);
@@ -138,6 +140,7 @@ export async function POST(request: Request) {
     const { resolveChurchId } = await import("@/lib/auth");
     const deptChurchId = await resolveChurchId("department", data.departmentId);
     const session = await requireChurchPermission("members:manage", deptChurchId);
+    requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
     // Scope par département dans cette église
     const churchRoles = session.user.churchRoles.filter((r) => r.churchId === deptChurchId);

--- a/src/app/api/ministries/route.ts
+++ b/src/app/api/ministries/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
 
 export async function GET(request: Request) {
@@ -94,7 +95,8 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
     const data = createSchema.parse(body);
-    await requireChurchPermission("departments:manage", data.churchId);
+    const session = await requireChurchPermission("departments:manage", data.churchId);
+    requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
     const ministry = await prisma.ministry.create({
       data,

--- a/src/app/api/service-requests/route.ts
+++ b/src/app/api/service-requests/route.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { hasPermission } from "@/lib/permissions";
+import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { DepartmentFunction } from "@prisma/client";
 import { z } from "zod";
 
@@ -78,6 +79,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const data = createSchema.parse(body);
     const session = await requireChurchPermission("planning:view", data.churchId);
+    requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
     const productionDept = await prisma.department.findFirst({
       where: {

--- a/src/app/api/users/[userId]/roles/route.ts
+++ b/src/app/api/users/[userId]/roles/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireRateLimit, RATE_LIMIT_SENSITIVE } from "@/lib/rate-limit";
 import { z } from "zod";
 
 // { id, isDeputy? } — format enrichi pour gérer principal vs adjoint
@@ -64,6 +65,7 @@ export async function POST(
 
     // Vérifier permission dans l'église ciblée
     const session = await requireChurchPermission("departments:manage", churchId);
+    requireRateLimit(request, { prefix: `roles:${session.user.id}`, ...RATE_LIMIT_SENSITIVE });
 
     // Les rôles privilégiés nécessitent users:manage (seul SUPER_ADMIN)
     if (PRIVILEGED_ROLES.includes(role as typeof PRIVILEGED_ROLES[number])) {
@@ -143,7 +145,8 @@ export async function PATCH(
     }
 
     // Vérifier permission dans l'église du rôle existant
-    await requireChurchPermission("departments:manage", existing.churchId);
+    const patchSession = await requireChurchPermission("departments:manage", existing.churchId);
+    requireRateLimit(request, { prefix: `roles:${patchSession.user.id}`, ...RATE_LIMIT_SENSITIVE });
 
     // Vérifier que le ministryId appartient à cette église
     if (ministryId) {
@@ -218,7 +221,8 @@ export async function DELETE(
     const { churchId, role } = roleSchema.parse(body);
 
     // Vérifier permission dans l'église ciblée
-    await requireChurchPermission("departments:manage", churchId);
+    const delSession = await requireChurchPermission("departments:manage", churchId);
+    requireRateLimit(request, { prefix: `roles:${delSession.user.id}`, ...RATE_LIMIT_SENSITIVE });
 
     await prisma.$transaction(async (tx) => {
       const existing = await tx.userChurchRole.findUnique({

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,3 +1,5 @@
+import { ApiError } from "./api-utils";
+
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
 
 interface RateLimitOptions {
@@ -26,6 +28,34 @@ export function rateLimit(
   }
 
   return { success: true, remaining: max - entry.count };
+}
+
+// Presets for different route types
+export const RATE_LIMIT_AUTH: RateLimitOptions = { windowMs: 60_000, max: 10 };
+export const RATE_LIMIT_MUTATION: RateLimitOptions = { windowMs: 60_000, max: 30 };
+export const RATE_LIMIT_SENSITIVE: RateLimitOptions = { windowMs: 60_000, max: 10 };
+
+function getClientIp(request: Request): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+  return "unknown";
+}
+
+/**
+ * Throws ApiError(429) if the rate limit is exceeded.
+ * Use `prefix` to namespace the key (e.g., "auth", "mut:userId").
+ * When no prefix is given, keys by IP (for unauthenticated routes).
+ */
+export function requireRateLimit(
+  request: Request,
+  options: RateLimitOptions & { prefix?: string } = {}
+) {
+  const { prefix, ...rateLimitOpts } = options;
+  const key = prefix ?? `ip:${getClientIp(request)}`;
+  const result = rateLimit(key, rateLimitOpts);
+  if (!result.success) {
+    throw new ApiError(429, "Trop de requêtes. Réessayez plus tard.");
+  }
 }
 
 // Cleanup stale entries periodically (every 5 minutes)


### PR DESCRIPTION
## Summary

- Add `requireRateLimit` helper in `src/lib/rate-limit.ts` that throws `ApiError(429)` when exceeded
- Three presets: `RATE_LIMIT_AUTH` (10/min), `RATE_LIMIT_MUTATION` (30/min), `RATE_LIMIT_SENSITIVE` (10/min)
- Auth POST route: rate-limited per IP (10 req/min)
- Sensitive admin routes (church onboard, role CRUD, member-user links, link requests): per-user, 10/min
- Standard CRUD mutations (members, events, departments, ministries, announcements, service requests, discipleships): per-user, 30/min

## Context

The security audit identified that `src/lib/rate-limit.ts` existed but was unused. This PR activates it on all mutation endpoints and the auth route.

## Test plan

- [ ] Verify auth flow (Google OAuth sign-in) works normally
- [ ] Verify CRUD operations work under normal usage
- [ ] Verify that rapid repeated requests (>10 or >30 per minute) return HTTP 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)