### PR TITLE
feat(planning): bus d'événements typé + émission planning:event:created

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -3,6 +3,7 @@ import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
+import { planningBus } from "@/modules/planning";
 import { z } from "zod";
 
 export async function GET(request: Request) {
@@ -232,6 +233,20 @@ export async function POST(request: Request) {
           });
         }
 
+        await planningBus.emit(
+          "planning:event:created",
+          { tx, churchId: data.churchId, userId: session.user.id },
+          {
+            eventId: parent.id,
+            churchId: data.churchId,
+            title: data.title,
+            type: data.type,
+            createdById: session.user.id,
+            isRecurrenceParent: true,
+            childCount: childDates.length,
+          }
+        );
+
         // Return parent with includes
         return tx.event.findUnique({
           where: { id: parent.id },
@@ -264,20 +279,37 @@ export async function POST(request: Request) {
     }
 
     // Single event creation
-    const event = await prisma.event.create({
-      data: {
-        title: data.title,
-        type: data.type,
-        date: new Date(data.date),
-        churchId: data.churchId,
-        planningDeadline: deadline,
-      },
-      include: {
-        church: { select: { id: true, name: true } },
-        eventDepts: {
-          include: { department: { select: { id: true, name: true } } },
+    const event = await prisma.$transaction(async (tx) => {
+      const created = await tx.event.create({
+        data: {
+          title: data.title,
+          type: data.type,
+          date: new Date(data.date),
+          churchId: data.churchId,
+          planningDeadline: deadline,
         },
-      },
+        include: {
+          church: { select: { id: true, name: true } },
+          eventDepts: {
+            include: { department: { select: { id: true, name: true } } },
+          },
+        },
+      });
+
+      await planningBus.emit(
+        "planning:event:created",
+        { tx, churchId: data.churchId, userId: session.user.id },
+        {
+          eventId: created.id,
+          churchId: data.churchId,
+          title: data.title,
+          type: data.type,
+          createdById: session.user.id,
+          isRecurrenceParent: false,
+        }
+      );
+
+      return created;
     });
 
     await logAudit({

--- a/src/modules/__tests__/planning-bus.test.ts
+++ b/src/modules/__tests__/planning-bus.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventBus } from "@/core/event-bus";
+import { planningBus } from "@/modules/planning";
+import type { PlanningEvents } from "@/modules/planning";
+import type { Prisma } from "@/generated/prisma/client";
+
+/** Contexte minimal pour les tests — tx est un mock. */
+function fakeCtx(churchId = "church-1", userId = "user-1") {
+  return {
+    tx: {} as Prisma.TransactionClient,
+    churchId,
+    userId,
+  };
+}
+
+describe("planningBus", () => {
+  beforeEach(() => {
+    planningBus.clear();
+  });
+
+  it("est une instance de EventBus", () => {
+    expect(planningBus).toBeInstanceOf(EventBus);
+  });
+
+  it("émet planning:event:created aux handlers enregistrés", async () => {
+    const handler = vi.fn();
+    planningBus.on("planning:event:created", handler);
+
+    const payload: PlanningEvents["planning:event:created"] = {
+      eventId: "evt-1",
+      churchId: "church-1",
+      title: "Culte du dimanche",
+      type: "CULTE",
+      createdById: "user-1",
+      isRecurrenceParent: false,
+    };
+
+    const ctx = fakeCtx();
+    await planningBus.emit("planning:event:created", ctx, payload);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(ctx, payload);
+  });
+
+  it("émet planning:event:created avec childCount pour une série récurrente", async () => {
+    const captured: PlanningEvents["planning:event:created"][] = [];
+    planningBus.on("planning:event:created", async (_ctx, payload) => {
+      captured.push(payload);
+    });
+
+    await planningBus.emit(
+      "planning:event:created",
+      fakeCtx(),
+      {
+        eventId: "evt-parent",
+        churchId: "church-1",
+        title: "Culte hebdo",
+        type: "CULTE",
+        createdById: "user-1",
+        isRecurrenceParent: true,
+        childCount: 51,
+      }
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].isRecurrenceParent).toBe(true);
+    expect(captured[0].childCount).toBe(51);
+  });
+
+  it("émet planning:request:executed", async () => {
+    const handler = vi.fn();
+    planningBus.on("planning:request:executed", handler);
+
+    await planningBus.emit(
+      "planning:request:executed",
+      fakeCtx(),
+      {
+        requestId: "req-1",
+        requestType: "AJOUT_EVENEMENT",
+        churchId: "church-1",
+        executedById: "user-1",
+        resourceId: "evt-2",
+      }
+    );
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("un handler qui throw interrompt la chaîne et remonte l'erreur", async () => {
+    planningBus.on("planning:event:created", async () => {
+      throw new Error("handler error");
+    });
+    const secondHandler = vi.fn();
+    planningBus.on("planning:event:created", secondHandler);
+
+    await expect(
+      planningBus.emit("planning:event:created", fakeCtx(), {
+        eventId: "e",
+        churchId: "c",
+        title: "T",
+        type: "CULTE",
+        createdById: "u",
+        isRecurrenceParent: false,
+      })
+    ).rejects.toThrow("handler error");
+
+    // Second handler not reached
+    expect(secondHandler).not.toHaveBeenCalled();
+  });
+
+  it("listenerCount retourne 0 sans handlers enregistrés", () => {
+    expect(planningBus.listenerCount("planning:event:created")).toBe(0);
+  });
+
+  it("listenerCount retourne le nombre correct après enregistrement", () => {
+    planningBus.on("planning:event:created", vi.fn());
+    planningBus.on("planning:event:created", vi.fn());
+    expect(planningBus.listenerCount("planning:event:created")).toBe(2);
+  });
+});

--- a/src/modules/planning/bus.ts
+++ b/src/modules/planning/bus.ts
@@ -1,0 +1,20 @@
+import { EventBus } from "@/core/event-bus";
+import type { PlanningEvents } from "./events";
+
+/**
+ * Bus d'événements du module planning — singleton process-level.
+ *
+ * Les autres modules (discipleship, media…) s'y abonnent via `planningBus.on()`
+ * lors du démarrage du process (ex. dans leur propre init ou dans @/lib/registry).
+ *
+ * Usage dans un handler API :
+ * ```ts
+ * await prisma.$transaction(async (tx) => {
+ *   const event = await tx.event.create({ ... });
+ *   await planningBus.emit("planning:event:created", { tx, churchId, userId }, {
+ *     eventId: event.id, ...
+ *   });
+ * });
+ * ```
+ */
+export const planningBus = new EventBus<PlanningEvents>();

--- a/src/modules/planning/events.ts
+++ b/src/modules/planning/events.ts
@@ -1,0 +1,50 @@
+/**
+ * Carte des événements émis par le module planning.
+ *
+ * Consommé par EventBus<PlanningEvents> — chaque clé est un nom d'événement,
+ * la valeur est le type de payload attendu par les handlers.
+ *
+ * IMPORTANT : ces événements transitent par le bus in-process, transaction-aware.
+ * Tout handler enregistré s'exécute dans la même transaction Prisma que l'émetteur.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PlanningEvents = {
+  /** Un événement unique a été créé (ou le parent d'une série récurrente). */
+  "planning:event:created": {
+    eventId: string;
+    churchId: string;
+    title: string;
+    type: string;
+    createdById: string;
+    isRecurrenceParent: boolean;
+    childCount?: number;
+  };
+
+  /** Un événement a été annulé (suppression douce ou via demande). */
+  "planning:event:cancelled": {
+    eventId: string;
+    churchId: string;
+    cancelledById: string;
+    requestId?: string;
+  };
+
+  /** Une demande (Request) a été approuvée et exécutée avec succès. */
+  "planning:request:executed": {
+    requestId: string;
+    requestType: string;
+    churchId: string;
+    executedById: string;
+    /** Identifiant de la ressource créée/modifiée, si applicable. */
+    resourceId?: string;
+  };
+
+  /** Le statut de planning d'un membre a été modifié. */
+  "planning:status:changed": {
+    eventId: string;
+    churchId: string;
+    departmentId: string;
+    memberId: string;
+    newStatus: string | null;
+    changedById: string;
+  };
+}

--- a/src/modules/planning/index.ts
+++ b/src/modules/planning/index.ts
@@ -1,5 +1,8 @@
 import { defineModule } from "@/core/module-registry";
 
+export { planningBus } from "./bus";
+export type { PlanningEvents } from "./events";
+
 /**
  * Module planning — ex-Koinonia.
  *


### PR DESCRIPTION
## Résumé

- Définit `PlanningEvents` — carte des 4 événements du module planning (event:created, event:cancelled, request:executed, status:changed)
- Crée `planningBus = new EventBus<PlanningEvents>()` — singleton process-level exporté depuis `src/modules/planning/index.ts`
- Wire `planning:event:created` dans `POST /api/events` : émission à l'intérieur de la transaction Prisma (cas récurrence + cas single event, maintenant wrappé dans `$transaction`)
- 7 tests unitaires couvrant : émission simple, série récurrente, cascade d'erreur, listenerCount

## Architecture

L'EventBus est transaction-aware : les handlers s'exécutent dans la même `tx` que la création de l'événement. Si un handler throw, la transaction est rollback.

Aucun handler n'est enregistré pour l'instant — les modules futurs (discipleship, media…) s'abonneront via `planningBus.on(...)`.

## Plan de test

- [ ] `npm run typecheck` — aucune erreur TS
- [ ] `npx vitest run` — 213/213 tests passent
- [ ] Créer un événement via `/admin/events` → vérifier que ça fonctionne toujours

🤖 Generated with [Claude Code](https://claude.com/claude-code)