### PR TITLE
feat(planning): notice de service par département — vue hebdomadaire (#150)

### DIFF
--- a/prisma/migrations/20260328000001_add_department_notice/migration.sql
+++ b/prisma/migrations/20260328000001_add_department_notice/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE `department_notices` (
+    `id` VARCHAR(191) NOT NULL,
+    `departmentId` VARCHAR(191) NOT NULL,
+    `eventId` VARCHAR(191) NOT NULL,
+    `content` TEXT NOT NULL,
+    `authorId` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    INDEX `department_notices_eventId_idx`(`eventId`),
+    UNIQUE INDEX `department_notices_departmentId_eventId_key`(`departmentId`, `eventId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `department_notices` ADD CONSTRAINT `department_notices_departmentId_fkey` FOREIGN KEY (`departmentId`) REFERENCES `departments`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `department_notices` ADD CONSTRAINT `department_notices_eventId_fkey` FOREIGN KEY (`eventId`) REFERENCES `events`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `department_notices` ADD CONSTRAINT `department_notices_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,6 +105,7 @@ model User {
   memberLinkRequests      MemberLinkRequest[] @relation("LinkRequester")
   reviewedLinkRequests    MemberLinkRequest[] @relation("LinkRequestReviewer")
   eventReports            EventReport[]       @relation("ReportAuthor")
+  departmentNotices       DepartmentNotice[]
 
   @@map("users")
 }
@@ -167,6 +168,7 @@ model Department {
   submittedRequests Request[]          @relation("RequestDepartment")
   assignedRequests  Request[]          @relation("RequestAssigned")
   reportSections    EventReportSection[]
+  notices           DepartmentNotice[]
 
   @@map("departments")
 }
@@ -304,6 +306,7 @@ model Event {
   statsEnabled               Boolean                  @default(false)
   discipleshipAttendances    DiscipleshipAttendance[]
   report                     EventReport?
+  departmentNotices          DepartmentNotice[]
 
   @@map("events")
 }
@@ -432,6 +435,26 @@ model Notification {
 
   @@index([userId, read, createdAt])
   @@map("notifications")
+}
+
+// ─── Notices de service ────────────────────────────────────────────
+
+model DepartmentNotice {
+  id           String     @id @default(cuid())
+  departmentId String
+  eventId      String
+  content      String     @db.Text
+  authorId     String
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
+
+  department   Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+  event        Event      @relation(fields: [eventId],      references: [id], onDelete: Cascade)
+  author       User       @relation(fields: [authorId],     references: [id])
+
+  @@unique([departmentId, eventId])
+  @@index([eventId])
+  @@map("department_notices")
 }
 
 // ─── Announcements & Service Requests ──────────────────────────────

--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -7,6 +7,7 @@ import PlanningGrid from "@/components/PlanningGrid";
 import DashboardActions from "@/components/DashboardActions";
 import MonthlyPlanningView from "@/components/MonthlyPlanningView";
 import DepartmentTasksView from "@/components/DepartmentTasksView";
+import WeeklyPlanningView from "@/components/WeeklyPlanningView";
 
 interface DashboardProps {
   searchParams: Promise<{ dept?: string; event?: string; view?: string; tour?: string }>;
@@ -140,7 +141,9 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
         </div>
       )}
 
-      {view === "tasks" ? (
+      {view === "week" ? (
+        <WeeklyPlanningView churchId={currentChurchId} canEdit={canEditPlanning} />
+      ) : view === "tasks" ? (
         selectedDeptId ? (
           <DepartmentTasksView
             departmentId={selectedDeptId}

--- a/src/app/api/departments/[departmentId]/notices/route.ts
+++ b/src/app/api/departments/[departmentId]/notices/route.ts
@@ -1,0 +1,87 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
+import { z } from "zod";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ departmentId: string }> }
+) {
+  try {
+    const { departmentId } = await params;
+    const churchId = await resolveChurchId("department", departmentId);
+    await requireChurchPermission("planning:view", churchId);
+
+    const { searchParams } = new URL(request.url);
+    const eventId = searchParams.get("eventId");
+    if (!eventId) throw new ApiError(400, "eventId requis");
+
+    const notice = await prisma.departmentNotice.findUnique({
+      where: { departmentId_eventId: { departmentId, eventId } },
+      select: {
+        content: true,
+        updatedAt: true,
+        author: { select: { name: true, displayName: true } },
+      },
+    });
+
+    return successResponse(
+      notice
+        ? {
+            content: notice.content,
+            updatedAt: notice.updatedAt.toISOString(),
+            authorName: notice.author.displayName ?? notice.author.name ?? null,
+          }
+        : null
+    );
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+const putSchema = z.object({
+  eventId: z.string().min(1),
+  content: z.string().max(2000),
+});
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ departmentId: string }> }
+) {
+  try {
+    const { departmentId } = await params;
+    const churchId = await resolveChurchId("department", departmentId);
+    const session = await requireChurchPermission("planning:edit", churchId);
+
+    const { eventId, content } = putSchema.parse(await request.json());
+
+    // Validate event belongs to the same church
+    const event = await prisma.event.findUnique({
+      where: { id: eventId },
+      select: { churchId: true },
+    });
+    if (!event || event.churchId !== churchId) {
+      throw new ApiError(404, "Événement introuvable");
+    }
+
+    const notice = await prisma.departmentNotice.upsert({
+      where: { departmentId_eventId: { departmentId, eventId } },
+      create: { departmentId, eventId, content, authorId: session.user.id },
+      update: { content, authorId: session.user.id },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "UPDATE",
+      entityType: "DepartmentNotice",
+      entityId: notice.id,
+      details: { departmentId, eventId },
+    });
+
+    return successResponse({ success: true });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/planning/weekly/route.ts
+++ b/src/app/api/planning/weekly/route.ts
@@ -1,0 +1,74 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const churchId = searchParams.get("churchId");
+    const weekStart = searchParams.get("weekStart"); // YYYY-MM-DD (Monday)
+
+    if (!churchId) throw new ApiError(400, "churchId requis");
+    if (!weekStart) throw new ApiError(400, "weekStart requis");
+
+    await requireChurchPermission("planning:view", churchId);
+
+    const from = new Date(weekStart);
+    from.setUTCHours(0, 0, 0, 0);
+    const to = new Date(from);
+    to.setUTCDate(to.getUTCDate() + 7);
+
+    const events = await prisma.event.findMany({
+      where: {
+        churchId,
+        date: { gte: from, lt: to },
+      },
+      orderBy: { date: "asc" },
+      include: {
+        eventDepts: {
+          include: {
+            department: { select: { id: true, name: true } },
+          },
+          orderBy: { department: { name: "asc" } },
+        },
+        departmentNotices: {
+          select: {
+            departmentId: true,
+            content: true,
+            updatedAt: true,
+            author: { select: { name: true, displayName: true } },
+          },
+        },
+      },
+    });
+
+    const data = events.map((event) => {
+      const noticeByDept = new Map(
+        event.departmentNotices.map((n) => [
+          n.departmentId,
+          {
+            content: n.content,
+            updatedAt: n.updatedAt.toISOString(),
+            authorName: n.author.displayName ?? n.author.name ?? null,
+          },
+        ])
+      );
+
+      return {
+        id: event.id,
+        title: event.title,
+        type: event.type,
+        date: event.date.toISOString(),
+        departments: event.eventDepts.map((ed) => ({
+          id: ed.department.id,
+          name: ed.department.name,
+          notice: noticeByDept.get(ed.department.id) ?? null,
+        })),
+      };
+    });
+
+    return successResponse(data);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/components/ViewToggle.tsx
+++ b/src/components/ViewToggle.tsx
@@ -26,8 +26,18 @@ export default function ViewToggle() {
         Par evenement
       </button>
       <button
+        onClick={() => setView("week")}
+        className={`px-4 py-2 text-sm font-medium border-l border-gray-200 transition-colors ${
+          currentView === "week"
+            ? "bg-icc-violet text-white"
+            : "text-gray-600 hover:bg-gray-50"
+        }`}
+      >
+        Semaine
+      </button>
+      <button
         onClick={() => setView("month")}
-        className={`px-4 py-2 text-sm font-medium rounded-r-lg transition-colors ${
+        className={`px-4 py-2 text-sm font-medium rounded-r-lg border-l border-gray-200 transition-colors ${
           currentView === "month"
             ? "bg-icc-violet text-white"
             : "text-gray-600 hover:bg-gray-50"

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Notice {
+  content: string;
+  updatedAt: string;
+  authorName: string | null;
+}
+
+interface Department {
+  id: string;
+  name: string;
+  notice: Notice | null;
+}
+
+interface WeekEvent {
+  id: string;
+  title: string;
+  type: string;
+  date: string;
+  departments: Department[];
+}
+
+interface WeeklyPlanningViewProps {
+  churchId: string;
+  canEdit: boolean;
+}
+
+function getWeekStart(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getUTCDay(); // 0 = Sunday
+  const diff = day === 0 ? -6 : 1 - day; // Monday
+  d.setUTCDate(d.getUTCDate() + diff);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+function toISODate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function formatWeekLabel(weekStart: Date): string {
+  const weekEnd = new Date(weekStart);
+  weekEnd.setUTCDate(weekEnd.getUTCDate() + 6);
+  const opts: Intl.DateTimeFormatOptions = { day: "numeric", month: "long" };
+  const start = weekStart.toLocaleDateString("fr-FR", opts);
+  const end = weekEnd.toLocaleDateString("fr-FR", { ...opts, year: "numeric" });
+  return `${start} – ${end}`;
+}
+
+function formatDayLabel(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+export default function WeeklyPlanningView({ churchId, canEdit }: WeeklyPlanningViewProps) {
+  const [weekStart, setWeekStart] = useState<Date>(() => getWeekStart(new Date()));
+  const [events, setEvents] = useState<WeekEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingKey, setEditingKey] = useState<string | null>(null); // "deptId:eventId"
+  const [editContent, setEditContent] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const fetchWeek = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/planning/weekly?churchId=${churchId}&weekStart=${toISODate(weekStart)}`
+      );
+      const data = await res.json();
+      setEvents(data.data ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, [churchId, weekStart]);
+
+  useEffect(() => {
+    fetchWeek();
+  }, [fetchWeek]);
+
+  function prevWeek() {
+    setWeekStart((w) => {
+      const d = new Date(w);
+      d.setUTCDate(d.getUTCDate() - 7);
+      return d;
+    });
+  }
+
+  function nextWeek() {
+    setWeekStart((w) => {
+      const d = new Date(w);
+      d.setUTCDate(d.getUTCDate() + 7);
+      return d;
+    });
+  }
+
+  function startEdit(deptId: string, eventId: string, current: string) {
+    setEditingKey(`${deptId}:${eventId}`);
+    setEditContent(current);
+    setSaveError(null);
+  }
+
+  function cancelEdit() {
+    setEditingKey(null);
+    setEditContent("");
+    setSaveError(null);
+  }
+
+  async function saveNotice(deptId: string, eventId: string) {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch(`/api/departments/${deptId}/notices`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ eventId, content: editContent }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? "Erreur lors de la sauvegarde");
+      }
+      setEditingKey(null);
+      await fetchWeek();
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Group events by day
+  const byDay = events.reduce<Record<string, WeekEvent[]>>((acc, ev) => {
+    const day = ev.date.slice(0, 10);
+    (acc[day] ??= []).push(ev);
+    return acc;
+  }, {});
+
+  return (
+    <div>
+      {/* Week navigation */}
+      <div className="flex items-center gap-3 mb-6">
+        <button
+          onClick={prevWeek}
+          className="p-2 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors"
+          aria-label="Semaine précédente"
+        >
+          ←
+        </button>
+        <span className="font-semibold text-gray-800 capitalize">
+          {formatWeekLabel(weekStart)}
+        </span>
+        <button
+          onClick={nextWeek}
+          className="p-2 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors"
+          aria-label="Semaine suivante"
+        >
+          →
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="p-8 text-center text-gray-400">Chargement...</div>
+      ) : Object.keys(byDay).length === 0 ? (
+        <div className="p-8 text-center text-gray-400 border-2 border-gray-200 border-dashed rounded-lg">
+          Aucun événement cette semaine
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {Object.entries(byDay).map(([day, dayEvents]) => (
+            <div key={day}>
+              <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3 capitalize">
+                {formatDayLabel(day)}
+              </h2>
+              <div className="space-y-4">
+                {dayEvents.map((event) => (
+                  <div key={event.id} className="border-2 border-gray-200 rounded-lg overflow-hidden">
+                    <div className="px-4 py-3 bg-gray-50 border-b border-gray-200">
+                      <span className="font-semibold text-gray-800">{event.title}</span>
+                      <span className="ml-2 text-xs text-gray-500">{event.type}</span>
+                    </div>
+                    {event.departments.length === 0 ? (
+                      <p className="px-4 py-3 text-sm text-gray-400">Aucun département assigné</p>
+                    ) : (
+                      <div className="divide-y divide-gray-100">
+                        {event.departments.map((dept) => {
+                          const key = `${dept.id}:${event.id}`;
+                          const isEditing = editingKey === key;
+                          return (
+                            <div key={dept.id} className="px-4 py-3">
+                              <div className="flex items-start justify-between gap-2">
+                                <span className="font-medium text-sm text-gray-700">
+                                  {dept.name}
+                                </span>
+                                {canEdit && !isEditing && (
+                                  <button
+                                    onClick={() =>
+                                      startEdit(dept.id, event.id, dept.notice?.content ?? "")
+                                    }
+                                    className="text-xs text-icc-violet hover:underline shrink-0"
+                                  >
+                                    {dept.notice ? "Modifier" : "Ajouter une notice"}
+                                  </button>
+                                )}
+                              </div>
+
+                              {isEditing ? (
+                                <div className="mt-2 space-y-2">
+                                  <textarea
+                                    value={editContent}
+                                    onChange={(e) => setEditContent(e.target.value)}
+                                    rows={3}
+                                    maxLength={2000}
+                                    className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet resize-none"
+                                    placeholder="Instructions, rappels, informations pour ce service…"
+                                    autoFocus
+                                  />
+                                  {saveError && (
+                                    <p className="text-xs text-icc-rouge">{saveError}</p>
+                                  )}
+                                  <div className="flex gap-2">
+                                    <button
+                                      onClick={() => saveNotice(dept.id, event.id)}
+                                      disabled={saving}
+                                      className="px-3 py-1.5 text-xs font-medium bg-icc-violet text-white rounded-lg hover:opacity-90 disabled:opacity-50"
+                                    >
+                                      {saving ? "Enregistrement…" : "Enregistrer"}
+                                    </button>
+                                    <button
+                                      onClick={cancelEdit}
+                                      disabled={saving}
+                                      className="px-3 py-1.5 text-xs font-medium border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+                                    >
+                                      Annuler
+                                    </button>
+                                  </div>
+                                </div>
+                              ) : dept.notice ? (
+                                <p className="mt-1 text-sm text-gray-600 whitespace-pre-wrap">
+                                  {dept.notice.content}
+                                </p>
+                              ) : (
+                                <p className="mt-1 text-xs text-gray-400 italic">
+                                  Aucune notice
+                                </p>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé

Implémentation de la notice de service par département, affichée dans une nouvelle vue planning hebdomadaire.

## Changements

- **BDD** : nouveau modèle `DepartmentNotice` lié à `departmentId` + `eventId` (unicité par couple)
- **Migration** : `20260328000001_add_department_notice`
- **API** `GET/PUT /api/departments/[departmentId]/notices` — lecture et upsert d'une notice (permission `planning:view` / `planning:edit`)
- **API** `GET /api/planning/weekly` — retourne les événements de la semaine avec leurs départements et notices
- **Composant** `WeeklyPlanningView` — navigation semaine (lundi–dimanche), liste des événements du jour, notices éditables inline pour les rôles autorisés
- **ViewToggle** — ajout du bouton "Semaine" entre "Par événement" et "Vue mensuelle"
- **Dashboard** — rendu de la vue `week`

## Plan de test

- [ ] `npm run typecheck` passe
- [ ] La vue "Semaine" apparaît dans le toggle du dashboard
- [ ] Les événements de la semaine courante s'affichent correctement
- [ ] Un responsable de département peut ajouter/modifier une notice sur un événement
- [ ] Un utilisateur en lecture seule voit les notices sans bouton d'édition
- [ ] La navigation semaine (précédente/suivante) recharge les données

Closes #150

🤖 Generated with [Claude Code](https://claude.ai/claude-code)