### PR TITLE
feat(permissions): migrer hasPermission → rolePermissions (15 fichiers)

### DIFF
--- a/src/app/(auth)/admin/discipleship/page.tsx
+++ b/src/app/(auth)/admin/discipleship/page.tsx
@@ -1,5 +1,5 @@
 import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import DiscipleshipClient from "./DiscipleshipClient";
 
@@ -18,7 +18,7 @@ export default async function DiscipleshipPage() {
 
   const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   const userPermissions = new Set(
-    churchRoles.flatMap((r) => hasPermission(r.role))
+    churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
 
   const canManage = userPermissions.has("discipleship:manage");

--- a/src/app/(auth)/admin/events/[eventId]/report/page.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/report/page.tsx
@@ -1,5 +1,5 @@
 import { requireAuth } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import EventReportClient from "./EventReportClient";
@@ -39,7 +39,7 @@ export default async function EventReportPage({
 
   // Allow access if user has events:manage OR reports:view for this church
   const churchRoles = session.user.churchRoles.filter((r) => r.churchId === event.churchId);
-  const perms = new Set(churchRoles.flatMap((r) => hasPermission(r.role)));
+  const perms = new Set(churchRoles.flatMap((r) => rolePermissions[r.role] ?? []));
   if (!perms.has("events:manage") && !perms.has("reports:view")) {
     const { ApiError } = await import("@/lib/api-utils");
     throw new ApiError(403, "Forbidden");

--- a/src/app/(auth)/admin/members/page.tsx
+++ b/src/app/(auth)/admin/members/page.tsx
@@ -1,5 +1,5 @@
 import { requireAuth, getCurrentChurchId, requireChurchPermission, getUserDepartmentScope } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import MembersClient from "./MembersClient";
 import LinkRequestsClient from "./LinkRequestsClient";
@@ -11,7 +11,7 @@ export default async function MembersPage() {
   await requireChurchPermission("members:view", churchId);
   const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   const userPermissions = new Set(
-    churchRoles.flatMap((r) => hasPermission(r.role))
+    churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canManage = userPermissions.has("members:manage");
   const scope = getUserDepartmentScope(session);

--- a/src/app/(auth)/admin/page.tsx
+++ b/src/app/(auth)/admin/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 
 export default async function AdminPage() {
   const session = await requireAuth();
@@ -8,7 +8,7 @@ export default async function AdminPage() {
   if (churchId) await requireChurchPermission("members:manage", churchId);
 
   const userRoles = session.user.churchRoles.map((r) => r.role);
-  const userPermissions = new Set(userRoles.flatMap((r) => hasPermission(r)));
+  const userPermissions = new Set(userRoles.flatMap((r) => rolePermissions[r] ?? []));
 
   if (userPermissions.has("church:manage")) {
     redirect("/admin/churches");

--- a/src/app/(auth)/communication/requests/page.tsx
+++ b/src/app/(auth)/communication/requests/page.tsx
@@ -1,5 +1,5 @@
 import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import { DEPT_FN } from "@/lib/department-functions";
 import { notFound } from "next/navigation";
@@ -18,7 +18,7 @@ export default async function CommunicationRequestsPage() {
 
   if (commDept) {
     const userPermissions = new Set(
-      session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+      session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
     const userDeptIds = session.user.churchRoles.flatMap((r) =>

--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import { auth, getCurrentChurchId } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import EventSelector from "@/components/EventSelector";
@@ -26,7 +26,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
 
   const currentChurchId = await getCurrentChurchId(session);
   const userPermissions = new Set(
-    session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+    session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canEditPlanning = userPermissions.has("planning:edit");
 

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import Image from "next/image";
 import { auth, signOut, getCurrentChurchId } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import ChurchSwitcher from "@/components/ChurchSwitcher";
 import AuthLayoutShell from "@/components/AuthLayoutShell";
 import NotificationBell from "@/components/NotificationBell";
@@ -72,7 +72,7 @@ export default async function AuthLayout({
 
   // Compute visible config links
   const userRoles = churchRoles.map((r) => r.role);
-  const userPermissions = new Set(userRoles.flatMap((r) => hasPermission(r)));
+  const userPermissions = new Set(userRoles.flatMap((r) => rolePermissions[r] ?? []));
   // Super admins have all permissions regardless of church roles
   if (session.user.isSuperAdmin) {
     configLinksDef.forEach((l) => l.permissions.forEach((p) => userPermissions.add(p)));

--- a/src/app/(auth)/media/requests/page.tsx
+++ b/src/app/(auth)/media/requests/page.tsx
@@ -1,5 +1,5 @@
 import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
@@ -20,7 +20,7 @@ export default async function MediaRequestsPage() {
 
   if (mediaDept) {
     const userPermissions = new Set(
-      session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+      session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
     const userDeptIds = session.user.churchRoles.flatMap((r) =>

--- a/src/app/(auth)/requests/[id]/edit/page.tsx
+++ b/src/app/(auth)/requests/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { requireAuth, getCurrentChurchId, requireChurchPermission } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import RequestForm, { type EditData } from "../../new/RequestForm";
 
@@ -48,7 +48,7 @@ export default async function EditRequestPage({ params }: Props) {
   const churchPermissions = new Set(
     session.user.churchRoles
       .filter((r) => r.churchId === churchId)
-      .flatMap((r) => hasPermission(r.role))
+      .flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canSubmitDemands = churchPermissions.has("planning:edit") || session.user.isSuperAdmin;
 

--- a/src/app/(auth)/requests/new/page.tsx
+++ b/src/app/(auth)/requests/new/page.tsx
@@ -1,5 +1,5 @@
 import { requireAuth, getCurrentChurchId, requireChurchPermission } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import RequestForm from "./RequestForm";
 
@@ -12,7 +12,7 @@ export default async function NewRequestPage() {
   const churchPermissions = new Set(
     session.user.churchRoles
       .filter((r) => r.churchId === churchId)
-      .flatMap((r) => hasPermission(r.role))
+      .flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canSubmitDemands = churchPermissions.has("planning:edit") || session.user.isSuperAdmin;
 

--- a/src/app/(auth)/secretariat/requests/page.tsx
+++ b/src/app/(auth)/secretariat/requests/page.tsx
@@ -1,5 +1,5 @@
 import { requireAuth, getCurrentChurchId, requireChurchPermission } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import { DEPT_FN } from "@/lib/department-functions";
 import { notFound } from "next/navigation";
@@ -18,7 +18,7 @@ export default async function SecretariatRequestsPage() {
 
   // Access check: events:manage OR member of secretariat dept
   const userPermissions = new Set(
-    session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+    session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
 

--- a/src/app/api/announcements/[id]/route.ts
+++ b/src/app/api/announcements/[id]/route.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { z } from "zod";
 
 const patchSchema = z.object({
@@ -38,7 +38,7 @@ export async function GET(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === minimal.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
     const isOwner = minimal.submittedById === session.user.id;
@@ -99,7 +99,7 @@ export async function PATCH(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === announcement.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || userPermissions.has("events:manage");
@@ -188,7 +188,7 @@ export async function DELETE(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === announcement.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || userPermissions.has("events:manage");

--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { DEPT_FN } from "@/lib/department-functions";
 import { z } from "zod";
@@ -48,7 +48,7 @@ export async function GET(request: Request) {
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || userPermissions.has("events:manage");

--- a/src/app/api/requests/[id]/route.ts
+++ b/src/app/api/requests/[id]/route.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { executeRequest } from "@/lib/request-executor";
 import { z } from "zod";
 import type { Prisma } from "@/generated/prisma/client";
@@ -47,7 +47,7 @@ export async function GET(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === minimal.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
     const userDeptIds = session.user.churchRoles
@@ -131,7 +131,7 @@ export async function PATCH(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === existing.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || userPermissions.has("events:manage");

--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { DEPT_FN } from "@/lib/department-functions";
 import { z } from "zod";
 
@@ -48,7 +48,7 @@ export async function GET(request: Request) {
     const churchPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || churchPermissions.has("events:manage");

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -74,6 +74,10 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
   ],
 };
 
+/**
+ * @deprecated Utiliser `rolePermissions` depuis `@/lib/registry` à la place.
+ * Cette fonction sera supprimée quand la migration Phase 2 sera complète.
+ */
 export function hasPermission(role: Role): string[] {
   return ROLE_PERMISSIONS[role] || [];
 }


### PR DESCRIPTION
## Résumé

- Remplace tous les appels à `hasPermission()` dans `src/app/` par `rolePermissions` depuis `@/lib/registry` (matrice pré-calculée depuis les manifestes de modules)
- Couvre 15 fichiers : 2 API routes announcements, 2 API routes requests, 9 pages auth, layout
- Marque `hasPermission()` `@deprecated` dans `src/lib/permissions.ts`

## Contexte

Phase 2 de l'issue #211 (plateforme modulaire v1.0) — `src/lib/permissions.ts` reste en place comme fallback mais n'est plus appelé depuis `src/app/`. La suppression définitive est prévue en fin de migration.

## Plan de test

- [ ] `npm run typecheck` — aucune erreur TS
- [ ] `npx vitest run` — 206/206 tests passent
- [ ] Vérifier que les pages protégées affichent toujours les bonnes données selon le rôle

🤖 Generated with [Claude Code](https://claude.com/claude-code)