### PR TITLE
chore: release v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v0.19.1] - 2026-04-04
+
+### Documentation
+
+- Explication du cookie de session (`__Secure-authjs.session-token` en prod, `authjs.session-token` en dev) pour les appels API restore via curl
+
 ## [v0.19.0] - 2026-04-04
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Release v0.19.1 — doc cookie de session pour les appels API restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)