### PR TITLE
fix: close 6 counter-audit security vulnerabilities

### DIFF
--- a/src/app/api/departments/route.ts
+++ b/src/app/api/departments/route.ts
@@ -61,6 +61,15 @@ export async function PATCH(request: Request) {
     if (ids.length === 0) throw new ApiError(400, "Au moins un ID requis");
     const { resolveChurchId } = await import("@/lib/auth");
     const deptChurchId = await resolveChurchId("department", ids[0]);
+
+    // Verify ALL ids belong to the same church
+    if (ids.length > 1) {
+      const allChurchIds = await Promise.all(ids.map((id) => resolveChurchId("department", id)));
+      if (allChurchIds.some((cid) => cid !== deptChurchId)) {
+        throw new ApiError(400, "Tous les départements doivent appartenir à la même église");
+      }
+    }
+
     const session = await requireChurchPermission("departments:manage", deptChurchId);
 
     const allowedMinistries = getMinisterMinistryIds(session, deptChurchId);

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
@@ -19,6 +19,16 @@ export async function GET(
     const churchId = await resolveChurchId("event", eventId);
     await requireChurchPermission("planning:view", churchId);
 
+    // Verify department belongs to same church as event
+    const deptCheck = await prisma.department.findUnique({
+      where: { id: departmentId },
+      select: { ministry: { select: { churchId: true } } },
+    });
+    if (!deptCheck) throw new ApiError(404, "Département introuvable");
+    if (deptCheck.ministry.churchId !== churchId) {
+      throw new ApiError(403, "Ce département n'appartient pas à l'église de cet événement");
+    }
+
     const eventDept = await prisma.eventDepartment.findUnique({
       where: {
         eventId_departmentId: { eventId, departmentId },
@@ -121,9 +131,11 @@ export async function PUT(
     });
 
     if (event?.planningDeadline && new Date() > new Date(event.planningDeadline)) {
-      // After deadline, only ADMIN and SECRETARY can modify
-      const userRoles = session.user.churchRoles.map((r) => r.role);
-      const canBypass = userRoles.some(
+      // After deadline, only ADMIN and SECRETARY in this church can modify
+      const churchRoles = session.user.churchRoles
+        .filter((r) => r.churchId === eventChurchId)
+        .map((r) => r.role);
+      const canBypass = churchRoles.some(
         (r) => r === "SUPER_ADMIN" || r === "ADMIN" || r === "SECRETARY"
       );
       if (!canBypass) {
@@ -136,6 +148,16 @@ export async function PUT(
 
     const body = await request.json();
     const { plannings } = planningSchema.parse(body);
+
+    // Verify department belongs to same church as event
+    const planDeptCheck = await prisma.department.findUnique({
+      where: { id: departmentId },
+      select: { ministry: { select: { churchId: true } } },
+    });
+    if (!planDeptCheck) throw new ApiError(404, "Département introuvable");
+    if (planDeptCheck.ministry.churchId !== eventChurchId) {
+      throw new ApiError(403, "Ce département n'appartient pas à l'église de cet événement");
+    }
 
     // Find or create event-department link
     let eventDept = await prisma.eventDepartment.findUnique({

--- a/src/app/api/events/[eventId]/departments/route.ts
+++ b/src/app/api/events/[eventId]/departments/route.ts
@@ -1,7 +1,18 @@
 import { prisma } from "@/lib/prisma";
 import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
-import { successResponse, errorResponse } from "@/lib/api-utils";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
+
+async function verifyDepartmentChurch(departmentId: string, expectedChurchId: string) {
+  const dept = await prisma.department.findUnique({
+    where: { id: departmentId },
+    select: { ministry: { select: { churchId: true } } },
+  });
+  if (!dept) throw new ApiError(404, "Département introuvable");
+  if (dept.ministry.churchId !== expectedChurchId) {
+    throw new ApiError(403, "Ce département n'appartient pas à l'église de cet événement");
+  }
+}
 
 const schema = z.object({
   departmentId: z.string().min(1, "Le département est requis"),
@@ -43,6 +54,7 @@ export async function POST(
     await requireChurchPermission("events:manage", churchId);
     const body = await request.json();
     const { departmentId, applyToSeries } = schema.parse(body);
+    await verifyDepartmentChurch(departmentId, churchId);
 
     if (applyToSeries) {
       const eventIds = await getSeriesEventIds(eventId);
@@ -79,6 +91,7 @@ export async function DELETE(
     await requireChurchPermission("events:manage", delChurchId);
     const body = await request.json();
     const { departmentId, applyToSeries } = schema.parse(body);
+    await verifyDepartmentChurch(departmentId, delChurchId);
 
     if (applyToSeries) {
       const eventIds = await getSeriesEventIds(eventId);

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -55,6 +55,15 @@ export async function PATCH(request: Request) {
     if (ids.length === 0) throw new ApiError(400, "Au moins un ID requis");
     const { resolveChurchId } = await import("@/lib/auth");
     const evtChurchId = await resolveChurchId("event", ids[0]);
+
+    // Verify ALL ids belong to the same church
+    if (ids.length > 1) {
+      const allChurchIds = await Promise.all(ids.map((id) => resolveChurchId("event", id)));
+      if (allChurchIds.some((cid) => cid !== evtChurchId)) {
+        throw new ApiError(400, "Tous les événements doivent appartenir à la même église");
+      }
+    }
+
     const patchSession = await requireChurchPermission("events:manage", evtChurchId);
 
     if (action === "delete") {

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -70,10 +70,17 @@ export async function PATCH(request: Request) {
 
     // Résoudre l'église à partir du premier membre
     if (ids.length === 0) throw new ApiError(400, "Au moins un ID requis");
-    const firstMemberChurchId = await (async () => {
-      const { resolveChurchId } = await import("@/lib/auth");
-      return resolveChurchId("member", ids[0]);
-    })();
+    const { resolveChurchId } = await import("@/lib/auth");
+    const firstMemberChurchId = await resolveChurchId("member", ids[0]);
+
+    // Verify ALL ids belong to the same church
+    if (ids.length > 1) {
+      const allChurchIds = await Promise.all(ids.map((id) => resolveChurchId("member", id)));
+      if (allChurchIds.some((cid) => cid !== firstMemberChurchId)) {
+        throw new ApiError(400, "Tous les STAR doivent appartenir à la même église");
+      }
+    }
+
     const session = await requireChurchPermission("members:manage", firstMemberChurchId);
     requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 

--- a/src/app/api/ministries/route.ts
+++ b/src/app/api/ministries/route.ts
@@ -42,6 +42,15 @@ export async function PATCH(request: Request) {
     if (ids.length === 0) throw new ApiError(400, "Au moins un ID requis");
     const { resolveChurchId } = await import("@/lib/auth");
     const minChurchId = await resolveChurchId("ministry", ids[0]);
+
+    // Verify ALL ids belong to the same church
+    if (ids.length > 1) {
+      const allChurchIds = await Promise.all(ids.map((id) => resolveChurchId("ministry", id)));
+      if (allChurchIds.some((cid) => cid !== minChurchId)) {
+        throw new ApiError(400, "Tous les ministères doivent appartenir à la même église");
+      }
+    }
+
     const session = await requireChurchPermission("departments:manage", minChurchId);
 
     if (action === "delete") {

--- a/src/app/api/service-requests/route.ts
+++ b/src/app/api/service-requests/route.ts
@@ -27,11 +27,13 @@ export async function GET(request: Request) {
     if (!churchId) throw new ApiError(400, "churchId requis");
     const session = await requireChurchPermission("planning:view", churchId);
 
-    const userPermissions = new Set(
-      session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+    const churchPermissions = new Set(
+      session.user.churchRoles
+        .filter((r) => r.churchId === churchId)
+        .flatMap((r) => hasPermission(r.role))
     );
     const canManage =
-      session.user.isSuperAdmin || userPermissions.has("events:manage");
+      session.user.isSuperAdmin || churchPermissions.has("events:manage");
 
     const serviceRequests = await prisma.serviceRequest.findMany({
       where: {

--- a/src/app/api/users/[userId]/roles/route.ts
+++ b/src/app/api/users/[userId]/roles/route.ts
@@ -229,6 +229,13 @@ export async function DELETE(
     const delSession = await requireChurchPermission("departments:manage", churchId);
     requireRateLimit(request, { prefix: `roles:${delSession.user.id}`, ...RATE_LIMIT_SENSITIVE });
 
+    // Block deletion of privileged roles by non-super-admins
+    if (PRIVILEGED_ROLES.includes(role as typeof PRIVILEGED_ROLES[number])) {
+      if (!delSession.user.isSuperAdmin) {
+        throw new ApiError(403, "Droits insuffisants pour supprimer ce rôle");
+      }
+    }
+
     await prisma.$transaction(async (tx) => {
       const existing = await tx.userChurchRole.findUnique({
         where: { userId_churchId_role: { userId, churchId, role } },


### PR DESCRIPTION
## Summary

Fixes all 6 vulnerabilities identified in the counter-audit:

- **Cross-tenant event↔department** (Constat 1): Verify department belongs to same church as event in planning GET/PUT and event-departments POST/DELETE
- **Bulk operations church validation** (Constat 2): Validate ALL IDs belong to the same church, not just the first — affects events, departments, members, and ministries PATCH handlers
- **Privileged role deletion guard** (Constat 3): Block non-super-admins from deleting SUPER_ADMIN/ADMIN/SECRETARY roles via DELETE endpoint
- **Service-requests canManage scope** (Constat 4): Filter permission check to roles in the requested church only
- **Planning deadline bypass scope** (Constat 5): Scope the ADMIN/SECRETARY bypass check to the event's church, not all session roles

## Test plan

- [ ] Verify cross-tenant department assignment to event is rejected (403)
- [ ] Verify bulk delete/update with mixed-church IDs is rejected (400)
- [ ] Verify non-super-admin cannot delete privileged roles (403)
- [ ] Verify service-requests visibility is scoped to requested church
- [ ] Verify planning deadline bypass only works with roles in the event's church
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)