### PR TITLE
docs: update guide, tour, and docs for v0.12.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ koinonia/
 │   │       ├── churches/
 │   │       ├── departments/
 │   │       ├── discipleships/   # CRUD, attendance, stats, tree, export
-│   │       ├── events/          # CRUD + [eventId]/report GET/PUT
+│   │       ├── events/          # CRUD + [eventId]/report GET/PUT + reports/export
 │   │       ├── member-user-links/
 │   │       ├── member-link-requests/
 │   │       ├── members/

--- a/docs/api.md
+++ b/docs/api.md
@@ -378,6 +378,8 @@ Recupere le compte rendu d'un evenement. Retourne `null` si aucun CR n'existe en
   "id": "clx...",
   "eventId": "clx...",
   "churchId": "clx...",
+  "speaker": "Pasteur Martin",
+  "messageTitle": "La foi en action",
   "notes": "Bonne participation generale.",
   "decisions": "Revoir la disposition des chaises.",
   "author": { "id": "clx...", "name": "Jean Dupont" },
@@ -406,6 +408,8 @@ Cree ou remplace entierement le compte rendu d'un evenement. Les sections exista
 **Body** (valide par Zod) :
 ```json
 {
+  "speaker": "Pasteur Martin",
+  "messageTitle": "La foi en action",
   "notes": "Bonne participation generale.",
   "decisions": "Revoir la disposition des chaises.",
   "sections": [
@@ -420,6 +424,8 @@ Cree ou remplace entierement le compte rendu d'un evenement. Les sections exista
 }
 ```
 
+- `speaker` : nom de l'orateur (optionnel)
+- `messageTitle` : titre du message (optionnel)
 - `notes` : notes generales du CR (optionnel)
 - `decisions` : decisions prises lors de l'evenement (optionnel)
 - `sections` : tableau de sections (peut etre vide)
@@ -434,6 +440,26 @@ Cree ou remplace entierement le compte rendu d'un evenement. Les sections exista
 **Erreurs** :
 - `404` si l'evenement est introuvable
 - `403` si les comptes rendus ne sont pas actives pour cet evenement
+
+### `GET /api/events/reports/export`
+
+Exporte les statistiques hebdomadaires des cultes au format Excel (.xlsx) sur une periode donnee.
+
+**Permission requise** : `reports:view`
+
+**Parametres** (query string) :
+- `churchId` (requis) : ID de l'eglise
+- `from` (optionnel) : date de debut (`YYYY-MM-DD`, defaut : 1er jour du mois courant)
+- `to` (optionnel) : date de fin (`YYYY-MM-DD`, defaut : dernier jour du mois courant)
+
+**Reponse** : fichier Excel (`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`) avec les colonnes :
+- Date du culte, Eglise, Orateur, Titre du message
+- Hommes, Femmes, Enfants, Total adultes, Total general
+- Nouveaux arrivants (H), Nouveaux arrivants (F), De passage, Nouveaux convertis
+
+**Erreurs** :
+- `400` si `churchId` est manquant
+- `403` si l'utilisateur n'a pas la permission `reports:view`
 
 ---
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -294,6 +294,8 @@ Compte-rendu d'un evenement. Un seul CR par evenement.
 | `id` | String (cuid) | Identifiant unique |
 | `eventId` | String (unique) | Ref vers `events` (un seul CR par evenement) |
 | `churchId` | String | Ref vers `churches` |
+| `speaker` | String? | Nom de l'orateur |
+| `messageTitle` | String? | Titre du message |
 | `notes` | String? (Text) | Notes generales du CR |
 | `decisions` | String? (Text) | Decisions prises lors de l'evenement |
 | `authorId` | String? | Ref vers `users` (auteur du CR, nullable) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -98,6 +98,8 @@
 - [x] Dashboard /admin/reports : liste + statistiques agregees par mois
 - [x] Role REPORTER : acces lecture/ecriture aux CR sans droits admin
 - [x] Permission reports:edit separee de reports:view
+- [x] Champs orateur et titre du message dans les comptes rendus
+- [x] Export Excel des statistiques hebdomadaires des cultes avec selection de periode
 - [ ] Export PDF des comptes rendus
 - [ ] Historique des modifications d'un CR
 

--- a/src/components/GuideContent.tsx
+++ b/src/components/GuideContent.tsx
@@ -118,7 +118,7 @@ const FEATURES: Feature[] = [
   },
   {
     name: "Comptes rendus",
-    description: "Saisie et consultation des comptes rendus d'événements avec statistiques par département.",
+    description: "Saisie des comptes rendus (orateur, titre du message, statistiques par département) et export Excel des statistiques hebdomadaires sur une période.",
     category: "Événements",
     screenshotTitle: "Comptes rendus",
     screenshotFile: "guide-reports.png",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -320,7 +320,7 @@ export default function Sidebar({
           open={openSection === "planning"}
           onToggle={() => toggle("planning")}
           isActive={isDashboardActive}
-          dataTour="sidebar-departments"
+          dataTour="sidebar-planning"
         >
           {departments.length === 0 ? (
             <p className="px-3 text-sm text-gray-400">
@@ -376,9 +376,11 @@ export default function Sidebar({
               </NavLink>
             )}
             {hasReports && (
-              <NavLink href="/admin/reports" active={pathname.startsWith("/admin/reports")} onClose={onClose}>
-                Comptes rendus
-              </NavLink>
+              <span data-tour="sidebar-reports">
+                <NavLink href="/admin/reports" active={pathname.startsWith("/admin/reports")} onClose={onClose}>
+                  Comptes rendus
+                </NavLink>
+              </span>
             )}
           </nav>
         </AccordionSection>
@@ -389,6 +391,7 @@ export default function Sidebar({
         <Link
           href="/admin/members"
           onClick={onClose}
+          data-tour="sidebar-members"
           className={`${sectionHeaderBase} ${isMembersActive ? sectionHeaderActive : sectionHeaderIdle} rounded-md`}
         >
           <IconMembers className="w-4 h-4 shrink-0" />
@@ -404,6 +407,7 @@ export default function Sidebar({
           open={openSection === "service"}
           onToggle={() => toggle("service")}
           isActive={isServiceActive}
+          dataTour="sidebar-service"
         >
           <nav className="space-y-0.5 pl-6">
             {serviceLinks.map((link) => (
@@ -423,6 +427,7 @@ export default function Sidebar({
           open={openSection === "discipleship"}
           onToggle={() => toggle("discipleship")}
           isActive={isDiscipleshipActive}
+          dataTour="sidebar-discipleship"
         >
           <nav className="space-y-0.5 pl-6">
             <NavLink href="/admin/discipleship" active={pathname === "/admin/discipleship"} onClose={onClose}>
@@ -440,7 +445,7 @@ export default function Sidebar({
           open={openSection === "config"}
           onToggle={() => toggle("config")}
           isActive={isConfigActive}
-          dataTour="sidebar-admin"
+          dataTour="sidebar-config"
         >
           <nav className="space-y-0.5 pl-6">
             {configLinks.map((link) => (

--- a/src/lib/tour-steps.ts
+++ b/src/lib/tour-steps.ts
@@ -1,6 +1,10 @@
 export type RoleKey = "SUPER_ADMIN" | "ADMIN" | "SECRETARY" | "MINISTER" | "DEPARTMENT_HEAD" | "DISCIPLE_MAKER" | "REPORTER";
 
-const ADMIN_ROLES: RoleKey[] = ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER"];
+const PLANNING_ROLES: RoleKey[] = ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD"];
+const CONFIG_ROLES: RoleKey[] = ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER"];
+const MEMBERS_ROLES: RoleKey[] = ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD"];
+const REPORT_ROLES: RoleKey[] = ["SUPER_ADMIN", "ADMIN", "SECRETARY", "REPORTER"];
+const DISCIPLESHIP_ROLES: RoleKey[] = ["SUPER_ADMIN", "ADMIN", "SECRETARY", "DEPARTMENT_HEAD", "DISCIPLE_MAKER"];
 
 export interface TourStep {
   /** CSS selector for the target element, or "center" for a centered modal */
@@ -21,31 +25,62 @@ const ALL_STEPS: TourStep[] = [
       "Bienvenue dans Koinonia ! Ce tour vous guide a travers les principales fonctionnalites.",
   },
   {
-    target: '[data-tour="sidebar-departments"]',
-    title: "Departements",
+    target: '[data-tour="sidebar-planning"]',
+    title: "Planning",
     content:
       "Vos departements sont listes ici. Cliquez sur un departement pour voir son planning.",
     viewport: "desktop",
+    roles: PLANNING_ROLES,
   },
   {
     target: '[data-tour="sidebar-events"]',
     title: "Evenements",
-    content: "Accedez a la liste des evenements et au calendrier.",
+    content: "Accedez a la liste des evenements, au calendrier et aux comptes rendus avec export Excel des statistiques.",
     viewport: "desktop",
   },
   {
-    target: '[data-tour="sidebar-admin"]',
-    title: "Administration",
-    content:
-      "Gerez les membres, departements, ministeres et evenements.",
+    target: '[data-tour="sidebar-members"]',
+    title: "Membres",
+    content: "Consultez et gerez les membres (STAR) de vos departements.",
     viewport: "desktop",
-    roles: ADMIN_ROLES,
+    roles: MEMBERS_ROLES,
+  },
+  {
+    target: '[data-tour="sidebar-service"]',
+    title: "Annonces",
+    content:
+      "Soumettez des annonces et suivez les demandes de service (secretariat, visuels, communication).",
+    viewport: "desktop",
+  },
+  {
+    target: '[data-tour="sidebar-discipleship"]',
+    title: "Discipolat",
+    content:
+      "Suivez les relations de discipolat, l'appel de presence et les statistiques.",
+    viewport: "desktop",
+    roles: DISCIPLESHIP_ROLES,
+  },
+  {
+    target: '[data-tour="sidebar-config"]',
+    title: "Configuration",
+    content:
+      "Gerez les departements, ministeres, eglises, acces et parametres.",
+    viewport: "desktop",
+    roles: CONFIG_ROLES,
+  },
+  {
+    target: '[data-tour="sidebar-reports"]',
+    title: "Comptes rendus",
+    content:
+      "Saisissez les comptes rendus de culte (orateur, statistiques) et exportez les donnees en Excel.",
+    viewport: "desktop",
+    roles: REPORT_ROLES,
   },
   {
     target: '[data-tour="bottom-nav"]',
     title: "Navigation",
     content:
-      "Naviguez entre les departements, evenements et l'administration.",
+      "Naviguez entre le planning, les evenements et les membres.",
     viewport: "mobile",
   },
   {
@@ -64,12 +99,14 @@ const ALL_STEPS: TourStep[] = [
     title: "Actions",
     content:
       "Basculez entre la vue par evenement, la vue mensuelle et la vue des taches.",
+    roles: PLANNING_ROLES,
   },
   {
     target: '[data-tour="event-selector"]',
     title: "Selecteur",
     content:
       "Selectionnez un evenement pour afficher le planning correspondant.",
+    roles: PLANNING_ROLES,
   },
 ];
 


### PR DESCRIPTION
## Summary
- **Tour guidé** : ajout des étapes manquantes (Membres, Annonces, Discipolat, Comptes rendus) et mise à jour des noms de sections (Administration→Configuration, Départements→Planning). Visibilité par rôle : le REPORTER voit les CR, le DISCIPLE_MAKER voit le discipolat.
- **Sidebar** : ajout des attributs `data-tour` sur les 6 sections pour le tour guidé
- **GuideContent** : description enrichie de la feature Comptes rendus (orateur, titre, export Excel)
- **API docs** : champs `speaker`/`messageTitle` dans GET/PUT report + nouveau endpoint `GET /api/events/reports/export`
- **Database docs** : colonnes `speaker` et `messageTitle` dans `event_reports`
- **Roadmap** : items cochés (export Excel + champs orateur/titre)

## Test plan
- [ ] Lancer le tour guidé en tant que SUPER_ADMIN → vérifier les 6 sections visibles
- [ ] Lancer le tour en tant que REPORTER → vérifier que Comptes rendus apparaît
- [ ] Lancer le tour en tant que DISCIPLE_MAKER → vérifier que Discipolat apparaît
- [ ] Vérifier le guide (/guide) → description Comptes rendus mise à jour

🤖 Generated with [Claude Code](https://claude.com/claude-code)