### PR TITLE
feat(discipleship): premier handler cross-module — cleanup attendance sur annulation

### DIFF
--- a/src/lib/__tests__/registry-handlers.test.ts
+++ b/src/lib/__tests__/registry-handlers.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+/**
+ * Vérifie les abonnements cross-module enregistrés dans src/lib/registry.ts.
+ *
+ * On importe le registry APRÈS le mock prisma pour que les handlers
+ * s'enregistrent sur planningBus avec le tx mock.
+ */
+describe("registry — abonnements cross-module", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Réinitialiser le bus entre les tests pour isoler les handlers
+    const { planningBus } = await import("@/modules/planning");
+    planningBus.clear();
+    // Ré-importer le registry pour re-enregistrer les handlers
+    vi.resetModules();
+  });
+
+  it("planning:event:cancelled supprime les DiscipleshipAttendance liées", async () => {
+    // Réinitialiser les modules pour obtenir un bus propre avec handlers fraîchement enregistrés
+    vi.resetModules();
+    const { planningBus } = await import("@/modules/planning");
+    // Charger le registry pour enregistrer les handlers
+    await import("@/lib/registry");
+
+    prismaMock.discipleshipAttendance.deleteMany.mockResolvedValue({ count: 2 });
+
+    const fakeTx = prismaMock as unknown as Parameters<typeof planningBus.emit>[1]["tx"];
+
+    await planningBus.emit(
+      "planning:event:cancelled",
+      { tx: fakeTx, churchId: "church-1", userId: "user-1" },
+      { eventId: "evt-1", churchId: "church-1", cancelledById: "user-1" }
+    );
+
+    expect(prismaMock.discipleshipAttendance.deleteMany).toHaveBeenCalledOnce();
+    expect(prismaMock.discipleshipAttendance.deleteMany).toHaveBeenCalledWith({
+      where: { eventId: "evt-1" },
+    });
+  });
+
+  it("planning:event:created ne déclenche pas de suppression d'attendance", async () => {
+    vi.resetModules();
+    const { planningBus } = await import("@/modules/planning");
+    await import("@/lib/registry");
+
+    const fakeTx = prismaMock as unknown as Parameters<typeof planningBus.emit>[1]["tx"];
+
+    await planningBus.emit(
+      "planning:event:created",
+      { tx: fakeTx, churchId: "church-1", userId: "user-1" },
+      {
+        eventId: "evt-1",
+        churchId: "church-1",
+        title: "Culte",
+        type: "CULTE",
+        createdById: "user-1",
+        isRecurrenceParent: false,
+      }
+    );
+
+    expect(prismaMock.discipleshipAttendance.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,7 +1,7 @@
 import { boot } from "@/core/boot";
 import { buildRolePermissions } from "@/core/permissions";
 import { coreModule } from "@/modules/core";
-import { planningModule } from "@/modules/planning";
+import { planningModule, planningBus } from "@/modules/planning";
 import { discipleshipModule } from "@/modules/discipleship";
 
 /**
@@ -19,3 +19,20 @@ export const registry = boot({
  * Remplace ROLE_PERMISSIONS de src/lib/permissions.ts dans les guards API.
  */
 export const rolePermissions = buildRolePermissions(registry);
+
+// ─── Abonnements cross-module ─────────────────────────────────────────────────
+//
+// Le registry est la racine de composition : seul endroit où tous les modules
+// sont visibles. Les abonnements ici permettent à un module de réagir aux
+// événements d'un autre sans importer directement depuis ce module.
+
+/**
+ * Discipleship → Planning : quand un événement est annulé, supprimer les
+ * enregistrements de présence discipleship liés (évite une FK violation et
+ * maintient la cohérence des données de suivi).
+ *
+ * S'exécute dans la même transaction que la suppression de l'événement.
+ */
+planningBus.on("planning:event:cancelled", async ({ tx }, { eventId }) => {
+  await tx.discipleshipAttendance.deleteMany({ where: { eventId } });
+});

--- a/src/modules/planning/services/request-executor.ts
+++ b/src/modules/planning/services/request-executor.ts
@@ -42,7 +42,9 @@ export async function executeRequest(
         result = await executeModificationEvenement(tx, churchId, payload);
         break;
       case "ANNULATION_EVENEMENT":
-        result = await executeAnnulationEvenement(tx, churchId, payload);
+        // ctx + requestId passés pour émettre planning:event:cancelled AVANT la suppression
+        // (les handlers doivent nettoyer les FK avant que l'event soit supprimé)
+        result = await executeAnnulationEvenement(tx, churchId, payload, ctx, requestId);
         break;
       case "MODIFICATION_PLANNING":
         result = await executeModificationPlanning(tx, churchId, payload);
@@ -66,15 +68,6 @@ export async function executeRequest(
         createdById: userId,
         isRecurrenceParent: !!(payload.recurrenceRule && payload.recurrenceEnd),
         childCount: result.childCount,
-      });
-    }
-
-    if (type === "ANNULATION_EVENEMENT" && result.resourceId) {
-      await planningBus.emit("planning:event:cancelled", ctx, {
-        eventId: result.resourceId,
-        churchId,
-        cancelledById: userId,
-        requestId,
       });
     }
 
@@ -255,7 +248,9 @@ async function executeModificationEvenement(
 async function executeAnnulationEvenement(
   tx: TxClient,
   churchId: string,
-  payload: Record<string, unknown>
+  payload: Record<string, unknown>,
+  ctx: { tx: TxClient; churchId: string; userId: string },
+  requestId: string
 ): Promise<ExecutionResult> {
   const eventId = payload.eventId as string;
 
@@ -267,6 +262,15 @@ async function executeAnnulationEvenement(
   });
   if (!event) return { success: false, error: "Événement introuvable" };
   if (event.churchId !== churchId) return { success: false, error: "Événement hors périmètre" };
+
+  // Émettre AVANT la suppression : les handlers (ex. discipleship) doivent
+  // nettoyer leurs FK dans la même transaction avant que l'event soit supprimé.
+  await planningBus.emit("planning:event:cancelled", ctx, {
+    eventId,
+    churchId,
+    cancelledById: ctx.userId,
+    requestId,
+  });
 
   const edIds = event.eventDepts.map((ed) => ed.id);
   if (edIds.length > 0) {


### PR DESCRIPTION
## Problème corrigé

`executeAnnulationEvenement` supprimait l'`Event` sans nettoyer `DiscipleshipAttendance`. Sans `ON DELETE CASCADE` dans le schéma, cette suppression levait une FK violation silencieuse dès qu'un événement avait des présences discipleship enregistrées.

## Solution

L'émission du bus est déplacée **avant** la suppression :

```
executeAnnulationEvenement
  1. valide l'event
  2. planningBus.emit("planning:event:cancelled")   ← handlers dans la même tx
     └── registry handler : discipleshipAttendance.deleteMany
  3. planning.deleteMany + eventDepartment.deleteMany + event.delete
```

Tout s'exécute dans la même `$transaction` Prisma — si le handler ou la suppression échoue, la transaction entière est rollback.

## Changements

- `src/modules/planning/services/request-executor.ts` : signature `executeAnnulationEvenement` accepte `ctx` + `requestId`, émet avant la suppression
- `src/lib/registry.ts` : premier handler cross-module enregistré sur `planning:event:cancelled`
- `src/lib/__tests__/registry-handlers.test.ts` : 2 tests (cleanup déclenché, isolation event:created)

## Plan de test

- [ ] `npm run typecheck` — aucune erreur TS
- [ ] `npx vitest run` — 215/215 tests passent
- [ ] `npm run lint:boundaries` — aucune violation
- [ ] Annuler un événement via ANNULATION_EVENEMENT → vérifier que les présences discipleship sont supprimées

🤖 Generated with [Claude Code](https://claude.com/claude-code)