### PR TITLE
fix(discipleship): filtre Mes disciples actif par défaut

### DIFF
--- a/src/app/(auth)/admin/discipleship/DiscipleshipClient.tsx
+++ b/src/app/(auth)/admin/discipleship/DiscipleshipClient.tsx
@@ -79,7 +79,7 @@ export default function DiscipleshipClient({ churchId, members, allAssignedDisci
   const [activeTab, setActiveTab] = useState<"relations" | "appel" | "stats">("relations");
   // Filtre global "Mes disciples" — visible uniquement si l'utilisateur est admin/secrétaire ET lié à un membre FD
   const showMineFilter = canManage && !!linkedMemberId;
-  const [filterMine, setFilterMine] = useState(false);
+  const [filterMine, setFilterMine] = useState(showMineFilter);
 
   const TAB_LABELS: Record<typeof activeTab, string> = {
     relations: "Relations",

--- a/src/app/(auth)/admin/discipleship/page.tsx
+++ b/src/app/(auth)/admin/discipleship/page.tsx
@@ -31,7 +31,7 @@ export default async function DiscipleshipPage() {
 
   // Résoudre le membre lié pour le filtre "Mes disciples"
   // Visible pour tout utilisateur avec canManage ayant une fiche STAR liée
-  const linkedMemberId = canManage && !session.user.isSuperAdmin
+  const linkedMemberId = canManage
     ? (await prisma.memberUserLink.findUnique({
         where: { userId_churchId: { userId: session.user.id, churchId } },
         select: { memberId: true },


### PR DESCRIPTION
Le filtre s'initialise à `showMineFilter` plutôt que `false` — actif par défaut quand disponible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)