### PR TITLE
fix(multi-tenant): scoper les pages admin à l'église sélectionnée

### DIFF
--- a/src/app/(auth)/admin/departments/page.tsx
+++ b/src/app/(auth)/admin/departments/page.tsx
@@ -5,23 +5,20 @@ import DepartmentsClient from "./DepartmentsClient";
 export default async function DepartmentsPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
-  if (churchId) await requireChurchPermission("departments:manage", churchId);
+  if (!churchId) return <p className="text-gray-500">Aucune église sélectionnée.</p>;
+  await requireChurchPermission("departments:manage", churchId);
 
   const scope = getUserDepartmentScope(session);
-  const churchRoles = session.user.churchRoles;
-  const isSuperAdmin = churchRoles.some((r) => r.role === "SUPER_ADMIN");
-  const churchIds = Array.from(new Set(churchRoles.map((r) => r.churchId)));
+  const isSuperAdmin = session.user.churchRoles.some((r) => r.role === "SUPER_ADMIN");
 
-  // For scoped users (MINISTER), get their ministryIds
-  const ministerMinistryIds = churchRoles
-    .filter((r) => r.role === "MINISTER" && r.ministryId)
+  // For scoped users (MINISTER), get their ministryIds in this church
+  const ministerMinistryIds = session.user.churchRoles
+    .filter((r) => r.churchId === churchId && r.role === "MINISTER" && r.ministryId)
     .map((r) => r.ministryId as string);
 
-  const departmentWhere = isSuperAdmin
-    ? undefined
-    : scope.scoped && ministerMinistryIds.length > 0
-      ? { ministryId: { in: ministerMinistryIds } }
-      : { ministry: { churchId: { in: churchIds } } };
+  const departmentWhere = scope.scoped && ministerMinistryIds.length > 0
+    ? { ministryId: { in: ministerMinistryIds } }
+    : { ministry: { churchId } };
 
   const departments = await prisma.department.findMany({
     where: departmentWhere,
@@ -32,16 +29,14 @@ export default async function DepartmentsPage() {
     orderBy: [{ ministry: { name: "asc" } }, { name: "asc" }],
   });
 
-  const ministryWhere = isSuperAdmin
-    ? undefined
-    : ministerMinistryIds.length > 0
-      ? { id: { in: ministerMinistryIds } }
-      : { churchId: { in: churchIds } };
+  const ministryWhere = ministerMinistryIds.length > 0
+    ? { id: { in: ministerMinistryIds } }
+    : { churchId };
 
   const ministries = await prisma.ministry.findMany({
     where: ministryWhere,
     include: { church: { select: { id: true, name: true } } },
-    orderBy: [{ church: { name: "asc" } }, { name: "asc" }],
+    orderBy: { name: "asc" },
   });
 
   return (

--- a/src/app/(auth)/admin/events/page.tsx
+++ b/src/app/(auth)/admin/events/page.tsx
@@ -5,22 +5,16 @@ import EventsClient from "./EventsClient";
 export default async function EventsPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
-  if (churchId) await requireChurchPermission("events:manage", churchId);
+  if (!churchId) return <p className="text-gray-500">Aucune église sélectionnée.</p>;
+  await requireChurchPermission("events:manage", churchId);
 
-  const churchRoles = session.user.churchRoles;
-  const isSuperAdmin = churchRoles.some((r) => r.role === "SUPER_ADMIN");
-  const churchIds = Array.from(new Set(churchRoles.map((r) => r.churchId)));
-
-  const churches = isSuperAdmin
-    ? await prisma.church.findMany({ orderBy: { name: "asc" } })
-    : churchRoles.map((r) => r.church);
-
-  const uniqueChurches = Array.from(
-    new Map(churches.map((c) => [c.id, c])).values()
-  );
+  const church = await prisma.church.findUnique({
+    where: { id: churchId },
+    select: { id: true, name: true },
+  });
 
   const events = await prisma.event.findMany({
-    where: isSuperAdmin ? undefined : { churchId: { in: churchIds } },
+    where: { churchId },
     include: {
       church: { select: { id: true, name: true } },
       eventDepts: {
@@ -40,7 +34,7 @@ export default async function EventsPage() {
           planningDeadline: e.planningDeadline?.toISOString() ?? null,
           createdAt: e.createdAt.toISOString(),
         }))}
-        churches={uniqueChurches.map((c) => ({ id: c.id, name: c.name }))}
+        churches={church ? [{ id: church.id, name: church.name }] : []}
       />
     </div>
   );

--- a/src/app/(auth)/admin/members/page.tsx
+++ b/src/app/(auth)/admin/members/page.tsx
@@ -7,37 +7,28 @@ import LinkRequestsClient from "./LinkRequestsClient";
 export default async function MembersPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
-  if (churchId) await requireChurchPermission("members:view", churchId);
-  const churchRoles = churchId
-    ? session.user.churchRoles.filter((r) => r.churchId === churchId)
-    : session.user.churchRoles;
+  if (!churchId) return <p className="text-gray-500">Aucune église sélectionnée.</p>;
+  await requireChurchPermission("members:view", churchId);
+  const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   const userPermissions = new Set(
     churchRoles.flatMap((r) => hasPermission(r.role))
   );
   const canManage = userPermissions.has("members:manage");
   const scope = getUserDepartmentScope(session);
 
-  const churchIds = Array.from(
-    new Set(session.user.churchRoles.map((r) => r.churchId))
-  );
-
   const membersWhere = scope.scoped
     ? { departments: { some: { departmentId: { in: scope.departmentIds } } } }
-    : churchIds.length > 0
-      ? { departments: { some: { department: { ministry: { churchId: { in: churchIds } } } } } }
-      : undefined;
+    : { departments: { some: { department: { ministry: { churchId } } } } };
 
   const departmentsWhere = scope.scoped
     ? { id: { in: scope.departmentIds } }
-    : churchIds.length > 0
-      ? { ministry: { churchId: { in: churchIds } } }
-      : undefined;
+    : { ministry: { churchId } };
 
   const pendingRequests = canManage
     ? await prisma.memberLinkRequest.findMany({
         where: {
           status: "PENDING",
-          ...(churchIds.length > 0 ? { churchId: { in: churchIds } } : {}),
+          churchId,
         },
         include: {
           user: { select: { id: true, name: true, email: true, image: true } },

--- a/src/app/(auth)/admin/ministries/page.tsx
+++ b/src/app/(auth)/admin/ministries/page.tsx
@@ -5,28 +5,24 @@ import MinistriesClient from "./MinistriesClient";
 export default async function MinistriesPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
-  if (churchId) await requireChurchPermission("departments:manage", churchId);
+  if (!churchId) return <p className="text-gray-500">Aucune église sélectionnée.</p>;
+  await requireChurchPermission("departments:manage", churchId);
 
-  const churchRoles = session.user.churchRoles;
-  const isSuperAdmin = churchRoles.some((r) => r.role === "SUPER_ADMIN");
+  const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
+  const isSuperAdmin = session.user.churchRoles.some((r) => r.role === "SUPER_ADMIN");
   const isMinisterOnly = !churchRoles.some((r) =>
     ["SUPER_ADMIN", "ADMIN"].includes(r.role)
   );
 
-  const churches = isSuperAdmin
-    ? await prisma.church.findMany({ orderBy: { name: "asc" } })
-    : churchRoles.map((r) => r.church);
-
-  const uniqueChurches = Array.from(
-    new Map(churches.map((c) => [c.id, c])).values()
-  );
+  const church = await prisma.church.findUnique({
+    where: { id: churchId },
+    select: { id: true, name: true },
+  });
 
   const ministries = await prisma.ministry.findMany({
-    where: isSuperAdmin
-      ? undefined
-      : { churchId: { in: uniqueChurches.map((c) => c.id) } },
+    where: { churchId },
     include: { church: { select: { id: true, name: true } } },
-    orderBy: [{ church: { name: "asc" } }, { name: "asc" }],
+    orderBy: { name: "asc" },
   });
 
   return (
@@ -34,7 +30,7 @@ export default async function MinistriesPage() {
       <h1 className="text-2xl font-bold text-gray-900 mb-6">Ministères</h1>
       <MinistriesClient
         initialMinistries={ministries}
-        churches={uniqueChurches.map((c) => ({ id: c.id, name: c.name }))}
+        churches={church ? [{ id: church.id, name: church.name }] : []}
         readOnly={isMinisterOnly}
         isSuperAdmin={isSuperAdmin}
       />

--- a/src/app/(auth)/admin/users/page.tsx
+++ b/src/app/(auth)/admin/users/page.tsx
@@ -5,18 +5,17 @@ import UsersClient from "./UsersClient";
 export default async function UsersPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
-  if (churchId) await requireChurchPermission("members:manage", churchId);
+  if (!churchId) return <p className="text-gray-500">Aucune église sélectionnée.</p>;
+  await requireChurchPermission("members:manage", churchId);
 
-  const churchRoles = session.user.churchRoles;
-  const isSuperAdmin = churchRoles.some((r) => r.role === "SUPER_ADMIN");
-  const churchIds = Array.from(new Set(churchRoles.map((r) => r.churchId)));
+  const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
+  const isSuperAdmin = session.user.churchRoles.some((r) => r.role === "SUPER_ADMIN");
 
   const users = await prisma.user.findMany({
-    where: isSuperAdmin
-      ? undefined
-      : { churchRoles: { some: { churchId: { in: churchIds } } } },
+    where: { churchRoles: { some: { churchId } } },
     include: {
       churchRoles: {
+        where: { churchId },
         include: {
           church: { select: { id: true, name: true } },
           ministry: { select: { id: true, name: true } },
@@ -29,16 +28,14 @@ export default async function UsersPage() {
     orderBy: { name: "asc" },
   });
 
-  const whereChurch = isSuperAdmin ? {} : { churchId: { in: churchIds } };
-
   const ministries = await prisma.ministry.findMany({
-    where: whereChurch,
+    where: { churchId },
     select: { id: true, name: true, churchId: true },
     orderBy: { name: "asc" },
   });
 
   const departments = await prisma.department.findMany({
-    where: { ministry: whereChurch },
+    where: { ministry: { churchId } },
     select: { id: true, name: true, ministry: { select: { churchId: true } } },
     orderBy: { name: "asc" },
   });


### PR DESCRIPTION
## Summary
- Les pages admin (utilisateurs, membres, événements, ministères, départements) chargeaient les données de **toutes** les églises de l'utilisateur au lieu de l'église sélectionnée dans le header
- Le sélecteur d'église (`ChurchSwitcher`) mettait bien à jour le cookie, mais les pages ignoraient `getCurrentChurchId()` et utilisaient toutes les `churchIds` des rôles
- Chaque page filtre maintenant strictement par `churchId` (église sélectionnée)

## Pages corrigées
- `admin/users/page.tsx` — users + ministères + départements filtrés par église
- `admin/members/page.tsx` — membres + demandes de liaison filtrés par église
- `admin/events/page.tsx` — événements filtrés par église
- `admin/ministries/page.tsx` — ministères filtrés par église
- `admin/departments/page.tsx` — départements + ministères filtrés par église

## Test plan
- [ ] Se connecter avec un utilisateur ayant des rôles dans 2+ églises
- [ ] Vérifier que chaque page admin n'affiche que les données de l'église sélectionnée
- [ ] Changer d'église dans le header et vérifier que les données se mettent à jour
- [ ] Vérifier qu'un utilisateur avec un seul rôle voit toujours ses données normalement

🤖 Generated with [Claude Code](https://claude.com/claude-code)