### PR TITLE
feat: add weekly church statistics Excel export

### DIFF
--- a/prisma/migrations/20260322000001_add_speaker_message_title_to_report/migration.sql
+++ b/prisma/migrations/20260322000001_add_speaker_message_title_to_report/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `event_reports` ADD COLUMN `speaker` VARCHAR(191) NULL;
+ALTER TABLE `event_reports` ADD COLUMN `messageTitle` VARCHAR(191) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -303,14 +303,16 @@ model Event {
 }
 
 model EventReport {
-  id        String   @id @default(cuid())
-  eventId   String   @unique
-  churchId  String
-  notes     String?  @db.Text
-  decisions String?  @db.Text
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  authorId  String?
+  id           String   @id @default(cuid())
+  eventId      String   @unique
+  churchId     String
+  speaker      String?
+  messageTitle String?
+  notes        String?  @db.Text
+  decisions    String?  @db.Text
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  authorId     String?
 
   event    Event                @relation(fields: [eventId],   references: [id])
   church   Church               @relation(fields: [churchId],  references: [id])

--- a/src/app/(auth)/admin/events/[eventId]/report/EventReportClient.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/report/EventReportClient.tsx
@@ -24,6 +24,8 @@ interface SectionData extends Omit<Section, "stats"> {
 
 interface ExistingReport {
   id: string;
+  speaker: string | null;
+  messageTitle: string | null;
   notes: string | null;
   decisions: string | null;
   sections: SectionData[];
@@ -127,6 +129,8 @@ export default function EventReportClient({ eventId, eventTitle, eventDate, even
     return eventDepts.map((d, i) => emptySection(d, i));
   };
 
+  const [speaker, setSpeaker] = useState(existingReport?.speaker ?? "");
+  const [messageTitle, setMessageTitle] = useState(existingReport?.messageTitle ?? "");
   const [notes, setNotes] = useState(existingReport?.notes ?? "");
   const [decisions, setDecisions] = useState(existingReport?.decisions ?? "");
   const [sections, setSections] = useState<Section[]>(initSections);
@@ -135,11 +139,15 @@ export default function EventReportClient({ eventId, eventTitle, eventDate, even
   const [copied, setCopied] = useState(false);
 
   // Refs pour accéder aux valeurs les plus récentes dans le callback debounced
+  const speakerRef = useRef(speaker);
+  const messageTitleRef = useRef(messageTitle);
   const notesRef = useRef(notes);
   const decisionsRef = useRef(decisions);
   const sectionsRef = useRef(sections);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
+  speakerRef.current = speaker;
+  messageTitleRef.current = messageTitle;
   notesRef.current = notes;
   decisionsRef.current = decisions;
   sectionsRef.current = sections;
@@ -164,6 +172,8 @@ export default function EventReportClient({ eventId, eventTitle, eventDate, even
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          speaker: speakerRef.current || null,
+          messageTitle: messageTitleRef.current || null,
           notes: notesRef.current || null,
           decisions: decisionsRef.current || null,
           sections: sectionsRef.current,
@@ -319,6 +329,32 @@ export default function EventReportClient({ eventId, eventTitle, eventDate, even
           </svg>
           {copied ? "Copié !" : "WhatsApp"}
         </button>
+      </div>
+
+      {/* Orateur et titre du message */}
+      <div className="bg-white rounded-lg border-2 border-gray-100 p-4 space-y-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Orateur</label>
+            <input
+              type="text"
+              value={speaker}
+              onChange={(e) => { setSpeaker(e.target.value); scheduleSave(); }}
+              placeholder="Nom de l'orateur"
+              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Titre du message</label>
+            <input
+              type="text"
+              value={messageTitle}
+              onChange={(e) => { setMessageTitle(e.target.value); scheduleSave(); }}
+              placeholder="Titre du message"
+              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+            />
+          </div>
+        </div>
       </div>
 
       {/* Sections */}

--- a/src/app/(auth)/admin/reports/ReportsClient.tsx
+++ b/src/app/(auth)/admin/reports/ReportsClient.tsx
@@ -28,6 +28,7 @@ interface EventItem {
 
 interface Props {
   events: EventItem[];
+  churchId: string;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -69,9 +70,19 @@ function fmtDateTime(iso: string) {
 
 type Tab = "list" | "stats";
 
-export default function ReportsClient({ events }: Props) {
+export default function ReportsClient({ events, churchId }: Props) {
   const [tab, setTab] = useState<Tab>("list");
   const [monthFilter, setMonthFilter] = useState<string>("all");
+  const [exportFrom, setExportFrom] = useState<string>(() => {
+    const now = new Date();
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-01`;
+  });
+  const [exportTo, setExportTo] = useState<string>(() => {
+    const now = new Date();
+    const last = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+    return `${last.getFullYear()}-${String(last.getMonth() + 1).padStart(2, "0")}-${String(last.getDate()).padStart(2, "0")}`;
+  });
+  const [exporting, setExporting] = useState(false);
   const [listMonthFilter, setListMonthFilter] = useState<string>(() => {
     // Default to current month
     const now = new Date();
@@ -312,6 +323,56 @@ export default function ReportsClient({ events }: Props) {
             <span className="text-xs text-gray-400">
               {withReport}/{totalEvents} événements avec CR · {pending} en attente
             </span>
+          </div>
+
+          {/* Export Excel */}
+          <div className="flex flex-wrap items-end gap-3 bg-white rounded-lg border border-gray-100 shadow-sm px-5 py-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">Du</label>
+              <input
+                type="date"
+                value={exportFrom}
+                onChange={(e) => setExportFrom(e.target.value)}
+                className="border-2 border-gray-200 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">Au</label>
+              <input
+                type="date"
+                value={exportTo}
+                onChange={(e) => setExportTo(e.target.value)}
+                className="border-2 border-gray-200 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+              />
+            </div>
+            <button
+              disabled={exporting}
+              onClick={async () => {
+                setExporting(true);
+                try {
+                  const params = new URLSearchParams({ churchId, from: exportFrom, to: exportTo });
+                  const res = await fetch(`/api/events/reports/export?${params}`);
+                  if (!res.ok) throw new Error("Erreur lors de l'export");
+                  const blob = await res.blob();
+                  const url = URL.createObjectURL(blob);
+                  const a = document.createElement("a");
+                  a.href = url;
+                  a.download = res.headers.get("Content-Disposition")?.match(/filename="(.+)"/)?.[1] ?? "export.xlsx";
+                  a.click();
+                  URL.revokeObjectURL(url);
+                } catch {
+                  alert("Erreur lors de l'export Excel.");
+                } finally {
+                  setExporting(false);
+                }
+              }}
+              className="inline-flex items-center gap-2 bg-icc-violet text-white px-4 py-1.5 rounded-lg text-sm font-medium hover:bg-icc-violet/90 disabled:opacity-50 transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              {exporting ? "Export en cours..." : "Exporter en Excel"}
+            </button>
           </div>
 
           {/* Bloc Présence (Accueil) */}

--- a/src/app/(auth)/admin/reports/page.tsx
+++ b/src/app/(auth)/admin/reports/page.tsx
@@ -42,6 +42,7 @@ export default async function ReportsPage() {
       </div>
 
       <ReportsClient
+        churchId={churchId}
         events={events.map((e) => ({
           id: e.id,
           title: e.title,

--- a/src/app/api/events/[eventId]/report/route.ts
+++ b/src/app/api/events/[eventId]/report/route.ts
@@ -15,6 +15,8 @@ const sectionSchema = z.object({
 });
 
 const upsertSchema = z.object({
+  speaker: z.string().nullable().optional(),
+  messageTitle: z.string().nullable().optional(),
   notes: z.string().nullable().optional(),
   decisions: z.string().nullable().optional(),
   sections: z.array(sectionSchema),
@@ -83,7 +85,7 @@ export async function PUT(
 
     if (!event.reportEnabled) throw new ApiError(403, "Les comptes rendus ne sont pas activés pour cet événement");
 
-    const { notes, decisions, sections } = upsertSchema.parse(await request.json());
+    const { speaker, messageTitle, notes, decisions, sections } = upsertSchema.parse(await request.json());
 
     // Validate all departmentIds belong to the event's church
     const deptIds = sections.map((s) => s.departmentId).filter((id): id is string => id !== null && id !== undefined);
@@ -111,11 +113,15 @@ export async function PUT(
         eventId,
         churchId: event.churchId,
         authorId: session.user.id,
+        speaker: speaker ?? null,
+        messageTitle: messageTitle ?? null,
         notes: notes ?? null,
         decisions: decisions ?? null,
         sections: { create: sectionData },
       },
       update: {
+        speaker: speaker ?? null,
+        messageTitle: messageTitle ?? null,
         notes: notes ?? null,
         decisions: decisions ?? null,
         sections: {

--- a/src/app/api/events/reports/export/route.ts
+++ b/src/app/api/events/reports/export/route.ts
@@ -1,0 +1,118 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { errorResponse, ApiError } from "@/lib/api-utils";
+import * as XLSX from "xlsx";
+
+/**
+ * Neutralise les valeurs pouvant être interprétées comme des formules Excel.
+ */
+function sanitizeExcelValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  if (/^[=+\-@\t\r]/.test(value)) return `'${value}`;
+  return value;
+}
+
+function sanitizeRow<T extends Record<string, unknown>>(row: T): T {
+  const sanitized = {} as Record<string, unknown>;
+  for (const [key, value] of Object.entries(row)) {
+    sanitized[key] = sanitizeExcelValue(value);
+  }
+  return sanitized as T;
+}
+
+function norm(s: string) {
+  return s.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().trim();
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const churchId = searchParams.get("churchId");
+
+    if (!churchId) throw new ApiError(400, "churchId requis");
+    await requireChurchPermission("reports:view", churchId);
+
+    const now = new Date();
+    const defaultFrom = new Date(now.getFullYear(), now.getMonth(), 1);
+    const defaultTo = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+
+    const from = searchParams.get("from") ? new Date(searchParams.get("from")!) : defaultFrom;
+    const to = searchParams.get("to") ? new Date(searchParams.get("to")!) : defaultTo;
+
+    const church = await prisma.church.findUnique({
+      where: { id: churchId },
+      select: { name: true },
+    });
+
+    const reports = await prisma.eventReport.findMany({
+      where: {
+        churchId,
+        event: { date: { gte: from, lte: to } },
+      },
+      include: {
+        event: { select: { title: true, date: true, type: true } },
+        sections: {
+          select: { label: true, stats: true },
+          orderBy: { position: "asc" },
+        },
+      },
+      orderBy: { event: { date: "desc" } },
+    });
+
+    const rows = reports.map((r) => {
+      // Find Accueil section stats
+      const accueil = r.sections.find((s) => norm(s.label) === "accueil");
+      const stats = (accueil?.stats as Record<string, number | null> | null) ?? {};
+      const hommes = stats["hommes"] ?? null;
+      const femmes = stats["femmes"] ?? null;
+      const enfants = stats["enfants"] ?? null;
+      const totalAdultes = hommes !== null && femmes !== null ? hommes + femmes : null;
+
+      // Find Integration section stats
+      const integration = r.sections.find((s) => {
+        const n = norm(s.label);
+        return n === "integration" || n.startsWith("integration");
+      });
+      const intStats = (integration?.stats as Record<string, number | null> | null) ?? {};
+
+      return {
+        "Date du culte": new Date(r.event.date).toLocaleDateString("fr-FR"),
+        "Église": church?.name ?? "",
+        "Orateur": r.speaker ?? "",
+        "Titre du message": r.messageTitle ?? "",
+        "Hommes": hommes,
+        "Femmes": femmes,
+        "Enfants": enfants,
+        "Total adultes": totalAdultes,
+        "Total général": totalAdultes !== null ? totalAdultes + (enfants ?? 0) : null,
+        "Nouveaux arrivants (H)": intStats["hommes"] ?? null,
+        "Nouveaux arrivants (F)": intStats["femmes"] ?? null,
+        "De passage": intStats["passage"] ?? null,
+        "Nouveaux convertis": intStats["convertis"] ?? null,
+      };
+    });
+
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(
+      wb,
+      XLSX.utils.json_to_sheet(rows.map(sanitizeRow)),
+      "Statistiques cultes"
+    );
+
+    const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
+
+    const fromStr = from.toLocaleDateString("fr-FR", { month: "long", year: "numeric" });
+    const toStr = to.toLocaleDateString("fr-FR", { month: "long", year: "numeric" });
+    const period = fromStr === toStr ? fromStr : `${fromStr}-${toStr}`;
+    const filename = `statistiques-cultes-${period.replace(/\s/g, "-")}.xlsx`;
+
+    return new Response(buf, {
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `speaker` and `messageTitle` fields to EventReport (schema + migration + API + UI)
- New export endpoint `GET /api/events/reports/export?churchId=X&from=YYYY-MM-DD&to=YYYY-MM-DD` generating an Excel file matching the ICC Bretagne weekly statistics template
- Export button with date range picker on the reports dashboard (Statistiques tab)
- Excel formula injection protection via `sanitizeExcelValue()`

## Columns exported
Date du culte, Église, Orateur, Titre du message, Hommes, Femmes, Enfants, Total adultes, Total général, Nouveaux arrivants (H/F), De passage, Nouveaux convertis

## Test plan
- [ ] Create/edit an event report, verify speaker and message title fields save correctly
- [ ] Navigate to Admin > Comptes rendus > Statistiques tab
- [ ] Select a date range and click "Exporter en Excel"
- [ ] Verify the downloaded .xlsx contains correct data matching the reports
- [ ] Verify permission check (reports:view required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)