### PR TITLE
feat: audit logging enrichi — couverture systématique

### DIFF
--- a/src/app/api/announcements/[id]/route.ts
+++ b/src/app/api/announcements/[id]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { hasPermission } from "@/lib/permissions";
 import { z } from "zod";
 
@@ -122,6 +123,8 @@ export async function PATCH(
       return result;
     });
 
+    await logAudit({ userId: session.user.id, churchId: announcement.churchId, action: "UPDATE", entityType: "Announcement", entityId: id, details: data });
+
     return successResponse(updated);
   } catch (error) {
     return errorResponse(error);
@@ -155,6 +158,8 @@ export async function DELETE(
     if (!canManage && !isOwner) throw new ApiError(403, "Accès refusé");
 
     await prisma.announcement.delete({ where: { id } });
+
+    await logAudit({ userId: session.user.id, churchId: announcement.churchId, action: "DELETE", entityType: "Announcement", entityId: id });
 
     return successResponse({ deleted: id });
   } catch (error) {

--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { hasPermission } from "@/lib/permissions";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { DepartmentFunction } from "@prisma/client";
@@ -204,6 +205,8 @@ export async function POST(request: Request) {
 
       return ann;
     });
+
+    await logAudit({ userId: session.user.id, churchId: data.churchId, action: "CREATE", entityType: "Announcement", entityId: announcement.id, details: { title: data.title } });
 
     return successResponse(announcement, 201);
   } catch (error) {

--- a/src/app/api/churches/[churchId]/route.ts
+++ b/src/app/api/churches/[churchId]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const updateSchema = z.object({
@@ -14,7 +15,7 @@ export async function PUT(
 ) {
   try {
     const { churchId } = await params;
-    await requireChurchPermission("church:manage", churchId);
+    const session = await requireChurchPermission("church:manage", churchId);
     const body = await request.json();
     const data = updateSchema.parse(body);
 
@@ -22,6 +23,8 @@ export async function PUT(
       where: { id: churchId },
       data,
     });
+
+    await logAudit({ userId: session.user.id, churchId, action: "UPDATE", entityType: "Church", entityId: churchId, details: data });
 
     return successResponse(church);
   } catch (error) {
@@ -35,7 +38,7 @@ export async function DELETE(
 ) {
   try {
     const { churchId } = await params;
-    await requireChurchPermission("church:manage", churchId);
+    const delSession = await requireChurchPermission("church:manage", churchId);
 
     const church = await prisma.church.findUnique({
       where: { id: churchId },
@@ -54,6 +57,8 @@ export async function DELETE(
     }
 
     await prisma.church.delete({ where: { id: churchId } });
+
+    await logAudit({ userId: delSession.user.id, churchId, action: "DELETE", entityType: "Church", entityId: churchId, details: { name: church.name } });
 
     return successResponse({ success: true });
   } catch (error) {

--- a/src/app/api/churches/route.ts
+++ b/src/app/api/churches/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireAuth, requirePermission, isSuperAdmin } from "@/lib/auth";
 import { successResponse, errorResponse } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 async function requireChurchManageOrSuperAdmin() {
@@ -38,7 +39,7 @@ const bulkSchema = z.object({
 
 export async function PATCH(request: Request) {
   try {
-    await requireChurchManageOrSuperAdmin();
+    const patchSession = await requireChurchManageOrSuperAdmin();
     const body = await request.json();
     const { ids, action, data } = bulkSchema.parse(body);
 
@@ -88,6 +89,9 @@ export async function PATCH(request: Request) {
         await tx.userChurchRole.deleteMany({ where: { churchId: { in: ids } } });
         await tx.church.deleteMany({ where: { id: { in: ids } } });
       });
+      for (const id of ids) {
+        await logAudit({ userId: patchSession.user.id, action: "DELETE", entityType: "Church", entityId: id });
+      }
       return successResponse({ deleted: ids.length });
     }
 
@@ -100,6 +104,9 @@ export async function PATCH(request: Request) {
       data,
     });
 
+    for (const id of ids) {
+      await logAudit({ userId: patchSession.user.id, action: "UPDATE", entityType: "Church", entityId: id, details: data });
+    }
     return successResponse({ updated: ids.length });
   } catch (error) {
     return errorResponse(error);
@@ -122,7 +129,7 @@ const createSchema = z.object({
 
 export async function POST(request: Request) {
   try {
-    await requireChurchManageOrSuperAdmin();
+    const postSession = await requireChurchManageOrSuperAdmin();
     const body = await request.json();
     const parsed = createSchema.parse(body);
     const slug = parsed.slug || generateSlug(parsed.name);
@@ -166,6 +173,8 @@ export async function POST(request: Request) {
         },
       });
     }
+
+    await logAudit({ userId: postSession.user.id, churchId: church.id, action: "CREATE", entityType: "Church", entityId: church.id, details: { name: parsed.name, slug } });
 
     return successResponse(church, 201);
   } catch (error) {

--- a/src/app/api/departments/[departmentId]/route.ts
+++ b/src/app/api/departments/[departmentId]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 import type { Session } from "next-auth";
 
@@ -64,6 +65,8 @@ export async function PUT(
       },
     });
 
+    await logAudit({ userId: session.user.id, churchId, action: "UPDATE", entityType: "Department", entityId: departmentId, details: data });
+
     return successResponse(department);
   } catch (error) {
     return errorResponse(error);
@@ -81,7 +84,7 @@ export async function PATCH(
   try {
     const { departmentId } = await params;
     const patchChurchId = await resolveChurchId("department", departmentId);
-    const session = await requireChurchPermission("events:manage", patchChurchId);
+    const patchSession = await requireChurchPermission("events:manage", patchChurchId);
     const body = await request.json();
     const data = patchFunctionSchema.parse(body);
 
@@ -90,7 +93,7 @@ export async function PATCH(
       select: { id: true, isSystem: true, ministry: { select: { churchId: true } } },
     });
     if (!dept) throw new ApiError(404, "Département introuvable");
-    if (dept.isSystem && !session.user.isSuperAdmin) {
+    if (dept.isSystem && !patchSession.user.isSuperAdmin) {
       throw new ApiError(403, "Ce département système ne peut pas être modifié");
     }
 
@@ -111,6 +114,8 @@ export async function PATCH(
       data: { function: data.function },
       select: { id: true, name: true, function: true },
     });
+
+    await logAudit({ userId: patchSession.user.id, churchId: patchChurchId, action: "UPDATE", entityType: "Department", entityId: departmentId, details: { function: data.function } });
 
     return successResponse(updated);
   } catch (error) {
@@ -149,6 +154,8 @@ export async function DELETE(
     }
 
     await prisma.department.delete({ where: { id: departmentId } });
+
+    await logAudit({ userId: session.user.id, churchId: delChurchId, action: "DELETE", entityType: "Department", entityId: departmentId, details: { name: department.name } });
 
     return successResponse({ success: true });
   } catch (error) {

--- a/src/app/api/departments/[departmentId]/tasks/route.ts
+++ b/src/app/api/departments/[departmentId]/tasks/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 export async function GET(
@@ -43,7 +44,7 @@ export async function POST(
   try {
     const { departmentId } = await params;
     const postChurchId = await resolveChurchId("department", departmentId);
-    await requireChurchPermission("planning:edit", postChurchId);
+    const postSession = await requireChurchPermission("planning:edit", postChurchId);
     const body = await request.json();
     const { name, description } = createSchema.parse(body);
 
@@ -71,6 +72,8 @@ export async function POST(
       },
     });
 
+    await logAudit({ userId: postSession.user.id, churchId: postChurchId, action: "CREATE", entityType: "Task", entityId: task.id, details: { name, departmentId } });
+
     return successResponse(task, 201);
   } catch (error) {
     return errorResponse(error);
@@ -84,7 +87,7 @@ export async function DELETE(
   try {
     const { departmentId } = await params;
     const delChurchId = await resolveChurchId("department", departmentId);
-    await requireChurchPermission("planning:edit", delChurchId);
+    const delSession = await requireChurchPermission("planning:edit", delChurchId);
     const body = await request.json();
     const { taskId } = z.object({ taskId: z.string() }).parse(body);
 
@@ -97,6 +100,8 @@ export async function DELETE(
     }
 
     await prisma.task.delete({ where: { id: taskId } });
+
+    await logAudit({ userId: delSession.user.id, churchId: delChurchId, action: "DELETE", entityType: "Task", entityId: taskId, details: { name: task.name, departmentId } });
 
     return successResponse({ success: true });
   } catch (error) {

--- a/src/app/api/departments/route.ts
+++ b/src/app/api/departments/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
 import type { Session } from "next-auth";
@@ -92,6 +93,9 @@ export async function PATCH(request: Request) {
         await tx.userDepartment.deleteMany({ where: { departmentId: { in: ids } } });
         await tx.department.deleteMany({ where: { id: { in: ids } } });
       });
+      for (const id of ids) {
+        await logAudit({ userId: session.user.id, churchId: deptChurchId, action: "DELETE", entityType: "Department", entityId: id });
+      }
       return successResponse({ deleted: ids.length });
     }
 
@@ -104,6 +108,9 @@ export async function PATCH(request: Request) {
       data,
     });
 
+    for (const id of ids) {
+      await logAudit({ userId: session.user.id, churchId: deptChurchId, action: "UPDATE", entityType: "Department", entityId: id, details: data });
+    }
     return successResponse({ updated: ids.length });
   } catch (error) {
     return errorResponse(error);
@@ -137,6 +144,8 @@ export async function POST(request: Request) {
         ministry: { select: { id: true, name: true, churchId: true } },
       },
     });
+
+    await logAudit({ userId: session.user.id, churchId: ministryChurchId, action: "CREATE", entityType: "Department", entityId: department.id, details: { name: data.name } });
 
     return successResponse(department, 201);
   } catch (error) {

--- a/src/app/api/discipleships/[id]/route.ts
+++ b/src/app/api/discipleships/[id]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, getDiscipleshipScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const updateSchema = z.object({
@@ -34,15 +35,7 @@ export async function PATCH(
       },
     });
 
-    await prisma.auditLog.create({
-      data: {
-        userId: session.user.id,
-        action: "UPDATE_DISCIPLESHIP",
-        entityType: "Discipleship",
-        entityId: id,
-        churchId: existing.churchId,
-      },
-    });
+    await logAudit({ userId: session.user.id, churchId: existing.churchId, action: "UPDATE", entityType: "Discipleship", entityId: id, details: { discipleMakerId } });
 
     return successResponse(updated);
   } catch (error) {
@@ -70,15 +63,7 @@ export async function DELETE(
 
     await prisma.discipleship.delete({ where: { id } });
 
-    await prisma.auditLog.create({
-      data: {
-        userId: session.user.id,
-        action: "DELETE_DISCIPLESHIP",
-        entityType: "Discipleship",
-        entityId: id,
-        churchId: existing.churchId,
-      },
-    });
+    await logAudit({ userId: session.user.id, churchId: existing.churchId, action: "DELETE", entityType: "Discipleship", entityId: id });
 
     return successResponse({ deleted: true });
   } catch (error) {

--- a/src/app/api/discipleships/attendance/route.ts
+++ b/src/app/api/discipleships/attendance/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, getDiscipleshipScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const schema = z.object({
@@ -61,6 +62,8 @@ export async function PUT(request: Request) {
         }),
       ]);
     }
+
+    await logAudit({ userId: session.user.id, churchId: event.churchId, action: "UPDATE", entityType: "DiscipleshipAttendance", entityId: eventId, details: { presentCount: presentMemberIds.length } });
 
     return successResponse({ saved: true });
   } catch (error) {

--- a/src/app/api/discipleships/route.ts
+++ b/src/app/api/discipleships/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, getDiscipleshipScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
 
@@ -106,16 +107,7 @@ export async function POST(request: Request) {
       },
     });
 
-    // Audit log
-    await prisma.auditLog.create({
-      data: {
-        userId: session.user.id,
-        action: "CREATE_DISCIPLESHIP",
-        entityType: "Discipleship",
-        entityId: discipleship.id,
-        churchId,
-      },
-    });
+    await logAudit({ userId: session.user.id, churchId, action: "CREATE", entityType: "Discipleship", entityId: discipleship.id });
 
     return successResponse(discipleship, 201);
   } catch (error) {

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
@@ -182,6 +182,7 @@ export async function PUT(
 
     await logAudit({
       userId: session.user.id,
+      churchId: eventChurchId,
       action: "UPDATE",
       entityType: "Planning",
       entityId: eventDept!.id,

--- a/src/app/api/events/[eventId]/departments/[deptId]/tasks/route.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/tasks/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 export async function GET(
@@ -51,7 +52,7 @@ export async function PUT(
   try {
     const { eventId, deptId: departmentId } = await params;
     const putChurchId = await resolveChurchId("event", eventId);
-    await requireChurchPermission("planning:edit", putChurchId);
+    const putSession = await requireChurchPermission("planning:edit", putChurchId);
     const body = await request.json();
     const { taskId, memberIds } = assignSchema.parse(body);
 
@@ -119,6 +120,8 @@ export async function PUT(
         },
       },
     });
+
+    await logAudit({ userId: putSession.user.id, churchId: putChurchId, action: "UPDATE", entityType: "TaskAssignment", entityId: taskId, details: { eventId, departmentId, memberIds } });
 
     return successResponse(updatedTask);
   } catch (error) {

--- a/src/app/api/events/[eventId]/report/route.ts
+++ b/src/app/api/events/[eventId]/report/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { Prisma } from "@prisma/client";
 import { z } from "zod";
 
@@ -118,6 +119,8 @@ export async function PUT(
         author: { select: { id: true, name: true } },
       },
     });
+
+    await logAudit({ userId: session.user.id, churchId: event.churchId, action: "UPDATE", entityType: "EventReport", entityId: report.id, details: { eventId } });
 
     return successResponse(report);
   } catch (error) {

--- a/src/app/api/events/[eventId]/route.ts
+++ b/src/app/api/events/[eventId]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 export async function GET(
@@ -50,7 +51,7 @@ export async function PUT(
   try {
     const { eventId } = await params;
     const churchId = await resolveChurchId("event", eventId);
-    await requireChurchPermission("events:manage", churchId);
+    const putSession = await requireChurchPermission("events:manage", churchId);
     const body = await request.json();
     const data = updateSchema.parse(body);
 
@@ -129,6 +130,8 @@ export async function PUT(
         },
       });
 
+      await logAudit({ userId: putSession.user.id, churchId, action: "UPDATE", entityType: "Event", entityId: eventId, details: { title: data.title, seriesUpdated: seriesEvents.length } });
+
       return successResponse({ ...event, seriesUpdated: seriesEvents.length });
     }
 
@@ -153,6 +156,8 @@ export async function PUT(
       },
     });
 
+    await logAudit({ userId: putSession.user.id, churchId, action: "UPDATE", entityType: "Event", entityId: eventId, details: { title: data.title } });
+
     return successResponse(event);
   } catch (error) {
     return errorResponse(error);
@@ -174,7 +179,7 @@ export async function PATCH(
   try {
     const { eventId } = await params;
     const churchId = await resolveChurchId("event", eventId);
-    await requireChurchPermission("events:manage", churchId);
+    const patchSession = await requireChurchPermission("events:manage", churchId);
     const body = await request.json();
     const { applyToSeries, ...rest } = patchSchema.parse(body);
 
@@ -201,6 +206,7 @@ export async function PATCH(
           },
           data: updateData,
         });
+        await logAudit({ userId: patchSession.user.id, churchId, action: "UPDATE", entityType: "Event", entityId: eventId, details: { ...updateData, appliedToSeries: true } });
         return successResponse({ applied: true });
       }
     }
@@ -210,6 +216,8 @@ export async function PATCH(
       data: updateData,
       select: { id: true, allowAnnouncements: true, trackedForDiscipleship: true, reportEnabled: true, statsEnabled: true },
     });
+
+    await logAudit({ userId: patchSession.user.id, churchId, action: "UPDATE", entityType: "Event", entityId: eventId, details: updateData });
 
     return successResponse(event);
   } catch (error) {
@@ -224,7 +232,7 @@ export async function DELETE(
   try {
     const { eventId } = await params;
     const churchId = await resolveChurchId("event", eventId);
-    await requireChurchPermission("events:manage", churchId);
+    const delSession = await requireChurchPermission("events:manage", churchId);
 
     const event = await prisma.event.findUnique({
       where: { id: eventId },
@@ -252,6 +260,8 @@ export async function DELETE(
       prisma.eventDepartment.deleteMany({ where: { eventId } }),
       prisma.event.delete({ where: { id: eventId } }),
     ]);
+
+    await logAudit({ userId: delSession.user.id, churchId, action: "DELETE", entityType: "Event", entityId: eventId, details: { title: event.title } });
 
     return successResponse({ success: true });
   } catch (error) {

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -55,7 +55,7 @@ export async function PATCH(request: Request) {
     if (ids.length === 0) throw new ApiError(400, "Au moins un ID requis");
     const { resolveChurchId } = await import("@/lib/auth");
     const evtChurchId = await resolveChurchId("event", ids[0]);
-    await requireChurchPermission("events:manage", evtChurchId);
+    const patchSession = await requireChurchPermission("events:manage", evtChurchId);
 
     if (action === "delete") {
       await prisma.$transaction(async (tx) => {
@@ -69,6 +69,9 @@ export async function PATCH(request: Request) {
         await tx.eventDepartment.deleteMany({ where: { eventId: { in: ids } } });
         await tx.event.deleteMany({ where: { id: { in: ids } } });
       });
+      for (const id of ids) {
+        await logAudit({ userId: patchSession.user.id, churchId: evtChurchId, action: "DELETE", entityType: "Event", entityId: id });
+      }
       return successResponse({ deleted: ids.length });
     }
 
@@ -86,6 +89,9 @@ export async function PATCH(request: Request) {
       data: updateData,
     });
 
+    for (const id of ids) {
+      await logAudit({ userId: patchSession.user.id, churchId: evtChurchId, action: "UPDATE", entityType: "Event", entityId: id, details: data });
+    }
     return successResponse({ updated: ids.length });
   } catch (error) {
     return errorResponse(error);

--- a/src/app/api/member-link-requests/[id]/route.ts
+++ b/src/app/api/member-link-requests/[id]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const schema = z.object({
@@ -42,6 +43,7 @@ export async function PATCH(
           reviewedById: session.user.id,
         },
       });
+      await logAudit({ userId: session.user.id, churchId, action: "UPDATE", entityType: "MemberLinkRequest", entityId: id, details: { action: "reject" } });
       return successResponse(updated);
     }
 
@@ -107,6 +109,8 @@ export async function PATCH(
         },
       });
     });
+
+    await logAudit({ userId: session.user.id, churchId, action: "UPDATE", entityType: "MemberLinkRequest", entityId: id, details: { action } });
 
     return successResponse({ approved: true });
   } catch (error) {

--- a/src/app/api/member-user-links/route.ts
+++ b/src/app/api/member-user-links/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_SENSITIVE } from "@/lib/rate-limit";
 import { z } from "zod";
 
@@ -55,6 +56,8 @@ export async function POST(request: Request) {
 
       return created;
     });
+
+    await logAudit({ userId: session.user.id, churchId, action: "CREATE", entityType: "MemberUserLink", entityId: link.id, details: { memberId, userId } });
 
     return successResponse(link, 201);
   } catch (error) {

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const updateSchema = z.object({
@@ -65,6 +66,8 @@ export async function PUT(
       },
     });
 
+    await logAudit({ userId: session.user.id, churchId, action: "UPDATE", entityType: "Member", entityId: memberId, details: { firstName: data.firstName, lastName: data.lastName } });
+
     return successResponse(member);
   } catch (error) {
     return errorResponse(error);
@@ -95,6 +98,8 @@ export async function DELETE(
     }
 
     await prisma.member.delete({ where: { id: memberId } });
+
+    await logAudit({ userId: session.user.id, churchId, action: "DELETE", entityType: "Member", entityId: memberId });
 
     return successResponse({ success: true });
   } catch (error) {

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
 
@@ -107,6 +108,9 @@ export async function PATCH(request: Request) {
         prisma.planning.deleteMany({ where: { memberId: { in: ids } } }),
         prisma.member.deleteMany({ where: { id: { in: ids } } }),
       ]);
+      for (const id of ids) {
+        await logAudit({ userId: session.user.id, churchId: firstMemberChurchId, action: "DELETE", entityType: "Member", entityId: id });
+      }
       return successResponse({ deleted: ids.length });
     }
 
@@ -119,6 +123,9 @@ export async function PATCH(request: Request) {
       data,
     });
 
+    for (const id of ids) {
+      await logAudit({ userId: session.user.id, churchId: firstMemberChurchId, action: "UPDATE", entityType: "Member", entityId: id, details: data });
+    }
     return successResponse({ updated: ids.length });
   } catch (error) {
     return errorResponse(error);
@@ -166,6 +173,8 @@ export async function POST(request: Request) {
         },
       },
     });
+
+    await logAudit({ userId: session.user.id, churchId: deptChurchId, action: "CREATE", entityType: "Member", entityId: member.id, details: { firstName: data.firstName, lastName: data.lastName } });
 
     return successResponse(member, 201);
   } catch (error) {

--- a/src/app/api/ministries/[ministryId]/route.ts
+++ b/src/app/api/ministries/[ministryId]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const updateSchema = z.object({
@@ -30,6 +31,8 @@ export async function PUT(
       data,
       include: { church: { select: { id: true, name: true } } },
     });
+
+    await logAudit({ userId: session.user.id, churchId, action: "UPDATE", entityType: "Ministry", entityId: ministryId, details: data });
 
     return successResponse(ministry);
   } catch (error) {
@@ -67,6 +70,8 @@ export async function DELETE(
     }
 
     await prisma.ministry.delete({ where: { id: ministryId } });
+
+    await logAudit({ userId: session.user.id, churchId: delChurchId, action: "DELETE", entityType: "Ministry", entityId: ministryId });
 
     return successResponse({ success: true });
   } catch (error) {

--- a/src/app/api/ministries/route.ts
+++ b/src/app/api/ministries/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
 
@@ -41,7 +42,7 @@ export async function PATCH(request: Request) {
     if (ids.length === 0) throw new ApiError(400, "Au moins un ID requis");
     const { resolveChurchId } = await import("@/lib/auth");
     const minChurchId = await resolveChurchId("ministry", ids[0]);
-    await requireChurchPermission("departments:manage", minChurchId);
+    const session = await requireChurchPermission("departments:manage", minChurchId);
 
     if (action === "delete") {
       await prisma.$transaction(async (tx) => {
@@ -68,6 +69,9 @@ export async function PATCH(request: Request) {
         await tx.userChurchRole.updateMany({ where: { ministryId: { in: ids } }, data: { ministryId: null } });
         await tx.ministry.deleteMany({ where: { id: { in: ids } } });
       });
+      for (const id of ids) {
+        await logAudit({ userId: session.user.id, churchId: minChurchId, action: "DELETE", entityType: "Ministry", entityId: id });
+      }
       return successResponse({ deleted: ids.length });
     }
 
@@ -80,6 +84,9 @@ export async function PATCH(request: Request) {
       data,
     });
 
+    for (const id of ids) {
+      await logAudit({ userId: session.user.id, churchId: minChurchId, action: "UPDATE", entityType: "Ministry", entityId: id, details: data });
+    }
     return successResponse({ updated: ids.length });
   } catch (error) {
     return errorResponse(error);
@@ -102,6 +109,8 @@ export async function POST(request: Request) {
       data,
       include: { church: { select: { id: true, name: true } } },
     });
+
+    await logAudit({ userId: session.user.id, churchId: data.churchId, action: "CREATE", entityType: "Ministry", entityId: ministry.id, details: { name: data.name } });
 
     return successResponse(ministry, 201);
   } catch (error) {

--- a/src/app/api/service-requests/[id]/route.ts
+++ b/src/app/api/service-requests/[id]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { hasPermission } from "@/lib/permissions";
 import { z } from "zod";
 
@@ -190,6 +191,8 @@ export async function PATCH(
 
       return result;
     });
+
+    await logAudit({ userId: session.user.id, churchId: serviceRequest.churchId, action: "UPDATE", entityType: "ServiceRequest", entityId: id, details: { status: data.status, type: serviceRequest.type } });
 
     return successResponse(updated);
   } catch (error) {

--- a/src/app/api/service-requests/route.ts
+++ b/src/app/api/service-requests/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { hasPermission } from "@/lib/permissions";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { DepartmentFunction } from "@prisma/client";
@@ -103,6 +104,8 @@ export async function POST(request: Request) {
         deadline: data.deadline ? new Date(data.deadline) : null,
       },
     });
+
+    await logAudit({ userId: session.user.id, churchId: data.churchId, action: "CREATE", entityType: "ServiceRequest", entityId: serviceRequest.id, details: { title: data.title, type: "VISUEL" } });
 
     return successResponse(serviceRequest, 201);
   } catch (error) {

--- a/src/app/api/users/[userId]/profile/route.ts
+++ b/src/app/api/users/[userId]/profile/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 
 const updateProfileSchema = z.object({
   displayName: z.string().min(1).max(100),
@@ -45,6 +46,8 @@ export async function PATCH(
       data: { displayName: data.displayName },
       select: { id: true, displayName: true },
     });
+
+    await logAudit({ userId: session.user.id, action: "UPDATE", entityType: "UserProfile", entityId: userId, details: { displayName: data.displayName } });
 
     return successResponse(user);
   } catch (error) {

--- a/src/app/api/users/[userId]/roles/route.ts
+++ b/src/app/api/users/[userId]/roles/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_SENSITIVE } from "@/lib/rate-limit";
 import { z } from "zod";
 
@@ -120,6 +121,8 @@ export async function POST(
       include: roleInclude,
     });
 
+    await logAudit({ userId: session.user.id, churchId, action: "CREATE", entityType: "UserRole", entityId: userRole.id, details: { targetUserId: userId, role } });
+
     return successResponse(userRole, 201);
   } catch (error) {
     return errorResponse(error);
@@ -205,6 +208,8 @@ export async function PATCH(
       });
     });
 
+    await logAudit({ userId: patchSession.user.id, churchId: existing.churchId, action: "UPDATE", entityType: "UserRole", entityId: roleId, details: { targetUserId: userId, ministryId } });
+
     return successResponse(updated);
   } catch (error) {
     return errorResponse(error);
@@ -234,6 +239,8 @@ export async function DELETE(
       await tx.userDepartment.deleteMany({ where: { userChurchRoleId: existing.id } });
       await tx.userChurchRole.delete({ where: { id: existing.id } });
     });
+
+    await logAudit({ userId: delSession.user.id, churchId, action: "DELETE", entityType: "UserRole", entityId: `${userId}:${role}`, details: { targetUserId: userId, role } });
 
     return successResponse({ success: true });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Ajout de `logAudit` sur **tous** les endpoints de mutation (POST, PUT, PATCH, DELETE) — 25 fichiers, ~50 mutations couvertes
- Standardisation des routes discipolat pour utiliser `logAudit` au lieu de `prisma.auditLog.create` direct
- Normalisation des actions : `CREATE`, `UPDATE`, `DELETE` (au lieu de `CREATE_DISCIPLESHIP`, etc.)
- Ajout du `churchId` manquant sur le log du planning

## Endpoints couverts
Churches, Ministries, Departments, Members, Events, Planning, Tasks, Announcements, Service Requests, User Roles, User Profile, Member Links, Discipleships, Attendance

## Test plan
- [ ] Vérifier que les mutations créent des entrées dans la page Audit Logs
- [ ] Vérifier que les logs contiennent userId, churchId, action, entityType, entityId
- [ ] Vérifier que `logAudit` ne casse pas le flux principal (try/catch silencieux)
- [ ] Run `npm run typecheck` (passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)