### PR TITLE
feat(cron): digest planning secrétariat + orchestrateur cron horaire

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -285,9 +285,14 @@ SMTP_FROM=Koinonia <noreply@votre-domaine.com>
 
 Déclencher un backup manuel depuis l'interface admin ou appeler directement le cron de rappels après avoir configuré un événement de test.
 
-## Webcron — rappels de service
+## Cron — tâches planifiées
 
-La route `POST /api/cron/reminders` envoie les rappels J-3 et J-1 (email + notification in-app). Elle doit être appelée **une fois par jour** par un service externe.
+La route `POST /api/cron` orchestre toutes les tâches planifiées. Elle doit être appelée **toutes les heures**. Chaque tâche gère sa propre fréquence en interne :
+
+| Tâche | Fréquence effective | Description |
+|-------|--------------------|--------------------------------------------|
+| Rappels de service | 1 fois/jour par église | Emails + notifications in-app J-3 et J-1 |
+| Digest planning | Horaire si changements | Email récapitulatif des modifications au secrétariat |
 
 ### Variables d'environnement requises
 
@@ -305,11 +310,11 @@ Générer une valeur sécurisée : `openssl rand -base64 32`
 
 Plus fiable que crontab : journalisation native, gestion des échecs, exécution rattrapée après un reboot.
 
-**1. Créer le service** `/etc/systemd/system/koinonia-reminders.service` :
+**1. Créer le service** `/etc/systemd/system/koinonia-cron.service` :
 
 ```ini
 [Unit]
-Description=Koinonia — rappels de service
+Description=Koinonia — tâches cron
 After=network-online.target koinonia.service
 Wants=network-online.target
 Requires=koinonia.service
@@ -318,22 +323,22 @@ Requires=koinonia.service
 Type=oneshot
 User=koinonia
 EnvironmentFile=/opt/koinonia/shared/.env
-ExecStart=/bin/sh -c 'curl -sf -X POST http://127.0.0.1:3000/api/cron/reminders -H "Authorization: Bearer $CRON_SECRET"'
+ExecStart=/bin/sh -c 'curl -sf -X POST http://127.0.0.1:3000/api/cron -H "Authorization: Bearer $CRON_SECRET"'
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=koinonia-reminders
+SyslogIdentifier=koinonia-cron
 ```
 
 > On appelle `127.0.0.1:3000` en local plutôt que le domaine public pour éviter de passer par Traefik/TLS.
 
-**2. Créer le timer** `/etc/systemd/system/koinonia-reminders.timer` :
+**2. Créer le timer** `/etc/systemd/system/koinonia-cron.timer` :
 
 ```ini
 [Unit]
-Description=Rappels de service Koinonia a 7h00
+Description=Tâches cron Koinonia — toutes les heures
 
 [Timer]
-OnCalendar=*-*-* 07:00:00
+OnCalendar=hourly
 Persistent=true
 RandomizedDelaySec=60
 
@@ -341,28 +346,33 @@ RandomizedDelaySec=60
 WantedBy=timers.target
 ```
 
+- `Persistent=true` : si le serveur était éteint, la tâche sera exécutée au prochain démarrage.
+- `RandomizedDelaySec=60` : délai aléatoire de 0 à 60s pour éviter les pics de charge.
+
 **3. Activer le timer** :
 
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable --now koinonia-reminders.timer
+sudo systemctl enable --now koinonia-cron.timer
 ```
 
 **4. Vérifier** :
 
 ```bash
 # Etat du timer
-sudo systemctl status koinonia-reminders.timer
+sudo systemctl status koinonia-cron.timer
 
 # Prochaine exécution
-sudo systemctl list-timers koinonia-reminders.timer
+sudo systemctl list-timers koinonia-cron.timer
 
 # Lancer manuellement pour tester
-sudo systemctl start koinonia-reminders.service
+sudo systemctl start koinonia-cron.service
 
 # Consulter les logs
-sudo journalctl -u koinonia-reminders -n 20
+sudo journalctl -u koinonia-cron -n 20
 ```
+
+> Si vous aviez l'ancien timer `koinonia-reminders.timer`, désactivez-le : `sudo systemctl disable --now koinonia-reminders.timer`
 
 ### Option 2 — crontab système
 
@@ -370,20 +380,20 @@ sudo journalctl -u koinonia-reminders -n 20
 sudo -u koinonia crontab -e
 ```
 
-Ajouter la ligne suivante (exécution chaque jour à 7h00) :
+Ajouter la ligne suivante (exécution toutes les heures) :
 
 ```
-0 7 * * * . /opt/koinonia/shared/.env && curl -sf -X POST http://127.0.0.1:3000/api/cron/reminders -H "Authorization: Bearer $CRON_SECRET" >> /opt/koinonia/logs/cron.log 2>&1
+0 * * * * . /opt/koinonia/shared/.env && curl -sf -X POST http://127.0.0.1:3000/api/cron -H "Authorization: Bearer $CRON_SECRET" >> /opt/koinonia/logs/cron.log 2>&1
 ```
 
 ### Option 3 — service webcron externe
 
 Configurer un service type [cron-job.org](https://cron-job.org) ou EasyCron :
 
-- **URL** : `https://votre-domaine.com/api/cron/reminders`
+- **URL** : `https://votre-domaine.com/api/cron`
 - **Méthode** : `POST`
 - **Header** : `Authorization: Bearer VOTRE_CRON_SECRET`
-- **Fréquence** : 1 fois par jour (ex : 7h00)
+- **Fréquence** : toutes les heures
 
 ## Captures du guide utilisateur
 
@@ -680,7 +690,7 @@ sudo systemctl start koinonia
 - [ ] `AUTH_SECRET` genere avec `openssl rand -base64 32`
 - [ ] `CRON_SECRET` genere avec `openssl rand -base64 32`
 - [ ] Variables SMTP configurees dans `shared/.env` (optionnel, pour les rappels email)
-- [ ] Timer systemd `koinonia-reminders.timer` activé (ou crontab/webcron externe) pour appeler `/api/cron/reminders` quotidiennement
+- [ ] Timer systemd `koinonia-cron.timer` activé (ou crontab/webcron externe) pour appeler `/api/cron` toutes les heures
 - [ ] Variables S3 configurees pour les backups (optionnel)
 - [ ] Timer systemd `koinonia-backup.timer` active (ou crontab) pour backup quotidien (optionnel)
 - [ ] Backup teste : declencher manuellement et verifier la presence dans S3

--- a/prisma/migrations/20260404000000_add_church_secretariat_cron_fields/migration.sql
+++ b/prisma/migrations/20260404000000_add_church_secretariat_cron_fields/migration.sql
@@ -1,0 +1,4 @@
+-- Add secretariatEmail, reminderLastSentAt, planningDigestLastSentAt to churches
+ALTER TABLE `churches` ADD COLUMN `secretariatEmail` VARCHAR(191) NULL;
+ALTER TABLE `churches` ADD COLUMN `reminderLastSentAt` DATETIME(3) NULL;
+ALTER TABLE `churches` ADD COLUMN `planningDigestLastSentAt` DATETIME(3) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,21 +52,24 @@ model VerificationToken {
 // ─── Domain models ─────────────────────────────────────────────────
 
 model Church {
-  id                String              @id @default(cuid())
-  name              String
-  slug              String              @unique
-  createdAt         DateTime            @default(now())
-  updatedAt         DateTime            @updatedAt
-  users             UserChurchRole[]
-  ministries        Ministry[]
-  events            Event[]
-  auditLogs         AuditLog[]
-  announcements     Announcement[]
-  requests          Request[]
-  memberUserLinks    MemberUserLink[]
-  memberLinkRequests MemberLinkRequest[]
-  discipleships      Discipleship[]
-  eventReports       EventReport[]
+  id                       String              @id @default(cuid())
+  name                     String
+  slug                     String              @unique
+  secretariatEmail         String?
+  reminderLastSentAt       DateTime?
+  planningDigestLastSentAt DateTime?
+  createdAt                DateTime            @default(now())
+  updatedAt                DateTime            @updatedAt
+  users                    UserChurchRole[]
+  ministries               Ministry[]
+  events                   Event[]
+  auditLogs                AuditLog[]
+  announcements            Announcement[]
+  requests                 Request[]
+  memberUserLinks          MemberUserLink[]
+  memberLinkRequests       MemberLinkRequest[]
+  discipleships            Discipleship[]
+  eventReports             EventReport[]
 
   @@map("churches")
 }

--- a/src/app/(auth)/admin/churches/[churchId]/ChurchEditClient.tsx
+++ b/src/app/(auth)/admin/churches/[churchId]/ChurchEditClient.tsx
@@ -6,13 +6,14 @@ import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 
 interface Props {
-  church: { id: string; name: string; slug: string };
+  church: { id: string; name: string; slug: string; secretariatEmail: string };
 }
 
 export default function ChurchEditClient({ church }: Props) {
   const router = useRouter();
   const [name, setName] = useState(church.name);
   const [slug, setSlug] = useState(church.slug);
+  const [secretariatEmail, setSecretariatEmail] = useState(church.secretariatEmail);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -27,7 +28,7 @@ export default function ChurchEditClient({ church }: Props) {
       const res = await fetch(`/api/churches/${church.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, slug }),
+        body: JSON.stringify({ name, slug, secretariatEmail: secretariatEmail || null }),
       });
 
       if (!res.ok) {
@@ -58,6 +59,13 @@ export default function ChurchEditClient({ church }: Props) {
           value={slug}
           onChange={(e) => setSlug(e.target.value)}
           required
+        />
+        <Input
+          label="Email secrétariat (digest planning)"
+          type="email"
+          value={secretariatEmail}
+          onChange={(e) => setSecretariatEmail(e.target.value)}
+          placeholder="secretariat@eglise.fr"
         />
         {error && <p className="text-sm text-red-600">{error}</p>}
         {success && (

--- a/src/app/(auth)/admin/churches/[churchId]/page.tsx
+++ b/src/app/(auth)/admin/churches/[churchId]/page.tsx
@@ -22,7 +22,7 @@ export default async function ChurchDetailPage({
       <h1 className="text-2xl font-bold text-gray-900 mb-6">
         Modifier l&apos;église
       </h1>
-      <ChurchEditClient church={{ id: church.id, name: church.name, slug: church.slug }} />
+      <ChurchEditClient church={{ id: church.id, name: church.name, slug: church.slug, secretariatEmail: church.secretariatEmail ?? "" }} />
     </div>
   );
 }

--- a/src/app/api/churches/[churchId]/route.ts
+++ b/src/app/api/churches/[churchId]/route.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 const updateSchema = z.object({
   name: z.string().min(1, "Le nom est requis"),
   slug: z.string().min(1, "Le slug est requis"),
+  secretariatEmail: z.string().email("Email invalide").nullish(),
 });
 
 export async function PUT(

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,0 +1,221 @@
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { sendEmail, buildReminderEmail, buildPlanningDigestEmail } from "@/lib/email";
+
+function authorizeCron(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    throw new ApiError(401, "Unauthorized");
+  }
+}
+
+// ─── Task: reminders ─────────────────────────────────────────────────────────
+// Envoie les rappels J-1 et J-3 aux membres en service.
+// Ne s'exécute qu'une fois par jour par église (reminderLastSentAt).
+
+async function runReminders() {
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  const churches = await prisma.church.findMany({
+    where: {
+      OR: [
+        { reminderLastSentAt: null },
+        { reminderLastSentAt: { lt: startOfToday } },
+      ],
+    },
+  });
+
+  let emailsSent = 0;
+  let notificationsCreated = 0;
+
+  for (const church of churches) {
+    const reminders = [1, 3];
+
+    for (const daysAhead of reminders) {
+      const targetDate = new Date(now);
+      targetDate.setDate(targetDate.getDate() + daysAhead);
+      const startOfDay = new Date(targetDate.getFullYear(), targetDate.getMonth(), targetDate.getDate());
+      const endOfDay = new Date(startOfDay.getTime() + 86400000);
+
+      const events = await prisma.event.findMany({
+        where: {
+          churchId: church.id,
+          date: { gte: startOfDay, lt: endOfDay },
+        },
+        include: {
+          eventDepts: {
+            include: {
+              department: true,
+              plannings: {
+                where: { status: { in: ["EN_SERVICE", "EN_SERVICE_DEBRIEF"] } },
+                include: { member: true },
+              },
+            },
+          },
+        },
+      });
+
+      for (const event of events) {
+        for (const eventDept of event.eventDepts) {
+          for (const planning of eventDept.plannings) {
+            const member = planning.member;
+            const memberName = `${member.firstName} ${member.lastName}`;
+            const { subject, html } = buildReminderEmail({
+              memberName,
+              eventTitle: event.title,
+              eventDate: event.date.toISOString(),
+              departmentName: eventDept.department.name,
+              daysUntil: daysAhead,
+            });
+
+            if (process.env.SMTP_HOST && member.email) {
+              try {
+                await sendEmail({ to: member.email, subject, html });
+                emailsSent++;
+              } catch {
+                console.error("Failed to send reminder email (recipient redacted)");
+              }
+            }
+
+            const deptHeads = await prisma.userDepartment.findMany({
+              where: { departmentId: eventDept.departmentId },
+              include: { userChurchRole: { select: { userId: true } } },
+            });
+
+            for (const deptHead of deptHeads) {
+              await prisma.notification.create({
+                data: {
+                  userId: deptHead.userChurchRole.userId,
+                  type: "PLANNING_REMINDER",
+                  title: `Rappel : ${event.title}`,
+                  message: `${memberName} est en service pour ${eventDept.department.name} ${daysAhead === 1 ? "demain" : `dans ${daysAhead} jours`}`,
+                  link: `/dashboard?dept=${eventDept.departmentId}&event=${event.id}`,
+                },
+              });
+              notificationsCreated++;
+            }
+          }
+        }
+      }
+    }
+
+    await prisma.church.update({
+      where: { id: church.id },
+      data: { reminderLastSentAt: now },
+    });
+  }
+
+  return { emailsSent, notificationsCreated };
+}
+
+// ─── Task: planning digest ────────────────────────────────────────────────────
+// Envoie un digest des modifications de planning au secrétariat.
+// S'exécute à chaque appel si des changements ont eu lieu depuis le dernier envoi.
+
+async function runPlanningDigest() {
+  const now = new Date();
+
+  const churches = await prisma.church.findMany({
+    where: { secretariatEmail: { not: null } },
+  });
+
+  let digestsSent = 0;
+
+  for (const church of churches) {
+    if (!church.secretariatEmail) continue;
+
+    const since = church.planningDigestLastSentAt ?? new Date(0);
+
+    // Récupérer les entrées d'audit Planning depuis le dernier digest
+    const auditEntries = await prisma.auditLog.findMany({
+      where: {
+        churchId: church.id,
+        entityType: "Planning",
+        createdAt: { gt: since },
+      },
+      include: { user: { select: { name: true, displayName: true } } },
+      orderBy: { createdAt: "asc" },
+    });
+
+    if (auditEntries.length === 0) continue;
+
+    // Récupérer l'état courant du planning pour les événements/depts concernés
+    const affectedEventDeptIds = [...new Set(auditEntries.map((a) => a.entityId))];
+
+    const eventDepts = await prisma.eventDepartment.findMany({
+      where: { id: { in: affectedEventDeptIds } },
+      include: {
+        event: true,
+        department: true,
+        plannings: {
+          include: { member: true },
+        },
+      },
+    });
+
+    // Construire les changements pour le template
+    const changes = auditEntries.flatMap((entry) => {
+      const eventDept = eventDepts.find((ed) => ed.id === entry.entityId);
+      if (!eventDept) return [];
+
+      const modifiedBy =
+        entry.user.displayName ?? entry.user.name ?? "Inconnu";
+
+      return eventDept.plannings.map((planning) => ({
+        memberName: `${planning.member.firstName} ${planning.member.lastName}`,
+        departmentName: eventDept.department.name,
+        eventTitle: eventDept.event.title,
+        eventDate: eventDept.event.date.toISOString(),
+        changeType: "updated" as const,
+        newStatus: planning.status,
+        modifiedBy,
+      }));
+    });
+
+    if (changes.length === 0) continue;
+
+    const { subject, html } = buildPlanningDigestEmail({
+      churchName: church.name,
+      changes,
+      since,
+    });
+
+    if (process.env.SMTP_HOST) {
+      try {
+        await sendEmail({ to: church.secretariatEmail, subject, html });
+        digestsSent++;
+      } catch {
+        console.error(`Failed to send planning digest for church ${church.id}`);
+      }
+    }
+
+    await prisma.church.update({
+      where: { id: church.id },
+      data: { planningDigestLastSentAt: now },
+    });
+  }
+
+  return { digestsSent };
+}
+
+// ─── Endpoint ─────────────────────────────────────────────────────────────────
+
+export async function POST(request: Request) {
+  try {
+    authorizeCron(request);
+
+    const [remindersResult, digestResult] = await Promise.all([
+      runReminders(),
+      runPlanningDigest(),
+    ]);
+
+    return successResponse({
+      reminders: remindersResult,
+      planningDigest: digestResult,
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -38,6 +38,87 @@ export async function sendEmail({ to, subject, html }: SendEmailOptions) {
   });
 }
 
+export interface PlanningChange {
+  memberName: string;
+  departmentName: string;
+  eventTitle: string;
+  eventDate: string;
+  changeType: "added" | "removed" | "updated";
+  newStatus?: string | null;
+  modifiedBy: string;
+}
+
+export function buildPlanningDigestEmail(params: {
+  churchName: string;
+  changes: PlanningChange[];
+  since: Date;
+}) {
+  const sinceStr = params.since.toLocaleString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  const changeTypeLabel = (type: PlanningChange["changeType"]) => {
+    if (type === "added") return "Ajouté au planning";
+    if (type === "removed") return "Retiré du planning";
+    return "Statut modifié";
+  };
+
+  const statusLabel = (status?: string | null) => {
+    if (!status) return "";
+    const labels: Record<string, string> = {
+      EN_SERVICE: "En service",
+      EN_SERVICE_DEBRIEF: "En service (débrief)",
+      INDISPONIBLE: "Indisponible",
+      REMPLACANT: "Remplaçant",
+    };
+    return labels[status] ?? status;
+  };
+
+  const rows = params.changes
+    .map(
+      (c) => `
+      <tr style="border-bottom: 1px solid #e5e7eb;">
+        <td style="padding: 8px 12px;">${escapeHtml(c.eventTitle)}<br><span style="color:#6b7280;font-size:12px;">${new Date(c.eventDate).toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" })}</span></td>
+        <td style="padding: 8px 12px;">${escapeHtml(c.departmentName)}</td>
+        <td style="padding: 8px 12px;">${escapeHtml(c.memberName)}</td>
+        <td style="padding: 8px 12px;">${changeTypeLabel(c.changeType)}${c.newStatus ? `<br><span style="color:#5E17EB;font-size:12px;">${statusLabel(c.newStatus)}</span>` : ""}</td>
+        <td style="padding: 8px 12px; color:#6b7280; font-size:12px;">${escapeHtml(c.modifiedBy)}</td>
+      </tr>`
+    )
+    .join("");
+
+  return {
+    subject: `[${escapeHtml(params.churchName)}] Digest planning — ${params.changes.length} modification${params.changes.length > 1 ? "s" : ""}`,
+    html: `
+      <div style="font-family: Montserrat, sans-serif; max-width: 700px; margin: 0 auto;">
+        <div style="background: #5E17EB; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
+          <h1 style="margin: 0; font-size: 20px;">Koinonia — Digest planning</h1>
+          <p style="margin: 4px 0 0; font-size: 13px; opacity: 0.85;">${escapeHtml(params.churchName)}</p>
+        </div>
+        <div style="padding: 20px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+          <p style="color: #6b7280; font-size: 13px; margin-top: 0;">Modifications depuis le ${sinceStr}</p>
+          <table style="width:100%; border-collapse: collapse; font-size: 14px;">
+            <thead>
+              <tr style="background: #f9fafb; text-align: left;">
+                <th style="padding: 8px 12px; font-weight: 600;">Événement</th>
+                <th style="padding: 8px 12px; font-weight: 600;">Département</th>
+                <th style="padding: 8px 12px; font-weight: 600;">Membre</th>
+                <th style="padding: 8px 12px; font-weight: 600;">Changement</th>
+                <th style="padding: 8px 12px; font-weight: 600;">Modifié par</th>
+              </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+      </div>
+    `,
+  };
+}
+
 export function buildReminderEmail(params: {
   memberName: string;
   eventTitle: string;


### PR DESCRIPTION
## Summary

- **Nouvel endpoint `POST /api/cron`** orchestrateur qui remplace `/api/cron/reminders`
- **Rappels J-1/J-3** : guard "1 fois/jour par église" via `Church.reminderLastSentAt` — le cron peut tourner toutes les heures sans spammer
- **Digest planning secrétariat** : email récapitulatif envoyé à `Church.secretariatEmail` à chaque heure si des modifications de planning ont eu lieu depuis le dernier envoi
- **Champ `secretariatEmail`** configurable dans Configuration > Église (UI + API)
- **Migration** : 3 nouveaux champs sur `Church` (`secretariatEmail`, `reminderLastSentAt`, `planningDigestLastSentAt`)
- **Doc** : timer systemd `koinonia-cron.timer` (hourly), note de migration depuis l'ancien `koinonia-reminders.timer`

## Migration depuis l'ancien timer

```bash
sudo systemctl disable --now koinonia-reminders.timer
# Créer koinonia-cron.service + koinonia-cron.timer (voir docs/production.md)
sudo systemctl enable --now koinonia-cron.timer
```

## Test plan

- [ ] Configurer `secretariatEmail` sur une église dans Configuration > Église
- [ ] Modifier un planning → vérifier qu'un digest est envoyé au prochain appel cron
- [ ] Appeler `/api/cron` deux fois dans la même heure → vérifier que les rappels ne partent qu'une fois
- [ ] Vérifier le typecheck : `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)