### PR TITLE
feat(modules): manifestes core, planning, discipleship (Phase 2 step 1)

### DIFF
--- a/src/modules/__tests__/manifests.test.ts
+++ b/src/modules/__tests__/manifests.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { ModuleRegistry } from "@/core/module-registry";
+import { coreModule } from "../core";
+import { planningModule } from "../planning";
+import { discipleshipModule } from "../discipleship";
+
+const ALL_MODULES = [coreModule, planningModule, discipleshipModule];
+
+function buildRegistry(mods = ALL_MODULES) {
+  const r = new ModuleRegistry();
+  for (const mod of mods) r.register(mod);
+  return r;
+}
+
+describe("Manifestes des modules", () => {
+  it("s'enregistrent sans erreur", () => {
+    expect(() => buildRegistry()).not.toThrow();
+  });
+
+  it("toutes les dépendances requises sont satisfaites", () => {
+    const errors = buildRegistry().validateDependencies();
+    expect(errors).toEqual([]);
+  });
+
+  it("l'ordre de chargement est résolvable sans cycle", () => {
+    const order = buildRegistry().resolveLoadOrder().map((m) => m.name);
+    expect(order.indexOf("core")).toBeLessThan(order.indexOf("planning"));
+    expect(order.indexOf("core")).toBeLessThan(order.indexOf("discipleship"));
+    expect(order.indexOf("planning")).toBeLessThan(order.indexOf("discipleship"));
+  });
+
+  it("aucun conflit de permission entre les modules", () => {
+    expect(() => buildRegistry().collectPermissions()).not.toThrow();
+  });
+
+  it("la somme des permissions correspond à la matrice RBAC actuelle", () => {
+    const perms = buildRegistry().collectPermissions();
+    const permNames = Object.keys(perms).sort();
+
+    expect(permNames).toEqual([
+      "church:manage",
+      "departments:manage",
+      "departments:view",
+      "discipleship:export",
+      "discipleship:manage",
+      "discipleship:view",
+      "events:manage",
+      "events:view",
+      "members:manage",
+      "members:view",
+      "planning:edit",
+      "planning:view",
+      "reports:edit",
+      "reports:view",
+      "users:manage",
+    ]);
+  });
+
+  it("core gère les permissions globales uniquement", () => {
+    const corePerms = Object.keys(coreModule.permissions ?? {});
+    expect(corePerms).toContain("church:manage");
+    expect(corePerms).toContain("users:manage");
+    expect(corePerms).not.toContain("planning:view");
+  });
+
+  it("planning sans core échoue à la validation", () => {
+    const r = new ModuleRegistry();
+    r.register(planningModule);
+    const errors = r.validateDependencies();
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toContain('"planning"');
+    expect(errors[0]).toContain('"core"');
+  });
+
+  it("discipleship sans planning échoue à la validation", () => {
+    const r = new ModuleRegistry();
+    r.register(coreModule);
+    r.register(discipleshipModule);
+    const errors = r.validateDependencies();
+    expect(errors.some((e) => e.includes('"planning"'))).toBe(true);
+  });
+});

--- a/src/modules/core/index.ts
+++ b/src/modules/core/index.ts
@@ -1,0 +1,27 @@
+import { defineModule } from "@/core/module-registry";
+
+/**
+ * Module core — obligatoire, toujours chargé.
+ *
+ * Périmètre :
+ *   - Authentification (NextAuth, Google OAuth)
+ *   - Gestion des utilisateurs et des rôles (RBAC)
+ *   - Gestion des églises (multi-tenant)
+ *   - Journaux d'audit
+ *   - Paramètres globaux
+ *
+ * Dépendances : aucune (module racine)
+ */
+export const coreModule = defineModule({
+  name: "core",
+  version: "1.0.0",
+
+  permissions: {
+    "church:manage": ["SUPER_ADMIN"],
+    "users:manage":  ["SUPER_ADMIN"],
+  },
+
+  navigation: [
+    { label: "Configuration", icon: "settings", href: "/admin", permission: "users:manage" },
+  ],
+});

--- a/src/modules/discipleship/index.ts
+++ b/src/modules/discipleship/index.ts
@@ -1,0 +1,27 @@
+import { defineModule } from "@/core/module-registry";
+
+/**
+ * Module discipleship — ex-Koinonia (discipolat).
+ *
+ * Périmètre :
+ *   - Relations disciple / faiseur de disciples
+ *   - Présences aux rencontres (DiscipleshipAttendance)
+ *   - Export statistiques
+ *
+ * Dépendances : core (obligatoire), planning (obligatoire — lie les disciples aux membres)
+ */
+export const discipleshipModule = defineModule({
+  name: "discipleship",
+  version: "1.0.0",
+  dependsOn: ["core", "planning"],
+
+  permissions: {
+    "discipleship:view":   ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD", "DISCIPLE_MAKER"],
+    "discipleship:manage": ["SUPER_ADMIN", "ADMIN", "SECRETARY", "DISCIPLE_MAKER"],
+    "discipleship:export": ["SUPER_ADMIN", "SECRETARY"],
+  },
+
+  navigation: [
+    { label: "Discipolat", icon: "discipleship", href: "/admin/discipleship", permission: "discipleship:view" },
+  ],
+});

--- a/src/modules/planning/index.ts
+++ b/src/modules/planning/index.ts
@@ -1,0 +1,45 @@
+import { defineModule } from "@/core/module-registry";
+
+/**
+ * Module planning — ex-Koinonia.
+ *
+ * Périmètre :
+ *   - Événements, planning par département, comptes rendus
+ *   - Membres (STAR) et départements
+ *   - Demandes (Request workflow)
+ *   - Annonces (diffusion interne, visuel, réseaux sociaux)
+ *
+ * Dépendances : core (obligatoire)
+ * Intégrations : media (optionnelle — cross-module via event bus uniquement)
+ */
+export const planningModule = defineModule({
+  name: "planning",
+  version: "1.0.0",
+  dependsOn: ["core"],
+  optionalDependencies: ["media"],
+
+  permissions: {
+    // Planning
+    "planning:view":       ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD"],
+    "planning:edit":       ["SUPER_ADMIN", "ADMIN", "MINISTER", "DEPARTMENT_HEAD"],
+    // Membres (STAR)
+    "members:view":        ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD"],
+    "members:manage":      ["SUPER_ADMIN", "ADMIN", "MINISTER", "DEPARTMENT_HEAD"],
+    // Événements
+    "events:view":         ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD", "REPORTER"],
+    "events:manage":       ["SUPER_ADMIN", "ADMIN", "SECRETARY"],
+    // Départements
+    "departments:view":    ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD"],
+    "departments:manage":  ["SUPER_ADMIN", "ADMIN", "MINISTER"],
+    // Comptes rendus
+    "reports:view":        ["SUPER_ADMIN", "ADMIN", "SECRETARY", "REPORTER"],
+    "reports:edit":        ["SUPER_ADMIN", "ADMIN", "SECRETARY", "REPORTER"],
+  },
+
+  navigation: [
+    { label: "Planning",    icon: "planning",    href: "/dashboard",    permission: "planning:view" },
+    { label: "Événements",  icon: "calendar",    href: "/events",       permission: "events:view" },
+    { label: "Membres",     icon: "members",     href: "/admin/members",permission: "members:view" },
+    { label: "Annonces",    icon: "megaphone",   href: "/announcements",permission: "events:view" },
+  ],
+});


### PR DESCRIPTION
## Summary

Deuxième livrable de la refonte modulaire (#211) — **manifestes déclaratifs**.

Trois nouveaux fichiers dans `src/modules/`, **aucun code existant touché** :

| Module | Fichier | Permissions déclarées | Dépendances |
|---|---|---|---|
| `core` | `src/modules/core/index.ts` | `church:manage`, `users:manage` | aucune |
| `planning` | `src/modules/planning/index.ts` | planning, members, events, departments, reports (10 perms) | `core` (req), `media` (opt) |
| `discipleship` | `src/modules/discipleship/index.ts` | `discipleship:view/manage/export` | `core`, `planning` |

Les manifestes couvrent l'**intégralité de la matrice RBAC actuelle** (`src/lib/permissions.ts`) — validé par test.

8 tests vitest (`src/modules/__tests__/manifests.test.ts`) :
- Enregistrement sans erreur
- Dépendances toutes satisfaites
- Ordre de chargement sans cycle (core < planning < discipleship)
- Pas de conflit de permission entre modules
- Couverture complète des 15 permissions de la matrice
- Cas d'échec : planning sans core, discipleship sans planning

Refs #211