### PR TITLE
fix(planning): corriger le parsing de la réponse API vue hebdomadaire

### DIFF
--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -81,7 +81,7 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
         `/api/planning/weekly?churchId=${churchId}&weekStart=${toISODate(weekStart)}`
       );
       const data = await res.json();
-      setEvents(data.data ?? []);
+      setEvents(Array.isArray(data) ? data : []);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Problème

La vue hebdomadaire n'affichait aucun événement.

## Cause

`successResponse()` retourne les données directement (`NextResponse.json(data)`), sans enveloppe. Le composant lisait `data.data` → toujours `undefined` → fallback sur `[]`.

## Fix

`setEvents(Array.isArray(data) ? data : [])` — lit la réponse directement.