### PR TITLE
fix: harden multi-tenant isolation on mutations and indirect writes

### DIFF
--- a/src/app/api/departments/route.ts
+++ b/src/app/api/departments/route.ts
@@ -112,6 +112,17 @@ export async function PATCH(request: Request) {
       return errorResponse(new Error("Aucune donnée à mettre à jour"));
     }
 
+    // Block cross-tenant destination: ministryId must belong to same church
+    if (data.ministryId) {
+      const targetMinistry = await prisma.ministry.findUnique({
+        where: { id: data.ministryId },
+        select: { churchId: true },
+      });
+      if (!targetMinistry || targetMinistry.churchId !== deptChurchId) {
+        throw new ApiError(403, "Le ministère cible n'appartient pas à la même église");
+      }
+    }
+
     await prisma.department.updateMany({
       where: { id: { in: ids } },
       data,

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts
@@ -111,6 +111,11 @@ describe("PUT /api/events/[eventId]/departments/[deptId]/planning", () => {
     vi.clearAllMocks();
     mockRequirePermission.mockResolvedValue(createAdminSession());
     prismaMock.department.findUnique.mockResolvedValue(mockDeptChurchCheck as never);
+    // Mock member validation: return members matching the requested IDs
+    prismaMock.member.findMany.mockImplementation((args: { where?: { id?: { in?: string[] } } }) => {
+      const ids = args?.where?.id?.in ?? [];
+      return Promise.resolve(ids.map((id: string) => ({ id })));
+    });
   });
 
   it("upserts planning statuses", async () => {

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
@@ -172,6 +172,18 @@ export async function PUT(
       });
     }
 
+    // Validate: all members must belong to this department
+    const memberIds = plannings.map((p) => p.memberId);
+    if (memberIds.length > 0) {
+      const validMembers = await prisma.member.findMany({
+        where: { id: { in: memberIds }, departmentId },
+        select: { id: true },
+      });
+      if (validMembers.length !== memberIds.length) {
+        throw new ApiError(400, "Un ou plusieurs membres n'appartiennent pas à ce département");
+      }
+    }
+
     // Validate: only one EN_SERVICE_DEBRIEF per department per event
     const debriefCount = plannings.filter(
       (p) => p.status === "EN_SERVICE_DEBRIEF"

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -125,6 +125,17 @@ export async function PATCH(request: Request) {
       return errorResponse(new Error("Aucune donnée à mettre à jour"));
     }
 
+    // Block cross-tenant destination: departmentId must belong to same church
+    if (data.departmentId) {
+      const targetDept = await prisma.department.findUnique({
+        where: { id: data.departmentId },
+        include: { ministry: { select: { churchId: true } } },
+      });
+      if (!targetDept || targetDept.ministry.churchId !== firstMemberChurchId) {
+        throw new ApiError(403, "Le département cible n'appartient pas à la même église");
+      }
+    }
+
     await prisma.member.updateMany({
       where: { id: { in: ids } },
       data,

--- a/src/app/api/ministries/route.ts
+++ b/src/app/api/ministries/route.ts
@@ -88,6 +88,11 @@ export async function PATCH(request: Request) {
       return errorResponse(new Error("Aucune donnée à mettre à jour"));
     }
 
+    // Block cross-tenant destination: churchId must match source church
+    if (data.churchId && data.churchId !== minChurchId) {
+      throw new ApiError(403, "Impossible de déplacer un ministère vers une autre église");
+    }
+
     await prisma.ministry.updateMany({
       where: { id: { in: ids } },
       data,

--- a/src/app/api/service-requests/[id]/route.ts
+++ b/src/app/api/service-requests/[id]/route.ts
@@ -109,7 +109,12 @@ export async function PATCH(
     const body = await request.json();
     const data = patchSchema.parse(body);
 
-    // Owner can only read — status changes restricted to dept members and managers
+    // Owner can only read — all modifications restricted to dept members and managers
+    if (isOwner && !canManage && !isAssignedDeptMember) {
+      throw new ApiError(403, "Le demandeur ne peut pas modifier sa propre demande");
+    }
+
+    // Status changes restricted to dept members and managers
     if (data.status !== undefined && !canManage && !isAssignedDeptMember) {
       throw new ApiError(403, "Seuls les membres du département assigné peuvent modifier le statut");
     }

--- a/src/app/api/service-requests/route.ts
+++ b/src/app/api/service-requests/route.ts
@@ -84,6 +84,26 @@ export async function POST(request: Request) {
     const session = await requireChurchPermission("planning:view", data.churchId);
     requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
+    // Validate cross-tenant references
+    if (data.departmentId) {
+      const dept = await prisma.department.findUnique({
+        where: { id: data.departmentId },
+        select: { ministry: { select: { churchId: true } } },
+      });
+      if (!dept || dept.ministry.churchId !== data.churchId) {
+        throw new ApiError(400, "Le département n'appartient pas à cette église");
+      }
+    }
+    if (data.ministryId) {
+      const ministry = await prisma.ministry.findUnique({
+        where: { id: data.ministryId },
+        select: { churchId: true },
+      });
+      if (!ministry || ministry.churchId !== data.churchId) {
+        throw new ApiError(400, "Le ministère n'appartient pas à cette église");
+      }
+    }
+
     const productionDept = await prisma.department.findFirst({
       where: {
         function: DepartmentFunction.PRODUCTION_MEDIA,


### PR DESCRIPTION
## Summary

Closes 4 remaining multi-tenant isolation gaps found in counter-audit round 2:

- **Bulk PATCH destination validation** (Constat 1 — Critique): Validate that destination `churchId`/`ministryId`/`departmentId` in update data belongs to the same church as source IDs. Affects ministries, departments, and members PATCH handlers.
- **Planning member validation** (Constat 2 — Élevée): Verify all `memberId`s in PUT belong to the target department before upserting planning records.
- **Service request cross-tenant references** (Constat 3 — Élevée): Validate `departmentId` and `ministryId` belong to the specified `churchId` when creating a service request.
- **Service request owner read-only** (Constat 4 — Moyenne): Block all modifications (not just status) when the caller is the owner and has no manager/dept-member role.

Tests updated to mock the new member validation in planning PUT.

## Test plan

- [ ] Bulk PATCH with cross-church destination `churchId`/`ministryId`/`departmentId` → 403
- [ ] Planning PUT with memberId from another department → 400
- [ ] Service request POST with cross-church `departmentId`/`ministryId` → 400
- [ ] Service request PATCH by owner (non-manager) → 403
- [ ] `npm test` — 80/80 passing
- [ ] `npm run typecheck` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)