### PR TITLE
fix(dashboard): ajouter le bouton Semaine dans DashboardActions

### DIFF
--- a/src/components/DashboardActions.tsx
+++ b/src/components/DashboardActions.tsx
@@ -31,6 +31,19 @@ export default function DashboardActions() {
         Planification
       </Link>
       <Link
+        href={buildHref("week")}
+        className={`inline-flex items-center gap-2 px-3 py-2 md:px-4 text-sm font-medium rounded-lg border transition-colors ${
+          currentView === "week"
+            ? "bg-icc-violet text-white border-icc-violet"
+            : "bg-white text-gray-600 border-gray-200 hover:bg-gray-50"
+        }`}
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+        Semaine
+      </Link>
+      <Link
         href={buildHref("month")}
         className={`inline-flex items-center gap-2 px-3 py-2 md:px-4 text-sm font-medium rounded-lg border transition-colors ${
           currentView === "month"


### PR DESCRIPTION
## Problème

La vue hebdomadaire était implémentée mais inaccessible : le bouton manquait dans `DashboardActions`, qui est la navigation principale du dashboard (et non `ViewToggle`).

## Fix

Ajout du lien `view=week` dans `DashboardActions`, entre "Planification" et "Vue planning".