### PR TITLE
fix(ci): inclure node_modules complet dans l'artifact de déploiement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,10 +68,7 @@ jobs:
           tar czf "koinonia-${VERSION}.tar.gz" \
             .next/standalone .next/static \
             prisma public package.json \
-            node_modules/.bin/prisma \
-            node_modules/prisma \
-            node_modules/.prisma \
-            node_modules/@prisma
+            node_modules
           echo "Built koinonia-${VERSION}.tar.gz"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## Problème

Chaque déploiement échouait avec une dépendance transitive de Prisma manquante différente :
- v0.15.2 : `@prisma/engines`
- v0.15.3 : `@prisma/debug`
- v0.15.4 : `@prisma/config`
- v0.15.5 : `effect`

## Fix

Remplacement de la sélection manuelle des packages Prisma par l'inclusion complète de `node_modules` dans l'artifact. Fin du whack-a-mole.

## Impact

L'artifact sera plus lourd mais fiable. Le runtime de l'app utilise `.next/standalone/node_modules`, donc pas d'impact sur les performances en production.