### PR TITLE
fix: scope server components to active church

### DIFF
--- a/src/app/(auth)/admin/access/page.tsx
+++ b/src/app/(auth)/admin/access/page.tsx
@@ -1,12 +1,12 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import AccessClient from "./AccessClient";
 
 export default async function AccessPage() {
-  const session = await requirePermission("departments:manage");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
-
   if (!churchId) return <p className="text-gray-500">Aucune église sélectionnée.</p>;
+  await requireChurchPermission("departments:manage", churchId);
 
   // All users in this church with their roles
   const users = await prisma.user.findMany({

--- a/src/app/(auth)/admin/departments/functions/page.tsx
+++ b/src/app/(auth)/admin/departments/functions/page.tsx
@@ -1,15 +1,15 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import DeptFunctionsClient from "./DeptFunctionsClient";
 
 export default async function DeptFunctionsPage() {
-  const session = await requirePermission("events:manage");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p className="text-gray-500">Aucune église sélectionnée.</p>;
+  await requireChurchPermission("events:manage", churchId);
 
   const departments = await prisma.department.findMany({
-    where: churchId
-      ? { ministry: { churchId } }
-      : { ministry: { churchId: session.user.churchRoles[0]?.churchId } },
+    where: { ministry: { churchId } },
     include: { ministry: { select: { name: true } } },
     orderBy: [{ ministry: { name: "asc" } }, { name: "asc" }],
   });

--- a/src/app/(auth)/admin/departments/page.tsx
+++ b/src/app/(auth)/admin/departments/page.tsx
@@ -1,9 +1,11 @@
-import { requirePermission, getUserDepartmentScope } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth, getUserDepartmentScope } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import DepartmentsClient from "./DepartmentsClient";
 
 export default async function DepartmentsPage() {
-  const session = await requirePermission("departments:manage");
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (churchId) await requireChurchPermission("departments:manage", churchId);
 
   const scope = getUserDepartmentScope(session);
   const churchRoles = session.user.churchRoles;

--- a/src/app/(auth)/admin/discipleship/page.tsx
+++ b/src/app/(auth)/admin/discipleship/page.tsx
@@ -1,19 +1,10 @@
-import { requireAnyPermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import DiscipleshipClient from "./DiscipleshipClient";
 
 export default async function DiscipleshipPage() {
-  const session = await requireAnyPermission("discipleship:view");
-
-  const userPermissions = new Set(
-    session.user.churchRoles.flatMap((r) => hasPermission(r.role))
-  );
-
-  const canManage = userPermissions.has("discipleship:manage");
-  const canExport = userPermissions.has("discipleship:export");
-  const isFD = session.user.churchRoles.some((r) => r.role === "DISCIPLE_MAKER") && !session.user.isSuperAdmin;
-
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) {
     return (
@@ -23,6 +14,16 @@ export default async function DiscipleshipPage() {
       </div>
     );
   }
+  await requireChurchPermission("discipleship:view", churchId);
+
+  const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
+  const userPermissions = new Set(
+    churchRoles.flatMap((r) => hasPermission(r.role))
+  );
+
+  const canManage = userPermissions.has("discipleship:manage");
+  const canExport = userPermissions.has("discipleship:export");
+  const isFD = churchRoles.some((r) => r.role === "DISCIPLE_MAKER") && !session.user.isSuperAdmin;
 
   // Pour un FD, résoudre le membre lié pour pré-remplir le formulaire
   const linkedMemberId = isFD

--- a/src/app/(auth)/admin/events/[eventId]/page.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/page.tsx
@@ -1,4 +1,4 @@
-import { requirePermission } from "@/lib/auth";
+import { requireAuth, requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import EventDetailClient from "./EventDetailClient";
@@ -8,8 +8,10 @@ export default async function EventDetailPage({
 }: {
   params: Promise<{ eventId: string }>;
 }) {
-  await requirePermission("events:manage");
+  await requireAuth();
   const { eventId } = await params;
+  const churchId = await resolveChurchId("event", eventId);
+  await requireChurchPermission("events:manage", churchId);
 
   const event = await prisma.event.findUnique({
     where: { id: eventId },

--- a/src/app/(auth)/admin/events/[eventId]/report/page.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/report/page.tsx
@@ -1,4 +1,5 @@
-import { requireAnyPermission } from "@/lib/auth";
+import { requireAuth, resolveChurchId } from "@/lib/auth";
+import { hasPermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import EventReportClient from "./EventReportClient";
@@ -8,8 +9,16 @@ export default async function EventReportPage({
 }: {
   params: Promise<{ eventId: string }>;
 }) {
-  await requireAnyPermission("events:manage", "reports:view");
+  const session = await requireAuth();
   const { eventId } = await params;
+  const churchId = await resolveChurchId("event", eventId);
+  // Allow access if user has events:manage OR reports:view for this church
+  const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
+  const perms = new Set(churchRoles.flatMap((r) => hasPermission(r.role)));
+  if (!perms.has("events:manage") && !perms.has("reports:view")) {
+    const { ApiError } = await import("@/lib/api-utils");
+    throw new ApiError(403, "Forbidden");
+  }
 
   const event = await prisma.event.findUnique({
     where: { id: eventId },

--- a/src/app/(auth)/admin/events/page.tsx
+++ b/src/app/(auth)/admin/events/page.tsx
@@ -1,9 +1,11 @@
-import { requirePermission } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import EventsClient from "./EventsClient";
 
 export default async function EventsPage() {
-  const session = await requirePermission("events:manage");
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (churchId) await requireChurchPermission("events:manage", churchId);
 
   const churchRoles = session.user.churchRoles;
   const isSuperAdmin = churchRoles.some((r) => r.role === "SUPER_ADMIN");

--- a/src/app/(auth)/admin/layout.tsx
+++ b/src/app/(auth)/admin/layout.tsx
@@ -1,20 +1,13 @@
-import { requireAnyPermission } from "@/lib/auth";
+import { requireAuth, getCurrentChurchId, requireChurchAccess } from "@/lib/auth";
 
 export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  await requireAnyPermission(
-    "members:manage",
-    "members:view",
-    "church:manage",
-    "users:manage",
-    "departments:manage",
-    "events:manage",
-    "discipleship:view",
-    "reports:view"
-  );
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (churchId) await requireChurchAccess(churchId);
 
   return <div className="p-6">{children}</div>;
 }

--- a/src/app/(auth)/admin/members/page.tsx
+++ b/src/app/(auth)/admin/members/page.tsx
@@ -1,13 +1,18 @@
-import { requireAnyPermission, getUserDepartmentScope } from "@/lib/auth";
+import { requireAuth, getCurrentChurchId, requireChurchPermission, getUserDepartmentScope } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import MembersClient from "./MembersClient";
 import LinkRequestsClient from "./LinkRequestsClient";
 
 export default async function MembersPage() {
-  const session = await requireAnyPermission("members:manage", "members:view");
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (churchId) await requireChurchPermission("members:view", churchId);
+  const churchRoles = churchId
+    ? session.user.churchRoles.filter((r) => r.churchId === churchId)
+    : session.user.churchRoles;
   const userPermissions = new Set(
-    session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+    churchRoles.flatMap((r) => hasPermission(r.role))
   );
   const canManage = userPermissions.has("members:manage");
   const scope = getUserDepartmentScope(session);

--- a/src/app/(auth)/admin/ministries/page.tsx
+++ b/src/app/(auth)/admin/ministries/page.tsx
@@ -1,9 +1,11 @@
-import { requirePermission } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import MinistriesClient from "./MinistriesClient";
 
 export default async function MinistriesPage() {
-  const session = await requirePermission("departments:manage");
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (churchId) await requireChurchPermission("departments:manage", churchId);
 
   const churchRoles = session.user.churchRoles;
   const isSuperAdmin = churchRoles.some((r) => r.role === "SUPER_ADMIN");

--- a/src/app/(auth)/admin/page.tsx
+++ b/src/app/(auth)/admin/page.tsx
@@ -1,9 +1,11 @@
 import { redirect } from "next/navigation";
-import { requirePermission } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 
 export default async function AdminPage() {
-  const session = await requirePermission("members:manage");
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (churchId) await requireChurchPermission("members:manage", churchId);
 
   const userRoles = session.user.churchRoles.map((r) => r.role);
   const userPermissions = new Set(userRoles.flatMap((r) => hasPermission(r)));

--- a/src/app/(auth)/admin/reports/page.tsx
+++ b/src/app/(auth)/admin/reports/page.tsx
@@ -1,12 +1,12 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import ReportsClient from "./ReportsClient";
 
 export default async function ReportsPage() {
-  const session = await requirePermission("reports:view");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
-
   if (!churchId) return <p className="text-gray-500">Aucune église sélectionnée.</p>;
+  await requireChurchPermission("reports:view", churchId);
 
   const events = await prisma.event.findMany({
     where: { churchId, reportEnabled: true },

--- a/src/app/(auth)/admin/users/page.tsx
+++ b/src/app/(auth)/admin/users/page.tsx
@@ -1,9 +1,11 @@
-import { requirePermission } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import UsersClient from "./UsersClient";
 
 export default async function UsersPage() {
-  const session = await requirePermission("members:manage");
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (churchId) await requireChurchPermission("members:manage", churchId);
 
   const churchRoles = session.user.churchRoles;
   const isSuperAdmin = churchRoles.some((r) => r.role === "SUPER_ADMIN");

--- a/src/app/(auth)/announcements/new/page.tsx
+++ b/src/app/(auth)/announcements/new/page.tsx
@@ -1,11 +1,12 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import AnnouncementForm from "./AnnouncementForm";
 
 export default async function NewAnnouncementPage() {
-  const session = await requirePermission("planning:view");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("planning:view", churchId);
 
   const targetEvents = await prisma.event.findMany({
     where: { churchId, allowAnnouncements: true, date: { gte: new Date() } },

--- a/src/app/(auth)/announcements/page.tsx
+++ b/src/app/(auth)/announcements/page.tsx
@@ -1,13 +1,14 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
 import AnnouncementsList from "./AnnouncementsList";
 
 export default async function AnnouncementsPage() {
-  const session = await requirePermission("planning:view");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("planning:view", churchId);
 
   const announcements = await prisma.announcement.findMany({
     where: { churchId, submittedById: session.user.id },

--- a/src/app/(auth)/communication/requests/page.tsx
+++ b/src/app/(auth)/communication/requests/page.tsx
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { DepartmentFunction } from "@prisma/client";
@@ -6,9 +6,10 @@ import { notFound } from "next/navigation";
 import CommunicationDashboard from "./CommunicationDashboard";
 
 export default async function CommunicationRequestsPage() {
-  const session = await requirePermission("planning:view");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("planning:view", churchId);
 
   const commDept = await prisma.department.findFirst({
     where: { function: DepartmentFunction.COMMUNICATION, ministry: { churchId } },

--- a/src/app/(auth)/media/requests/new/page.tsx
+++ b/src/app/(auth)/media/requests/new/page.tsx
@@ -1,10 +1,11 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import StandaloneVisualForm from "./StandaloneVisualForm";
 
 export default async function NewStandaloneVisualPage() {
-  const session = await requirePermission("planning:view");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("planning:view", churchId);
 
   const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   const sourceOptions: { type: "department" | "ministry"; id: string; label: string }[] = [];

--- a/src/app/(auth)/media/requests/page.tsx
+++ b/src/app/(auth)/media/requests/page.tsx
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
@@ -8,9 +8,10 @@ import { notFound } from "next/navigation";
 import MediaDashboard from "./MediaDashboard";
 
 export default async function MediaRequestsPage() {
-  const session = await requirePermission("planning:view");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("planning:view", churchId);
 
   const mediaDept = await prisma.department.findFirst({
     where: { function: DepartmentFunction.PRODUCTION_MEDIA, ministry: { churchId } },

--- a/src/app/(auth)/secretariat/announcements/page.tsx
+++ b/src/app/(auth)/secretariat/announcements/page.tsx
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { DepartmentFunction } from "@prisma/client";
@@ -6,9 +6,10 @@ import { notFound } from "next/navigation";
 import SecretariatDashboard from "./SecretariatDashboard";
 
 export default async function SecretariatAnnouncementsPage() {
-  const session = await requirePermission("planning:view");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("planning:view", churchId);
 
   const secretariatDept = await prisma.department.findFirst({
     where: { function: DepartmentFunction.SECRETARIAT, ministry: { churchId } },


### PR DESCRIPTION
## Summary
- Replace `requirePermission`/`requireAnyPermission` with church-scoped `requireChurchPermission` + `getCurrentChurchId` across all 19 server component pages
- Admin layout now uses lightweight `requireChurchAccess` instead of checking 8 permissions
- Event detail and report pages use `resolveChurchId` to derive church from the event resource
- Permission checks for members and discipleship pages now scope to church-specific roles

## Context
Part of the multi-tenant security hardening (audit findings). Server components were checking permissions globally across all churches instead of scoping to the user's active church, which could leak data between tenants.

## Test plan
- [ ] Verify admin pages load correctly for single-church users
- [ ] Verify multi-church users see only active church data
- [ ] Verify SUPER_ADMIN still has full access
- [ ] Verify MINISTER sees only scoped departments/members
- [ ] Run `npm run typecheck` (passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)