### PR TITLE
fix(planning): admin peut modifier le planning après la date limite

### DIFF
--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts
@@ -34,7 +34,7 @@ const mockDeptChurchCheck = { ministry: { churchId: "church-1" } };
 describe("GET /api/events/[eventId]/departments/[deptId]/planning", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequireAuth.mockResolvedValue(createAdminSession());
+    mockRequirePermission.mockResolvedValue(createAdminSession());
     prismaMock.department.findUnique.mockResolvedValue(mockDeptChurchCheck as never);
   });
 
@@ -103,6 +103,7 @@ describe("GET /api/events/[eventId]/departments/[deptId]/planning", () => {
 
     const body = await res.json();
     expect(body.deadlinePassed).toBe(true);
+    expect(body.canBypassDeadline).toBe(true); // ADMIN can bypass
   });
 });
 

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
@@ -17,7 +17,14 @@ export async function GET(
   try {
     const { eventId, deptId: departmentId } = await params;
     const churchId = await resolveChurchId("event", eventId);
-    await requireChurchPermission("planning:view", churchId);
+    const session = await requireChurchPermission("planning:view", churchId);
+
+    const churchRoles = session.user.churchRoles
+      .filter((r) => r.churchId === churchId)
+      .map((r) => r.role);
+    const canBypassDeadline = churchRoles.some(
+      (r) => r === "SUPER_ADMIN" || r === "ADMIN" || r === "SECRETARY"
+    );
 
     // Verify department belongs to same church as event
     const deptCheck = await prisma.department.findUnique({
@@ -83,6 +90,7 @@ export async function GET(
         })),
         planningDeadline: event?.planningDeadline ?? null,
         deadlinePassed,
+        canBypassDeadline,
       });
     }
 
@@ -106,6 +114,7 @@ export async function GET(
       members,
       planningDeadline: eventDept.event.planningDeadline,
       deadlinePassed,
+      canBypassDeadline,
     });
   } catch (error) {
     return errorResponse(error);

--- a/src/components/PlanningGrid.tsx
+++ b/src/components/PlanningGrid.tsx
@@ -53,10 +53,11 @@ export default function PlanningGrid({
   const [fetchError, setFetchError] = useState(false);
   const [saveError, setSaveError] = useState(false);
   const [deadlinePassed, setDeadlinePassed] = useState(false);
+  const [canBypassDeadline, setCanBypassDeadline] = useState(false);
   const [planningDeadline, setPlanningDeadline] = useState<string | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  const isReadOnly = readOnly || deadlinePassed;
+  const isReadOnly = readOnly || (deadlinePassed && !canBypassDeadline);
 
   const fetchPlanning = useCallback(async () => {
     setLoading(true);
@@ -69,6 +70,7 @@ export default function PlanningGrid({
       const data = await res.json();
       setMembers(data.members);
       setDeadlinePassed(data.deadlinePassed ?? false);
+      setCanBypassDeadline(data.canBypassDeadline ?? false);
       setPlanningDeadline(data.planningDeadline ?? null);
       setDirty(false);
     } catch {
@@ -173,6 +175,9 @@ export default function PlanningGrid({
           <span className="text-gray-400 italic">
             {deadlinePassed ? "Échéance dépassée" : "Lecture seule"}
           </span>
+        )}
+        {deadlinePassed && canBypassDeadline && (
+          <span className="text-orange-500 italic text-xs">Échéance dépassée — modification autorisée</span>
         )}
         {saveError && <span className="text-icc-rouge">Erreur d&apos;enregistrement</span>}
         {!isReadOnly && saving && <span className="text-blue-500">Enregistrement...</span>}


### PR DESCRIPTION
## Problème

Closes #207

Après la date limite de planification, le planning était affiché en lecture seule pour **tous les utilisateurs**, y compris SUPER_ADMIN, ADMIN et SECRETARY.

## Cause

Le `GET /api/events/[eventId]/departments/[deptId]/planning` retournait `deadlinePassed: true` sans tenir compte du rôle. Dans `PlanningGrid` :

```typescript
const isReadOnly = readOnly || deadlinePassed; // bloquait tout le monde
```

Pourtant le `PUT` autorisait déjà ces rôles à contourner la deadline.

## Fix

- **`route.ts` (GET)** : calcule `canBypassDeadline` selon les rôles de l'utilisateur dans l'église (`SUPER_ADMIN`, `ADMIN`, `SECRETARY`) et l'inclut dans la réponse
- **`PlanningGrid.tsx`** : utilise `isReadOnly = readOnly || (deadlinePassed && !canBypassDeadline)` — affiche aussi un badge "Échéance dépassée — modification autorisée" pour les admins

## Test plan

- [ ] En tant que DEPARTMENT_HEAD : le planning est bien en lecture seule après la deadline
- [ ] En tant qu'ADMIN : le planning reste éditable après la deadline
- [ ] En tant que SUPER_ADMIN : le planning reste éditable après la deadline
- [ ] En tant que SECRETARY : le planning reste éditable après la deadline
- [ ] Le badge "Échéance dépassée — modification autorisée" s'affiche pour admin après deadline

🤖 Generated with [Claude Code](https://claude.com/claude-code)