### PR TITLE
fix(deploy): ajouter prisma generate manquant avant le build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,7 @@ jobs:
             # 4. Installer les dependances et construire
             cd "$DEPLOY_PATH/releases/koinonia-${VERSION}"
             npm install --production=false
+            npx prisma generate
             npx prisma migrate deploy
             npm run build
 


### PR DESCRIPTION
## Summary
- Le workflow de déploiement exécutait `prisma migrate deploy` mais pas `prisma generate`, le client Prisma ne correspondait donc plus au schéma après une migration
- Cause racine du bug "Création des événements KO" après la migration N-N membres/départements
- Ajout de `npx prisma generate` entre `npm install` et `prisma migrate deploy`

## Test plan
- [ ] Déclencher un déploiement (tag ou workflow_dispatch)
- [ ] Vérifier que la création d'événements fonctionne
- [ ] Vérifier que les pages membres/discipolat fonctionnent

🤖 Generated with [Claude Code](https://claude.com/claude-code)