### PR TITLE
fix(discipleship): filtre Mes disciples accessible aux SuperAdmins

### DIFF
--- a/src/app/(auth)/admin/discipleship/page.tsx
+++ b/src/app/(auth)/admin/discipleship/page.tsx
@@ -31,7 +31,7 @@ export default async function DiscipleshipPage() {
 
   // Résoudre le membre lié pour le filtre "Mes disciples"
   // Visible pour tout utilisateur avec canManage ayant une fiche STAR liée
-  const linkedMemberId = canManage && !session.user.isSuperAdmin
+  const linkedMemberId = canManage
     ? (await prisma.memberUserLink.findUnique({
         where: { userId_churchId: { userId: session.user.id, churchId } },
         select: { memberId: true },


### PR DESCRIPTION
Le fix précédent (#196) excluait les SuperAdmins (`!session.user.isSuperAdmin`). Suppression de cette restriction — un SuperAdmin avec une fiche STAR liée doit aussi voir le filtre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)