### PR TITLE
fix(access): nouveaux utilisateurs invisibles dans la gestion des accès

### DIFF
--- a/src/app/(auth)/admin/access/page.tsx
+++ b/src/app/(auth)/admin/access/page.tsx
@@ -8,9 +8,14 @@ export default async function AccessPage() {
   if (!churchId) return <p className="text-gray-500">Aucune église sélectionnée.</p>;
   await requireChurchPermission("departments:manage", churchId);
 
-  // All users in this church with their roles
+  // All users in this church (with roles) + new users (no roles yet)
   const users = await prisma.user.findMany({
-    where: { churchRoles: { some: { churchId } } },
+    where: {
+      OR: [
+        { churchRoles: { some: { churchId } } },
+        { churchRoles: { none: {} } },
+      ],
+    },
     select: {
       id: true,
       name: true,


### PR DESCRIPTION
## Summary
- Les utilisateurs connectés via Google OAuth sans rôle attribué n'apparaissaient pas dans la page "Accès & rôles"
- La requête Prisma filtrait par `churchRoles: { some: { churchId } }`, excluant les utilisateurs sans aucun rôle
- Ajout d'un `OR` pour inclure aussi les utilisateurs avec `churchRoles: { none: {} }`

## Test plan
- [ ] Se connecter avec un nouveau compte Google (sans rôle)
- [ ] Vérifier qu'il apparaît dans Admin > Accès & rôles
- [ ] Lui attribuer un rôle et vérifier qu'il fonctionne

🤖 Generated with [Claude Code](https://claude.com/claude-code)