### PR TITLE
chore: release v0.19.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v0.19.6] - 2026-04-06
+
+### Corrigé
+
+- Dashboard : sélecteur de mois utilisait l'heure UTC — le mois courant pouvait être décalé en début de mois pour les utilisateurs hors UTC (#204)
+
+### Amélioré
+
+- Guide utilisateur : ajout des features manquantes (stats planning, calendrier, profil, discipolat ×3, demandes ×5, journaux d'audit, fonctions départements) (#204)
+- Guide utilisateur : correction des niveaux d'accès par rôle selon la matrice de permissions réelle (#204)
+- Tour interactif : SECRETARY ajoutée au discipolat, étape "Annonces" → "Demandes", accents corrigés, contenus réécrits (#204)
+- Docs : ajout `docs/guide-screenshots.md` — liste des 24 captures et procédure de publication (#204)
+
 ## [v0.19.5] - 2026-04-06
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v0.19.6

### Corrigé
- Dashboard : sélecteur de mois basé sur l'heure locale (plus UTC)

### Amélioré
- Guide utilisateur : 24 features documentées, accès par rôle corrigés
- Tour interactif : contenus réécrits, accents corrigés, SECRETARY + discipolat
- Docs : `guide-screenshots.md` avec procédure de publication des captures

🤖 Generated with [Claude Code](https://claude.com/claude-code)