### PR TITLE
chore: release v0.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v0.19.5] - 2026-04-06
+
+### Corrigé
+
+- Sélecteur d'église : remplacement de `router.refresh()` par `window.location.reload()` pour garantir le rechargement sur tous les navigateurs (#202)
+- Accès & rôles : les utilisateurs membres d'une autre église sont maintenant visibles pour l'attribution de rôles (#202)
+- Discipolat : seuls SUPER_ADMIN, ADMIN et SECRETARY ont la vue globale — les autres rôles (DISCIPLE_MAKER, MINISTER, DEPARTMENT_HEAD) sont scopés à leurs propres disciples (#202)
+
 ## [v0.19.4] - 2026-04-05
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v0.19.5

### Corrigé

- Sélecteur d'église : `window.location.reload()` au lieu de `router.refresh()` pour garantir le rechargement sur tous les navigateurs
- Accès & rôles : les utilisateurs membres d'une autre église sont maintenant visibles pour l'attribution de rôles
- Discipolat : seuls SUPER_ADMIN, ADMIN et SECRETARY ont la vue globale — les autres rôles (DISCIPLE_MAKER, MINISTER, DEPARTMENT_HEAD) sont scopés à leurs propres disciples

🤖 Generated with [Claude Code](https://claude.com/claude-code)