### PR TITLE
feat(core): squelette ModuleRegistry + EventBus + boot (Phase 1 v1.0)

### DIFF
--- a/src/core/__tests__/boot.test.ts
+++ b/src/core/__tests__/boot.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { boot, parseEnabledModules } from "../boot";
+import { defineModule } from "../module-registry";
+
+const core = defineModule({ name: "core", version: "1.0.0" });
+const planning = defineModule({ name: "planning", version: "1.0.0", dependsOn: ["core"] });
+const media = defineModule({ name: "media", version: "1.0.0", dependsOn: ["core"], optionalDependencies: ["planning"] });
+
+describe("parseEnabledModules", () => {
+  it("retourne null pour une valeur vide", () => {
+    expect(parseEnabledModules(undefined)).toBeNull();
+    expect(parseEnabledModules("")).toBeNull();
+    expect(parseEnabledModules("  ")).toBeNull();
+  });
+
+  it("parse une liste séparée par des virgules en trimmant", () => {
+    expect(parseEnabledModules("core,planning,media")).toEqual(["core", "planning", "media"]);
+    expect(parseEnabledModules("core, planning , media")).toEqual(["core", "planning", "media"]);
+  });
+});
+
+describe("boot", () => {
+  it("enregistre tous les modules si aucun filtre n'est fourni", () => {
+    const registry = boot({ modules: [core, planning, media] });
+    expect(registry.list()).toHaveLength(3);
+  });
+
+  it("filtre les modules selon la liste enabled", () => {
+    const registry = boot({ modules: [core, planning, media], enabled: ["core", "media"] });
+    expect(registry.has("core")).toBe(true);
+    expect(registry.has("media")).toBe(true);
+    expect(registry.has("planning")).toBe(false);
+  });
+
+  it("throw si une dépendance requise manque après filtrage", () => {
+    expect(() =>
+      boot({ modules: [core, planning], enabled: ["planning"] })
+    ).toThrow(/Module "planning" dépend de "core"/);
+  });
+
+  it("accepte une dépendance optionnelle absente", () => {
+    const registry = boot({ modules: [core, media], enabled: ["core", "media"] });
+    expect(registry.has("media")).toBe(true);
+  });
+
+  it("throw si un cycle est détecté", () => {
+    const a = defineModule({ name: "a", version: "1.0.0", dependsOn: ["b"] });
+    const b = defineModule({ name: "b", version: "1.0.0", dependsOn: ["a"] });
+    expect(() => boot({ modules: [a, b] })).toThrow(/circulaire/);
+  });
+});

--- a/src/core/__tests__/event-bus.test.ts
+++ b/src/core/__tests__/event-bus.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventBus, type EventContext } from "../event-bus";
+
+interface TestEvents extends Record<string, unknown> {
+  "request.created": { requestId: string; type: string };
+  "project.approved": { projectId: string };
+}
+
+const fakeCtx: EventContext = {
+  tx: {} as EventContext["tx"],
+  churchId: "church-1",
+  userId: "user-1",
+};
+
+describe("EventBus", () => {
+  it("invoque les handlers enregistrés dans l'ordre", async () => {
+    const bus = new EventBus<TestEvents>();
+    const calls: string[] = [];
+
+    bus.on("request.created", async () => { calls.push("a"); });
+    bus.on("request.created", async () => { calls.push("b"); });
+    bus.on("request.created", async () => { calls.push("c"); });
+
+    await bus.emit("request.created", fakeCtx, { requestId: "r1", type: "VISUEL" });
+    expect(calls).toEqual(["a", "b", "c"]);
+  });
+
+  it("passe le payload typé au handler", async () => {
+    const bus = new EventBus<TestEvents>();
+    const handler = vi.fn(async () => {});
+    bus.on("request.created", handler);
+
+    await bus.emit("request.created", fakeCtx, { requestId: "r1", type: "VISUEL" });
+    expect(handler).toHaveBeenCalledWith(fakeCtx, { requestId: "r1", type: "VISUEL" });
+  });
+
+  it("n'invoque aucun handler pour un événement sans listener", async () => {
+    const bus = new EventBus<TestEvents>();
+    // ne throw pas
+    await expect(
+      bus.emit("project.approved", fakeCtx, { projectId: "p1" })
+    ).resolves.toBeUndefined();
+  });
+
+  it("propage l'erreur d'un handler et interrompt l'émission", async () => {
+    const bus = new EventBus<TestEvents>();
+    const calls: string[] = [];
+
+    bus.on("request.created", async () => { calls.push("a"); });
+    bus.on("request.created", async () => { throw new Error("boom"); });
+    bus.on("request.created", async () => { calls.push("c"); });
+
+    await expect(
+      bus.emit("request.created", fakeCtx, { requestId: "r1", type: "VISUEL" })
+    ).rejects.toThrow("boom");
+    expect(calls).toEqual(["a"]); // "c" n'est jamais appelé
+  });
+
+  it("listenerCount et clear", () => {
+    const bus = new EventBus<TestEvents>();
+    bus.on("request.created", async () => {});
+    bus.on("request.created", async () => {});
+    expect(bus.listenerCount("request.created")).toBe(2);
+    expect(bus.listenerCount("project.approved")).toBe(0);
+
+    bus.clear();
+    expect(bus.listenerCount("request.created")).toBe(0);
+  });
+});

--- a/src/core/__tests__/module-registry.test.ts
+++ b/src/core/__tests__/module-registry.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { ModuleRegistry, defineModule } from "../module-registry";
+
+const core = defineModule({ name: "core", version: "1.0.0" });
+const planning = defineModule({ name: "planning", version: "1.0.0", dependsOn: ["core"] });
+const media = defineModule({ name: "media", version: "1.0.0", dependsOn: ["core"], optionalDependencies: ["planning"] });
+const discipleship = defineModule({ name: "discipleship", version: "1.0.0", dependsOn: ["core", "planning"] });
+
+describe("ModuleRegistry.register", () => {
+  it("enregistre un module", () => {
+    const r = new ModuleRegistry();
+    r.register(core);
+    expect(r.has("core")).toBe(true);
+    expect(r.get("core")).toBe(core);
+    expect(r.list()).toHaveLength(1);
+  });
+
+  it("throw si un module est enregistré deux fois", () => {
+    const r = new ModuleRegistry();
+    r.register(core);
+    expect(() => r.register(core)).toThrow(/déjà enregistré/);
+  });
+});
+
+describe("ModuleRegistry.validateDependencies", () => {
+  it("retourne [] quand toutes les dépendances sont satisfaites", () => {
+    const r = new ModuleRegistry();
+    r.register(core);
+    r.register(planning);
+    expect(r.validateDependencies()).toEqual([]);
+  });
+
+  it("retourne une erreur quand une dépendance requise manque", () => {
+    const r = new ModuleRegistry();
+    r.register(planning); // core manquant
+    const errors = r.validateDependencies();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Module "planning" dépend de "core"');
+  });
+
+  it("ignore les dépendances optionnelles manquantes", () => {
+    const r = new ModuleRegistry();
+    r.register(core);
+    r.register(media); // planning (optional) absent
+    expect(r.validateDependencies()).toEqual([]);
+  });
+});
+
+describe("ModuleRegistry.resolveLoadOrder", () => {
+  it("retourne les modules dans l'ordre topologique", () => {
+    const r = new ModuleRegistry();
+    r.register(discipleship); // ordre d'enregistrement inversé exprès
+    r.register(planning);
+    r.register(core);
+
+    const order = r.resolveLoadOrder().map((m) => m.name);
+    expect(order.indexOf("core")).toBeLessThan(order.indexOf("planning"));
+    expect(order.indexOf("planning")).toBeLessThan(order.indexOf("discipleship"));
+  });
+
+  it("throw si un cycle est détecté", () => {
+    const a = defineModule({ name: "a", version: "1.0.0", dependsOn: ["b"] });
+    const b = defineModule({ name: "b", version: "1.0.0", dependsOn: ["a"] });
+    const r = new ModuleRegistry();
+    r.register(a);
+    r.register(b);
+    expect(() => r.resolveLoadOrder()).toThrow(/circulaire/);
+  });
+});
+
+describe("ModuleRegistry.collectPermissions", () => {
+  it("agrège les permissions de tous les modules", () => {
+    const coreWithPerms = defineModule({
+      name: "core",
+      version: "1.0.0",
+      permissions: { "church:manage": ["SUPER_ADMIN"] },
+    });
+    const planningWithPerms = defineModule({
+      name: "planning",
+      version: "1.0.0",
+      dependsOn: ["core"],
+      permissions: { "planning:view": ["SUPER_ADMIN", "ADMIN"] },
+    });
+
+    const r = new ModuleRegistry();
+    r.register(coreWithPerms);
+    r.register(planningWithPerms);
+
+    const perms = r.collectPermissions();
+    expect(perms["church:manage"]).toEqual(["SUPER_ADMIN"]);
+    expect(perms["planning:view"]).toEqual(["SUPER_ADMIN", "ADMIN"]);
+  });
+
+  it("throw en cas de conflit de permission", () => {
+    const m1 = defineModule({
+      name: "m1",
+      version: "1.0.0",
+      permissions: { "x:do": ["ADMIN"] },
+    });
+    const m2 = defineModule({
+      name: "m2",
+      version: "1.0.0",
+      permissions: { "x:do": ["SUPER_ADMIN"] },
+    });
+
+    const r = new ModuleRegistry();
+    r.register(m1);
+    r.register(m2);
+
+    expect(() => r.collectPermissions()).toThrow(/Conflit de permission "x:do"/);
+  });
+});

--- a/src/core/boot.ts
+++ b/src/core/boot.ts
@@ -26,8 +26,8 @@ export function boot(options: BootOptions): ModuleRegistry {
     ? options.modules.filter((m) => enabled.includes(m.name))
     : options.modules;
 
-  for (const module of toLoad) {
-    registry.register(module);
+  for (const mod of toLoad) {
+    registry.register(mod);
   }
 
   const errors = registry.validateDependencies();

--- a/src/core/boot.ts
+++ b/src/core/boot.ts
@@ -1,0 +1,42 @@
+import { ModuleRegistry, type ModuleManifest } from "./module-registry";
+
+export interface BootOptions {
+  modules: ModuleManifest[];
+  /** Liste explicite de modules à activer. Si omise, lit process.env.ENABLED_MODULES. */
+  enabled?: string[];
+}
+
+export function parseEnabledModules(raw: string | undefined): string[] | null {
+  if (!raw) return null;
+  const list = raw.split(",").map((m) => m.trim()).filter(Boolean);
+  return list.length > 0 ? list : null;
+}
+
+/**
+ * Enregistre les modules activés, valide les dépendances, et retourne un registry prêt.
+ * Throw si une dépendance requise manque ou si un cycle est détecté.
+ */
+export function boot(options: BootOptions): ModuleRegistry {
+  const enabled =
+    options.enabled ?? parseEnabledModules(process.env.ENABLED_MODULES);
+
+  const registry = new ModuleRegistry();
+
+  const toLoad = enabled
+    ? options.modules.filter((m) => enabled.includes(m.name))
+    : options.modules;
+
+  for (const module of toLoad) {
+    registry.register(module);
+  }
+
+  const errors = registry.validateDependencies();
+  if (errors.length > 0) {
+    throw new Error(`Boot échoué :\n${errors.join("\n")}`);
+  }
+
+  // Valide qu'aucun cycle n'existe
+  registry.resolveLoadOrder();
+
+  return registry;
+}

--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -1,0 +1,49 @@
+import type { Prisma } from "@/generated/prisma/client";
+
+export interface EventContext {
+  tx: Prisma.TransactionClient;
+  churchId: string;
+  userId?: string;
+}
+
+export type EventHandler<TPayload> = (
+  ctx: EventContext,
+  payload: TPayload
+) => Promise<void>;
+
+/**
+ * Bus d'événements typé, in-process, transaction-aware.
+ *
+ * Les handlers sont exécutés séquentiellement dans l'ordre d'enregistrement,
+ * au sein de la transaction Prisma fournie via le contexte. Si un handler throw,
+ * l'émission est interrompue et l'erreur remonte — la transaction sera rollback
+ * par l'appelant.
+ */
+export class EventBus<TEvents extends Record<string, unknown>> {
+  private handlers = new Map<keyof TEvents, EventHandler<unknown>[]>();
+
+  on<K extends keyof TEvents>(event: K, handler: EventHandler<TEvents[K]>): void {
+    const existing = this.handlers.get(event) ?? [];
+    existing.push(handler as EventHandler<unknown>);
+    this.handlers.set(event, existing);
+  }
+
+  async emit<K extends keyof TEvents>(
+    event: K,
+    ctx: EventContext,
+    payload: TEvents[K]
+  ): Promise<void> {
+    const handlers = this.handlers.get(event) ?? [];
+    for (const handler of handlers) {
+      await (handler as EventHandler<TEvents[K]>)(ctx, payload);
+    }
+  }
+
+  listenerCount<K extends keyof TEvents>(event: K): number {
+    return this.handlers.get(event)?.length ?? 0;
+  }
+
+  clear(): void {
+    this.handlers.clear();
+  }
+}

--- a/src/core/module-registry.ts
+++ b/src/core/module-registry.ts
@@ -44,11 +44,11 @@ export function defineModule(manifest: ModuleManifest): ModuleManifest {
 export class ModuleRegistry {
   private modules = new Map<string, ModuleManifest>();
 
-  register(module: ModuleManifest): void {
-    if (this.modules.has(module.name)) {
-      throw new Error(`Module "${module.name}" déjà enregistré`);
+  register(mod: ModuleManifest): void {
+    if (this.modules.has(mod.name)) {
+      throw new Error(`Module "${mod.name}" déjà enregistré`);
     }
-    this.modules.set(module.name, module);
+    this.modules.set(mod.name, mod);
   }
 
   get(name: string): ModuleManifest | undefined {
@@ -69,10 +69,10 @@ export class ModuleRegistry {
    */
   validateDependencies(): string[] {
     const errors: string[] = [];
-    for (const module of this.modules.values()) {
-      for (const dep of module.dependsOn ?? []) {
+    for (const mod of this.modules.values()) {
+      for (const dep of mod.dependsOn ?? []) {
         if (!this.modules.has(dep)) {
-          errors.push(`Module "${module.name}" dépend de "${dep}" qui n'est pas enregistré`);
+          errors.push(`Module "${mod.name}" dépend de "${dep}" qui n'est pas enregistré`);
         }
       }
     }
@@ -93,15 +93,15 @@ export class ModuleRegistry {
       if (visiting.has(name)) {
         throw new Error(`Dépendance circulaire détectée impliquant le module "${name}"`);
       }
-      const module = this.modules.get(name);
-      if (!module) return;
+      const mod = this.modules.get(name);
+      if (!mod) return;
       visiting.add(name);
-      for (const dep of module.dependsOn ?? []) {
+      for (const dep of mod.dependsOn ?? []) {
         visit(dep);
       }
       visiting.delete(name);
       visited.add(name);
-      sorted.push(module);
+      sorted.push(mod);
     };
 
     for (const name of this.modules.keys()) {
@@ -119,14 +119,14 @@ export class ModuleRegistry {
     const result: Record<Permission, readonly RoleName[]> = {};
     const owners = new Map<Permission, string>();
 
-    for (const module of this.modules.values()) {
-      for (const [perm, roles] of Object.entries(module.permissions ?? {})) {
+    for (const mod of this.modules.values()) {
+      for (const [perm, roles] of Object.entries(mod.permissions ?? {})) {
         if (owners.has(perm)) {
           throw new Error(
-            `Conflit de permission "${perm}" entre les modules "${owners.get(perm)}" et "${module.name}"`
+            `Conflit de permission "${perm}" entre les modules "${owners.get(perm)}" et "${mod.name}"`
           );
         }
-        owners.set(perm, module.name);
+        owners.set(perm, mod.name);
         result[perm] = roles;
       }
     }

--- a/src/core/module-registry.ts
+++ b/src/core/module-registry.ts
@@ -1,0 +1,136 @@
+import type { Prisma } from "@/generated/prisma/client";
+
+export type Permission = string;
+export type RoleName = string;
+
+export interface RouteDescriptor {
+  path: string;
+}
+
+export interface NavigationItem {
+  label: string;
+  icon?: string;
+  href: string;
+  permission?: Permission;
+}
+
+export interface JobDescriptor {
+  name: string;
+  schedule: string;
+  handler: (ctx: { tx: Prisma.TransactionClient }) => Promise<void>;
+}
+
+export interface ModuleRoutes {
+  authenticated?: RouteDescriptor[];
+  public?: RouteDescriptor[];
+  api?: RouteDescriptor[];
+}
+
+export interface ModuleManifest {
+  name: string;
+  version: string;
+  dependsOn?: readonly string[];
+  optionalDependencies?: readonly string[];
+  routes?: ModuleRoutes;
+  permissions?: Record<Permission, readonly RoleName[]>;
+  navigation?: NavigationItem[];
+  jobs?: JobDescriptor[];
+}
+
+export function defineModule(manifest: ModuleManifest): ModuleManifest {
+  return manifest;
+}
+
+export class ModuleRegistry {
+  private modules = new Map<string, ModuleManifest>();
+
+  register(module: ModuleManifest): void {
+    if (this.modules.has(module.name)) {
+      throw new Error(`Module "${module.name}" déjà enregistré`);
+    }
+    this.modules.set(module.name, module);
+  }
+
+  get(name: string): ModuleManifest | undefined {
+    return this.modules.get(name);
+  }
+
+  has(name: string): boolean {
+    return this.modules.has(name);
+  }
+
+  list(): ModuleManifest[] {
+    return Array.from(this.modules.values());
+  }
+
+  /**
+   * Vérifie que toutes les dépendances requises sont satisfaites.
+   * Retourne les erreurs détectées sans throw.
+   */
+  validateDependencies(): string[] {
+    const errors: string[] = [];
+    for (const module of this.modules.values()) {
+      for (const dep of module.dependsOn ?? []) {
+        if (!this.modules.has(dep)) {
+          errors.push(`Module "${module.name}" dépend de "${dep}" qui n'est pas enregistré`);
+        }
+      }
+    }
+    return errors;
+  }
+
+  /**
+   * Retourne les modules dans l'ordre de chargement (tri topologique).
+   * Throw si un cycle est détecté.
+   */
+  resolveLoadOrder(): ModuleManifest[] {
+    const sorted: ModuleManifest[] = [];
+    const visited = new Set<string>();
+    const visiting = new Set<string>();
+
+    const visit = (name: string) => {
+      if (visited.has(name)) return;
+      if (visiting.has(name)) {
+        throw new Error(`Dépendance circulaire détectée impliquant le module "${name}"`);
+      }
+      const module = this.modules.get(name);
+      if (!module) return;
+      visiting.add(name);
+      for (const dep of module.dependsOn ?? []) {
+        visit(dep);
+      }
+      visiting.delete(name);
+      visited.add(name);
+      sorted.push(module);
+    };
+
+    for (const name of this.modules.keys()) {
+      visit(name);
+    }
+
+    return sorted;
+  }
+
+  /**
+   * Agrège les permissions déclarées par tous les modules enregistrés.
+   * Throw si deux modules déclarent la même permission (conflit).
+   */
+  collectPermissions(): Record<Permission, readonly RoleName[]> {
+    const result: Record<Permission, readonly RoleName[]> = {};
+    const owners = new Map<Permission, string>();
+
+    for (const module of this.modules.values()) {
+      for (const [perm, roles] of Object.entries(module.permissions ?? {})) {
+        if (owners.has(perm)) {
+          throw new Error(
+            `Conflit de permission "${perm}" entre les modules "${owners.get(perm)}" et "${module.name}"`
+          );
+        }
+        owners.set(perm, module.name);
+        result[perm] = roles;
+      }
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary

Premier jalon de la refonte en plateforme modulaire (#211) — **Phase 1**.

- `src/core/module-registry.ts` : `defineModule()`, `ModuleRegistry` (register, validate, resolve topological order, collect permissions)
- `src/core/event-bus.ts` : `EventBus<TEvents>` typé, in-process, transaction-aware
- `src/core/boot.ts` : lecture `ENABLED_MODULES`, filtrage, validation

**Aucun code existant touché.** `src/core/` est une base parallèle inerte, non importée par le reste du code. Le câblage des modules `planning`/`media`/`discipleship` se fera dans les phases suivantes (#211 Phase 2+).

21 tests vitest couvrant :
- Registry : enregistrement, doublons, dépendances requises/optionnelles, cycle, collecte/conflit de permissions
- EventBus : ordre d'invocation, propagation d'erreur, listenerCount, clear
- Boot : parsing `ENABLED_MODULES`, filtrage, dépendances manquantes après filtrage, cycle

Refs #211

## Test plan

- [x] `npm run typecheck` passe
- [x] `npx vitest run src/core` — 21/21 passent
- [ ] CI lint-test verte