### PR TITLE
test: security tests for multi-tenant authorization

### DIFF
--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -30,6 +30,14 @@ export const prismaMock = {
   planning: createModelMock(),
   auditLog: createModelMock(),
   notification: createModelMock(),
+  serviceRequest: createModelMock(),
+  memberLinkRequest: createModelMock(),
+  memberUserLink: createModelMock(),
+  announcement: createModelMock(),
+  taskAssignment: createModelMock(),
+  eventReport: createModelMock(),
+  discipleshipAttendance: createModelMock(),
+  announcementEvent: createModelMock(),
   $transaction: vi.fn((fn: (tx: typeof prismaMock) => Promise<unknown>) =>
     fn(prismaMock)
   ),

--- a/src/app/api/departments/__tests__/route.test.ts
+++ b/src/app/api/departments/__tests__/route.test.ts
@@ -7,8 +7,11 @@ import {
 
 // Mock auth before importing route handlers
 const mockRequirePermission = vi.fn();
+const mockResolveChurchId = vi.fn().mockResolvedValue("church-1");
 vi.mock("@/lib/auth", () => ({
   requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+  requireChurchPermission: (...args: unknown[]) => mockRequirePermission(...args),
+  resolveChurchId: (...args: unknown[]) => mockResolveChurchId(...args),
 }));
 
 // Mock prisma
@@ -32,7 +35,7 @@ describe("GET /api/departments", () => {
     ];
     prismaMock.department.findMany.mockResolvedValue(departments);
 
-    const request = new Request("http://localhost/api/departments");
+    const request = new Request("http://localhost/api/departments?churchId=church-1");
     const res = await GET(request);
 
     expect(res.status).toBe(200);
@@ -44,7 +47,7 @@ describe("GET /api/departments", () => {
   it("filters by ministryId", async () => {
     prismaMock.department.findMany.mockResolvedValue([]);
 
-    const request = new Request("http://localhost/api/departments?ministryId=min-1");
+    const request = new Request("http://localhost/api/departments?churchId=church-1&ministryId=min-1");
     await GET(request);
 
     expect(prismaMock.department.findMany).toHaveBeenCalledWith(
@@ -72,7 +75,7 @@ describe("GET /api/departments", () => {
   it("returns 401 when not authenticated", async () => {
     mockRequirePermission.mockRejectedValue(new Error("UNAUTHORIZED"));
 
-    const request = new Request("http://localhost/api/departments");
+    const request = new Request("http://localhost/api/departments?churchId=church-1");
     const res = await GET(request);
 
     expect(res.status).toBe(401);

--- a/src/app/api/events/[eventId]/__tests__/security.test.ts
+++ b/src/app/api/events/[eventId]/__tests__/security.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import {
+  createAdminSession,
+  createSuperAdminSession,
+  createDepartmentHeadSession,
+} from "@/__mocks__/auth";
+
+// We need to fully mock @/lib/auth because importing the real module pulls in
+// next-auth which requires Next.js server modules unavailable in Vitest.
+// Provide real implementations of requireChurchPermission and resolveChurchId
+// that use our mock session and mock prisma.
+const mockAuth = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/auth", () => {
+  // Inline implementations that mirror the real auth functions
+  // but use our mockAuth instead of the NextAuth auth() call.
+  async function requireAuth() {
+    const session = await mockAuth();
+    if (!session?.user) throw new Error("UNAUTHORIZED");
+    return session;
+  }
+
+  async function requireChurchPermission(permission: string, churchId: string) {
+    const session = await requireAuth();
+    if (session.user.isSuperAdmin) return session;
+
+    const roles = session.user.churchRoles.filter(
+      (r: { churchId: string }) => r.churchId === churchId
+    );
+    if (roles.length === 0) throw new Error("FORBIDDEN");
+
+    // Inline permission check
+    const ROLE_PERMISSIONS: Record<string, string[]> = {
+      SUPER_ADMIN: ["planning:view", "planning:edit", "members:view", "members:manage", "events:view", "events:manage", "departments:view", "departments:manage", "church:manage", "users:manage", "discipleship:view", "discipleship:manage", "discipleship:export", "reports:view", "reports:edit"],
+      ADMIN: ["planning:view", "planning:edit", "members:view", "members:manage", "events:view", "events:manage", "departments:view", "departments:manage", "discipleship:view", "discipleship:manage", "reports:view", "reports:edit"],
+      SECRETARY: ["planning:view", "members:view", "events:view", "events:manage", "departments:view", "discipleship:view", "discipleship:export", "reports:view", "reports:edit"],
+      MINISTER: ["planning:view", "planning:edit", "members:view", "members:manage", "events:view", "departments:view", "departments:manage", "discipleship:view"],
+      DEPARTMENT_HEAD: ["planning:view", "planning:edit", "members:view", "members:manage", "events:view", "departments:view", "discipleship:view"],
+      DISCIPLE_MAKER: ["discipleship:view", "discipleship:manage"],
+      REPORTER: ["events:view", "reports:view", "reports:edit"],
+    };
+
+    const userPermissions = new Set(
+      roles.flatMap((r: { role: string }) => ROLE_PERMISSIONS[r.role] || [])
+    );
+    if (!userPermissions.has(permission)) throw new Error("FORBIDDEN");
+
+    return session;
+  }
+
+  async function resolveChurchId(
+    resourceType: string,
+    resourceId: string
+  ): Promise<string> {
+    // Import prismaMock dynamically — it's already set up via vi.mock
+    const { prisma } = await import("@/lib/prisma");
+
+    const { ApiError } = await import("@/lib/api-utils");
+
+    switch (resourceType) {
+      case "event": {
+        const event = await prisma.event.findUnique({
+          where: { id: resourceId },
+          select: { churchId: true },
+        });
+        if (!event) throw new ApiError(404, "Événement introuvable");
+        return event.churchId;
+      }
+      default:
+        throw new ApiError(400, "Type de ressource non supporté");
+    }
+  }
+
+  return {
+    requireAuth,
+    requireChurchPermission,
+    resolveChurchId,
+    auth: () => mockAuth(),
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  };
+});
+
+const { GET, DELETE } = await import("../route");
+
+function makeParams(eventId: string) {
+  return { params: Promise.resolve({ eventId }) };
+}
+
+describe("GET /api/events/[eventId] — multi-tenant isolation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows admin to view event in their church", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.event.findUnique
+      .mockResolvedValueOnce({ churchId: "church-1" })
+      .mockResolvedValueOnce({
+        id: "evt-1",
+        title: "Culte",
+        churchId: "church-1",
+        eventDepts: [],
+      });
+
+    const request = new Request("http://localhost/api/events/evt-1");
+    const res = await GET(request, makeParams("evt-1"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("evt-1");
+  });
+
+  it("rejects admin from church-1 viewing event in church-2", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.event.findUnique.mockResolvedValueOnce({ churchId: "church-2" });
+
+    const request = new Request("http://localhost/api/events/evt-2");
+    const res = await GET(request, makeParams("evt-2"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when event does not exist", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.event.findUnique.mockResolvedValueOnce(null);
+
+    const request = new Request("http://localhost/api/events/nonexistent");
+    const res = await GET(request, makeParams("nonexistent"));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("super admin can view event in any church", async () => {
+    mockAuth.mockResolvedValue(createSuperAdminSession());
+    prismaMock.event.findUnique
+      .mockResolvedValueOnce({ churchId: "church-999" })
+      .mockResolvedValueOnce({
+        id: "evt-other",
+        title: "Remote Event",
+        churchId: "church-999",
+        eventDepts: [],
+      });
+
+    const request = new Request("http://localhost/api/events/evt-other");
+    const res = await GET(request, makeParams("evt-other"));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("department head cannot view event outside their church", async () => {
+    mockAuth.mockResolvedValue(
+      createDepartmentHeadSession(
+        [{ id: "dept-1", name: "Son" }],
+        "church-1"
+      )
+    );
+    prismaMock.event.findUnique.mockResolvedValueOnce({ churchId: "church-2" });
+
+    const request = new Request("http://localhost/api/events/evt-cross");
+    const res = await GET(request, makeParams("evt-cross"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    prismaMock.event.findUnique.mockResolvedValueOnce({ churchId: "church-1" });
+
+    const request = new Request("http://localhost/api/events/evt-1");
+    const res = await GET(request, makeParams("evt-1"));
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("DELETE /api/events/[eventId] — multi-tenant isolation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects admin from church-1 deleting event in church-2", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.event.findUnique.mockResolvedValueOnce({ churchId: "church-2" });
+
+    const request = new Request("http://localhost/api/events/evt-2", {
+      method: "DELETE",
+    });
+    const res = await DELETE(request, makeParams("evt-2"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows admin to delete event in their church", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.event.findUnique
+      .mockResolvedValueOnce({ churchId: "church-1" })
+      .mockResolvedValueOnce({ id: "evt-1", churchId: "church-1" });
+
+    prismaMock.eventDepartment.findMany.mockResolvedValue([]);
+    prismaMock.$transaction.mockResolvedValue(undefined);
+
+    const request = new Request("http://localhost/api/events/evt-1", {
+      method: "DELETE",
+    });
+    const res = await DELETE(request, makeParams("evt-1"));
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts
@@ -7,9 +7,12 @@ import {
 
 const mockRequireAuth = vi.fn();
 const mockRequirePermission = vi.fn();
+const mockResolveChurchId = vi.fn().mockResolvedValue("church-1");
 vi.mock("@/lib/auth", () => ({
   requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
   requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+  requireChurchPermission: (...args: unknown[]) => mockRequirePermission(...args),
+  resolveChurchId: (...args: unknown[]) => mockResolveChurchId(...args),
 }));
 
 vi.mock("@/lib/prisma", () => ({

--- a/src/app/api/events/__tests__/route.test.ts
+++ b/src/app/api/events/__tests__/route.test.ts
@@ -3,8 +3,11 @@ import { prismaMock } from "@/__mocks__/prisma";
 import { createAdminSession } from "@/__mocks__/auth";
 
 const mockRequirePermission = vi.fn();
+const mockResolveChurchId = vi.fn().mockResolvedValue("church-1");
 vi.mock("@/lib/auth", () => ({
   requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+  requireChurchPermission: (...args: unknown[]) => mockRequirePermission(...args),
+  resolveChurchId: (...args: unknown[]) => mockResolveChurchId(...args),
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -37,7 +40,7 @@ describe("GET /api/events", () => {
     ];
     prismaMock.event.findMany.mockResolvedValue(events);
 
-    const request = new Request("http://localhost/api/events");
+    const request = new Request("http://localhost/api/events?churchId=church-1");
     const res = await GET(request);
 
     expect(res.status).toBe(200);
@@ -62,7 +65,7 @@ describe("GET /api/events", () => {
   it("returns 401 when not authenticated", async () => {
     mockRequirePermission.mockRejectedValue(new Error("UNAUTHORIZED"));
 
-    const request = new Request("http://localhost/api/events");
+    const request = new Request("http://localhost/api/events?churchId=church-1");
     const res = await GET(request);
 
     expect(res.status).toBe(401);

--- a/src/lib/__tests__/auth-security.test.ts
+++ b/src/lib/__tests__/auth-security.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import {
+  createAdminSession,
+  createSuperAdminSession,
+  createDepartmentHeadSession,
+} from "@/__mocks__/auth";
+
+// Mock auth() to return a configurable session
+const mockAuth = vi.fn();
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: mockAuth,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+// Override the auth export that requireAuth uses internally
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...original,
+    auth: () => mockAuth(),
+  };
+});
+
+const {
+  requireChurchPermission,
+  requireChurchAccess,
+  resolveChurchId,
+} = await import("@/lib/auth");
+
+describe("requireChurchPermission", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows access for admin in the correct church", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+
+    const session = await requireChurchPermission("events:view", "church-1");
+    expect(session.user.id).toBe("user-1");
+  });
+
+  it("rejects admin from church-1 accessing church-2", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+
+    await expect(
+      requireChurchPermission("events:view", "church-2")
+    ).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("rejects user with no roles in target church", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+
+    await expect(
+      requireChurchPermission("events:view", "church-999")
+    ).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("rejects when user has role but lacks specific permission", async () => {
+    // Department head does NOT have departments:manage
+    mockAuth.mockResolvedValue(
+      createDepartmentHeadSession(
+        [{ id: "dept-1", name: "Son" }],
+        "church-1"
+      )
+    );
+
+    await expect(
+      requireChurchPermission("departments:manage", "church-1")
+    ).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("allows department head with correct permission in correct church", async () => {
+    mockAuth.mockResolvedValue(
+      createDepartmentHeadSession(
+        [{ id: "dept-1", name: "Son" }],
+        "church-1"
+      )
+    );
+
+    // Department head HAS planning:view
+    const session = await requireChurchPermission("planning:view", "church-1");
+    expect(session.user.id).toBe("user-1");
+  });
+
+  it("super admin bypasses all church checks", async () => {
+    mockAuth.mockResolvedValue(createSuperAdminSession());
+
+    // Super admin can access any church even if not in their churchRoles
+    const session = await requireChurchPermission("church:manage", "church-999");
+    expect(session.user.isSuperAdmin).toBe(true);
+  });
+
+  it("rejects unauthenticated user", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    await expect(
+      requireChurchPermission("events:view", "church-1")
+    ).rejects.toThrow("UNAUTHORIZED");
+  });
+});
+
+describe("requireChurchAccess", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows user with any role in the church", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+
+    const session = await requireChurchAccess("church-1");
+    expect(session.user.id).toBe("user-1");
+  });
+
+  it("rejects user with no role in the church", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+
+    await expect(requireChurchAccess("church-2")).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("super admin can access any church", async () => {
+    mockAuth.mockResolvedValue(createSuperAdminSession());
+
+    const session = await requireChurchAccess("church-999");
+    expect(session.user.isSuperAdmin).toBe(true);
+  });
+});
+
+describe("resolveChurchId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves churchId from event", async () => {
+    prismaMock.event.findUnique.mockResolvedValue({ churchId: "church-1" });
+
+    const churchId = await resolveChurchId("event", "evt-1");
+    expect(churchId).toBe("church-1");
+    expect(prismaMock.event.findUnique).toHaveBeenCalledWith({
+      where: { id: "evt-1" },
+      select: { churchId: true },
+    });
+  });
+
+  it("resolves churchId from department via ministry", async () => {
+    prismaMock.department.findUnique.mockResolvedValue({
+      ministry: { churchId: "church-2" },
+    });
+
+    const churchId = await resolveChurchId("department", "dept-1");
+    expect(churchId).toBe("church-2");
+  });
+
+  it("resolves churchId from member via department.ministry", async () => {
+    prismaMock.member.findUnique.mockResolvedValue({
+      department: { ministry: { churchId: "church-3" } },
+    });
+
+    const churchId = await resolveChurchId("member", "member-1");
+    expect(churchId).toBe("church-3");
+  });
+
+  it("resolves churchId from ministry", async () => {
+    prismaMock.ministry.findUnique.mockResolvedValue({ churchId: "church-1" });
+
+    const churchId = await resolveChurchId("ministry", "min-1");
+    expect(churchId).toBe("church-1");
+  });
+
+  it("throws 404 when event not found", async () => {
+    prismaMock.event.findUnique.mockResolvedValue(null);
+
+    await expect(resolveChurchId("event", "nonexistent")).rejects.toThrow(
+      "Événement introuvable"
+    );
+  });
+
+  it("throws 404 when department not found", async () => {
+    prismaMock.department.findUnique.mockResolvedValue(null);
+
+    await expect(resolveChurchId("department", "nonexistent")).rejects.toThrow(
+      "Département introuvable"
+    );
+  });
+
+  it("throws 404 when member not found", async () => {
+    prismaMock.member.findUnique.mockResolvedValue(null);
+
+    await expect(resolveChurchId("member", "nonexistent")).rejects.toThrow(
+      "Membre introuvable"
+    );
+  });
+
+  it("throws 404 when ministry not found", async () => {
+    prismaMock.ministry.findUnique.mockResolvedValue(null);
+
+    await expect(resolveChurchId("ministry", "nonexistent")).rejects.toThrow(
+      "Ministère introuvable"
+    );
+  });
+});
+
+describe("multi-tenant isolation scenarios", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("admin of church-1 cannot manage events in church-2", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+
+    // Event belongs to church-2
+    prismaMock.event.findUnique.mockResolvedValue({ churchId: "church-2" });
+
+    const churchId = await resolveChurchId("event", "evt-church2");
+    expect(churchId).toBe("church-2");
+
+    // Permission check fails because admin is only in church-1
+    await expect(
+      requireChurchPermission("events:manage", churchId)
+    ).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("admin of church-1 cannot view members in church-2", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+
+    prismaMock.member.findUnique.mockResolvedValue({
+      department: { ministry: { churchId: "church-2" } },
+    });
+
+    const churchId = await resolveChurchId("member", "member-church2");
+    await expect(
+      requireChurchPermission("members:view", churchId)
+    ).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("department head in church-1 cannot access departments in church-2", async () => {
+    mockAuth.mockResolvedValue(
+      createDepartmentHeadSession(
+        [{ id: "dept-1", name: "Son" }],
+        "church-1"
+      )
+    );
+
+    prismaMock.department.findUnique.mockResolvedValue({
+      ministry: { churchId: "church-2" },
+    });
+
+    const churchId = await resolveChurchId("department", "dept-church2");
+    await expect(
+      requireChurchPermission("planning:view", churchId)
+    ).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("user with roles in multiple churches can only access their own churches", async () => {
+    // User has ADMIN in church-1 and DEPARTMENT_HEAD in church-2
+    const multiChurchSession = {
+      user: {
+        id: "user-multi",
+        email: "multi@example.com",
+        name: "Multi User",
+        displayName: null,
+        image: null,
+        isSuperAdmin: false,
+        hasSeenTour: false,
+        churchRoles: [
+          {
+            id: "role-1",
+            churchId: "church-1",
+            role: "ADMIN" as const,
+            ministryId: null,
+            church: { id: "church-1", name: "Church A", slug: "church-a" },
+            departments: [],
+          },
+          {
+            id: "role-2",
+            churchId: "church-2",
+            role: "DEPARTMENT_HEAD" as const,
+            ministryId: null,
+            church: { id: "church-2", name: "Church B", slug: "church-b" },
+            departments: [{ department: { id: "dept-b1", name: "Son" } }],
+          },
+        ],
+      },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    };
+
+    mockAuth.mockResolvedValue(multiChurchSession);
+
+    // Can manage events in church-1 (ADMIN has events:manage)
+    await expect(
+      requireChurchPermission("events:manage", "church-1")
+    ).resolves.toBeDefined();
+
+    // Cannot manage events in church-2 (DEPARTMENT_HEAD lacks events:manage)
+    await expect(
+      requireChurchPermission("events:manage", "church-2")
+    ).rejects.toThrow("FORBIDDEN");
+
+    // Can view planning in church-2 (DEPARTMENT_HEAD has planning:view)
+    await expect(
+      requireChurchPermission("planning:view", "church-2")
+    ).resolves.toBeDefined();
+
+    // Cannot access church-3 at all
+    await expect(
+      requireChurchPermission("events:view", "church-3")
+    ).rejects.toThrow("FORBIDDEN");
+  });
+});

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { rateLimit } from "@/lib/rate-limit";
+
+describe("rateLimit", () => {
+  it("allows requests within the limit", () => {
+    const key = `test-allow-${Date.now()}`;
+    const result = rateLimit(key, { max: 5, windowMs: 60_000 });
+    expect(result.success).toBe(true);
+    expect(result.remaining).toBe(4);
+  });
+
+  it("tracks remaining count correctly", () => {
+    const key = `test-count-${Date.now()}`;
+    const opts = { max: 3, windowMs: 60_000 };
+
+    expect(rateLimit(key, opts).remaining).toBe(2);
+    expect(rateLimit(key, opts).remaining).toBe(1);
+    expect(rateLimit(key, opts).remaining).toBe(0);
+  });
+
+  it("blocks after exceeding the limit", () => {
+    const key = `test-block-${Date.now()}`;
+    const opts = { max: 2, windowMs: 60_000 };
+
+    expect(rateLimit(key, opts).success).toBe(true);
+    expect(rateLimit(key, opts).success).toBe(true);
+    expect(rateLimit(key, opts).success).toBe(false);
+    expect(rateLimit(key, opts).remaining).toBe(0);
+  });
+
+  it("resets after window expires", () => {
+    const key = `test-reset-${Date.now()}`;
+    const opts = { max: 1, windowMs: 1 };
+
+    expect(rateLimit(key, opts).success).toBe(true);
+
+    // Wait just enough for the window to expire
+    const start = Date.now();
+    while (Date.now() - start < 5) {
+      // busy-wait a few ms
+    }
+
+    expect(rateLimit(key, opts).success).toBe(true);
+  });
+
+  it("isolates different keys", () => {
+    const key1 = `test-isolate-a-${Date.now()}`;
+    const key2 = `test-isolate-b-${Date.now()}`;
+    const opts = { max: 1, windowMs: 60_000 };
+
+    expect(rateLimit(key1, opts).success).toBe(true);
+    expect(rateLimit(key1, opts).success).toBe(false);
+
+    // Different key should still be allowed
+    expect(rateLimit(key2, opts).success).toBe(true);
+  });
+
+  it("uses default values (60 requests, 60s window)", () => {
+    const key = `test-defaults-${Date.now()}`;
+    const result = rateLimit(key);
+    expect(result.success).toBe(true);
+    expect(result.remaining).toBe(59);
+  });
+});


### PR DESCRIPTION
## Summary

- **auth-security.test.ts** (22 tests): `requireChurchPermission`, `requireChurchAccess`, `resolveChurchId`, and multi-tenant isolation scenarios
- **rate-limit.test.ts** (6 tests): `rateLimit` function (allow/block/reset/isolation/defaults)
- **events/[eventId]/security.test.ts** (8 tests): End-to-end cross-tenant rejection on GET/DELETE event routes
- Fix existing tests broken by the security hardening (missing `churchId` param, missing auth mock exports)
- Add missing models to Prisma mock (serviceRequest, announcement, memberUserLink, etc.)

## Context

Following the security audit and multi-tenant authorization hardening, these tests verify that:
- Admin of church-1 cannot access resources in church-2
- Department heads are scoped to their church
- Super admins bypass all church checks
- Unauthenticated users are rejected
- Non-existent resources return 404 (not data leaks)
- Rate limiting blocks/allows correctly by key

## Test plan

- [x] All 80 tests pass (`npm test`)
- [x] TypeScript check passes (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)