### PR TITLE
fix(planning): scoper la vue hebdomadaire au département sélectionné

### DIFF
--- a/src/app/(auth)/admin/events/EventsClient.tsx
+++ b/src/app/(auth)/admin/events/EventsClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import Select from "@/components/ui/Select";
+import { EVENT_TYPE_OPTIONS, getEventTypeLabel } from "@/lib/event-types";
 import Modal from "@/components/ui/Modal";
 import DataTable from "@/components/ui/DataTable";
 import BulkActionBar from "@/components/ui/BulkActionBar";
@@ -443,7 +444,7 @@ export default function EventsClient({ initialEvents, churches }: Props) {
                 </span>
               ),
             },
-            { header: "Type", accessor: "type" },
+            { header: "Type", accessor: (ev: EventItem) => getEventTypeLabel(ev.type) },
             {
               header: "Date",
               accessor: (ev: EventItem) => formatDate(ev.date),
@@ -546,10 +547,12 @@ export default function EventsClient({ initialEvents, churches }: Props) {
               onChange={(e) => setTitle(e.target.value)}
               required
             />
-            <Input
+            <Select
               label="Type"
               value={type}
               onChange={(e) => setType(e.target.value)}
+              options={EVENT_TYPE_OPTIONS}
+              placeholder="Choisir un type"
               required
             />
             <Input
@@ -651,10 +654,11 @@ export default function EventsClient({ initialEvents, churches }: Props) {
             onChange={(e) => setBulkTitle(e.target.value)}
             placeholder="Laisser vide pour ne pas modifier"
           />
-          <Input
+          <Select
             label="Type"
             value={bulkType}
             onChange={(e) => setBulkType(e.target.value)}
+            options={EVENT_TYPE_OPTIONS}
             placeholder="Laisser vide pour ne pas modifier"
           />
           <Input

--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -97,9 +97,9 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
       }))?.name ?? undefined
     : undefined;
 
-  // Fetch department name (for month view and tasks view)
+  // Fetch department name (for month, tasks and week views)
   const selectedDepartment =
-    (view === "month" || view === "tasks") && selectedDeptId
+    (view === "month" || view === "tasks" || view === "week") && selectedDeptId
       ? await prisma.department.findUnique({
           where: { id: selectedDeptId },
           select: { name: true },
@@ -142,7 +142,19 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
       )}
 
       {view === "week" ? (
-        <WeeklyPlanningView churchId={currentChurchId} churchName={churchName} canEdit={canEditPlanning} />
+        selectedDeptId ? (
+          <WeeklyPlanningView
+            churchId={currentChurchId}
+            departmentId={selectedDeptId}
+            departmentName={selectedDepartment?.name}
+            churchName={churchName}
+            canEdit={canEditPlanning}
+          />
+        ) : (
+          <div className="p-8 text-center text-gray-400 border-2 border-gray-200 border-dashed rounded-lg">
+            Sélectionnez un département dans la barre latérale
+          </div>
+        )
       ) : view === "tasks" ? (
         selectedDeptId ? (
           <DepartmentTasksView

--- a/src/app/(auth)/dashboard/stats/StatsClient.tsx
+++ b/src/app/(auth)/dashboard/stats/StatsClient.tsx
@@ -58,10 +58,15 @@ interface StatsData {
 
 interface Props {
   departments: Department[];
+  initialDeptId?: string;
 }
 
-export default function StatsClient({ departments }: Props) {
-  const [selectedDeptId, setSelectedDeptId] = useState(departments[0]?.id || "");
+export default function StatsClient({ departments, initialDeptId }: Props) {
+  const [selectedDeptId, setSelectedDeptId] = useState(
+    (initialDeptId && departments.some((d) => d.id === initialDeptId))
+      ? initialDeptId
+      : (departments[0]?.id || "")
+  );
   const [data, setData] = useState<StatsData | null>(null);
   const [loading, setLoading] = useState(false);
   const [months, setMonths] = useState("6");

--- a/src/app/(auth)/dashboard/stats/page.tsx
+++ b/src/app/(auth)/dashboard/stats/page.tsx
@@ -3,9 +3,15 @@ import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import StatsClient from "./StatsClient";
 
-export default async function StatsPage() {
+interface StatsPageProps {
+  searchParams: Promise<{ dept?: string }>;
+}
+
+export default async function StatsPage({ searchParams }: StatsPageProps) {
   const session = await auth();
   if (!session?.user) redirect("/");
+
+  const { dept: initialDeptId } = await searchParams;
 
   const currentChurchId = await getCurrentChurchId(session);
   if (!currentChurchId) {
@@ -31,6 +37,7 @@ export default async function StatsPage() {
           name: d.name,
           ministryName: d.ministry.name,
         }))}
+        initialDeptId={initialDeptId}
       />
     </div>
   );

--- a/src/app/(auth)/events/EventsPageClient.tsx
+++ b/src/app/(auth)/events/EventsPageClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
+import { getEventTypeBadge, getEventTypeLabel } from "@/lib/event-types";
 
 interface EventDept {
   id: string;
@@ -48,17 +49,6 @@ function formatEventDate(iso: string) {
   });
 }
 
-const typeBadgeColors: Record<string, string> = {
-  CULTE: "bg-icc-violet/10 text-icc-violet",
-  PRIERE: "bg-icc-jaune/20 text-yellow-700",
-  REUNION: "bg-icc-bleu/10 text-icc-bleu",
-  CONFERENCE: "bg-icc-rouge/10 text-icc-rouge",
-  AUTRE: "bg-gray-100 text-gray-600",
-};
-
-function getTypeBadgeClass(type: string) {
-  return typeBadgeColors[type] || "bg-gray-100 text-gray-600";
-}
 
 const monthOptions = buildMonthOptions();
 
@@ -144,9 +134,9 @@ export default function EventsPageClient({ churchId }: { churchId: string }) {
                   {formatEventDate(event.date)}
                 </span>
                 <span
-                  className={`text-xs font-medium px-2 py-0.5 rounded-full ${getTypeBadgeClass(event.type)}`}
+                  className={`text-xs font-medium px-2 py-0.5 rounded-full ${getEventTypeBadge(event.type)}`}
                 >
-                  {event.type}
+                  {getEventTypeLabel(event.type)}
                 </span>
               </div>
               <h3 className="font-semibold text-gray-800 mb-3">{event.title}</h3>

--- a/src/app/(auth)/events/calendar/CalendarClient.tsx
+++ b/src/app/(auth)/events/calendar/CalendarClient.tsx
@@ -21,6 +21,11 @@ function getEventColors(type: string) {
   return getEventTypeColors(type);
 }
 
+/** Build YYYY-MM-DD from local date components — avoids UTC offset shift from toISOString() */
+function localDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
 export default function CalendarClient({ events }: Props) {
   const now = new Date();
   const [currentMonth, setCurrentMonth] = useState(
@@ -50,21 +55,13 @@ export default function CalendarClient({ events }: Props) {
     // Previous month padding
     for (let i = 0; i < startDow; i++) {
       const d = new Date(year, month - 1, -startDow + i + 1);
-      days.push({
-        date: d.getDate(),
-        inMonth: false,
-        dateStr: d.toISOString().split("T")[0],
-      });
+      days.push({ date: d.getDate(), inMonth: false, dateStr: localDateStr(d) });
     }
 
     // Current month
     for (let d = 1; d <= lastDay.getDate(); d++) {
       const dt = new Date(year, month - 1, d);
-      days.push({
-        date: d,
-        inMonth: true,
-        dateStr: dt.toISOString().split("T")[0],
-      });
+      days.push({ date: d, inMonth: true, dateStr: localDateStr(dt) });
     }
 
     // Next month padding
@@ -72,11 +69,7 @@ export default function CalendarClient({ events }: Props) {
     if (remaining < 7) {
       for (let i = 1; i <= remaining; i++) {
         const d = new Date(year, month, i);
-        days.push({
-          date: d.getDate(),
-          inMonth: false,
-          dateStr: d.toISOString().split("T")[0],
-        });
+        days.push({ date: d.getDate(), inMonth: false, dateStr: localDateStr(d) });
       }
     }
 
@@ -94,7 +87,7 @@ export default function CalendarClient({ events }: Props) {
     return map;
   }, [events]);
 
-  const todayStr = new Date().toISOString().split("T")[0];
+  const todayStr = localDateStr(new Date());
 
   return (
     <div>

--- a/src/app/(auth)/events/calendar/CalendarClient.tsx
+++ b/src/app/(auth)/events/calendar/CalendarClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import Link from "next/link";
+import { getEventTypeColors, EVENT_TYPE_COLORS } from "@/lib/event-types";
 
 interface CalendarEvent {
   id: string;
@@ -16,16 +17,8 @@ interface Props {
 
 const DAYS_FR = ["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"];
 
-const EVENT_TYPE_COLORS: Record<string, { bg: string; text: string; hover: string; dot: string; label: string }> = {
-  CULTE:      { bg: "bg-icc-violet/10", text: "text-icc-violet",    hover: "hover:bg-icc-violet",  dot: "bg-icc-violet",  label: "Culte" },
-  PRIERE:     { bg: "bg-icc-jaune/20",  text: "text-yellow-700",    hover: "hover:bg-yellow-500",  dot: "bg-yellow-500",  label: "Priere" },
-  REUNION:    { bg: "bg-icc-bleu/10",   text: "text-icc-bleu",      hover: "hover:bg-icc-bleu",    dot: "bg-icc-bleu",    label: "Reunion" },
-  CONFERENCE: { bg: "bg-icc-rouge/10",  text: "text-icc-rouge",     hover: "hover:bg-icc-rouge",   dot: "bg-icc-rouge",   label: "Conference" },
-  AUTRE:      { bg: "bg-gray-100",      text: "text-gray-600",      hover: "hover:bg-gray-500",    dot: "bg-gray-400",    label: "Autre" },
-};
-
 function getEventColors(type: string) {
-  return EVENT_TYPE_COLORS[type] || EVENT_TYPE_COLORS.AUTRE;
+  return getEventTypeColors(type);
 }
 
 export default function CalendarClient({ events }: Props) {

--- a/src/app/(auth)/requests/new/RequestForm.tsx
+++ b/src/app/(auth)/requests/new/RequestForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
+import { EVENT_TYPES, EVENT_TYPE_LABELS } from "@/lib/event-types";
 
 type RequestCategory = "announcement" | "demand" | null;
 type DemandType =
@@ -52,7 +53,6 @@ const DEMAND_TYPES: { key: DemandType; label: string; icon: string }[] = [
 
 const DEMAND_TYPE_KEYS = DEMAND_TYPES.map((d) => d.key) as string[];
 
-const EVENT_TYPES = ["CULTE", "PRIERE", "REUNION", "FORMATION", "EVENEMENT", "AUTRE"];
 
 const DEADLINE_OFFSETS = [
   { value: "", label: "Manuel" },
@@ -556,7 +556,7 @@ export default function RequestForm({
               className="block w-full px-3 py-2 border-2 border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-icc-violet"
             >
               {EVENT_TYPES.map((t) => (
-                <option key={t} value={t}>{t}</option>
+                <option key={t} value={t}>{EVENT_TYPE_LABELS[t]}</option>
               ))}
             </select>
           </div>
@@ -711,8 +711,8 @@ export default function RequestForm({
               className="block w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet"
             >
               <option value="">— Inchangé —</option>
-              {["CULTE", "PRIERE", "REUNION", "CONFERENCE", "AUTRE"].map((t) => (
-                <option key={t} value={t}>{t}</option>
+              {EVENT_TYPES.map((t) => (
+                <option key={t} value={t}>{EVENT_TYPE_LABELS[t]}</option>
               ))}
             </select>
           </div>

--- a/src/app/api/departments/[departmentId]/monthly-planning/route.ts
+++ b/src/app/api/departments/[departmentId]/monthly-planning/route.ts
@@ -76,6 +76,7 @@ export async function GET(
     const events = eventDepartments.map((ed) => ({
       id: ed.event.id,
       title: ed.event.title,
+      type: ed.event.type,
       date: ed.event.date.toISOString(),
       members: ed.plannings.map((p) => ({
         id: p.member.id,

--- a/src/app/api/departments/[departmentId]/notices/route.ts
+++ b/src/app/api/departments/[departmentId]/notices/route.ts
@@ -85,3 +85,41 @@ export async function PUT(
     return errorResponse(error);
   }
 }
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ departmentId: string }> }
+) {
+  try {
+    const { departmentId } = await params;
+    const churchId = await resolveChurchId("department", departmentId);
+    const session = await requireChurchPermission("planning:edit", churchId);
+
+    const { searchParams } = new URL(request.url);
+    const eventId = searchParams.get("eventId");
+    if (!eventId) throw new ApiError(400, "eventId requis");
+
+    const notice = await prisma.departmentNotice.findUnique({
+      where: { departmentId_eventId: { departmentId, eventId } },
+      select: { id: true },
+    });
+    if (!notice) throw new ApiError(404, "Notice introuvable");
+
+    await prisma.departmentNotice.delete({
+      where: { departmentId_eventId: { departmentId, eventId } },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "DELETE",
+      entityType: "DepartmentNotice",
+      entityId: notice.id,
+      details: { departmentId, eventId },
+    });
+
+    return successResponse({ success: true });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/planning/weekly/route.ts
+++ b/src/app/api/planning/weekly/route.ts
@@ -7,9 +7,11 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const churchId = searchParams.get("churchId");
     const weekStart = searchParams.get("weekStart"); // YYYY-MM-DD (Monday)
+    const departmentId = searchParams.get("departmentId");
 
     if (!churchId) throw new ApiError(400, "churchId requis");
     if (!weekStart) throw new ApiError(400, "weekStart requis");
+    if (!departmentId) throw new ApiError(400, "departmentId requis");
 
     await requireChurchPermission("planning:view", churchId);
 
@@ -18,22 +20,29 @@ export async function GET(request: Request) {
     const to = new Date(from);
     to.setUTCDate(to.getUTCDate() + 7);
 
+    // Only events that have this department assigned
     const events = await prisma.event.findMany({
       where: {
         churchId,
         date: { gte: from, lt: to },
+        eventDepts: { some: { departmentId } },
       },
       orderBy: { date: "asc" },
       include: {
         eventDepts: {
+          where: { departmentId },
           include: {
-            department: { select: { id: true, name: true } },
+            plannings: {
+              where: { status: { not: null } },
+              include: {
+                member: { select: { id: true, firstName: true, lastName: true } },
+              },
+            },
           },
-          orderBy: { department: { name: "asc" } },
         },
         departmentNotices: {
+          where: { departmentId },
           select: {
-            departmentId: true,
             content: true,
             updatedAt: true,
             author: { select: { name: true, displayName: true } },
@@ -43,27 +52,30 @@ export async function GET(request: Request) {
     });
 
     const data = events.map((event) => {
-      const noticeByDept = new Map(
-        event.departmentNotices.map((n) => [
-          n.departmentId,
-          {
-            content: n.content,
-            updatedAt: n.updatedAt.toISOString(),
-            authorName: n.author.displayName ?? n.author.name ?? null,
-          },
-        ])
-      );
+      const eventDept = event.eventDepts[0]; // filtered to this dept only
+      const notice = event.departmentNotices[0] ?? null;
 
       return {
         id: event.id,
         title: event.title,
         type: event.type,
         date: event.date.toISOString(),
-        departments: event.eventDepts.map((ed) => ({
-          id: ed.department.id,
-          name: ed.department.name,
-          notice: noticeByDept.get(ed.department.id) ?? null,
-        })),
+        planningDeadline: event.planningDeadline?.toISOString() ?? null,
+        notice: notice
+          ? {
+              content: notice.content,
+              updatedAt: notice.updatedAt.toISOString(),
+              authorName: notice.author.displayName ?? notice.author.name ?? null,
+            }
+          : null,
+        members: eventDept
+          ? eventDept.plannings.map((p) => ({
+              id: p.member.id,
+              firstName: p.member.firstName,
+              lastName: p.member.lastName,
+              status: p.status,
+            }))
+          : [],
       };
     });
 

--- a/src/app/api/planning/weekly/route.ts
+++ b/src/app/api/planning/weekly/route.ts
@@ -51,6 +51,22 @@ export async function GET(request: Request) {
       },
     });
 
+    // Fetch task assignments for all events in the week
+    const eventIds = events.map((e) => e.id);
+    const taskAssignments = await prisma.taskAssignment.findMany({
+      where: { eventId: { in: eventIds }, task: { departmentId } },
+      include: { task: { select: { name: true } } },
+    });
+
+    // Build map: eventId -> memberId -> task names
+    const taskMap = new Map<string, Map<string, string[]>>();
+    for (const ta of taskAssignments) {
+      if (!taskMap.has(ta.eventId)) taskMap.set(ta.eventId, new Map());
+      const memberTasks = taskMap.get(ta.eventId)!;
+      if (!memberTasks.has(ta.memberId)) memberTasks.set(ta.memberId, []);
+      memberTasks.get(ta.memberId)!.push(ta.task.name);
+    }
+
     const data = events.map((event) => {
       const eventDept = event.eventDepts[0]; // filtered to this dept only
       const notice = event.departmentNotices[0] ?? null;
@@ -74,6 +90,7 @@ export async function GET(request: Request) {
               firstName: p.member.firstName,
               lastName: p.member.lastName,
               status: p.status,
+              tasks: taskMap.get(event.id)?.get(p.member.id) ?? [],
             }))
           : [],
       };

--- a/src/app/api/planning/weekly/route.ts
+++ b/src/app/api/planning/weekly/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: Request) {
           where: { departmentId },
           include: {
             plannings: {
-              where: { status: { not: null } },
+              where: { status: { in: ["EN_SERVICE", "EN_SERVICE_DEBRIEF"] } },
               include: {
                 member: { select: { id: true, firstName: true, lastName: true } },
               },

--- a/src/components/DashboardActions.tsx
+++ b/src/components/DashboardActions.tsx
@@ -70,12 +70,8 @@ export default function DashboardActions() {
         Tâches
       </Link>
       <Link
-        href="/dashboard/stats"
-        className={`inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border transition-colors ${
-          false
-            ? "bg-icc-violet text-white border-icc-violet"
-            : "bg-white text-gray-600 border-gray-200 hover:bg-gray-50"
-        }`}
+        href={dept ? `/dashboard/stats?dept=${dept}` : "/dashboard/stats"}
+        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border transition-colors bg-white text-gray-600 border-gray-200 hover:bg-gray-50"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />

--- a/src/components/DashboardActions.tsx
+++ b/src/components/DashboardActions.tsx
@@ -28,7 +28,7 @@ export default function DashboardActions() {
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
         </svg>
-        Planification
+        Saisie
       </Link>
       <Link
         href={buildHref("week")}
@@ -41,7 +41,7 @@ export default function DashboardActions() {
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
         </svg>
-        Semaine
+        Vue semaine
       </Link>
       <Link
         href={buildHref("month")}
@@ -54,7 +54,7 @@ export default function DashboardActions() {
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
         </svg>
-        Vue planning
+        Vue mois
       </Link>
       <Link
         href={buildHref("tasks")}

--- a/src/components/EventSelector.tsx
+++ b/src/components/EventSelector.tsx
@@ -16,72 +16,139 @@ interface EventSelectorProps {
   selectedDeptId: string | null;
 }
 
+function toYearMonth(isoDate: string): string {
+  return isoDate.slice(0, 7); // "YYYY-MM"
+}
+
+function formatMonthLabel(ym: string): string {
+  const [y, m] = ym.split("-").map(Number);
+  return new Date(y, m - 1, 1).toLocaleDateString("fr-FR", {
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function formatEventLabel(event: Event): string {
+  const date = new Date(event.date).toLocaleDateString("fr-FR", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
+  return `${event.title} — ${date}`;
+}
+
 export default function EventSelector({
   events,
   selectedEventId,
   selectedDeptId,
 }: EventSelectorProps) {
   const router = useRouter();
-  const [monthFilter, setMonthFilter] = useState("");
 
-  // Auto-select the next upcoming event on first render
-  useEffect(() => {
-    if (!selectedEventId && events.length > 0 && selectedDeptId) {
-      const now = new Date();
-      const upcoming = events.find((e) => new Date(e.date) >= now);
-      const eventId = (upcoming || events[0]).id;
-      // Preserve existing search params (e.g. tour=1)
-      const params = new URLSearchParams(window.location.search);
-      params.set("dept", selectedDeptId);
-      params.set("event", eventId);
-      router.replace(`/dashboard?${params.toString()}`);
+  // Sorted unique months that have at least one event
+  const months = useMemo(() => {
+    const set = new Set(events.map((e) => toYearMonth(e.date)));
+    return Array.from(set).sort();
+  }, [events]);
+
+  // Derive initial month from selected event, or default to current/nearest month
+  const initialMonth = useMemo(() => {
+    if (selectedEventId) {
+      const ev = events.find((e) => e.id === selectedEventId);
+      if (ev) return toYearMonth(ev.date);
     }
-  }, [selectedEventId, events, selectedDeptId, router]);
+    const now = toYearMonth(new Date().toISOString());
+    // Pick current month if it has events, otherwise the next available month
+    return months.find((m) => m >= now) ?? months[0] ?? "";
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const filteredEvents = useMemo(() => {
-    if (!monthFilter) return events;
-    return events.filter((e) => e.date.startsWith(monthFilter));
-  }, [events, monthFilter]);
+  const [selectedMonth, setSelectedMonth] = useState(initialMonth);
 
-  const handleChange = (eventId: string) => {
-    const params = new URLSearchParams();
+  // Events for the selected month
+  const monthEvents = useMemo(
+    () => events.filter((e) => toYearMonth(e.date) === selectedMonth),
+    [events, selectedMonth]
+  );
+
+  // Auto-select event when month changes or on initial load
+  useEffect(() => {
+    if (!selectedMonth) return;
+
+    if (monthEvents.length === 0) return;
+
+    // If the currently selected event is in this month, keep it
+    if (selectedEventId && monthEvents.some((e) => e.id === selectedEventId)) return;
+
+    // Auto-select: pick the next upcoming event, otherwise the first
+    const now = new Date();
+    const upcoming = monthEvents.find((e) => new Date(e.date) >= now);
+    const eventId = (upcoming ?? monthEvents[0]).id;
+
+    const params = new URLSearchParams(window.location.search);
     if (selectedDeptId) params.set("dept", selectedDeptId);
-    if (eventId) params.set("event", eventId);
+    params.set("event", eventId);
+    router.replace(`/dashboard?${params.toString()}`);
+  }, [selectedMonth, monthEvents]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function handleMonthChange(ym: string) {
+    setSelectedMonth(ym);
+    // Event will be auto-selected by the effect above
+  }
+
+  function handleEventChange(eventId: string) {
+    const params = new URLSearchParams(window.location.search);
+    if (selectedDeptId) params.set("dept", selectedDeptId);
+    params.set("event", eventId);
     router.push(`/dashboard?${params.toString()}`);
-  };
+  }
+
+  if (events.length === 0) {
+    return (
+      <p className="text-sm text-gray-400 italic" data-tour="event-selector">
+        Aucun événement disponible
+      </p>
+    );
+  }
 
   return (
-    <div data-tour="event-selector">
-      <label className="block mb-1 text-sm font-medium text-gray-700">
-        Evenement
-      </label>
-      <input
-        type="month"
-        value={monthFilter}
-        onChange={(e) => setMonthFilter(e.target.value)}
-        className="w-full px-3 py-2.5 md:py-2 mb-2 border-2 border-gray-300 rounded-lg shadow-sm text-base md:text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-icc-violet"
-        placeholder="Filtrer par mois"
-      />
-      <select
-        value={selectedEventId || ""}
-        onChange={(e) => handleChange(e.target.value)}
-        className="w-full px-3 py-2.5 md:py-2 border-2 border-gray-300 rounded-lg shadow-sm text-base md:text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-icc-violet"
-      >
-        <option value="" disabled>
-          Choisir un evenement
-        </option>
-        {filteredEvents.map((event) => (
-          <option key={event.id} value={event.id}>
-            {event.title} (
-            {new Date(event.date).toLocaleDateString("fr-FR")})
-          </option>
-        ))}
-      </select>
-      {monthFilter && filteredEvents.length === 0 && (
-        <p className="mt-1 text-xs text-gray-400">
-          Aucun evenement pour ce mois
-        </p>
-      )}
+    <div data-tour="event-selector" className="flex flex-wrap gap-3 items-end">
+      {/* Month select */}
+      <div className="flex-1 min-w-[160px]">
+        <label className="block mb-1 text-sm font-medium text-gray-700">
+          Mois
+        </label>
+        <select
+          value={selectedMonth}
+          onChange={(e) => handleMonthChange(e.target.value)}
+          className="w-full px-3 py-2.5 md:py-2 border-2 border-gray-300 rounded-lg shadow-sm text-base md:text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-icc-violet capitalize"
+        >
+          <option value="" disabled>Choisir le mois</option>
+          {months.map((ym) => (
+            <option key={ym} value={ym} className="capitalize">
+              {formatMonthLabel(ym)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Event select */}
+      <div className="flex-[2] min-w-[220px]">
+        <label className="block mb-1 text-sm font-medium text-gray-700">
+          Événement
+        </label>
+        <select
+          value={selectedEventId || ""}
+          onChange={(e) => handleEventChange(e.target.value)}
+          disabled={monthEvents.length === 0}
+          className="w-full px-3 py-2.5 md:py-2 border-2 border-gray-300 rounded-lg shadow-sm text-base md:text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-icc-violet disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <option value="" disabled>Choisir un événement</option>
+          {monthEvents.map((event) => (
+            <option key={event.id} value={event.id}>
+              {formatEventLabel(event)}
+            </option>
+          ))}
+        </select>
+      </div>
     </div>
   );
 }

--- a/src/components/MonthlyPlanningView.tsx
+++ b/src/components/MonthlyPlanningView.tsx
@@ -235,7 +235,7 @@ export default function MonthlyPlanningView({ departmentId, departmentName, chur
         </div>
       )}
 
-      <div ref={printRef} className="max-w-lg mx-auto rounded-xl overflow-hidden shadow-lg border border-gray-100">
+      <div ref={printRef} className="max-w-2xl mx-auto rounded-xl overflow-hidden shadow-lg border border-gray-100">
         {loading ? (
           <div className="p-8 text-center text-gray-400 bg-white">Chargement...</div>
         ) : events.length === 0 ? (

--- a/src/components/MonthlyPlanningView.tsx
+++ b/src/components/MonthlyPlanningView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { getEventTypeBadge, getEventTypeLabel } from "@/lib/event-types";
 
 interface MemberItem {
   id: string;
@@ -13,6 +14,7 @@ interface MemberItem {
 interface EventItem {
   id: string;
   title: string;
+  type: string;
   date: string;
   members: MemberItem[];
 }
@@ -275,7 +277,12 @@ export default function MonthlyPlanningView({ departmentId, departmentName, chur
 
                       {/* Content */}
                       <div className="flex-1 px-4 py-3 min-w-0">
-                        <p className="font-bold text-icc-violet text-xs uppercase tracking-wide mb-2">{event.title}</p>
+                        <div className="flex flex-wrap items-center gap-1.5 mb-2">
+                          <p className="font-bold text-icc-violet text-xs uppercase tracking-wide">{event.title}</p>
+                          <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${getEventTypeBadge(event.type)}`}>
+                            {getEventTypeLabel(event.type)}
+                          </span>
+                        </div>
 
                         {event.members.length === 0 ? (
                           <p className="text-xs text-gray-400 italic">(aucun STAR en service)</p>

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -323,24 +323,33 @@ export default function WeeklyPlanningView({
                             ))}
                           </div>
                         )}
+                        {canEdit && !event.notice && !isEditing && (
+                          <button
+                            data-html2canvas-ignore="true"
+                            onClick={() => startEdit(event.id, "")}
+                            className="mt-2 text-[11px] text-icc-violet hover:underline"
+                          >
+                            + Ajouter une notice
+                          </button>
+                        )}
                       </div>
                     </div>
 
-                    {/* Notice */}
-                    <div className={`px-4 pb-3 border-t ${event.notice?.content && !isEditing ? "border-icc-violet/20 bg-icc-violet/5" : "border-gray-100"}`}>
-                      <div className="flex items-center justify-between mt-2 mb-1">
-                        <span className={`text-[11px] font-semibold uppercase tracking-wide ${event.notice?.content && !isEditing ? "text-icc-violet/70" : "text-gray-400"}`}>
-                          ⚠️ Notice de service
-                        </span>
-                        {canEdit && !isEditing && !exporting && (
-                          <div className="flex items-center gap-2">
-                            <button
-                              onClick={() => startEdit(event.id, event.notice?.content ?? "")}
-                              className="text-[11px] text-icc-violet hover:underline"
-                            >
-                              {event.notice ? "Modifier" : "Ajouter"}
-                            </button>
-                            {event.notice && (
+                    {/* Notice — affiché uniquement si contenu existe ou en cours d'édition */}
+                    {(event.notice?.content || isEditing) && (
+                      <div className={`px-4 pb-3 border-t ${event.notice?.content && !isEditing ? "border-icc-violet/20 bg-icc-violet/5" : "border-gray-100"}`}>
+                        <div className="flex items-center justify-between mt-2 mb-1">
+                          <span className={`text-[11px] font-semibold uppercase tracking-wide ${event.notice?.content && !isEditing ? "text-icc-violet/70" : "text-gray-400"}`}>
+                            ⚠️ Notice de service
+                          </span>
+                          {canEdit && !isEditing && (
+                            <div data-html2canvas-ignore="true" className="flex items-center gap-2">
+                              <button
+                                onClick={() => startEdit(event.id, event.notice?.content ?? "")}
+                                className="text-[11px] text-icc-violet hover:underline"
+                              >
+                                Modifier
+                              </button>
                               <button
                                 onClick={() => deleteNotice(event.id)}
                                 disabled={saving}
@@ -348,48 +357,46 @@ export default function WeeklyPlanningView({
                               >
                                 Supprimer
                               </button>
-                            )}
+                            </div>
+                          )}
+                        </div>
+
+                        {isEditing ? (
+                          <div className="space-y-2">
+                            <textarea
+                              value={editContent}
+                              onChange={(e) => setEditContent(e.target.value)}
+                              rows={3}
+                              maxLength={2000}
+                              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet resize-none"
+                              placeholder="Instructions, rappels, informations pour ce service…"
+                              autoFocus
+                            />
+                            {saveError && <p className="text-xs text-icc-rouge">{saveError}</p>}
+                            <div className="flex gap-2">
+                              <button
+                                onClick={() => saveNotice(event.id)}
+                                disabled={saving}
+                                className="px-3 py-1.5 text-xs font-medium bg-icc-violet text-white rounded-lg hover:opacity-90 disabled:opacity-50"
+                              >
+                                {saving ? "Enregistrement…" : "Enregistrer"}
+                              </button>
+                              <button
+                                onClick={cancelEdit}
+                                disabled={saving}
+                                className="px-3 py-1.5 text-xs font-medium border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+                              >
+                                Annuler
+                              </button>
+                            </div>
                           </div>
+                        ) : (
+                          <p className="text-sm text-icc-violet/80 whitespace-pre-wrap leading-relaxed">
+                            {event.notice!.content}
+                          </p>
                         )}
                       </div>
-
-                      {isEditing ? (
-                        <div className="space-y-2">
-                          <textarea
-                            value={editContent}
-                            onChange={(e) => setEditContent(e.target.value)}
-                            rows={3}
-                            maxLength={2000}
-                            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet resize-none"
-                            placeholder="Instructions, rappels, informations pour ce service…"
-                            autoFocus
-                          />
-                          {saveError && <p className="text-xs text-icc-rouge">{saveError}</p>}
-                          <div className="flex gap-2">
-                            <button
-                              onClick={() => saveNotice(event.id)}
-                              disabled={saving}
-                              className="px-3 py-1.5 text-xs font-medium bg-icc-violet text-white rounded-lg hover:opacity-90 disabled:opacity-50"
-                            >
-                              {saving ? "Enregistrement…" : "Enregistrer"}
-                            </button>
-                            <button
-                              onClick={cancelEdit}
-                              disabled={saving}
-                              className="px-3 py-1.5 text-xs font-medium border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50"
-                            >
-                              Annuler
-                            </button>
-                          </div>
-                        </div>
-                      ) : event.notice?.content ? (
-                        <p className="text-sm text-icc-violet/80 whitespace-pre-wrap leading-relaxed">
-                          {event.notice.content}
-                        </p>
-                      ) : (
-                        <p className="text-xs text-gray-400 italic">Aucune notice</p>
-                      )}
-                    </div>
+                    )}
                   </div>
                 );
               })}

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -308,9 +308,9 @@ export default function WeeklyPlanningView({
                     )}
 
                     {/* Notice */}
-                    <div className="px-4 pb-3 border-t border-gray-100">
+                    <div className={`px-4 pb-3 border-t ${event.notice && !isEditing ? "border-icc-violet/20 bg-icc-violet/5" : "border-gray-100"}`}>
                       <div className="flex items-center justify-between mt-2 mb-1">
-                        <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wide">
+                        <span className={`text-[11px] font-semibold uppercase tracking-wide ${event.notice && !isEditing ? "text-icc-violet/70" : "text-gray-400"}`}>
                           Notice de service
                         </span>
                         {canEdit && !isEditing && !exporting && (
@@ -353,7 +353,7 @@ export default function WeeklyPlanningView({
                           </div>
                         </div>
                       ) : event.notice ? (
-                        <p className="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed">
+                        <p className="text-sm text-icc-violet/80 whitespace-pre-wrap leading-relaxed">
                           {event.notice.content}
                         </p>
                       ) : (

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -295,7 +295,7 @@ export default function WeeklyPlanningView({
                         {event.members.map((m) => (
                           <div key={m.id} className="flex items-center gap-2">
                             <span className="text-sm font-semibold text-gray-900">
-                              🙌 {m.firstName} {m.lastName}
+                              {m.firstName} {m.lastName}
                             </span>
                             {m.status === "EN_SERVICE_DEBRIEF" && (
                               <span className="text-[11px] font-semibold text-white bg-icc-violet px-2 py-0.5 rounded-full">

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -122,6 +122,26 @@ export default function WeeklyPlanningView({
     setSaveError(null);
   }
 
+  async function deleteNotice(eventId: string) {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch(
+        `/api/departments/${departmentId}/notices?eventId=${eventId}`,
+        { method: "DELETE" }
+      );
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? "Erreur lors de la suppression");
+      }
+      await fetchWeek();
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setSaving(false);
+    }
+  }
+
   async function saveNotice(eventId: string) {
     setSaving(true);
     setSaveError(null);
@@ -277,49 +297,59 @@ export default function WeeklyPlanningView({
 
                 return (
                   <div key={event.id} className="bg-white rounded-lg overflow-hidden shadow-sm">
-                    {/* Event header row */}
+                    {/* Event header row + members */}
                     <div className="flex">
                       <div className="bg-icc-violet w-16 shrink-0 flex flex-col items-center justify-center py-3">
                         <span className="text-xs font-semibold text-white/80 uppercase leading-none">{weekday}</span>
                         <span className="text-2xl font-black text-white leading-none mt-0.5">{day}</span>
                       </div>
                       <div className="flex-1 px-4 py-3 min-w-0">
-                        <p className="font-bold text-icc-violet text-xs uppercase tracking-wide">{event.title}</p>
-                        <p className="text-xs text-gray-400 mt-0.5">{event.type}</p>
+                        <p className="font-bold text-icc-violet text-xs uppercase tracking-wide mb-2">{event.title}</p>
+                        {event.members.length === 0 ? (
+                          <p className="text-xs text-gray-400 italic">(aucun STAR en service)</p>
+                        ) : (
+                          <div className="space-y-1.5">
+                            {event.members.map((m) => (
+                              <div key={m.id} className="flex flex-wrap items-center gap-1.5">
+                                <span className="text-sm text-gray-600 font-medium">
+                                  {m.firstName} {m.lastName}
+                                </span>
+                                {m.status === "EN_SERVICE_DEBRIEF" && (
+                                  <span className="text-[11px] font-semibold text-white bg-icc-violet px-2 py-0.5 rounded-full">
+                                    Debrief
+                                  </span>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        )}
                       </div>
                     </div>
 
-                    {/* Members en service */}
-                    {event.members.length > 0 && (
-                      <div className="px-4 pt-2 pb-3 border-t border-gray-100 space-y-1.5">
-                        {event.members.map((m) => (
-                          <div key={m.id} className="flex flex-wrap items-center gap-1.5">
-                            <span className="text-sm text-gray-600 font-medium">
-                              {m.firstName} {m.lastName}
-                            </span>
-                            {m.status === "EN_SERVICE_DEBRIEF" && (
-                              <span className="text-[11px] font-semibold text-white bg-icc-violet px-2 py-0.5 rounded-full">
-                                Debrief
-                              </span>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
-
                     {/* Notice */}
-                    <div className={`px-4 pb-3 border-t ${event.notice && !isEditing ? "border-icc-violet/20 bg-icc-violet/5" : "border-gray-100"}`}>
+                    <div className={`px-4 pb-3 border-t ${event.notice?.content && !isEditing ? "border-icc-violet/20 bg-icc-violet/5" : "border-gray-100"}`}>
                       <div className="flex items-center justify-between mt-2 mb-1">
-                        <span className={`text-[11px] font-semibold uppercase tracking-wide ${event.notice && !isEditing ? "text-icc-violet/70" : "text-gray-400"}`}>
+                        <span className={`text-[11px] font-semibold uppercase tracking-wide ${event.notice?.content && !isEditing ? "text-icc-violet/70" : "text-gray-400"}`}>
                           ⚠️ Notice de service
                         </span>
                         {canEdit && !isEditing && !exporting && (
-                          <button
-                            onClick={() => startEdit(event.id, event.notice?.content ?? "")}
-                            className="text-[11px] text-icc-violet hover:underline"
-                          >
-                            {event.notice ? "Modifier" : "Ajouter"}
-                          </button>
+                          <div className="flex items-center gap-2">
+                            <button
+                              onClick={() => startEdit(event.id, event.notice?.content ?? "")}
+                              className="text-[11px] text-icc-violet hover:underline"
+                            >
+                              {event.notice ? "Modifier" : "Ajouter"}
+                            </button>
+                            {event.notice && (
+                              <button
+                                onClick={() => deleteNotice(event.id)}
+                                disabled={saving}
+                                className="text-[11px] text-icc-rouge hover:underline disabled:opacity-50"
+                              >
+                                Supprimer
+                              </button>
+                            )}
+                          </div>
                         )}
                       </div>
 
@@ -352,7 +382,7 @@ export default function WeeklyPlanningView({
                             </button>
                           </div>
                         </div>
-                      ) : event.notice ? (
+                      ) : event.notice?.content ? (
                         <p className="text-sm text-icc-violet/80 whitespace-pre-wrap leading-relaxed">
                           {event.notice.content}
                         </p>

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { getEventTypeBadge, getEventTypeLabel } from "@/lib/event-types";
 
 interface Member {
   id: string;
@@ -305,7 +306,12 @@ export default function WeeklyPlanningView({
                         <span className="text-2xl font-black text-white leading-none mt-0.5">{day}</span>
                       </div>
                       <div className="flex-1 px-4 py-3 min-w-0">
-                        <p className="font-bold text-icc-violet text-xs uppercase tracking-wide mb-2">{event.title}</p>
+                        <div className="flex flex-wrap items-center gap-1.5 mb-2">
+                          <p className="font-bold text-icc-violet text-xs uppercase tracking-wide">{event.title}</p>
+                          <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${getEventTypeBadge(event.type)}`}>
+                            {getEventTypeLabel(event.type)}
+                          </span>
+                        </div>
                         {event.members.length === 0 ? (
                           <p className="text-xs text-gray-400 italic">(aucun STAR en service)</p>
                         ) : (

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -293,8 +293,8 @@ export default function WeeklyPlanningView({
                     {event.members.length > 0 && (
                       <div className="px-4 pt-2 pb-3 border-t border-gray-100 space-y-1.5">
                         {event.members.map((m) => (
-                          <div key={m.id} className="flex items-center gap-2">
-                            <span className="text-sm font-semibold text-gray-900">
+                          <div key={m.id} className="flex flex-wrap items-center gap-1.5">
+                            <span className="text-sm text-gray-600 font-medium">
                               {m.firstName} {m.lastName}
                             </span>
                             {m.status === "EN_SERVICE_DEBRIEF" && (
@@ -311,7 +311,7 @@ export default function WeeklyPlanningView({
                     <div className={`px-4 pb-3 border-t ${event.notice && !isEditing ? "border-icc-violet/20 bg-icc-violet/5" : "border-gray-100"}`}>
                       <div className="flex items-center justify-between mt-2 mb-1">
                         <span className={`text-[11px] font-semibold uppercase tracking-wide ${event.notice && !isEditing ? "text-icc-violet/70" : "text-gray-400"}`}>
-                          Notice de service
+                          ⚠️ Notice de service
                         </span>
                         {canEdit && !isEditing && !exporting && (
                           <button

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -6,7 +6,7 @@ interface Member {
   id: string;
   firstName: string;
   lastName: string;
-  status: "EN_SERVICE" | "EN_SERVICE_DEBRIEF" | "INDISPONIBLE" | "REMPLACANT" | null;
+  status: "EN_SERVICE" | "EN_SERVICE_DEBRIEF" | null;
 }
 
 interface Notice {
@@ -33,19 +33,6 @@ interface WeeklyPlanningViewProps {
   canEdit: boolean;
 }
 
-const STATUS_LABEL: Record<string, string> = {
-  EN_SERVICE: "En service",
-  EN_SERVICE_DEBRIEF: "Debrief",
-  INDISPONIBLE: "Indisponible",
-  REMPLACANT: "Remplaçant",
-};
-
-const STATUS_CLASS: Record<string, string> = {
-  EN_SERVICE: "bg-green-100 text-green-700",
-  EN_SERVICE_DEBRIEF: "bg-icc-violet text-white",
-  INDISPONIBLE: "bg-red-100 text-red-600",
-  REMPLACANT: "bg-yellow-100 text-yellow-700",
-};
 
 function getWeekStart(date: Date): Date {
   const d = new Date(date);
@@ -287,12 +274,6 @@ export default function WeeklyPlanningView({
               {events.map((event) => {
                 const { day, weekday } = formatDayShort(event.date);
                 const isEditing = editingEventId === event.id;
-                const enService = event.members.filter(
-                  (m) => m.status === "EN_SERVICE" || m.status === "EN_SERVICE_DEBRIEF"
-                );
-                const autres = event.members.filter(
-                  (m) => m.status === "INDISPONIBLE" || m.status === "REMPLACANT"
-                );
 
                 return (
                   <div key={event.id} className="bg-white rounded-lg overflow-hidden shadow-sm">
@@ -308,10 +289,10 @@ export default function WeeklyPlanningView({
                       </div>
                     </div>
 
-                    {/* Members */}
+                    {/* Members en service */}
                     {event.members.length > 0 && (
                       <div className="px-4 pt-2 pb-3 border-t border-gray-100 space-y-1.5">
-                        {enService.map((m) => (
+                        {event.members.map((m) => (
                           <div key={m.id} className="flex items-center gap-2">
                             <span className="text-sm font-semibold text-gray-900">
                               {m.firstName} {m.lastName}
@@ -319,21 +300,6 @@ export default function WeeklyPlanningView({
                             {m.status === "EN_SERVICE_DEBRIEF" && (
                               <span className="text-[11px] font-semibold text-white bg-icc-violet px-2 py-0.5 rounded-full">
                                 Debrief
-                              </span>
-                            )}
-                          </div>
-                        ))}
-                        {enService.length > 0 && autres.length > 0 && (
-                          <div className="h-px bg-gray-100" />
-                        )}
-                        {autres.map((m) => (
-                          <div key={m.id} className="flex items-center gap-2">
-                            <span className="text-sm text-gray-500">
-                              {m.firstName} {m.lastName}
-                            </span>
-                            {m.status && (
-                              <span className={`text-[11px] font-medium px-2 py-0.5 rounded-full ${STATUS_CLASS[m.status] ?? ""}`}>
-                                {STATUS_LABEL[m.status]}
                               </span>
                             )}
                           </div>

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -2,16 +2,17 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 
+interface Member {
+  id: string;
+  firstName: string;
+  lastName: string;
+  status: "EN_SERVICE" | "EN_SERVICE_DEBRIEF" | "INDISPONIBLE" | "REMPLACANT" | null;
+}
+
 interface Notice {
   content: string;
   updatedAt: string;
   authorName: string | null;
-}
-
-interface Department {
-  id: string;
-  name: string;
-  notice: Notice | null;
 }
 
 interface WeekEvent {
@@ -19,14 +20,32 @@ interface WeekEvent {
   title: string;
   type: string;
   date: string;
-  departments: Department[];
+  planningDeadline: string | null;
+  notice: Notice | null;
+  members: Member[];
 }
 
 interface WeeklyPlanningViewProps {
   churchId: string;
+  departmentId: string;
+  departmentName?: string;
   churchName?: string;
   canEdit: boolean;
 }
+
+const STATUS_LABEL: Record<string, string> = {
+  EN_SERVICE: "En service",
+  EN_SERVICE_DEBRIEF: "Debrief",
+  INDISPONIBLE: "Indisponible",
+  REMPLACANT: "Remplaçant",
+};
+
+const STATUS_CLASS: Record<string, string> = {
+  EN_SERVICE: "bg-green-100 text-green-700",
+  EN_SERVICE_DEBRIEF: "bg-icc-violet text-white",
+  INDISPONIBLE: "bg-red-100 text-red-600",
+  REMPLACANT: "bg-yellow-100 text-yellow-700",
+};
 
 function getWeekStart(date: Date): Date {
   const d = new Date(date);
@@ -50,11 +69,6 @@ function formatWeekLabel(weekStart: Date): string {
   return `${start} – ${end}`;
 }
 
-function formatDayLabel(isoDate: string): string {
-  const d = new Date(isoDate);
-  return d.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" });
-}
-
 function formatDayShort(isoDate: string) {
   const d = new Date(isoDate);
   return {
@@ -63,11 +77,21 @@ function formatDayShort(isoDate: string) {
   };
 }
 
-export default function WeeklyPlanningView({ churchId, churchName, canEdit }: WeeklyPlanningViewProps) {
+function getExportFileName(departmentName: string | undefined, weekStart: Date) {
+  return `Planning-${departmentName ?? "dept"}-semaine-${toISODate(weekStart)}`;
+}
+
+export default function WeeklyPlanningView({
+  churchId,
+  departmentId,
+  departmentName,
+  churchName,
+  canEdit,
+}: WeeklyPlanningViewProps) {
   const [weekStart, setWeekStart] = useState<Date>(() => getWeekStart(new Date()));
   const [events, setEvents] = useState<WeekEvent[]>([]);
   const [loading, setLoading] = useState(true);
-  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [editingEventId, setEditingEventId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState("");
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -78,14 +102,14 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
     setLoading(true);
     try {
       const res = await fetch(
-        `/api/planning/weekly?churchId=${churchId}&weekStart=${toISODate(weekStart)}`
+        `/api/planning/weekly?churchId=${churchId}&departmentId=${departmentId}&weekStart=${toISODate(weekStart)}`
       );
       const data = await res.json();
-      setEvents(data.data ?? []);
+      setEvents(Array.isArray(data) ? data : []);
     } finally {
       setLoading(false);
     }
-  }, [churchId, weekStart]);
+  }, [churchId, departmentId, weekStart]);
 
   useEffect(() => {
     fetchWeek();
@@ -99,23 +123,23 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
     setWeekStart((w) => { const d = new Date(w); d.setUTCDate(d.getUTCDate() + 7); return d; });
   }
 
-  function startEdit(deptId: string, eventId: string, current: string) {
-    setEditingKey(`${deptId}:${eventId}`);
+  function startEdit(eventId: string, current: string) {
+    setEditingEventId(eventId);
     setEditContent(current);
     setSaveError(null);
   }
 
   function cancelEdit() {
-    setEditingKey(null);
+    setEditingEventId(null);
     setEditContent("");
     setSaveError(null);
   }
 
-  async function saveNotice(deptId: string, eventId: string) {
+  async function saveNotice(eventId: string) {
     setSaving(true);
     setSaveError(null);
     try {
-      const res = await fetch(`/api/departments/${deptId}/notices`, {
+      const res = await fetch(`/api/departments/${departmentId}/notices`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ eventId, content: editContent }),
@@ -124,17 +148,13 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
         const err = await res.json();
         throw new Error(err.error ?? "Erreur lors de la sauvegarde");
       }
-      setEditingKey(null);
+      setEditingEventId(null);
       await fetchWeek();
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : "Erreur");
     } finally {
       setSaving(false);
     }
-  }
-
-  function getExportFileName() {
-    return `Notices-semaine-${toISODate(weekStart)}`;
   }
 
   async function copyImage() {
@@ -145,13 +165,13 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
       const canvas = await html2canvas(printRef.current, { scale: 2, useCORS: true });
       try {
         const blob = await new Promise<Blob>((resolve, reject) => {
-          canvas.toBlob((b: Blob | null) => { if (b) resolve(b); else reject(new Error("toBlob failed")); }, "image/png");
+          canvas.toBlob((b: Blob | null) => { if (b) resolve(b); else reject(new Error("failed")); }, "image/png");
         });
         await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
         alert("Image copiée dans le presse-papier");
       } catch {
         const w = window.open();
-        if (w) { w.document.write(`<img src="${canvas.toDataURL("image/png")}" />`); w.document.title = "Notices semaine"; }
+        if (w) { w.document.write(`<img src="${canvas.toDataURL("image/png")}" />`); }
       }
     } catch { /* ignore */ } finally { setExporting(null); }
   }
@@ -163,7 +183,7 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
       const html2canvas = (await import("html2canvas-pro")).default;
       const canvas = await html2canvas(printRef.current, { scale: 2, useCORS: true });
       const link = document.createElement("a");
-      link.download = `${getExportFileName()}.png`;
+      link.download = `${getExportFileName(departmentName, weekStart)}.png`;
       link.href = canvas.toDataURL("image/png");
       link.click();
     } catch { /* ignore */ } finally { setExporting(null); }
@@ -184,20 +204,12 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
       let renderWidth = pdfWidth;
       let renderHeight = pdfWidth * imgRatio;
       if (renderHeight > pdfHeight) { renderHeight = pdfHeight; renderWidth = pdfHeight / imgRatio; }
-      const offsetX = (pdfWidth - renderWidth) / 2;
-      pdf.addImage(imgData, "PNG", offsetX, 0, renderWidth, renderHeight);
-      pdf.save(`${getExportFileName()}.pdf`);
+      pdf.addImage(imgData, "PNG", (pdfWidth - renderWidth) / 2, 0, renderWidth, renderHeight);
+      pdf.save(`${getExportFileName(departmentName, weekStart)}.pdf`);
     } catch { /* ignore */ } finally { setExporting(null); }
   }
 
-  // Group events by day
-  const byDay = events.reduce<Record<string, WeekEvent[]>>((acc, ev) => {
-    const day = ev.date.slice(0, 10);
-    (acc[day] ??= []).push(ev);
-    return acc;
-  }, {});
-
-  const hasContent = Object.keys(byDay).length > 0;
+  const hasContent = events.length > 0;
 
   return (
     <div>
@@ -206,7 +218,6 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
         <button
           onClick={prevWeek}
           className="p-2 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-icc-violet hover:bg-icc-violet-light transition-colors"
-          aria-label="Semaine précédente"
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
@@ -218,7 +229,6 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
         <button
           onClick={nextWeek}
           className="p-2 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-icc-violet hover:bg-icc-violet-light transition-colors"
-          aria-label="Semaine suivante"
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
@@ -229,31 +239,22 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
       {/* Export buttons */}
       {!loading && hasContent && (
         <div className="flex flex-wrap justify-end gap-2 mb-4">
-          <button
-            onClick={copyImage}
-            disabled={!!exporting}
-            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-white bg-icc-violet rounded-lg hover:bg-icc-violet/90 disabled:opacity-50"
-          >
+          <button onClick={copyImage} disabled={!!exporting}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-white bg-icc-violet rounded-lg hover:bg-icc-violet/90 disabled:opacity-50">
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
             </svg>
             {exporting === "copy" ? "Copie..." : "Copier image"}
           </button>
-          <button
-            onClick={downloadImage}
-            disabled={!!exporting}
-            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-icc-violet border-2 border-icc-violet rounded-lg hover:bg-icc-violet/10 disabled:opacity-50"
-          >
+          <button onClick={downloadImage} disabled={!!exporting}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-icc-violet border-2 border-icc-violet rounded-lg hover:bg-icc-violet/10 disabled:opacity-50">
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
             </svg>
             {exporting === "image" ? "Export..." : "Télécharger PNG"}
           </button>
-          <button
-            onClick={exportPdf}
-            disabled={!!exporting}
-            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-icc-violet border-2 border-icc-violet rounded-lg hover:bg-icc-violet/10 disabled:opacity-50"
-          >
+          <button onClick={exportPdf} disabled={!!exporting}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-icc-violet border-2 border-icc-violet rounded-lg hover:bg-icc-violet/10 disabled:opacity-50">
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
             </svg>
@@ -268,115 +269,134 @@ export default function WeeklyPlanningView({ churchId, churchName, canEdit }: We
           <div className="p-8 text-center text-gray-400 bg-white">Chargement...</div>
         ) : !hasContent ? (
           <div className="p-8 text-center text-gray-400 border-2 border-gray-200 border-dashed rounded-xl">
-            Aucun événement cette semaine
+            Aucun service cette semaine
           </div>
         ) : (
           <>
             {/* Header */}
             <div className="bg-icc-violet px-6 py-4">
-              <p className="text-lg font-bold text-white leading-tight">
-                {churchName ?? "ICC"}
-              </p>
-              <p className="text-sm text-white/80 mt-0.5 capitalize">
-                Semaine du {formatWeekLabel(weekStart)}
+              <p className="text-lg font-bold text-white leading-tight">{churchName ?? "ICC"}</p>
+              <p className="text-sm text-white/80 mt-0.5">
+                {departmentName ? `${departmentName} — ` : ""}
+                <span className="capitalize">{formatWeekLabel(weekStart)}</span>
               </p>
             </div>
 
-            {/* Days */}
-            <div className="bg-gray-50 px-5 py-4 space-y-4">
-              {Object.entries(byDay).map(([day, dayEvents]) => (
-                <div key={day}>
-                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2 capitalize">
-                    {formatDayLabel(day)}
-                  </p>
-                  <div className="space-y-3">
-                    {dayEvents.map((event) => {
-                      const { day: dayNum, weekday } = formatDayShort(event.date);
-                      return (
-                        <div key={event.id} className="bg-white rounded-lg overflow-hidden shadow-sm">
-                          {/* Event header */}
-                          <div className="flex">
-                            <div className="bg-icc-violet w-16 shrink-0 flex flex-col items-center justify-center py-3">
-                              <span className="text-xs font-semibold text-white/80 uppercase leading-none">{weekday}</span>
-                              <span className="text-2xl font-black text-white leading-none mt-0.5">{dayNum}</span>
-                            </div>
-                            <div className="flex-1 px-4 py-3 min-w-0">
-                              <p className="font-bold text-icc-violet text-xs uppercase tracking-wide">
-                                {event.title}
-                              </p>
-                              <p className="text-xs text-gray-400 mt-0.5">{event.type}</p>
-                            </div>
+            {/* Events */}
+            <div className="bg-gray-50 px-5 py-4 space-y-3">
+              {events.map((event) => {
+                const { day, weekday } = formatDayShort(event.date);
+                const isEditing = editingEventId === event.id;
+                const enService = event.members.filter(
+                  (m) => m.status === "EN_SERVICE" || m.status === "EN_SERVICE_DEBRIEF"
+                );
+                const autres = event.members.filter(
+                  (m) => m.status === "INDISPONIBLE" || m.status === "REMPLACANT"
+                );
+
+                return (
+                  <div key={event.id} className="bg-white rounded-lg overflow-hidden shadow-sm">
+                    {/* Event header row */}
+                    <div className="flex">
+                      <div className="bg-icc-violet w-16 shrink-0 flex flex-col items-center justify-center py-3">
+                        <span className="text-xs font-semibold text-white/80 uppercase leading-none">{weekday}</span>
+                        <span className="text-2xl font-black text-white leading-none mt-0.5">{day}</span>
+                      </div>
+                      <div className="flex-1 px-4 py-3 min-w-0">
+                        <p className="font-bold text-icc-violet text-xs uppercase tracking-wide">{event.title}</p>
+                        <p className="text-xs text-gray-400 mt-0.5">{event.type}</p>
+                      </div>
+                    </div>
+
+                    {/* Members */}
+                    {event.members.length > 0 && (
+                      <div className="px-4 pt-2 pb-3 border-t border-gray-100 space-y-1.5">
+                        {enService.map((m) => (
+                          <div key={m.id} className="flex items-center gap-2">
+                            <span className="text-sm font-semibold text-gray-900">
+                              {m.firstName} {m.lastName}
+                            </span>
+                            {m.status === "EN_SERVICE_DEBRIEF" && (
+                              <span className="text-[11px] font-semibold text-white bg-icc-violet px-2 py-0.5 rounded-full">
+                                Debrief
+                              </span>
+                            )}
                           </div>
+                        ))}
+                        {enService.length > 0 && autres.length > 0 && (
+                          <div className="h-px bg-gray-100" />
+                        )}
+                        {autres.map((m) => (
+                          <div key={m.id} className="flex items-center gap-2">
+                            <span className="text-sm text-gray-500">
+                              {m.firstName} {m.lastName}
+                            </span>
+                            {m.status && (
+                              <span className={`text-[11px] font-medium px-2 py-0.5 rounded-full ${STATUS_CLASS[m.status] ?? ""}`}>
+                                {STATUS_LABEL[m.status]}
+                              </span>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
 
-                          {/* Departments + notices */}
-                          {event.departments.length > 0 && (
-                            <div className="divide-y divide-gray-100 border-t border-gray-100">
-                              {event.departments.map((dept) => {
-                                const key = `${dept.id}:${event.id}`;
-                                const isEditing = editingKey === key;
-                                return (
-                                  <div key={dept.id} className="px-4 py-2.5">
-                                    <div className="flex items-start justify-between gap-2">
-                                      <span className="text-xs font-semibold text-gray-600 uppercase tracking-wide">
-                                        {dept.name}
-                                      </span>
-                                      {canEdit && !isEditing && !exporting && (
-                                        <button
-                                          onClick={() => startEdit(dept.id, event.id, dept.notice?.content ?? "")}
-                                          className="text-[11px] text-icc-violet hover:underline shrink-0"
-                                        >
-                                          {dept.notice ? "Modifier" : "Ajouter"}
-                                        </button>
-                                      )}
-                                    </div>
+                    {/* Notice */}
+                    <div className="px-4 pb-3 border-t border-gray-100">
+                      <div className="flex items-center justify-between mt-2 mb-1">
+                        <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wide">
+                          Notice de service
+                        </span>
+                        {canEdit && !isEditing && !exporting && (
+                          <button
+                            onClick={() => startEdit(event.id, event.notice?.content ?? "")}
+                            className="text-[11px] text-icc-violet hover:underline"
+                          >
+                            {event.notice ? "Modifier" : "Ajouter"}
+                          </button>
+                        )}
+                      </div>
 
-                                    {isEditing ? (
-                                      <div className="mt-2 space-y-2">
-                                        <textarea
-                                          value={editContent}
-                                          onChange={(e) => setEditContent(e.target.value)}
-                                          rows={3}
-                                          maxLength={2000}
-                                          className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet resize-none"
-                                          placeholder="Instructions, rappels, informations pour ce service…"
-                                          autoFocus
-                                        />
-                                        {saveError && <p className="text-xs text-icc-rouge">{saveError}</p>}
-                                        <div className="flex gap-2">
-                                          <button
-                                            onClick={() => saveNotice(dept.id, event.id)}
-                                            disabled={saving}
-                                            className="px-3 py-1.5 text-xs font-medium bg-icc-violet text-white rounded-lg hover:opacity-90 disabled:opacity-50"
-                                          >
-                                            {saving ? "Enregistrement…" : "Enregistrer"}
-                                          </button>
-                                          <button
-                                            onClick={cancelEdit}
-                                            disabled={saving}
-                                            className="px-3 py-1.5 text-xs font-medium border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50"
-                                          >
-                                            Annuler
-                                          </button>
-                                        </div>
-                                      </div>
-                                    ) : dept.notice ? (
-                                      <p className="mt-1 text-sm text-gray-700 whitespace-pre-wrap leading-relaxed">
-                                        {dept.notice.content}
-                                      </p>
-                                    ) : (
-                                      <p className="mt-1 text-xs text-gray-400 italic">Aucune notice</p>
-                                    )}
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          )}
+                      {isEditing ? (
+                        <div className="space-y-2">
+                          <textarea
+                            value={editContent}
+                            onChange={(e) => setEditContent(e.target.value)}
+                            rows={3}
+                            maxLength={2000}
+                            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet resize-none"
+                            placeholder="Instructions, rappels, informations pour ce service…"
+                            autoFocus
+                          />
+                          {saveError && <p className="text-xs text-icc-rouge">{saveError}</p>}
+                          <div className="flex gap-2">
+                            <button
+                              onClick={() => saveNotice(event.id)}
+                              disabled={saving}
+                              className="px-3 py-1.5 text-xs font-medium bg-icc-violet text-white rounded-lg hover:opacity-90 disabled:opacity-50"
+                            >
+                              {saving ? "Enregistrement…" : "Enregistrer"}
+                            </button>
+                            <button
+                              onClick={cancelEdit}
+                              disabled={saving}
+                              className="px-3 py-1.5 text-xs font-medium border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+                            >
+                              Annuler
+                            </button>
+                          </div>
                         </div>
-                      );
-                    })}
+                      ) : event.notice ? (
+                        <p className="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed">
+                          {event.notice.content}
+                        </p>
+                      ) : (
+                        <p className="text-xs text-gray-400 italic">Aucune notice</p>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </>
         )}

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -295,7 +295,7 @@ export default function WeeklyPlanningView({
                         {event.members.map((m) => (
                           <div key={m.id} className="flex items-center gap-2">
                             <span className="text-sm font-semibold text-gray-900">
-                              {m.firstName} {m.lastName}
+                              🙌 {m.firstName} {m.lastName}
                             </span>
                             {m.status === "EN_SERVICE_DEBRIEF" && (
                               <span className="text-[11px] font-semibold text-white bg-icc-violet px-2 py-0.5 rounded-full">

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -7,6 +7,7 @@ interface Member {
   firstName: string;
   lastName: string;
   status: "EN_SERVICE" | "EN_SERVICE_DEBRIEF" | null;
+  tasks: string[];
 }
 
 interface Notice {
@@ -271,7 +272,7 @@ export default function WeeklyPlanningView({
       )}
 
       {/* Printable card */}
-      <div ref={printRef} className="max-w-lg mx-auto rounded-xl overflow-hidden shadow-lg border border-gray-100">
+      <div ref={printRef} className="max-w-2xl mx-auto rounded-xl overflow-hidden shadow-lg border border-gray-100">
         {loading ? (
           <div className="p-8 text-center text-gray-400 bg-white">Chargement...</div>
         ) : !hasContent ? (
@@ -314,6 +315,11 @@ export default function WeeklyPlanningView({
                                 <span className="text-sm text-gray-900 font-bold">
                                   {m.firstName} {m.lastName}
                                 </span>
+                                {m.tasks.map((task) => (
+                                  <span key={task} className="text-[11px] font-medium border border-icc-violet/40 text-icc-violet px-2 py-0.5 rounded-full">
+                                    {task}
+                                  </span>
+                                ))}
                                 {m.status === "EN_SERVICE_DEBRIEF" && (
                                   <span className="text-[11px] font-semibold text-white bg-icc-violet px-2 py-0.5 rounded-full">
                                     Debrief
@@ -326,7 +332,7 @@ export default function WeeklyPlanningView({
 
                         {/* Notice — dans le flex, séparée par un trait */}
                         {(event.notice?.content || isEditing) && (
-                          <div className={`mt-3 pt-2 border-t ${event.notice?.content && !isEditing ? "border-icc-violet/20" : "border-gray-100"}`}>
+                          <div className={`mt-3 pt-2 border-t rounded-lg ${event.notice?.content && !isEditing ? "border-icc-violet/20 bg-icc-violet/5 px-2 pb-2" : "border-gray-100"}`}>
                             <div className="flex items-center justify-between mb-1">
                               <span className={`text-[11px] font-semibold uppercase tracking-wide ${event.notice?.content && !isEditing ? "text-icc-violet/70" : "text-gray-400"}`}>
                                 ⚠️ Notice de service

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -311,7 +311,7 @@ export default function WeeklyPlanningView({
                           <div className="space-y-1.5">
                             {event.members.map((m) => (
                               <div key={m.id} className="flex flex-wrap items-center gap-1.5">
-                                <span className="text-sm text-gray-600 font-medium">
+                                <span className="text-sm text-gray-900 font-bold">
                                   {m.firstName} {m.lastName}
                                 </span>
                                 {m.status === "EN_SERVICE_DEBRIEF" && (
@@ -323,6 +323,69 @@ export default function WeeklyPlanningView({
                             ))}
                           </div>
                         )}
+
+                        {/* Notice — dans le flex, séparée par un trait */}
+                        {(event.notice?.content || isEditing) && (
+                          <div className={`mt-3 pt-2 border-t ${event.notice?.content && !isEditing ? "border-icc-violet/20" : "border-gray-100"}`}>
+                            <div className="flex items-center justify-between mb-1">
+                              <span className={`text-[11px] font-semibold uppercase tracking-wide ${event.notice?.content && !isEditing ? "text-icc-violet/70" : "text-gray-400"}`}>
+                                ⚠️ Notice de service
+                              </span>
+                              {canEdit && !isEditing && (
+                                <div data-html2canvas-ignore="true" className="flex items-center gap-2">
+                                  <button
+                                    onClick={() => startEdit(event.id, event.notice?.content ?? "")}
+                                    className="text-[11px] text-icc-violet hover:underline"
+                                  >
+                                    Modifier
+                                  </button>
+                                  <button
+                                    onClick={() => deleteNotice(event.id)}
+                                    disabled={saving}
+                                    className="text-[11px] text-icc-rouge hover:underline disabled:opacity-50"
+                                  >
+                                    Supprimer
+                                  </button>
+                                </div>
+                              )}
+                            </div>
+                            {isEditing ? (
+                              <div className="space-y-2">
+                                <textarea
+                                  value={editContent}
+                                  onChange={(e) => setEditContent(e.target.value)}
+                                  rows={3}
+                                  maxLength={2000}
+                                  className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet resize-none"
+                                  placeholder="Instructions, rappels, informations pour ce service…"
+                                  autoFocus
+                                />
+                                {saveError && <p className="text-xs text-icc-rouge">{saveError}</p>}
+                                <div className="flex gap-2">
+                                  <button
+                                    onClick={() => saveNotice(event.id)}
+                                    disabled={saving}
+                                    className="px-3 py-1.5 text-xs font-medium bg-icc-violet text-white rounded-lg hover:opacity-90 disabled:opacity-50"
+                                  >
+                                    {saving ? "Enregistrement…" : "Enregistrer"}
+                                  </button>
+                                  <button
+                                    onClick={cancelEdit}
+                                    disabled={saving}
+                                    className="px-3 py-1.5 text-xs font-medium border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+                                  >
+                                    Annuler
+                                  </button>
+                                </div>
+                              </div>
+                            ) : (
+                              <p className={`text-sm whitespace-pre-wrap leading-relaxed ${event.notice?.content ? "text-icc-violet/80" : "text-gray-400 italic"}`}>
+                                {event.notice!.content}
+                              </p>
+                            )}
+                          </div>
+                        )}
+
                         {canEdit && !event.notice && !isEditing && (
                           <button
                             data-html2canvas-ignore="true"
@@ -334,69 +397,6 @@ export default function WeeklyPlanningView({
                         )}
                       </div>
                     </div>
-
-                    {/* Notice — affiché uniquement si contenu existe ou en cours d'édition */}
-                    {(event.notice?.content || isEditing) && (
-                      <div className={`px-4 pb-3 border-t ${event.notice?.content && !isEditing ? "border-icc-violet/20 bg-icc-violet/5" : "border-gray-100"}`}>
-                        <div className="flex items-center justify-between mt-2 mb-1">
-                          <span className={`text-[11px] font-semibold uppercase tracking-wide ${event.notice?.content && !isEditing ? "text-icc-violet/70" : "text-gray-400"}`}>
-                            ⚠️ Notice de service
-                          </span>
-                          {canEdit && !isEditing && (
-                            <div data-html2canvas-ignore="true" className="flex items-center gap-2">
-                              <button
-                                onClick={() => startEdit(event.id, event.notice?.content ?? "")}
-                                className="text-[11px] text-icc-violet hover:underline"
-                              >
-                                Modifier
-                              </button>
-                              <button
-                                onClick={() => deleteNotice(event.id)}
-                                disabled={saving}
-                                className="text-[11px] text-icc-rouge hover:underline disabled:opacity-50"
-                              >
-                                Supprimer
-                              </button>
-                            </div>
-                          )}
-                        </div>
-
-                        {isEditing ? (
-                          <div className="space-y-2">
-                            <textarea
-                              value={editContent}
-                              onChange={(e) => setEditContent(e.target.value)}
-                              rows={3}
-                              maxLength={2000}
-                              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet resize-none"
-                              placeholder="Instructions, rappels, informations pour ce service…"
-                              autoFocus
-                            />
-                            {saveError && <p className="text-xs text-icc-rouge">{saveError}</p>}
-                            <div className="flex gap-2">
-                              <button
-                                onClick={() => saveNotice(event.id)}
-                                disabled={saving}
-                                className="px-3 py-1.5 text-xs font-medium bg-icc-violet text-white rounded-lg hover:opacity-90 disabled:opacity-50"
-                              >
-                                {saving ? "Enregistrement…" : "Enregistrer"}
-                              </button>
-                              <button
-                                onClick={cancelEdit}
-                                disabled={saving}
-                                className="px-3 py-1.5 text-xs font-medium border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50"
-                              >
-                                Annuler
-                              </button>
-                            </div>
-                          </div>
-                        ) : (
-                          <p className="text-sm text-icc-violet/80 whitespace-pre-wrap leading-relaxed">
-                            {event.notice!.content}
-                          </p>
-                        )}
-                      </div>
-                    )}
                   </div>
                 );
               })}

--- a/src/lib/event-types.ts
+++ b/src/lib/event-types.ts
@@ -1,0 +1,47 @@
+export const EVENT_TYPES = ["CULTE", "PRIERE", "REUNION", "FORMATION", "AUTRE"] as const;
+export type EventType = (typeof EVENT_TYPES)[number];
+
+export const EVENT_TYPE_LABELS: Record<string, string> = {
+  CULTE:     "Culte",
+  PRIERE:    "Prière",
+  REUNION:   "Réunion",
+  FORMATION: "Formation",
+  AUTRE:     "Autre",
+};
+
+/** Tailwind classes for badge display (bg + text) */
+export const EVENT_TYPE_BADGE: Record<string, string> = {
+  CULTE:     "bg-icc-violet/10 text-icc-violet",
+  PRIERE:    "bg-orange-100 text-orange-600",
+  REUNION:   "bg-icc-bleu/10 text-icc-bleu",
+  FORMATION: "bg-icc-rouge/10 text-icc-rouge",
+  AUTRE:     "bg-green-100 text-green-700",
+};
+
+/** Full color tokens for calendar / dot indicators */
+export const EVENT_TYPE_COLORS: Record<string, {
+  bg: string; text: string; hover: string; dot: string; label: string;
+}> = {
+  CULTE:     { bg: "bg-icc-violet/10", text: "text-icc-violet",  hover: "hover:bg-icc-violet",  dot: "bg-icc-violet",  label: "Culte" },
+  PRIERE:    { bg: "bg-orange-100",    text: "text-orange-600",  hover: "hover:bg-orange-500",  dot: "bg-orange-500",  label: "Prière" },
+  REUNION:   { bg: "bg-icc-bleu/10",  text: "text-icc-bleu",    hover: "hover:bg-icc-bleu",    dot: "bg-icc-bleu",    label: "Réunion" },
+  FORMATION: { bg: "bg-icc-rouge/10", text: "text-icc-rouge",   hover: "hover:bg-icc-rouge",   dot: "bg-icc-rouge",   label: "Formation" },
+  AUTRE:     { bg: "bg-green-100",    text: "text-green-700",   hover: "hover:bg-green-600",   dot: "bg-green-500",   label: "Autre" },
+};
+
+export const EVENT_TYPE_OPTIONS = EVENT_TYPES.map((t) => ({
+  value: t,
+  label: EVENT_TYPE_LABELS[t],
+}));
+
+export function getEventTypeBadge(type: string): string {
+  return EVENT_TYPE_BADGE[type] ?? EVENT_TYPE_BADGE.AUTRE;
+}
+
+export function getEventTypeColors(type: string) {
+  return EVENT_TYPE_COLORS[type] ?? EVENT_TYPE_COLORS.AUTRE;
+}
+
+export function getEventTypeLabel(type: string): string {
+  return EVENT_TYPE_LABELS[type] ?? type;
+}


### PR DESCRIPTION
## Problème

La vue hebdomadaire affichait tous les départements de tous les événements au lieu d'être scopée au département sélectionné dans la sidebar — contrairement aux autres vues du dashboard.

## Fix

- **API** : `departmentId` obligatoire, filtre les événements sur ce département uniquement, retourne les membres planifiés + la notice du département
- **Composant** : prend `departmentId` en prop, affiche membres (en service / debrief / indisponible / remplaçant) + notice éditable par événement
- **Dashboard** : passe `selectedDeptId` et affiche le message "Sélectionnez un département" si aucun sélectionné

## Plan de test

- [ ] La vue semaine est vide si aucun département sélectionné
- [ ] Elle affiche uniquement les événements où le département sélectionné est assigné
- [ ] Les membres avec leur statut s'affichent correctement
- [ ] La notice est éditable et se sauvegarde
- [ ] L'export PDF/PNG capture le bon contenu