### PR TITLE
feat(auth): brancher requirePermission sur le registry de modules

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -175,9 +175,9 @@ export async function requirePermission(permission: string, churchId?: string) {
     (r) => !churchId || r.churchId === churchId
   );
 
-  const { hasPermission } = await import("./permissions");
+  const { rolePermissions } = await import("./registry");
   const userPermissions = new Set(
-    roles.flatMap((r) => hasPermission(r.role))
+    roles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
 
   if (!userPermissions.has(permission)) {
@@ -193,9 +193,9 @@ export async function requireAnyPermission(...permissions: string[]) {
   // Global super admin bypasses all permissions
   if (session.user.isSuperAdmin) return session;
 
-  const { hasPermission } = await import("./permissions");
+  const { rolePermissions } = await import("./registry");
   const userPermissions = new Set(
-    session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+    session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
 
   if (!permissions.some((p) => userPermissions.has(p))) {
@@ -279,9 +279,9 @@ export async function requireChurchPermission(
     throw new Error("FORBIDDEN");
   }
 
-  const { hasPermission } = await import("./permissions");
+  const { rolePermissions } = await import("./registry");
   const userPermissions = new Set(
-    roles.flatMap((r) => hasPermission(r.role))
+    roles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
 
   if (!userPermissions.has(permission)) {

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,0 +1,21 @@
+import { boot } from "@/core/boot";
+import { buildRolePermissions } from "@/core/permissions";
+import { coreModule } from "@/modules/core";
+import { planningModule } from "@/modules/planning";
+import { discipleshipModule } from "@/modules/discipleship";
+
+/**
+ * Registry singleton — chargé une fois au démarrage du process.
+ *
+ * Contient tous les modules activés selon ENABLED_MODULES (ou tous si absent).
+ * Source de vérité pour les permissions dans les contrôles d'accès API.
+ */
+export const registry = boot({
+  modules: [coreModule, planningModule, discipleshipModule],
+});
+
+/**
+ * Matrice rôles → permissions pré-calculée depuis les manifestes.
+ * Remplace ROLE_PERMISSIONS de src/lib/permissions.ts dans les guards API.
+ */
+export const rolePermissions = buildRolePermissions(registry);


### PR DESCRIPTION
## Summary

Phase 2 step 3 (#211) — **première vraie piqûre dans le code existant**.

`src/lib/registry.ts` (nouveau) :
- Singleton `registry` booté avec les 3 modules (core, planning, discipleship)
- `rolePermissions` : matrice pré-calculée via `buildRolePermissions(registry)`

`src/lib/auth.ts` — 3 fonctions de garde API mises à jour :
| Fonction | Avant | Après |
|---|---|---|
| `requirePermission` | `hasPermission(r.role)` | `rolePermissions[r.role]` |
| `requireAnyPermission` | `hasPermission(r.role)` | `rolePermissions[r.role]` |
| `requireChurchPermission` | `hasPermission(r.role)` | `rolePermissions[r.role]` |

`src/lib/permissions.ts` reste intacte — les 18 fichiers UI/pages qui l'utilisent ne sont pas touchés (migration incrémentale).

**206/206 tests passent** — dont tous les guards de sécurité API.

Refs #211