### PR TITLE
feat(planning): déplacer request-executor dans le module + émissions EventBus

### DIFF
--- a/src/app/api/requests/[id]/route.ts
+++ b/src/app/api/requests/[id]/route.ts
@@ -2,8 +2,8 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { hasPermission } from "@/lib/permissions";
-import { executeRequest } from "@/lib/request-executor";
+import { rolePermissions } from "@/lib/registry";
+import { executeRequest } from "@/modules/planning";
 import { z } from "zod";
 import type { Prisma } from "@/generated/prisma/client";
 
@@ -47,7 +47,7 @@ export async function GET(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === minimal.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
     const userDeptIds = session.user.churchRoles
@@ -131,7 +131,7 @@ export async function PATCH(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === existing.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || userPermissions.has("events:manage");

--- a/src/modules/__tests__/request-executor.test.ts
+++ b/src/modules/__tests__/request-executor.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { executeRequest } from "@/modules/planning";
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+// executeRequest takes a tx (transaction client), use prismaMock directly
+const tx = prismaMock as unknown as Parameters<typeof executeRequest>[0];
+
+describe("executeDemandeAcces — privilege escalation prevention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.user.findUnique.mockResolvedValue({ id: "user-1" });
+  });
+
+  it("rejects SUPER_ADMIN role", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "SUPER_ADMIN",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non autorisé");
+  });
+
+  it("rejects ADMIN role", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "ADMIN",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non autorisé");
+  });
+
+  it("rejects SECRETARY role", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "SECRETARY",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non autorisé");
+  });
+
+  it("allows DISCIPLE_MAKER role", async () => {
+    prismaMock.userChurchRole.create.mockResolvedValue({ id: "role-1" });
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "DISCIPLE_MAKER",
+    }, "approver-1");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("allows REPORTER role", async () => {
+    prismaMock.userChurchRole.create.mockResolvedValue({ id: "role-1" });
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "REPORTER",
+    }, "approver-1");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("allows MINISTER role with valid ministryId", async () => {
+    prismaMock.ministry.count.mockResolvedValue(1);
+    prismaMock.userChurchRole.create.mockResolvedValue({ id: "role-1" });
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "MINISTER",
+      ministryId: "ministry-1",
+    }, "approver-1");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects MINISTER without ministryId", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "MINISTER",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ministryId requis");
+  });
+
+  it("rejects MINISTER with cross-tenant ministryId", async () => {
+    prismaMock.ministry.count.mockResolvedValue(0); // 0 = not in this church
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "MINISTER",
+      ministryId: "ministry-other-church",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("hors périmètre");
+  });
+
+  it("allows DEPARTMENT_HEAD with valid departmentIds", async () => {
+    prismaMock.department.count.mockResolvedValue(1);
+    prismaMock.userChurchRole.create.mockResolvedValue({ id: "role-1" });
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "DEPARTMENT_HEAD",
+      departmentIds: ["dept-1"],
+    }, "approver-1");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects DEPARTMENT_HEAD without departmentIds", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "DEPARTMENT_HEAD",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("departmentIds requis");
+  });
+
+  it("rejects DEPARTMENT_HEAD with empty departmentIds", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "DEPARTMENT_HEAD",
+      departmentIds: [],
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("departmentIds requis");
+  });
+
+  it("rejects DEPARTMENT_HEAD with cross-tenant departmentIds", async () => {
+    prismaMock.department.count.mockResolvedValue(0); // 0 of 1 valid
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "DEPARTMENT_HEAD",
+      departmentIds: ["dept-other-church"],
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("hors périmètre");
+  });
+
+  it("rejects unknown/arbitrary role string", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "OWNER",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non autorisé");
+  });
+});
+
+describe("executeAjoutEvenement — date validation / DoS prevention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.event.create.mockResolvedValue({ id: "evt-1" });
+  });
+
+  it("rejects invalid eventDate", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "AJOUT_EVENEMENT", {
+      eventTitle: "Culte",
+      eventType: "CULTE",
+      eventDate: "not-a-date",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("eventDate invalide");
+  });
+
+  it("rejects invalid recurrenceEnd", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "AJOUT_EVENEMENT", {
+      eventTitle: "Culte",
+      eventType: "CULTE",
+      eventDate: "2025-01-05",
+      recurrenceRule: "weekly",
+      recurrenceEnd: "not-a-date",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("recurrenceEnd invalide");
+  });
+
+  it("caps recurrence at 104 occurrences (no infinite loop)", async () => {
+    prismaMock.event.create.mockResolvedValue({ id: "evt-1" });
+    prismaMock.eventDepartment.createMany.mockResolvedValue({ count: 0 });
+
+    // recurrenceEnd far in the future — would create hundreds of events without the cap
+    const result = await executeRequest(tx, "req-1", "church-1", "AJOUT_EVENEMENT", {
+      eventTitle: "Culte",
+      eventType: "CULTE",
+      eventDate: "2020-01-05",
+      recurrenceRule: "weekly",
+      recurrenceEnd: "2100-01-01",
+    }, "approver-1");
+
+    // Should succeed but capped, and signal truncation
+    expect(result.success).toBe(true);
+    expect(result.recurrenceTruncated).toBe(true);
+    expect(result.maxOccurrences).toBe(104);
+    // Total event.create calls: 1 (parent) + at most 104 (children)
+    expect(prismaMock.event.create.mock.calls.length).toBeLessThanOrEqual(105);
+  });
+});

--- a/src/modules/planning/index.ts
+++ b/src/modules/planning/index.ts
@@ -2,6 +2,8 @@ import { defineModule } from "@/core/module-registry";
 
 export { planningBus } from "./bus";
 export type { PlanningEvents } from "./events";
+export { executeRequest } from "./services/request-executor";
+export type { ExecutionResult } from "./services/request-executor";
 
 /**
  * Module planning — ex-Koinonia.

--- a/src/modules/planning/services/request-executor.ts
+++ b/src/modules/planning/services/request-executor.ts
@@ -1,52 +1,100 @@
 import type { Prisma } from "@/generated/prisma/client";
+import { planningBus } from "../bus";
 
-interface ExecutionResult {
+export interface ExecutionResult {
   success: boolean;
   error?: string;
+  /** ID de la ressource créée ou modifiée (event, role…), si applicable. */
+  resourceId?: string;
   recurrenceTruncated?: boolean;
   maxOccurrences?: number;
+  /** Nombre d'occurrences enfants créées (AJOUT_EVENEMENT récurrent uniquement). */
+  childCount?: number;
 }
 
 type TxClient = Prisma.TransactionClient;
 
 /**
- * Execute the action associated with an approved request.
- * Called within a transaction after status is set to APPROUVEE.
- * On success, sets status to EXECUTEE. On failure, sets ERREUR + executionError.
+ * Exécute l'action associée à une demande approuvée.
+ *
+ * Doit être appelé dans une transaction Prisma.
+ * En cas de succès émet les événements planningBus correspondants.
+ * Retourne `{ success: false, error }` sans throw — l'appelant gère ERREUR vs EXECUTEE.
  */
 export async function executeRequest(
   tx: TxClient,
-  _requestId: string,
+  requestId: string,
   churchId: string,
   type: string,
   payload: Record<string, unknown>,
-  _approvedById: string
+  userId: string
 ): Promise<ExecutionResult> {
+  const ctx = { tx, churchId, userId };
+
   try {
+    let result: ExecutionResult;
+
     switch (type) {
       case "AJOUT_EVENEMENT":
-        return await executeAjoutEvenement(tx, churchId, payload);
-
+        result = await executeAjoutEvenement(tx, churchId, payload);
+        break;
       case "MODIFICATION_EVENEMENT":
-        return await executeModificationEvenement(tx, churchId, payload);
-
+        result = await executeModificationEvenement(tx, churchId, payload);
+        break;
       case "ANNULATION_EVENEMENT":
-        return await executeAnnulationEvenement(tx, churchId, payload);
-
+        result = await executeAnnulationEvenement(tx, churchId, payload);
+        break;
       case "MODIFICATION_PLANNING":
-        return await executeModificationPlanning(tx, churchId, payload);
-
+        result = await executeModificationPlanning(tx, churchId, payload);
+        break;
       case "DEMANDE_ACCES":
-        return await executeDemandeAcces(tx, churchId, payload);
-
+        result = await executeDemandeAcces(tx, churchId, payload);
+        break;
       default:
         return { success: false, error: `Type de demande non exécutable : ${type}` };
     }
+
+    if (!result.success) return result;
+
+    // Événements spécifiques par type
+    if (type === "AJOUT_EVENEMENT" && result.resourceId) {
+      await planningBus.emit("planning:event:created", ctx, {
+        eventId: result.resourceId,
+        churchId,
+        title: payload.eventTitle as string,
+        type: payload.eventType as string,
+        createdById: userId,
+        isRecurrenceParent: !!(payload.recurrenceRule && payload.recurrenceEnd),
+        childCount: result.childCount,
+      });
+    }
+
+    if (type === "ANNULATION_EVENEMENT" && result.resourceId) {
+      await planningBus.emit("planning:event:cancelled", ctx, {
+        eventId: result.resourceId,
+        churchId,
+        cancelledById: userId,
+        requestId,
+      });
+    }
+
+    // Événement générique — émis pour toute exécution réussie
+    await planningBus.emit("planning:request:executed", ctx, {
+      requestId,
+      requestType: type,
+      churchId,
+      executedById: userId,
+      resourceId: result.resourceId,
+    });
+
+    return result;
   } catch (error) {
     const message = error instanceof Error ? error.message : "Erreur inconnue";
     return { success: false, error: message };
   }
 }
+
+// ─── Helpers internes ─────────────────────────────────────────────────────────
 
 function computeDeadlineFromOffset(eventDate: Date, offset: string): Date {
   const result = new Date(eventDate);
@@ -61,7 +109,11 @@ function computeDeadlineFromOffset(eventDate: Date, offset: string): Date {
 
 const MAX_RECURRENCE_OCCURRENCES = 104; // ~2 ans hebdomadaires
 
-function generateRecurrenceDates(startDate: Date, rule: string, endDate: Date): { dates: Date[]; truncated: boolean } {
+function generateRecurrenceDates(
+  startDate: Date,
+  rule: string,
+  endDate: Date
+): { dates: Date[]; truncated: boolean } {
   if (isNaN(endDate.getTime())) return { dates: [], truncated: false };
   const dates: Date[] = [];
   const current = new Date(startDate);
@@ -76,6 +128,8 @@ function generateRecurrenceDates(startDate: Date, rule: string, endDate: Date): 
   const truncated = dates.length === MAX_RECURRENCE_OCCURRENCES && current <= endDate;
   return { dates, truncated };
 }
+
+// ─── Exécuteurs par type ──────────────────────────────────────────────────────
 
 async function executeAjoutEvenement(
   tx: TxClient,
@@ -100,11 +154,8 @@ async function executeAjoutEvenement(
     return { success: false, error: "eventDate invalide" };
   }
 
-  if (recurrenceEnd) {
-    const endDateCheck = new Date(recurrenceEnd);
-    if (isNaN(endDateCheck.getTime())) {
-      return { success: false, error: "recurrenceEnd invalide" };
-    }
+  if (recurrenceEnd && isNaN(new Date(recurrenceEnd).getTime())) {
+    return { success: false, error: "recurrenceEnd invalide" };
   }
 
   if (departmentIds && departmentIds.length > 0) {
@@ -128,15 +179,7 @@ async function executeAjoutEvenement(
     const { dates: childDates, truncated } = generateRecurrenceDates(eventDate, recurrenceRule, endDate);
 
     const parent = await tx.event.create({
-      data: {
-        title,
-        type,
-        date: eventDate,
-        churchId,
-        planningDeadline: deadline,
-        recurrenceRule,
-        isRecurrenceParent: true,
-      },
+      data: { title, type, date: eventDate, churchId, planningDeadline: deadline, recurrenceRule, isRecurrenceParent: true },
     });
 
     if (departmentIds && departmentIds.length > 0) {
@@ -146,22 +189,10 @@ async function executeAjoutEvenement(
     }
 
     for (const childDate of childDates) {
-      const childDeadline = useOffset
-        ? computeDeadlineFromOffset(childDate, deadlineOffset!)
-        : deadline;
-
+      const childDeadline = useOffset ? computeDeadlineFromOffset(childDate, deadlineOffset!) : deadline;
       const child = await tx.event.create({
-        data: {
-          title,
-          type,
-          date: childDate,
-          churchId,
-          planningDeadline: childDeadline,
-          recurrenceRule,
-          seriesId: parent.id,
-        },
+        data: { title, type, date: childDate, churchId, planningDeadline: childDeadline, recurrenceRule, seriesId: parent.id },
       });
-
       if (departmentIds && departmentIds.length > 0) {
         await tx.eventDepartment.createMany({
           data: departmentIds.map((departmentId) => ({ eventId: child.id, departmentId })),
@@ -171,18 +202,14 @@ async function executeAjoutEvenement(
 
     return {
       success: true,
+      resourceId: parent.id,
+      childCount: childDates.length,
       ...(truncated ? { recurrenceTruncated: true, maxOccurrences: MAX_RECURRENCE_OCCURRENCES } : {}),
     };
   }
 
   const event = await tx.event.create({
-    data: {
-      title,
-      type,
-      date: eventDate,
-      churchId,
-      planningDeadline: deadline,
-    },
+    data: { title, type, date: eventDate, churchId, planningDeadline: deadline },
   });
 
   if (departmentIds && departmentIds.length > 0) {
@@ -191,7 +218,7 @@ async function executeAjoutEvenement(
     });
   }
 
-  return { success: true };
+  return { success: true, resourceId: event.id };
 }
 
 async function executeModificationEvenement(
@@ -207,12 +234,8 @@ async function executeModificationEvenement(
   }
 
   const event = await tx.event.findUnique({ where: { id: eventId }, select: { id: true, churchId: true } });
-  if (!event) {
-    return { success: false, error: "Événement introuvable" };
-  }
-  if (event.churchId !== churchId) {
-    return { success: false, error: "Événement hors périmètre" };
-  }
+  if (!event) return { success: false, error: "Événement introuvable" };
+  if (event.churchId !== churchId) return { success: false, error: "Événement hors périmètre" };
 
   await tx.event.update({
     where: { id: eventId },
@@ -226,7 +249,7 @@ async function executeModificationEvenement(
     },
   });
 
-  return { success: true };
+  return { success: true, resourceId: eventId };
 }
 
 async function executeAnnulationEvenement(
@@ -236,20 +259,14 @@ async function executeAnnulationEvenement(
 ): Promise<ExecutionResult> {
   const eventId = payload.eventId as string;
 
-  if (!eventId) {
-    return { success: false, error: "Données manquantes : eventId" };
-  }
+  if (!eventId) return { success: false, error: "Données manquantes : eventId" };
 
   const event = await tx.event.findUnique({
     where: { id: eventId },
     include: { eventDepts: { select: { id: true } } },
   });
-  if (!event) {
-    return { success: false, error: "Événement introuvable" };
-  }
-  if (event.churchId !== churchId) {
-    return { success: false, error: "Événement hors périmètre" };
-  }
+  if (!event) return { success: false, error: "Événement introuvable" };
+  if (event.churchId !== churchId) return { success: false, error: "Événement hors périmètre" };
 
   const edIds = event.eventDepts.map((ed) => ed.id);
   if (edIds.length > 0) {
@@ -259,7 +276,7 @@ async function executeAnnulationEvenement(
   }
   await tx.event.delete({ where: { id: eventId } });
 
-  return { success: true };
+  return { success: true, resourceId: eventId };
 }
 
 async function executeModificationPlanning(
@@ -275,12 +292,8 @@ async function executeModificationPlanning(
   }
 
   const event = await tx.event.findUnique({ where: { id: eventId }, select: { id: true, churchId: true } });
-  if (!event) {
-    return { success: false, error: "Événement introuvable" };
-  }
-  if (event.churchId !== churchId) {
-    return { success: false, error: "Événement hors périmètre" };
-  }
+  if (!event) return { success: false, error: "Événement introuvable" };
+  if (event.churchId !== churchId) return { success: false, error: "Événement hors périmètre" };
 
   if (departmentIds.length > 0) {
     const validDepts = await tx.department.count({
@@ -291,44 +304,30 @@ async function executeModificationPlanning(
     }
   }
 
-  // Fetch current EventDepartment records for this event
   const currentEventDepts = await tx.eventDepartment.findMany({
     where: { eventId },
     select: { id: true, departmentId: true },
   });
 
   const currentDeptIds = currentEventDepts.map((ed) => ed.departmentId);
-  const requestedDeptIds = departmentIds;
+  const toAdd = departmentIds.filter((id) => !currentDeptIds.includes(id));
+  const toRemove = currentEventDepts.filter((ed) => !departmentIds.includes(ed.departmentId));
 
-  // Departments to add: in requested but not in current
-  const toAdd = requestedDeptIds.filter((id) => !currentDeptIds.includes(id));
-
-  // Departments to remove: in current but not in requested
-  const toRemove = currentEventDepts.filter((ed) => !requestedDeptIds.includes(ed.departmentId));
-
-  // Remove departments: cascade delete plannings first, then EventDepartment records
   if (toRemove.length > 0) {
     const removeIds = toRemove.map((ed) => ed.id);
     await tx.planning.deleteMany({ where: { eventDepartmentId: { in: removeIds } } });
     await tx.eventDepartment.deleteMany({ where: { id: { in: removeIds } } });
   }
 
-  // Add new departments
   if (toAdd.length > 0) {
     await tx.eventDepartment.createMany({
       data: toAdd.map((departmentId) => ({ eventId, departmentId })),
     });
   }
 
-  return {
-    success: true,
-    error: undefined,
-  };
+  return { success: true, resourceId: eventId };
 }
 
-// Rôles pouvant être attribués via une DEMANDE_ACCES.
-// SUPER_ADMIN, ADMIN, SECRETARY sont explicitement exclus — ils ne peuvent
-// être assignés que par un super-administrateur via l'interface d'administration.
 const DEMANDE_ACCES_ALLOWED_ROLES = [
   "MINISTER",
   "DEPARTMENT_HEAD",
@@ -354,7 +353,6 @@ async function executeDemandeAcces(
     return { success: false, error: `Rôle non autorisé via demande d'accès : ${role}` };
   }
 
-  // MINISTER et DEPARTMENT_HEAD nécessitent un scope obligatoire
   if (role === "MINISTER" && !ministryId) {
     return { success: false, error: "ministryId requis pour le rôle MINISTER" };
   }
@@ -363,15 +361,11 @@ async function executeDemandeAcces(
   }
 
   const user = await tx.user.findUnique({ where: { id: targetUserId }, select: { id: true } });
-  if (!user) {
-    return { success: false, error: "Utilisateur cible introuvable" };
-  }
+  if (!user) return { success: false, error: "Utilisateur cible introuvable" };
 
   if (ministryId) {
     const validMinistry = await tx.ministry.count({ where: { id: ministryId, churchId } });
-    if (validMinistry === 0) {
-      return { success: false, error: "Ministère invalide ou hors périmètre" };
-    }
+    if (validMinistry === 0) return { success: false, error: "Ministère invalide ou hors périmètre" };
   }
 
   if (departmentIds && departmentIds.length > 0) {
@@ -383,21 +377,18 @@ async function executeDemandeAcces(
     }
   }
 
-  await tx.userChurchRole.create({
+  const ucr = await tx.userChurchRole.create({
     data: {
       userId: targetUserId,
       churchId,
       role: role as "MINISTER" | "DEPARTMENT_HEAD" | "DISCIPLE_MAKER" | "REPORTER",
       ...(role === "MINISTER" && ministryId ? { ministryId } : {}),
       ...(role === "DEPARTMENT_HEAD" && departmentIds?.length
-        ? {
-            departments: {
-              create: departmentIds.map((departmentId) => ({ departmentId })),
-            },
-          }
+        ? { departments: { create: departmentIds.map((departmentId) => ({ departmentId })) } }
         : {}),
     },
+    select: { id: true },
   });
 
-  return { success: true };
+  return { success: true, resourceId: ucr.id };
 }


### PR DESCRIPTION
## Résumé

- Déplace `src/lib/request-executor.ts` → `src/modules/planning/services/request-executor.ts`
- Enrichit `ExecutionResult` avec `resourceId` et `childCount`
- 3 émissions EventBus câblées dans les exécuteurs :
  - `AJOUT_EVENEMENT` → `planning:event:created` (avec eventId + childCount pour les récurrences)
  - `ANNULATION_EVENEMENT` → `planning:event:cancelled`
  - Toute exécution réussie → `planning:request:executed` (catch-all)
- Exporte `executeRequest` + `ExecutionResult` depuis `src/modules/planning/index.ts`
- Migre `src/app/api/requests/[id]/route.ts` : import depuis `@/modules/planning`, `hasPermission` → `rolePermissions`
- Déplace le test vers `src/modules/__tests__/request-executor.test.ts`

## Frontières modules

`npm run lint:boundaries` — aucune violation (20 modules, 34 dépendances)

## Plan de test

- [ ] `npm run typecheck` — aucune erreur TS
- [ ] `npx vitest run` — 213/213 tests passent
- [ ] Approuver une demande AJOUT_EVENEMENT → vérifier que l'événement est créé et que le bus émet

🤖 Generated with [Claude Code](https://claude.com/claude-code)