### PR TITLE
fix(events): page 404 correcte pour un eventId inexistant

### DIFF
--- a/src/app/(auth)/admin/events/[eventId]/page.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/page.tsx
@@ -1,4 +1,4 @@
-import { requireAuth, requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { requireChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import EventDetailClient from "./EventDetailClient";
@@ -8,10 +8,7 @@ export default async function EventDetailPage({
 }: {
   params: Promise<{ eventId: string }>;
 }) {
-  await requireAuth();
   const { eventId } = await params;
-  const churchId = await resolveChurchId("event", eventId);
-  await requireChurchPermission("events:manage", churchId);
 
   const event = await prisma.event.findUnique({
     where: { id: eventId },
@@ -24,6 +21,8 @@ export default async function EventDetailPage({
   });
 
   if (!event) notFound();
+
+  await requireChurchPermission("events:manage", event.churchId);
 
   const allDepartments = await prisma.department.findMany({
     where: { ministry: { churchId: event.churchId } },

--- a/src/app/(auth)/admin/events/[eventId]/report/page.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/report/page.tsx
@@ -1,7 +1,8 @@
-import { requireAuth, resolveChurchId } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth";
 import { hasPermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
+import { ApiError } from "@/lib/api-utils";
 import EventReportClient from "./EventReportClient";
 
 export default async function EventReportPage({
@@ -11,14 +12,6 @@ export default async function EventReportPage({
 }) {
   const session = await requireAuth();
   const { eventId } = await params;
-  const churchId = await resolveChurchId("event", eventId);
-  // Allow access if user has events:manage OR reports:view for this church
-  const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
-  const perms = new Set(churchRoles.flatMap((r) => hasPermission(r.role)));
-  if (!perms.has("events:manage") && !perms.has("reports:view")) {
-    const { ApiError } = await import("@/lib/api-utils");
-    throw new ApiError(403, "Forbidden");
-  }
 
   const event = await prisma.event.findUnique({
     where: { id: eventId },
@@ -44,6 +37,13 @@ export default async function EventReportPage({
 
   if (!event) notFound();
   if (!event.reportEnabled) notFound();
+
+  // Allow access if user has events:manage OR reports:view for this church
+  const churchRoles = session.user.churchRoles.filter((r) => r.churchId === event.churchId);
+  const perms = new Set(churchRoles.flatMap((r) => hasPermission(r.role)));
+  if (!perms.has("events:manage") && !perms.has("reports:view")) {
+    throw new ApiError(403, "Forbidden");
+  }
 
   // Départements liés à l'événement pour pré-remplir les sections
   const eventDepts = await prisma.eventDepartment.findMany({


### PR DESCRIPTION
## Problème

`resolveChurchId("event", eventId)` throw `ApiError(404, "Événement introuvable")` dans les Server Components avant que `notFound()` soit appelé. Next.js ne sait pas gérer une `ApiError` non catchée → crash avec erreur 500 au lieu d'une page 404 propre.

Reproductible sur `/admin/events/[id]` et `/admin/events/[id]/report` avec un `eventId` invalide ou supprimé (ex: lien mis en favori, événement supprimé).

## Fix

Inverser l'ordre : requête Prisma en premier → `notFound()` si absent → permission check depuis `event.churchId`. Supprime l'appel à `resolveChurchId` dans ces deux pages.

## Test plan
- [ ] Naviguer vers `/admin/events/id-inexistant` → page 404 Next.js (plus de crash)
- [ ] Naviguer vers `/admin/events/id-inexistant/report` → page 404 Next.js
- [ ] Naviguer vers un événement valide → fonctionne normalement
- [ ] `npm run typecheck` ✓

🤖 Generated with [Claude Code](https://claude.ai/claude-code)