### PR TITLE
chore: release v0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v0.15.5] - 2026-03-28
+
+### Améliorations
+
+- Message WhatsApp du compte rendu reformaté : zéro émoji, en-têtes en gras, structure lisible centrée sur les informations (#151)
+
 ## [v0.15.4] - 2026-03-28
 
 ### Correctifs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

- Message WhatsApp du compte rendu reformaté : zéro émoji, en-têtes en gras, structure lisible centrée sur les informations (#151)

## Changelog

- Bump version `0.15.4` → `0.15.5`
- Mise à jour `CHANGELOG.md`