### PR TITLE
feat(members): STAR multi-département avec département principal

### DIFF
--- a/prisma/migrations/20260323000001_member_multi_department/migration.sql
+++ b/prisma/migrations/20260323000001_member_multi_department/migration.sql
@@ -1,0 +1,31 @@
+-- Migration: member_multi_department
+-- Remplace la relation 1-N Member→Department par une N-N via MemberDepartment.
+-- Le département existant devient le département principal (isPrimary = true).
+
+-- 1. Créer la table de jointure
+CREATE TABLE `member_departments` (
+  `id`           VARCHAR(191) NOT NULL,
+  `memberId`     VARCHAR(191) NOT NULL,
+  `departmentId` VARCHAR(191) NOT NULL,
+  `isPrimary`    BOOLEAN      NOT NULL DEFAULT false,
+
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `member_departments_memberId_departmentId_key` (`memberId`, `departmentId`),
+  CONSTRAINT `member_departments_memberId_fkey`
+    FOREIGN KEY (`memberId`) REFERENCES `members`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `member_departments_departmentId_fkey`
+    FOREIGN KEY (`departmentId`) REFERENCES `departments`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- 2. Migrer les données existantes : chaque membre → ligne isPrimary = true
+INSERT INTO `member_departments` (`id`, `memberId`, `departmentId`, `isPrimary`)
+SELECT
+  CONCAT('md_', `id`) AS `id`,
+  `id`                AS `memberId`,
+  `departmentId`      AS `departmentId`,
+  true                AS `isPrimary`
+FROM `members`;
+
+-- 3. Supprimer la contrainte FK et la colonne departmentId de members
+ALTER TABLE `members` DROP FOREIGN KEY `members_departmentId_fkey`;
+ALTER TABLE `members` DROP COLUMN `departmentId`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -164,7 +164,7 @@ model Department {
   isSystem                Boolean            @default(false)
   function                DepartmentFunction?
   ministry                Ministry           @relation(fields: [ministryId], references: [id])
-  members                 Member[]
+  memberDepts             MemberDepartment[]
   eventDepts              EventDepartment[]
   userDepts               UserDepartment[]
   tasks                   Task[]
@@ -183,8 +183,7 @@ model Member {
   lastName        String
   email           String?
   phone           String?
-  departmentId    String
-  department      Department          @relation(fields: [departmentId], references: [id])
+  departments     MemberDepartment[]
   plannings       Planning[]
   taskAssignments TaskAssignment[]
   createdAt       DateTime            @default(now())
@@ -198,6 +197,19 @@ model Member {
   attendances         DiscipleshipAttendance[]
 
   @@map("members")
+}
+
+model MemberDepartment {
+  id           String     @id @default(cuid())
+  memberId     String
+  departmentId String
+  isPrimary    Boolean    @default(false)
+
+  member     Member     @relation(fields: [memberId],     references: [id], onDelete: Cascade)
+  department Department @relation(fields: [departmentId], references: [id])
+
+  @@unique([memberId, departmentId])
+  @@map("member_departments")
 }
 
 model MemberUserLink {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -86,7 +86,7 @@ async function main() {
           data: {
             firstName: firstNames[Math.floor(Math.random() * firstNames.length)],
             lastName: lastNames[Math.floor(Math.random() * lastNames.length)],
-            departmentId: dept.id,
+            departments: { create: { departmentId: dept.id, isPrimary: true } },
           },
         });
       }

--- a/src/app/(auth)/admin/members/LinkRequestsClient.tsx
+++ b/src/app/(auth)/admin/members/LinkRequestsClient.tsx
@@ -15,7 +15,7 @@ interface LinkRequest {
     id: string;
     firstName: string;
     lastName: string;
-    department: { name: string; ministry: { name: string } };
+    departments: { isPrimary: boolean; department: { name: string; ministry: { name: string } } }[];
   } | null;
   firstName: string | null;
   lastName: string | null;
@@ -109,7 +109,7 @@ export default function LinkRequestsClient({
                 <p className="text-gray-600">
                   Revendique la fiche :{" "}
                   <strong>{req.member.firstName} {req.member.lastName}</strong>
-                  <span className="text-gray-400"> · {req.member.department.ministry.name} / {req.member.department.name}</span>
+                  {(() => { const pd = req.member.departments.find((d) => d.isPrimary) ?? req.member.departments[0]; return pd ? <span className="text-gray-400"> · {pd.department.ministry.name} / {pd.department.name}</span> : null; })()}
                 </p>
               ) : (
                 <p className="text-gray-600">

--- a/src/app/(auth)/admin/members/MembersClient.tsx
+++ b/src/app/(auth)/admin/members/MembersClient.tsx
@@ -10,16 +10,20 @@ import BulkActionBar from "@/components/ui/BulkActionBar";
 
 type UserResult = { id: string; name: string | null; email: string; displayName: string | null; image: string | null };
 
+interface DeptRef {
+  id: string;
+  name: string;
+  isPrimary: boolean;
+  ministry: { id: string; name: string };
+}
+
 interface Member {
   id: string;
   firstName: string;
   lastName: string;
   churchId: string;
-  department: {
-    id: string;
-    name: string;
-    ministry: { id: string; name: string };
-  };
+  primaryDepartment: { id: string; name: string; ministry: { id: string; name: string } } | null;
+  allDepartments: DeptRef[];
   userLink: { userId: string; userName: string | null; userEmail: string } | null;
 }
 
@@ -36,6 +40,7 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [departmentId, setDepartmentId] = useState(departments[0]?.id || "");
+  const [additionalDeptIds, setAdditionalDeptIds] = useState<string[]>([]);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [filterDept, setFilterDept] = useState("");
@@ -97,11 +102,18 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
     }
   }
 
+  function toggleAdditionalDept(deptId: string) {
+    setAdditionalDeptIds((prev) =>
+      prev.includes(deptId) ? prev.filter((id) => id !== deptId) : [...prev, deptId]
+    );
+  }
+
   function openCreate() {
     setEditing(null);
     setFirstName("");
     setLastName("");
     setDepartmentId(departments[0]?.id || "");
+    setAdditionalDeptIds([]);
     setError("");
     setModalOpen(true);
   }
@@ -110,7 +122,9 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
     setEditing(m);
     setFirstName(m.firstName);
     setLastName(m.lastName);
-    setDepartmentId(m.department.id);
+    const primaryId = m.primaryDepartment?.id ?? m.allDepartments[0]?.id ?? departments[0]?.id ?? "";
+    setDepartmentId(primaryId);
+    setAdditionalDeptIds(m.allDepartments.filter((d) => !d.isPrimary).map((d) => d.id));
     setError("");
     setModalOpen(true);
   }
@@ -127,7 +141,12 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
       const res = await fetch(url, {
         method,
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ firstName, lastName, departmentId }),
+        body: JSON.stringify({
+          firstName,
+          lastName,
+          departmentId,
+          additionalDepartmentIds: additionalDeptIds.filter((id) => id !== departmentId),
+        }),
       });
 
       if (!res.ok) {
@@ -137,10 +156,13 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
 
       const saved = await res.json();
 
+      // Normaliser la réponse API en format Member
+      const normalizedMember = normalizeMember(saved);
+
       if (editing) {
-        setMembers((prev) => prev.map((m) => (m.id === saved.id ? saved : m)));
+        setMembers((prev) => prev.map((m) => (m.id === normalizedMember.id ? normalizedMember : m)));
       } else {
-        setMembers((prev) => [...prev, saved]);
+        setMembers((prev) => [...prev, normalizedMember]);
       }
 
       setModalOpen(false);
@@ -149,6 +171,41 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
     } finally {
       setLoading(false);
     }
+  }
+
+  // Normaliser la réponse API (departments[]) vers le format Member du client
+  function normalizeMember(raw: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    departments?: { isPrimary: boolean; department: { id: string; name: string; ministry: { id: string; name: string; churchId?: string } } }[];
+    userLink?: { userId: string; userName?: string | null; userEmail?: string; user?: { name: string | null; email: string } } | null;
+    churchId?: string;
+  }): Member {
+    const depts = raw.departments ?? [];
+    const primaryDept = depts.find((d) => d.isPrimary) ?? depts[0];
+    return {
+      id: raw.id,
+      firstName: raw.firstName,
+      lastName: raw.lastName,
+      churchId: raw.churchId ?? primaryDept?.department.ministry.churchId ?? "",
+      primaryDepartment: primaryDept
+        ? { id: primaryDept.department.id, name: primaryDept.department.name, ministry: primaryDept.department.ministry }
+        : null,
+      allDepartments: depts.map((d) => ({
+        id: d.department.id,
+        name: d.department.name,
+        isPrimary: d.isPrimary,
+        ministry: d.department.ministry,
+      })),
+      userLink: raw.userLink
+        ? {
+            userId: raw.userLink.userId,
+            userName: raw.userLink.userName ?? raw.userLink.user?.name ?? null,
+            userEmail: raw.userLink.userEmail ?? raw.userLink.user?.email ?? "",
+          }
+        : null,
+    };
   }
 
   async function handleDelete(m: Member) {
@@ -201,7 +258,7 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
     const data: Record<string, string> = {};
     if (bulkFirstName) data.firstName = bulkFirstName;
     if (bulkLastName) data.lastName = bulkLastName;
-    if (bulkDepartmentId) data.departmentId = bulkDepartmentId;
+    if (bulkDepartmentId) data.primaryDepartmentId = bulkDepartmentId;
 
     if (Object.keys(data).length === 0) {
       setBulkError("Remplissez au moins un champ");
@@ -226,15 +283,24 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
       setMembers((prev) =>
         prev.map((m) => {
           if (!selectedIds.has(m.id)) return m;
-          const updated = { ...m, ...data };
-          if (data.departmentId) {
-            const dept = departments.find((d) => d.id === data.departmentId);
+          const updated = { ...m };
+          if (data.firstName) updated.firstName = data.firstName;
+          if (data.lastName) updated.lastName = data.lastName;
+          if (data.primaryDepartmentId) {
+            const dept = departments.find((d) => d.id === data.primaryDepartmentId);
             if (dept) {
-              updated.department = {
-                id: dept.id,
-                name: dept.name,
-                ministry: m.department.ministry,
-              };
+              updated.primaryDepartment = { id: dept.id, name: dept.name, ministry: m.primaryDepartment?.ministry ?? { id: "", name: dept.ministryName } };
+              updated.allDepartments = updated.allDepartments.map((d) => ({
+                ...d,
+                isPrimary: d.id === data.primaryDepartmentId,
+              }));
+              // Si le nouveau dept principal n'est pas encore dans la liste, l'ajouter
+              if (!updated.allDepartments.find((d) => d.id === data.primaryDepartmentId)) {
+                updated.allDepartments = [
+                  { id: dept.id, name: dept.name, isPrimary: true, ministry: { id: "", name: dept.ministryName } },
+                  ...updated.allDepartments,
+                ];
+              }
             }
           }
           return updated;
@@ -250,7 +316,7 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
   }
 
   const filtered = filterDept
-    ? members.filter((m) => m.department.id === filterDept)
+    ? members.filter((m) => m.allDepartments.some((d) => d.id === filterDept))
     : members;
 
   return (
@@ -277,12 +343,28 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
             { header: "Nom", accessor: "lastName" },
             { header: "Prénom", accessor: "firstName" },
             {
-              header: "Département",
-              accessor: (m: Member) => m.department.name,
+              header: "Département principal",
+              accessor: (m: Member) => m.primaryDepartment?.name ?? "—",
+            },
+            {
+              header: "Autres départements",
+              accessor: (m: Member) => {
+                const secondary = m.allDepartments.filter((d) => !d.isPrimary);
+                if (secondary.length === 0) return <span className="text-xs text-gray-400">—</span>;
+                return (
+                  <div className="flex flex-wrap gap-1">
+                    {secondary.map((d) => (
+                      <span key={d.id} className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
+                        {d.name}
+                      </span>
+                    ))}
+                  </div>
+                );
+              },
             },
             {
               header: "Ministère",
-              accessor: (m: Member) => m.department.ministry.name,
+              accessor: (m: Member) => m.primaryDepartment?.ministry.name ?? "—",
             },
             {
               header: "Compte",
@@ -349,14 +431,39 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
             required
           />
           <Select
-            label="Département"
+            label="Département principal"
             value={departmentId}
-            onChange={(e) => setDepartmentId(e.target.value)}
+            onChange={(e) => {
+              const newPrimary = e.target.value;
+              setDepartmentId(newPrimary);
+              // Retirer le nouveau dept principal des départements supplémentaires s'il y était
+              setAdditionalDeptIds((prev) => prev.filter((id) => id !== newPrimary));
+            }}
             options={departments.map((d) => ({
               value: d.id,
               label: `${d.name} (${d.ministryName})`,
             }))}
           />
+          <div>
+            <p className="text-sm font-medium text-gray-700 mb-2">Départements supplémentaires</p>
+            <div className="space-y-1 max-h-40 overflow-y-auto border-2 border-gray-200 rounded-lg p-2">
+              {departments
+                .filter((d) => d.id !== departmentId)
+                .map((d) => (
+                  <label key={d.id} className="flex items-center gap-2 cursor-pointer hover:bg-gray-50 rounded px-1 py-0.5">
+                    <input
+                      type="checkbox"
+                      checked={additionalDeptIds.includes(d.id)}
+                      onChange={() => toggleAdditionalDept(d.id)}
+                      className="rounded border-gray-300 text-icc-violet focus:ring-icc-violet"
+                    />
+                    <span className="text-sm text-gray-700">
+                      {d.name} <span className="text-gray-400 text-xs">({d.ministryName})</span>
+                    </span>
+                  </label>
+                ))}
+            </div>
+          </div>
           {error && <p className="text-sm text-red-600">{error}</p>}
           <div className="flex justify-end gap-2">
             <Button
@@ -443,7 +550,7 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
             placeholder="Laisser vide pour ne pas modifier"
           />
           <Select
-            label="Département"
+            label="Département principal"
             value={bulkDepartmentId}
             onChange={(e) => setBulkDepartmentId(e.target.value)}
             placeholder="Ne pas modifier"

--- a/src/app/(auth)/admin/members/page.tsx
+++ b/src/app/(auth)/admin/members/page.tsx
@@ -22,9 +22,9 @@ export default async function MembersPage() {
   );
 
   const membersWhere = scope.scoped
-    ? { departmentId: { in: scope.departmentIds } }
+    ? { departments: { some: { departmentId: { in: scope.departmentIds } } } }
     : churchIds.length > 0
-      ? { department: { ministry: { churchId: { in: churchIds } } } }
+      ? { departments: { some: { department: { ministry: { churchId: { in: churchIds } } } } } }
       : undefined;
 
   const departmentsWhere = scope.scoped
@@ -41,7 +41,17 @@ export default async function MembersPage() {
         },
         include: {
           user: { select: { id: true, name: true, email: true, image: true } },
-          member: { select: { id: true, firstName: true, lastName: true, department: { select: { name: true, ministry: { select: { name: true } } } } } },
+          member: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              departments: {
+                where: { isPrimary: true },
+                include: { department: { select: { name: true, ministry: { select: { name: true } } } } },
+              },
+            },
+          },
           church: { select: { id: true, name: true } },
         },
         orderBy: { createdAt: "asc" },
@@ -51,12 +61,13 @@ export default async function MembersPage() {
   const members = await prisma.member.findMany({
     where: membersWhere,
     include: {
-      department: {
-        select: {
-          id: true,
-          name: true,
-          ministry: { select: { id: true, name: true, churchId: true } },
+      departments: {
+        include: {
+          department: {
+            select: { id: true, name: true, ministry: { select: { id: true, name: true, churchId: true } } },
+          },
         },
+        orderBy: { isPrimary: "desc" },
       },
       userLink: {
         select: { userId: true, user: { select: { name: true, email: true } } },
@@ -98,13 +109,25 @@ export default async function MembersPage() {
       )}
 
       <MembersClient
-        initialMembers={members.map((m) => ({
-          ...m,
-          userLink: m.userLink
-            ? { userId: m.userLink.userId, userName: m.userLink.user.name, userEmail: m.userLink.user.email }
-            : null,
-          churchId: m.department.ministry.churchId,
-        }))}
+        initialMembers={members.map((m) => {
+          const primaryDept = m.departments.find((d) => d.isPrimary) ?? m.departments[0];
+          return {
+            ...m,
+            primaryDepartment: primaryDept
+              ? { id: primaryDept.department.id, name: primaryDept.department.name, ministry: { id: primaryDept.department.ministry.id, name: primaryDept.department.ministry.name } }
+              : null,
+            allDepartments: m.departments.map((d) => ({
+              id: d.department.id,
+              name: d.department.name,
+              isPrimary: d.isPrimary,
+              ministry: { id: d.department.ministry.id, name: d.department.ministry.name },
+            })),
+            userLink: m.userLink
+              ? { userId: m.userLink.userId, userName: m.userLink.user.name, userEmail: m.userLink.user.email }
+              : null,
+            churchId: primaryDept?.department.ministry.churchId ?? "",
+          };
+        })}
         departments={departments.map((d) => ({
           id: d.id,
           name: d.name,

--- a/src/app/(auth)/profile/page.tsx
+++ b/src/app/(auth)/profile/page.tsx
@@ -20,7 +20,10 @@ export default async function ProfilePage() {
           id: true,
           firstName: true,
           lastName: true,
-          department: { select: { name: true, ministry: { select: { name: true } } } },
+          departments: {
+            where: { isPrimary: true },
+            include: { department: { select: { name: true, ministry: { select: { name: true } } } } },
+          },
         },
       },
       church: { select: { id: true, name: true } },
@@ -88,9 +91,9 @@ export default async function ProfilePage() {
                 <div>
                   <p className="font-medium text-gray-900">{l.member.firstName} {l.member.lastName}</p>
                   <p className="text-xs text-gray-500">
-                    {l.member.department.ministry.name} / {l.member.department.name}
+                    {l.member.departments[0]?.department.ministry.name} / {l.member.departments[0]?.department.name}
                   </p>
-                  {l.member.department.name === "Sans département" && (
+                  {l.member.departments[0]?.department.name === "Sans département" && (
                     <p className="text-xs text-amber-600 mt-0.5">
                       Profil incomplet — contactez un administrateur pour être rattaché à un département.
                     </p>

--- a/src/app/api/departments/[departmentId]/members/route.ts
+++ b/src/app/api/departments/[departmentId]/members/route.ts
@@ -12,7 +12,7 @@ export async function GET(
     await requireChurchPermission("members:view", churchId);
 
     const members = await prisma.member.findMany({
-      where: { departmentId },
+      where: { departments: { some: { departmentId } } },
       orderBy: { lastName: "asc" },
     });
 

--- a/src/app/api/departments/[departmentId]/route.ts
+++ b/src/app/api/departments/[departmentId]/route.ts
@@ -144,7 +144,7 @@ export async function DELETE(
 
     const department = await prisma.department.findUnique({
       where: { id: departmentId },
-      include: { members: true },
+      include: { memberDepts: true },
     });
 
     if (!department) {
@@ -155,7 +155,7 @@ export async function DELETE(
       throw new ApiError(403, "Ce département système ne peut pas être supprimé");
     }
 
-    if (department.members.length > 0) {
+    if (department.memberDepts.length > 0) {
       throw new ApiError(
         400,
         "Impossible de supprimer un département qui contient des STAR"

--- a/src/app/api/discipleships/route.ts
+++ b/src/app/api/discipleships/route.ts
@@ -77,7 +77,11 @@ export async function POST(request: Request) {
       if (!sysDept) throw new ApiError(500, "Département système introuvable pour cette église");
 
       const created = await prisma.member.create({
-        data: { firstName: parsed.newMember.firstName, lastName: parsed.newMember.lastName, departmentId: sysDept.id },
+        data: {
+          firstName: parsed.newMember.firstName,
+          lastName: parsed.newMember.lastName,
+          departments: { create: { departmentId: sysDept.id, isPrimary: true } },
+        },
       });
       discipleId = created.id;
     } else {

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts
@@ -48,9 +48,9 @@ describe("GET /api/events/[eventId]/departments/[deptId]/planning", () => {
         { id: "p-1", memberId: "m-1", status: "EN_SERVICE" },
       ],
       department: {
-        members: [
-          { id: "m-1", firstName: "Jean", lastName: "Dupont" },
-          { id: "m-2", firstName: "Marie", lastName: "Martin" },
+        memberDepts: [
+          { member: { id: "m-1", firstName: "Jean", lastName: "Dupont" } },
+          { member: { id: "m-2", firstName: "Marie", lastName: "Martin" } },
         ],
       },
     };
@@ -74,7 +74,7 @@ describe("GET /api/events/[eventId]/departments/[deptId]/planning", () => {
       .mockResolvedValueOnce(mockDeptChurchCheck as never) // cross-tenant check
       .mockResolvedValueOnce({
         id: "dept-1",
-        members: [{ id: "m-1", firstName: "Jean", lastName: "Dupont" }],
+        memberDepts: [{ member: { id: "m-1", firstName: "Jean", lastName: "Dupont" } }],
       } as never); // fallback path
     prismaMock.event.findUnique.mockResolvedValue({ id: "evt-1", planningDeadline: null } as never);
 
@@ -95,7 +95,7 @@ describe("GET /api/events/[eventId]/departments/[deptId]/planning", () => {
       departmentId: "dept-1",
       event: { planningDeadline: pastDate },
       plannings: [],
-      department: { members: [] },
+      department: { memberDepts: [] },
     });
 
     const request = new Request("http://localhost/api/events/evt-1/departments/dept-1/planning");

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
@@ -39,7 +39,12 @@ export async function GET(
           include: { member: true },
         },
         department: {
-          include: { members: { orderBy: { lastName: "asc" } } },
+          include: {
+            memberDepts: {
+              include: { member: true },
+              orderBy: { member: { lastName: "asc" } },
+            },
+          },
         },
       },
     });
@@ -48,7 +53,12 @@ export async function GET(
     if (!eventDept) {
       const department = await prisma.department.findUnique({
         where: { id: departmentId },
-        include: { members: { orderBy: { lastName: "asc" } } },
+        include: {
+          memberDepts: {
+            include: { member: true },
+            orderBy: { member: { lastName: "asc" } },
+          },
+        },
       });
 
       if (!department) {
@@ -66,7 +76,7 @@ export async function GET(
 
       return successResponse({
         eventDepartment: null,
-        members: department.members.map((m) => ({
+        members: department.memberDepts.map(({ member: m }) => ({
           ...m,
           status: null,
           planningId: null,
@@ -76,7 +86,7 @@ export async function GET(
       });
     }
 
-    const members = eventDept.department.members.map((member) => {
+    const members = eventDept.department.memberDepts.map(({ member }) => {
       const planning = eventDept.plannings.find(
         (p) => p.memberId === member.id
       );
@@ -176,7 +186,7 @@ export async function PUT(
     const memberIds = plannings.map((p) => p.memberId);
     if (memberIds.length > 0) {
       const validMembers = await prisma.member.findMany({
-        where: { id: { in: memberIds }, departmentId },
+        where: { id: { in: memberIds }, departments: { some: { departmentId } } },
         select: { id: true },
       });
       if (validMembers.length !== memberIds.length) {

--- a/src/app/api/member-link-requests/[id]/route.ts
+++ b/src/app/api/member-link-requests/[id]/route.ts
@@ -72,7 +72,7 @@ export async function PATCH(
             firstName: linkRequest.firstName!,
             lastName: linkRequest.lastName!,
             phone: linkRequest.phone ?? undefined,
-            departmentId,
+            departments: { create: { departmentId, isPrimary: true } },
           },
         });
         memberId = newMember.id;

--- a/src/app/api/member-link-requests/route.ts
+++ b/src/app/api/member-link-requests/route.ts
@@ -50,14 +50,18 @@ export async function POST(request: Request) {
         where: { id: data.memberId },
         include: {
           userLink: true,
-          department: { include: { ministry: { select: { churchId: true } } } },
+          departments: {
+            where: { isPrimary: true },
+            include: { department: { include: { ministry: { select: { churchId: true } } } } },
+          },
         },
       });
       if (!member) throw new ApiError(404, "STAR introuvable");
       if (member.userLink) throw new ApiError(409, "Ce STAR est déjà lié à un compte");
 
       // Vérifier que le membre appartient bien à l'église indiquée
-      if (member.department.ministry.churchId !== data.churchId) {
+      const primaryChurchId = member.departments[0]?.department.ministry.churchId;
+      if (primaryChurchId !== data.churchId) {
         throw new ApiError(400, "Ce STAR n'appartient pas à cette église");
       }
 

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -4,10 +4,23 @@ import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
+// Helper : inclure les départements d'un membre (principal en premier)
+const memberDepartmentsInclude = {
+  departments: {
+    include: {
+      department: {
+        select: { id: true, name: true, ministry: { select: { id: true, name: true } } },
+      },
+    },
+    orderBy: { isPrimary: "desc" as const },
+  },
+};
+
 const updateSchema = z.object({
   firstName: z.string().min(1, "Le prénom est requis"),
   lastName: z.string().min(1, "Le nom est requis"),
-  departmentId: z.string().min(1, "Le département est requis"),
+  departmentId: z.string().min(1, "Le département principal est requis"),
+  additionalDepartmentIds: z.array(z.string()).optional(),
   email: z.string().email("Email invalide").nullable().optional(),
   phone: z.string().nullable().optional(),
 });
@@ -31,51 +44,58 @@ export async function PUT(
     const session = await requireChurchPermission("members:manage", churchId);
     const scopedDeptIds = getChurchDeptScope(session, churchId);
     const body = await request.json();
-    const data = updateSchema.parse(body);
+    const { departmentId, additionalDepartmentIds = [], ...memberData } = updateSchema.parse(body);
 
     if (scopedDeptIds) {
       const existing = await prisma.member.findUnique({
         where: { id: memberId },
-        select: { departmentId: true },
+        include: { departments: { where: { isPrimary: true }, select: { departmentId: true } } },
       });
 
-      if (!existing) {
-        throw new ApiError(404, "STAR introuvable");
-      }
+      if (!existing) throw new ApiError(404, "STAR introuvable");
 
-      if (!scopedDeptIds.includes(existing.departmentId)) {
+      const primaryDeptId = existing.departments[0]?.departmentId;
+      if (!primaryDeptId || !scopedDeptIds.includes(primaryDeptId)) {
         throw new ApiError(403, "Ce STAR est hors de votre périmètre");
       }
 
-      if (!scopedDeptIds.includes(data.departmentId)) {
+      if (!scopedDeptIds.includes(departmentId)) {
         throw new ApiError(403, "Département cible non autorisé");
       }
     }
 
-    // Block cross-tenant destination: departmentId must belong to same church
-    const targetDept = await prisma.department.findUnique({
-      where: { id: data.departmentId },
+    // Valider que tous les départements appartiennent à la même église
+    const allDeptIds = [departmentId, ...additionalDepartmentIds.filter((id) => id !== departmentId)];
+    const depts = await prisma.department.findMany({
+      where: { id: { in: allDeptIds } },
       include: { ministry: { select: { churchId: true } } },
     });
-    if (!targetDept || targetDept.ministry.churchId !== churchId) {
-      throw new ApiError(403, "Le département cible n'appartient pas à la même église");
+    if (depts.length !== allDeptIds.length || depts.some((d) => d.ministry.churchId !== churchId)) {
+      throw new ApiError(403, "Tous les départements doivent appartenir à la même église");
     }
 
-    const member = await prisma.member.update({
-      where: { id: memberId },
-      data,
-      include: {
-        department: {
-          select: {
-            id: true,
-            name: true,
-            ministry: { select: { id: true, name: true } },
-          },
-        },
-      },
+    const member = await prisma.$transaction(async (tx) => {
+      // Mettre à jour les champs scalaires
+      await tx.member.update({ where: { id: memberId }, data: memberData });
+
+      // Reconstruire les affiliations départementales
+      // 1. Retirer les affiliations qui ne sont plus dans la liste
+      await tx.memberDepartment.deleteMany({
+        where: { memberId, departmentId: { notIn: allDeptIds } },
+      });
+      // 2. Upsert chaque département avec le bon flag isPrimary
+      for (const deptId of allDeptIds) {
+        await tx.memberDepartment.upsert({
+          where: { memberId_departmentId: { memberId, departmentId: deptId } },
+          update: { isPrimary: deptId === departmentId },
+          create: { memberId, departmentId: deptId, isPrimary: deptId === departmentId },
+        });
+      }
+
+      return tx.member.findUnique({ where: { id: memberId }, include: memberDepartmentsInclude });
     });
 
-    await logAudit({ userId: session.user.id, churchId, action: "UPDATE", entityType: "Member", entityId: memberId, details: { firstName: data.firstName, lastName: data.lastName } });
+    await logAudit({ userId: session.user.id, churchId, action: "UPDATE", entityType: "Member", entityId: memberId, details: { firstName: memberData.firstName, lastName: memberData.lastName } });
 
     return successResponse(member);
   } catch (error) {
@@ -95,14 +115,13 @@ export async function DELETE(
 
     const member = await prisma.member.findUnique({
       where: { id: memberId },
-      select: { id: true, departmentId: true },
+      include: { departments: { where: { isPrimary: true }, select: { departmentId: true } } },
     });
 
-    if (!member) {
-      throw new ApiError(404, "STAR introuvable");
-    }
+    if (!member) throw new ApiError(404, "STAR introuvable");
 
-    if (scopedDeptIds && !scopedDeptIds.includes(member.departmentId)) {
+    const primaryDeptId = member.departments[0]?.departmentId;
+    if (scopedDeptIds && (!primaryDeptId || !scopedDeptIds.includes(primaryDeptId))) {
       throw new ApiError(403, "Ce STAR est hors de votre périmètre");
     }
 

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -5,6 +5,18 @@ import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
 
+// Helper : inclure les départements d'un membre (principal en premier)
+const memberDepartmentsInclude = {
+  departments: {
+    include: {
+      department: {
+        select: { id: true, name: true, ministry: { select: { id: true, name: true } } },
+      },
+    },
+    orderBy: { isPrimary: "desc" as const },
+  },
+};
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
@@ -28,22 +40,15 @@ export async function GET(request: Request) {
 
     const members = await prisma.member.findMany({
       where: {
-        department: { ministry: { churchId } },
-        ...(departmentId
-          ? { departmentId }
-          : scopedDeptIds
-            ? { departmentId: { in: scopedDeptIds } }
-            : {}),
-      },
-      include: {
-        department: {
-          select: {
-            id: true,
-            name: true,
-            ministry: { select: { id: true, name: true } },
-          },
+        departments: {
+          some: departmentId
+            ? { departmentId }
+            : scopedDeptIds
+              ? { departmentId: { in: scopedDeptIds } }
+              : { department: { ministry: { churchId } } },
         },
       },
+      include: memberDepartmentsInclude,
       orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
     });
 
@@ -59,7 +64,7 @@ const bulkSchema = z.object({
   data: z.object({
     firstName: z.string().min(1).optional(),
     lastName: z.string().min(1).optional(),
-    departmentId: z.string().min(1).optional(),
+    primaryDepartmentId: z.string().min(1).optional(),
   }).optional(),
 });
 
@@ -95,17 +100,18 @@ export async function PATCH(request: Request) {
     if (scopedDeptIds) {
       const members = await prisma.member.findMany({
         where: { id: { in: ids } },
-        select: { departmentId: true },
+        include: { departments: { where: { isPrimary: true }, select: { departmentId: true } } },
       });
 
-      const allInScope = members.every((m) =>
-        scopedDeptIds.includes(m.departmentId)
-      );
+      const allInScope = members.every((m) => {
+        const primaryDeptId = m.departments[0]?.departmentId;
+        return primaryDeptId ? scopedDeptIds.includes(primaryDeptId) : false;
+      });
       if (!allInScope) {
         throw new ApiError(403, "Certains STAR sont hors de votre périmètre");
       }
 
-      if (action === "update" && data?.departmentId && !scopedDeptIds.includes(data.departmentId)) {
+      if (action === "update" && data?.primaryDepartmentId && !scopedDeptIds.includes(data.primaryDepartmentId)) {
         throw new ApiError(403, "Département cible non autorisé");
       }
     }
@@ -130,10 +136,12 @@ export async function PATCH(request: Request) {
       return errorResponse(new Error("Aucune donnée à mettre à jour"));
     }
 
-    // Block cross-tenant destination: departmentId must belong to same church
-    if (data.departmentId) {
+    const { primaryDepartmentId, ...scalarData } = data;
+
+    // Block cross-tenant destination
+    if (primaryDepartmentId) {
       const targetDept = await prisma.department.findUnique({
-        where: { id: data.departmentId },
+        where: { id: primaryDepartmentId },
         include: { ministry: { select: { churchId: true } } },
       });
       if (!targetDept || targetDept.ministry.churchId !== firstMemberChurchId) {
@@ -141,9 +149,25 @@ export async function PATCH(request: Request) {
       }
     }
 
-    await prisma.member.updateMany({
-      where: { id: { in: ids } },
-      data,
+    await prisma.$transaction(async (tx) => {
+      if (Object.keys(scalarData).length > 0) {
+        await tx.member.updateMany({ where: { id: { in: ids } }, data: scalarData });
+      }
+      if (primaryDepartmentId) {
+        for (const memberId of ids) {
+          // Retirer le flag isPrimary de l'ancien département principal
+          await tx.memberDepartment.updateMany({
+            where: { memberId, isPrimary: true },
+            data: { isPrimary: false },
+          });
+          // Upsert le nouveau département principal
+          await tx.memberDepartment.upsert({
+            where: { memberId_departmentId: { memberId, departmentId: primaryDepartmentId } },
+            update: { isPrimary: true },
+            create: { memberId, departmentId: primaryDepartmentId, isPrimary: true },
+          });
+        }
+      }
     });
 
     for (const id of ids) {
@@ -158,17 +182,18 @@ export async function PATCH(request: Request) {
 const createSchema = z.object({
   firstName: z.string().min(1, "Le prénom est requis"),
   lastName: z.string().min(1, "Le nom est requis"),
-  departmentId: z.string().min(1, "Le département est requis"),
+  departmentId: z.string().min(1, "Le département principal est requis"),
+  additionalDepartmentIds: z.array(z.string()).optional(),
 });
 
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const data = createSchema.parse(body);
+    const { departmentId, additionalDepartmentIds = [], ...memberData } = createSchema.parse(body);
 
     // Résoudre l'église du département cible
     const { resolveChurchId } = await import("@/lib/auth");
-    const deptChurchId = await resolveChurchId("department", data.departmentId);
+    const deptChurchId = await resolveChurchId("department", departmentId);
     const session = await requireChurchPermission("members:manage", deptChurchId);
     requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
@@ -180,24 +205,34 @@ export async function POST(request: Request) {
       ? null
       : Array.from(new Set(churchRoles.flatMap((r) => r.departments.map((d) => d.department.id))));
 
-    if (scopedDeptIds && !scopedDeptIds.includes(data.departmentId)) {
+    if (scopedDeptIds && !scopedDeptIds.includes(departmentId)) {
       throw new ApiError(403, "Vous ne pouvez pas créer un STAR dans ce département");
     }
 
+    // Valider que tous les départements supplémentaires appartiennent à la même église
+    const allDeptIds = [departmentId, ...additionalDepartmentIds.filter((id) => id !== departmentId)];
+    if (additionalDepartmentIds.length > 0) {
+      const depts = await prisma.department.findMany({
+        where: { id: { in: allDeptIds } },
+        include: { ministry: { select: { churchId: true } } },
+      });
+      const wrongChurch = depts.some((d) => d.ministry.churchId !== deptChurchId);
+      if (wrongChurch || depts.length !== allDeptIds.length) {
+        throw new ApiError(400, "Tous les départements doivent appartenir à la même église");
+      }
+    }
+
     const member = await prisma.member.create({
-      data,
-      include: {
-        department: {
-          select: {
-            id: true,
-            name: true,
-            ministry: { select: { id: true, name: true } },
-          },
+      data: {
+        ...memberData,
+        departments: {
+          create: allDeptIds.map((id) => ({ departmentId: id, isPrimary: id === departmentId })),
         },
       },
+      include: memberDepartmentsInclude,
     });
 
-    await logAudit({ userId: session.user.id, churchId: deptChurchId, action: "CREATE", entityType: "Member", entityId: member.id, details: { firstName: data.firstName, lastName: data.lastName } });
+    await logAudit({ userId: session.user.id, churchId: deptChurchId, action: "CREATE", entityType: "Member", entityId: member.id, details: { firstName: memberData.firstName, lastName: memberData.lastName } });
 
     return successResponse(member, 201);
   } catch (error) {

--- a/src/app/api/ministries/route.ts
+++ b/src/app/api/ministries/route.ts
@@ -69,9 +69,21 @@ export async function PATCH(request: Request) {
             })
           ).map((ed) => ed.id);
           await tx.planning.deleteMany({ where: { eventDepartmentId: { in: eventDeptIds } } });
-          await tx.planning.deleteMany({ where: { member: { departmentId: { in: deptIds } } } });
+          // Membres dont le seul département est dans cette liste (via MemberDepartment)
+          const memberIdsToDelete = (
+            await tx.member.findMany({
+              where: { departments: { every: { departmentId: { in: deptIds } } } },
+              select: { id: true },
+            })
+          ).map((m) => m.id);
+          if (memberIdsToDelete.length > 0) {
+            await tx.planning.deleteMany({ where: { memberId: { in: memberIdsToDelete } } });
+          }
+          await tx.memberDepartment.deleteMany({ where: { departmentId: { in: deptIds } } });
           await tx.eventDepartment.deleteMany({ where: { departmentId: { in: deptIds } } });
-          await tx.member.deleteMany({ where: { departmentId: { in: deptIds } } });
+          if (memberIdsToDelete.length > 0) {
+            await tx.member.deleteMany({ where: { id: { in: memberIdsToDelete } } });
+          }
           await tx.userDepartment.deleteMany({ where: { departmentId: { in: deptIds } } });
         }
         await tx.department.deleteMany({ where: { ministryId: { in: ids } } });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -324,13 +324,16 @@ export async function resolveChurchId(
       const member = await prisma.member.findUnique({
         where: { id: resourceId },
         include: {
-          department: {
-            include: { ministry: { select: { churchId: true } } },
+          departments: {
+            where: { isPrimary: true },
+            include: { department: { include: { ministry: { select: { churchId: true } } } } },
           },
         },
       });
       if (!member) throw new ApiError(404, "Membre introuvable");
-      return member.department.ministry.churchId;
+      const primary = member.departments[0];
+      if (!primary) throw new ApiError(404, "Membre sans département principal");
+      return primary.department.ministry.churchId;
     }
     case "serviceRequest": {
       const sr = await prisma.serviceRequest.findUnique({


### PR DESCRIPTION
## Résumé

- Remplace la FK unique `Member.departmentId` par une table de jointure `MemberDepartment` (`memberId`, `departmentId`, `isPrimary`)
- Un STAR peut désormais servir dans plusieurs départements sans doublon de fiche
- La notion de **département principal** est préservée via le flag `isPrimary`

## Changements

### Base de données
- Nouveau modèle `MemberDepartment` dans le schema Prisma
- Migration SQL avec data migration incluse : chaque `Member.departmentId` existant est migré vers `member_departments` avec `isPrimary = true`

### API
- `GET/POST/PUT/DELETE /api/members` — filtrage et validation via la relation N-N
- `PATCH /api/members` (bulk) — changement de département principal
- Validation planning : un membre est eligible s'il appartient au département (via `MemberDepartment`)
- Routes impactées : `discipleships`, `ministries` (cascade delete), `member-link-requests`, `profile`

### UI admin (`/admin/membres`)
- Formulaire création/édition : sélecteur de **département principal** + **checkboxes** pour les départements supplémentaires
- Table : colonne "Département principal" + colonne "Autres départements" (badges)
- Filtre par département : inclut les membres de ce département (quel que soit le rang)

## Plan de test

- [ ] Créer un STAR avec un seul département → fonctionne comme avant
- [ ] Créer un STAR avec plusieurs départements → apparaît dans les deux listes de planning
- [ ] Modifier le département principal d'un STAR → les plannings existants restent intacts
- [ ] Supprimer un STAR multi-département → suppression propre
- [ ] Suppression d'un ministère → STAR dont tous les depts sont dans ce ministère sont supprimés ; STAR avec un dept externe restent
- [ ] `db:migrate:deploy` en prod → vérifier la data migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)