### PR TITLE
feat(v1.0): services planning + bus d'événements + migration permissions

### DIFF
--- a/src/app/(auth)/admin/discipleship/page.tsx
+++ b/src/app/(auth)/admin/discipleship/page.tsx
@@ -1,5 +1,5 @@
 import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import DiscipleshipClient from "./DiscipleshipClient";
 
@@ -18,7 +18,7 @@ export default async function DiscipleshipPage() {
 
   const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   const userPermissions = new Set(
-    churchRoles.flatMap((r) => hasPermission(r.role))
+    churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
 
   const canManage = userPermissions.has("discipleship:manage");

--- a/src/app/(auth)/admin/events/[eventId]/report/page.tsx
+++ b/src/app/(auth)/admin/events/[eventId]/report/page.tsx
@@ -1,5 +1,5 @@
 import { requireAuth } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import EventReportClient from "./EventReportClient";
@@ -39,7 +39,7 @@ export default async function EventReportPage({
 
   // Allow access if user has events:manage OR reports:view for this church
   const churchRoles = session.user.churchRoles.filter((r) => r.churchId === event.churchId);
-  const perms = new Set(churchRoles.flatMap((r) => hasPermission(r.role)));
+  const perms = new Set(churchRoles.flatMap((r) => rolePermissions[r.role] ?? []));
   if (!perms.has("events:manage") && !perms.has("reports:view")) {
     const { ApiError } = await import("@/lib/api-utils");
     throw new ApiError(403, "Forbidden");

--- a/src/app/(auth)/admin/members/page.tsx
+++ b/src/app/(auth)/admin/members/page.tsx
@@ -1,5 +1,5 @@
 import { requireAuth, getCurrentChurchId, requireChurchPermission, getUserDepartmentScope } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import MembersClient from "./MembersClient";
 import LinkRequestsClient from "./LinkRequestsClient";
@@ -11,7 +11,7 @@ export default async function MembersPage() {
   await requireChurchPermission("members:view", churchId);
   const churchRoles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   const userPermissions = new Set(
-    churchRoles.flatMap((r) => hasPermission(r.role))
+    churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canManage = userPermissions.has("members:manage");
   const scope = getUserDepartmentScope(session);

--- a/src/app/(auth)/admin/page.tsx
+++ b/src/app/(auth)/admin/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 
 export default async function AdminPage() {
   const session = await requireAuth();
@@ -8,7 +8,7 @@ export default async function AdminPage() {
   if (churchId) await requireChurchPermission("members:manage", churchId);
 
   const userRoles = session.user.churchRoles.map((r) => r.role);
-  const userPermissions = new Set(userRoles.flatMap((r) => hasPermission(r)));
+  const userPermissions = new Set(userRoles.flatMap((r) => rolePermissions[r] ?? []));
 
   if (userPermissions.has("church:manage")) {
     redirect("/admin/churches");

--- a/src/app/(auth)/communication/requests/page.tsx
+++ b/src/app/(auth)/communication/requests/page.tsx
@@ -1,5 +1,5 @@
 import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import { DEPT_FN } from "@/lib/department-functions";
 import { notFound } from "next/navigation";
@@ -18,7 +18,7 @@ export default async function CommunicationRequestsPage() {
 
   if (commDept) {
     const userPermissions = new Set(
-      session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+      session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
     const userDeptIds = session.user.churchRoles.flatMap((r) =>

--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import { auth, getCurrentChurchId } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import EventSelector from "@/components/EventSelector";
@@ -26,7 +26,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
 
   const currentChurchId = await getCurrentChurchId(session);
   const userPermissions = new Set(
-    session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+    session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canEditPlanning = userPermissions.has("planning:edit");
 

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import Image from "next/image";
 import { auth, signOut, getCurrentChurchId } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import ChurchSwitcher from "@/components/ChurchSwitcher";
 import AuthLayoutShell from "@/components/AuthLayoutShell";
 import NotificationBell from "@/components/NotificationBell";
@@ -72,7 +72,7 @@ export default async function AuthLayout({
 
   // Compute visible config links
   const userRoles = churchRoles.map((r) => r.role);
-  const userPermissions = new Set(userRoles.flatMap((r) => hasPermission(r)));
+  const userPermissions = new Set(userRoles.flatMap((r) => rolePermissions[r] ?? []));
   // Super admins have all permissions regardless of church roles
   if (session.user.isSuperAdmin) {
     configLinksDef.forEach((l) => l.permissions.forEach((p) => userPermissions.add(p)));

--- a/src/app/(auth)/media/requests/page.tsx
+++ b/src/app/(auth)/media/requests/page.tsx
@@ -1,5 +1,5 @@
 import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
@@ -20,7 +20,7 @@ export default async function MediaRequestsPage() {
 
   if (mediaDept) {
     const userPermissions = new Set(
-      session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+      session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
     const userDeptIds = session.user.churchRoles.flatMap((r) =>

--- a/src/app/(auth)/requests/[id]/edit/page.tsx
+++ b/src/app/(auth)/requests/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { requireAuth, getCurrentChurchId, requireChurchPermission } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import RequestForm, { type EditData } from "../../new/RequestForm";
 
@@ -48,7 +48,7 @@ export default async function EditRequestPage({ params }: Props) {
   const churchPermissions = new Set(
     session.user.churchRoles
       .filter((r) => r.churchId === churchId)
-      .flatMap((r) => hasPermission(r.role))
+      .flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canSubmitDemands = churchPermissions.has("planning:edit") || session.user.isSuperAdmin;
 

--- a/src/app/(auth)/requests/new/page.tsx
+++ b/src/app/(auth)/requests/new/page.tsx
@@ -1,5 +1,5 @@
 import { requireAuth, getCurrentChurchId, requireChurchPermission } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import RequestForm from "./RequestForm";
 
@@ -12,7 +12,7 @@ export default async function NewRequestPage() {
   const churchPermissions = new Set(
     session.user.churchRoles
       .filter((r) => r.churchId === churchId)
-      .flatMap((r) => hasPermission(r.role))
+      .flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canSubmitDemands = churchPermissions.has("planning:edit") || session.user.isSuperAdmin;
 

--- a/src/app/(auth)/secretariat/requests/page.tsx
+++ b/src/app/(auth)/secretariat/requests/page.tsx
@@ -1,5 +1,5 @@
 import { requireAuth, getCurrentChurchId, requireChurchPermission } from "@/lib/auth";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import { DEPT_FN } from "@/lib/department-functions";
 import { notFound } from "next/navigation";
@@ -18,7 +18,7 @@ export default async function SecretariatRequestsPage() {
 
   // Access check: events:manage OR member of secretariat dept
   const userPermissions = new Set(
-    session.user.churchRoles.flatMap((r) => hasPermission(r.role))
+    session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
 

--- a/src/app/api/announcements/[id]/route.ts
+++ b/src/app/api/announcements/[id]/route.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { z } from "zod";
 
 const patchSchema = z.object({
@@ -38,7 +38,7 @@ export async function GET(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === minimal.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
     const isOwner = minimal.submittedById === session.user.id;
@@ -99,7 +99,7 @@ export async function PATCH(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === announcement.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || userPermissions.has("events:manage");
@@ -188,7 +188,7 @@ export async function DELETE(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === announcement.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || userPermissions.has("events:manage");

--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { DEPT_FN } from "@/lib/department-functions";
 import { z } from "zod";
@@ -48,7 +48,7 @@ export async function GET(request: Request) {
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || userPermissions.has("events:manage");

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -3,6 +3,7 @@ import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
+import { planningBus } from "@/modules/planning";
 import { z } from "zod";
 
 export async function GET(request: Request) {
@@ -232,6 +233,20 @@ export async function POST(request: Request) {
           });
         }
 
+        await planningBus.emit(
+          "planning:event:created",
+          { tx, churchId: data.churchId, userId: session.user.id },
+          {
+            eventId: parent.id,
+            churchId: data.churchId,
+            title: data.title,
+            type: data.type,
+            createdById: session.user.id,
+            isRecurrenceParent: true,
+            childCount: childDates.length,
+          }
+        );
+
         // Return parent with includes
         return tx.event.findUnique({
           where: { id: parent.id },
@@ -264,20 +279,37 @@ export async function POST(request: Request) {
     }
 
     // Single event creation
-    const event = await prisma.event.create({
-      data: {
-        title: data.title,
-        type: data.type,
-        date: new Date(data.date),
-        churchId: data.churchId,
-        planningDeadline: deadline,
-      },
-      include: {
-        church: { select: { id: true, name: true } },
-        eventDepts: {
-          include: { department: { select: { id: true, name: true } } },
+    const event = await prisma.$transaction(async (tx) => {
+      const created = await tx.event.create({
+        data: {
+          title: data.title,
+          type: data.type,
+          date: new Date(data.date),
+          churchId: data.churchId,
+          planningDeadline: deadline,
         },
-      },
+        include: {
+          church: { select: { id: true, name: true } },
+          eventDepts: {
+            include: { department: { select: { id: true, name: true } } },
+          },
+        },
+      });
+
+      await planningBus.emit(
+        "planning:event:created",
+        { tx, churchId: data.churchId, userId: session.user.id },
+        {
+          eventId: created.id,
+          churchId: data.churchId,
+          title: data.title,
+          type: data.type,
+          createdById: session.user.id,
+          isRecurrenceParent: false,
+        }
+      );
+
+      return created;
     });
 
     await logAudit({

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -3,7 +3,7 @@ import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
-import { planningBus } from "@/modules/planning";
+import { planningBus, deleteEvents } from "@/modules/planning";
 import { z } from "zod";
 
 export async function GET(request: Request) {
@@ -69,19 +69,10 @@ export async function PATCH(request: Request) {
 
     if (action === "delete") {
       await prisma.$transaction(async (tx) => {
-        const eventDeptIds = (
-          await tx.eventDepartment.findMany({
-            where: { eventId: { in: ids } },
-            select: { id: true },
-          })
-        ).map((ed) => ed.id);
-        await tx.planning.deleteMany({ where: { eventDepartmentId: { in: eventDeptIds } } });
-        await tx.eventDepartment.deleteMany({ where: { eventId: { in: ids } } });
-        await tx.discipleshipAttendance.deleteMany({ where: { eventId: { in: ids } } });
-        await tx.eventReport.deleteMany({ where: { eventId: { in: ids } } });
-        await tx.taskAssignment.deleteMany({ where: { eventId: { in: ids } } });
-        await tx.announcementEvent.deleteMany({ where: { eventId: { in: ids } } });
-        await tx.event.deleteMany({ where: { id: { in: ids } } });
+        await deleteEvents(
+          { tx, churchId: evtChurchId, userId: patchSession.user.id },
+          ids
+        );
       });
       for (const id of ids) {
         await logAudit({ userId: patchSession.user.id, churchId: evtChurchId, action: "DELETE", entityType: "Event", entityId: id });

--- a/src/app/api/requests/[id]/route.ts
+++ b/src/app/api/requests/[id]/route.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { executeRequest } from "@/lib/request-executor";
 import { z } from "zod";
 import type { Prisma } from "@/generated/prisma/client";
@@ -47,7 +47,7 @@ export async function GET(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === minimal.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
     const userDeptIds = session.user.churchRoles
@@ -131,7 +131,7 @@ export async function PATCH(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === existing.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || userPermissions.has("events:manage");

--- a/src/app/api/requests/[id]/route.ts
+++ b/src/app/api/requests/[id]/route.ts
@@ -2,8 +2,8 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { hasPermission } from "@/lib/permissions";
-import { executeRequest } from "@/lib/request-executor";
+import { rolePermissions } from "@/lib/registry";
+import { executeRequest } from "@/modules/planning";
 import { z } from "zod";
 import type { Prisma } from "@/generated/prisma/client";
 
@@ -47,7 +47,7 @@ export async function GET(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === minimal.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage = session.user.isSuperAdmin || userPermissions.has("events:manage");
     const userDeptIds = session.user.churchRoles
@@ -131,7 +131,7 @@ export async function PATCH(
     const userPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === existing.churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || userPermissions.has("events:manage");

--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { hasPermission } from "@/lib/permissions";
+import { rolePermissions } from "@/lib/registry";
 import { DEPT_FN } from "@/lib/department-functions";
 import { z } from "zod";
 
@@ -48,7 +48,7 @@ export async function GET(request: Request) {
     const churchPermissions = new Set(
       session.user.churchRoles
         .filter((r) => r.churchId === churchId)
-        .flatMap((r) => hasPermission(r.role))
+        .flatMap((r) => rolePermissions[r.role] ?? [])
     );
     const canManage =
       session.user.isSuperAdmin || churchPermissions.has("events:manage");

--- a/src/lib/__tests__/registry-handlers.test.ts
+++ b/src/lib/__tests__/registry-handlers.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+/**
+ * Vérifie les abonnements cross-module enregistrés dans src/lib/registry.ts.
+ *
+ * On importe le registry APRÈS le mock prisma pour que les handlers
+ * s'enregistrent sur planningBus avec le tx mock.
+ */
+describe("registry — abonnements cross-module", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Réinitialiser le bus entre les tests pour isoler les handlers
+    const { planningBus } = await import("@/modules/planning");
+    planningBus.clear();
+    // Ré-importer le registry pour re-enregistrer les handlers
+    vi.resetModules();
+  });
+
+  it("planning:event:cancelled supprime les DiscipleshipAttendance liées", async () => {
+    // Réinitialiser les modules pour obtenir un bus propre avec handlers fraîchement enregistrés
+    vi.resetModules();
+    const { planningBus } = await import("@/modules/planning");
+    // Charger le registry pour enregistrer les handlers
+    await import("@/lib/registry");
+
+    prismaMock.discipleshipAttendance.deleteMany.mockResolvedValue({ count: 2 });
+
+    const fakeTx = prismaMock as unknown as Parameters<typeof planningBus.emit>[1]["tx"];
+
+    await planningBus.emit(
+      "planning:event:cancelled",
+      { tx: fakeTx, churchId: "church-1", userId: "user-1" },
+      { eventId: "evt-1", churchId: "church-1", cancelledById: "user-1" }
+    );
+
+    expect(prismaMock.discipleshipAttendance.deleteMany).toHaveBeenCalledOnce();
+    expect(prismaMock.discipleshipAttendance.deleteMany).toHaveBeenCalledWith({
+      where: { eventId: "evt-1" },
+    });
+  });
+
+  it("planning:event:created ne déclenche pas de suppression d'attendance", async () => {
+    vi.resetModules();
+    const { planningBus } = await import("@/modules/planning");
+    await import("@/lib/registry");
+
+    const fakeTx = prismaMock as unknown as Parameters<typeof planningBus.emit>[1]["tx"];
+
+    await planningBus.emit(
+      "planning:event:created",
+      { tx: fakeTx, churchId: "church-1", userId: "user-1" },
+      {
+        eventId: "evt-1",
+        churchId: "church-1",
+        title: "Culte",
+        type: "CULTE",
+        createdById: "user-1",
+        isRecurrenceParent: false,
+      }
+    );
+
+    expect(prismaMock.discipleshipAttendance.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -74,6 +74,10 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
   ],
 };
 
+/**
+ * @deprecated Utiliser `rolePermissions` depuis `@/lib/registry` à la place.
+ * Cette fonction sera supprimée quand la migration Phase 2 sera complète.
+ */
 export function hasPermission(role: Role): string[] {
   return ROLE_PERMISSIONS[role] || [];
 }

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,7 +1,7 @@
 import { boot } from "@/core/boot";
 import { buildRolePermissions } from "@/core/permissions";
 import { coreModule } from "@/modules/core";
-import { planningModule } from "@/modules/planning";
+import { planningModule, planningBus } from "@/modules/planning";
 import { discipleshipModule } from "@/modules/discipleship";
 
 /**
@@ -19,3 +19,20 @@ export const registry = boot({
  * Remplace ROLE_PERMISSIONS de src/lib/permissions.ts dans les guards API.
  */
 export const rolePermissions = buildRolePermissions(registry);
+
+// ─── Abonnements cross-module ─────────────────────────────────────────────────
+//
+// Le registry est la racine de composition : seul endroit où tous les modules
+// sont visibles. Les abonnements ici permettent à un module de réagir aux
+// événements d'un autre sans importer directement depuis ce module.
+
+/**
+ * Discipleship → Planning : quand un événement est annulé, supprimer les
+ * enregistrements de présence discipleship liés (évite une FK violation et
+ * maintient la cohérence des données de suivi).
+ *
+ * S'exécute dans la même transaction que la suppression de l'événement.
+ */
+planningBus.on("planning:event:cancelled", async ({ tx }, { eventId }) => {
+  await tx.discipleshipAttendance.deleteMany({ where: { eventId } });
+});

--- a/src/modules/__tests__/event-service.test.ts
+++ b/src/modules/__tests__/event-service.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+// Importer après le mock prisma
+const { deleteEvents } = await import("@/modules/planning");
+const { planningBus } = await import("@/modules/planning");
+
+type TxClient = Parameters<typeof deleteEvents>[0]["tx"];
+const tx = prismaMock as unknown as TxClient;
+
+function makeCtx(churchId = "church-1", userId = "user-1") {
+  return { tx, churchId, userId };
+}
+
+describe("deleteEvents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    planningBus.clear();
+    prismaMock.eventDepartment.findMany.mockResolvedValue([]);
+  });
+
+  it("est un no-op si la liste est vide", async () => {
+    await deleteEvents(makeCtx(), []);
+    expect(prismaMock.event.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("émet planning:event:cancelled pour chaque eventId", async () => {
+    const handler = vi.fn();
+    planningBus.on("planning:event:cancelled", handler);
+
+    await deleteEvents(makeCtx(), ["evt-1", "evt-2"]);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[0][1]).toMatchObject({ eventId: "evt-1" });
+    expect(handler.mock.calls[1][1]).toMatchObject({ eventId: "evt-2" });
+  });
+
+  it("supprime toutes les tables FK avant l'event", async () => {
+    prismaMock.eventDepartment.findMany.mockResolvedValue([
+      { id: "ed-1" },
+    ] as never);
+
+    await deleteEvents(makeCtx(), ["evt-1"]);
+
+    // Ordre : planning → eventDepartment → taskAssignment → eventReport → announcementEvent → event
+    const calls = Object.entries(prismaMock).reduce<string[]>((acc, [model, mock]) => {
+      const m = mock as Record<string, { mock?: { calls: unknown[][] } }>;
+      if (m.deleteMany?.mock?.calls?.length) acc.push(model);
+      return acc;
+    }, []);
+
+    expect(calls).toContain("planning");
+    expect(calls).toContain("eventDepartment");
+    expect(calls).toContain("taskAssignment");
+    expect(calls).toContain("eventReport");
+    expect(calls).toContain("announcementEvent");
+    expect(calls).toContain("event");
+  });
+
+  it("supprime event.deleteMany avec tous les ids", async () => {
+    await deleteEvents(makeCtx(), ["evt-1", "evt-2", "evt-3"]);
+
+    expect(prismaMock.event.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["evt-1", "evt-2", "evt-3"] } },
+    });
+  });
+
+  it("utilise cancelledById = 'system' si userId absent", async () => {
+    const handler = vi.fn();
+    planningBus.on("planning:event:cancelled", handler);
+
+    await deleteEvents({ tx, churchId: "church-1" }, ["evt-1"]);
+
+    expect(handler.mock.calls[0][1]).toMatchObject({ cancelledById: "system" });
+  });
+});

--- a/src/modules/__tests__/planning-bus.test.ts
+++ b/src/modules/__tests__/planning-bus.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventBus } from "@/core/event-bus";
+import { planningBus } from "@/modules/planning";
+import type { PlanningEvents } from "@/modules/planning";
+import type { Prisma } from "@/generated/prisma/client";
+
+/** Contexte minimal pour les tests — tx est un mock. */
+function fakeCtx(churchId = "church-1", userId = "user-1") {
+  return {
+    tx: {} as Prisma.TransactionClient,
+    churchId,
+    userId,
+  };
+}
+
+describe("planningBus", () => {
+  beforeEach(() => {
+    planningBus.clear();
+  });
+
+  it("est une instance de EventBus", () => {
+    expect(planningBus).toBeInstanceOf(EventBus);
+  });
+
+  it("émet planning:event:created aux handlers enregistrés", async () => {
+    const handler = vi.fn();
+    planningBus.on("planning:event:created", handler);
+
+    const payload: PlanningEvents["planning:event:created"] = {
+      eventId: "evt-1",
+      churchId: "church-1",
+      title: "Culte du dimanche",
+      type: "CULTE",
+      createdById: "user-1",
+      isRecurrenceParent: false,
+    };
+
+    const ctx = fakeCtx();
+    await planningBus.emit("planning:event:created", ctx, payload);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(ctx, payload);
+  });
+
+  it("émet planning:event:created avec childCount pour une série récurrente", async () => {
+    const captured: PlanningEvents["planning:event:created"][] = [];
+    planningBus.on("planning:event:created", async (_ctx, payload) => {
+      captured.push(payload);
+    });
+
+    await planningBus.emit(
+      "planning:event:created",
+      fakeCtx(),
+      {
+        eventId: "evt-parent",
+        churchId: "church-1",
+        title: "Culte hebdo",
+        type: "CULTE",
+        createdById: "user-1",
+        isRecurrenceParent: true,
+        childCount: 51,
+      }
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].isRecurrenceParent).toBe(true);
+    expect(captured[0].childCount).toBe(51);
+  });
+
+  it("émet planning:request:executed", async () => {
+    const handler = vi.fn();
+    planningBus.on("planning:request:executed", handler);
+
+    await planningBus.emit(
+      "planning:request:executed",
+      fakeCtx(),
+      {
+        requestId: "req-1",
+        requestType: "AJOUT_EVENEMENT",
+        churchId: "church-1",
+        executedById: "user-1",
+        resourceId: "evt-2",
+      }
+    );
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("un handler qui throw interrompt la chaîne et remonte l'erreur", async () => {
+    planningBus.on("planning:event:created", async () => {
+      throw new Error("handler error");
+    });
+    const secondHandler = vi.fn();
+    planningBus.on("planning:event:created", secondHandler);
+
+    await expect(
+      planningBus.emit("planning:event:created", fakeCtx(), {
+        eventId: "e",
+        churchId: "c",
+        title: "T",
+        type: "CULTE",
+        createdById: "u",
+        isRecurrenceParent: false,
+      })
+    ).rejects.toThrow("handler error");
+
+    // Second handler not reached
+    expect(secondHandler).not.toHaveBeenCalled();
+  });
+
+  it("listenerCount retourne 0 sans handlers enregistrés", () => {
+    expect(planningBus.listenerCount("planning:event:created")).toBe(0);
+  });
+
+  it("listenerCount retourne le nombre correct après enregistrement", () => {
+    planningBus.on("planning:event:created", vi.fn());
+    planningBus.on("planning:event:created", vi.fn());
+    expect(planningBus.listenerCount("planning:event:created")).toBe(2);
+  });
+});

--- a/src/modules/__tests__/request-executor.test.ts
+++ b/src/modules/__tests__/request-executor.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { executeRequest } from "@/modules/planning";
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+// executeRequest takes a tx (transaction client), use prismaMock directly
+const tx = prismaMock as unknown as Parameters<typeof executeRequest>[0];
+
+describe("executeDemandeAcces — privilege escalation prevention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.user.findUnique.mockResolvedValue({ id: "user-1" });
+  });
+
+  it("rejects SUPER_ADMIN role", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "SUPER_ADMIN",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non autorisé");
+  });
+
+  it("rejects ADMIN role", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "ADMIN",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non autorisé");
+  });
+
+  it("rejects SECRETARY role", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "SECRETARY",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non autorisé");
+  });
+
+  it("allows DISCIPLE_MAKER role", async () => {
+    prismaMock.userChurchRole.create.mockResolvedValue({ id: "role-1" });
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "DISCIPLE_MAKER",
+    }, "approver-1");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("allows REPORTER role", async () => {
+    prismaMock.userChurchRole.create.mockResolvedValue({ id: "role-1" });
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "REPORTER",
+    }, "approver-1");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("allows MINISTER role with valid ministryId", async () => {
+    prismaMock.ministry.count.mockResolvedValue(1);
+    prismaMock.userChurchRole.create.mockResolvedValue({ id: "role-1" });
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "MINISTER",
+      ministryId: "ministry-1",
+    }, "approver-1");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects MINISTER without ministryId", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "MINISTER",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ministryId requis");
+  });
+
+  it("rejects MINISTER with cross-tenant ministryId", async () => {
+    prismaMock.ministry.count.mockResolvedValue(0); // 0 = not in this church
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "MINISTER",
+      ministryId: "ministry-other-church",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("hors périmètre");
+  });
+
+  it("allows DEPARTMENT_HEAD with valid departmentIds", async () => {
+    prismaMock.department.count.mockResolvedValue(1);
+    prismaMock.userChurchRole.create.mockResolvedValue({ id: "role-1" });
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "DEPARTMENT_HEAD",
+      departmentIds: ["dept-1"],
+    }, "approver-1");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects DEPARTMENT_HEAD without departmentIds", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "DEPARTMENT_HEAD",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("departmentIds requis");
+  });
+
+  it("rejects DEPARTMENT_HEAD with empty departmentIds", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "DEPARTMENT_HEAD",
+      departmentIds: [],
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("departmentIds requis");
+  });
+
+  it("rejects DEPARTMENT_HEAD with cross-tenant departmentIds", async () => {
+    prismaMock.department.count.mockResolvedValue(0); // 0 of 1 valid
+
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "DEPARTMENT_HEAD",
+      departmentIds: ["dept-other-church"],
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("hors périmètre");
+  });
+
+  it("rejects unknown/arbitrary role string", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "DEMANDE_ACCES", {
+      targetUserId: "user-1",
+      role: "OWNER",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("non autorisé");
+  });
+});
+
+describe("executeAjoutEvenement — date validation / DoS prevention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.event.create.mockResolvedValue({ id: "evt-1" });
+  });
+
+  it("rejects invalid eventDate", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "AJOUT_EVENEMENT", {
+      eventTitle: "Culte",
+      eventType: "CULTE",
+      eventDate: "not-a-date",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("eventDate invalide");
+  });
+
+  it("rejects invalid recurrenceEnd", async () => {
+    const result = await executeRequest(tx, "req-1", "church-1", "AJOUT_EVENEMENT", {
+      eventTitle: "Culte",
+      eventType: "CULTE",
+      eventDate: "2025-01-05",
+      recurrenceRule: "weekly",
+      recurrenceEnd: "not-a-date",
+    }, "approver-1");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("recurrenceEnd invalide");
+  });
+
+  it("caps recurrence at 104 occurrences (no infinite loop)", async () => {
+    prismaMock.event.create.mockResolvedValue({ id: "evt-1" });
+    prismaMock.eventDepartment.createMany.mockResolvedValue({ count: 0 });
+
+    // recurrenceEnd far in the future — would create hundreds of events without the cap
+    const result = await executeRequest(tx, "req-1", "church-1", "AJOUT_EVENEMENT", {
+      eventTitle: "Culte",
+      eventType: "CULTE",
+      eventDate: "2020-01-05",
+      recurrenceRule: "weekly",
+      recurrenceEnd: "2100-01-01",
+    }, "approver-1");
+
+    // Should succeed but capped, and signal truncation
+    expect(result.success).toBe(true);
+    expect(result.recurrenceTruncated).toBe(true);
+    expect(result.maxOccurrences).toBe(104);
+    // Total event.create calls: 1 (parent) + at most 104 (children)
+    expect(prismaMock.event.create.mock.calls.length).toBeLessThanOrEqual(105);
+  });
+});

--- a/src/modules/planning/bus.ts
+++ b/src/modules/planning/bus.ts
@@ -1,0 +1,20 @@
+import { EventBus } from "@/core/event-bus";
+import type { PlanningEvents } from "./events";
+
+/**
+ * Bus d'événements du module planning — singleton process-level.
+ *
+ * Les autres modules (discipleship, media…) s'y abonnent via `planningBus.on()`
+ * lors du démarrage du process (ex. dans leur propre init ou dans @/lib/registry).
+ *
+ * Usage dans un handler API :
+ * ```ts
+ * await prisma.$transaction(async (tx) => {
+ *   const event = await tx.event.create({ ... });
+ *   await planningBus.emit("planning:event:created", { tx, churchId, userId }, {
+ *     eventId: event.id, ...
+ *   });
+ * });
+ * ```
+ */
+export const planningBus = new EventBus<PlanningEvents>();

--- a/src/modules/planning/events.ts
+++ b/src/modules/planning/events.ts
@@ -1,0 +1,50 @@
+/**
+ * Carte des événements émis par le module planning.
+ *
+ * Consommé par EventBus<PlanningEvents> — chaque clé est un nom d'événement,
+ * la valeur est le type de payload attendu par les handlers.
+ *
+ * IMPORTANT : ces événements transitent par le bus in-process, transaction-aware.
+ * Tout handler enregistré s'exécute dans la même transaction Prisma que l'émetteur.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PlanningEvents = {
+  /** Un événement unique a été créé (ou le parent d'une série récurrente). */
+  "planning:event:created": {
+    eventId: string;
+    churchId: string;
+    title: string;
+    type: string;
+    createdById: string;
+    isRecurrenceParent: boolean;
+    childCount?: number;
+  };
+
+  /** Un événement a été annulé (suppression douce ou via demande). */
+  "planning:event:cancelled": {
+    eventId: string;
+    churchId: string;
+    cancelledById: string;
+    requestId?: string;
+  };
+
+  /** Une demande (Request) a été approuvée et exécutée avec succès. */
+  "planning:request:executed": {
+    requestId: string;
+    requestType: string;
+    churchId: string;
+    executedById: string;
+    /** Identifiant de la ressource créée/modifiée, si applicable. */
+    resourceId?: string;
+  };
+
+  /** Le statut de planning d'un membre a été modifié. */
+  "planning:status:changed": {
+    eventId: string;
+    churchId: string;
+    departmentId: string;
+    memberId: string;
+    newStatus: string | null;
+    changedById: string;
+  };
+}

--- a/src/modules/planning/index.ts
+++ b/src/modules/planning/index.ts
@@ -4,6 +4,7 @@ export { planningBus } from "./bus";
 export type { PlanningEvents } from "./events";
 export { executeRequest } from "./services/request-executor";
 export type { ExecutionResult } from "./services/request-executor";
+export { deleteEvents } from "./services/event.service";
 
 /**
  * Module planning — ex-Koinonia.

--- a/src/modules/planning/index.ts
+++ b/src/modules/planning/index.ts
@@ -1,5 +1,8 @@
 import { defineModule } from "@/core/module-registry";
 
+export { planningBus } from "./bus";
+export type { PlanningEvents } from "./events";
+
 /**
  * Module planning — ex-Koinonia.
  *

--- a/src/modules/planning/index.ts
+++ b/src/modules/planning/index.ts
@@ -2,6 +2,8 @@ import { defineModule } from "@/core/module-registry";
 
 export { planningBus } from "./bus";
 export type { PlanningEvents } from "./events";
+export { executeRequest } from "./services/request-executor";
+export type { ExecutionResult } from "./services/request-executor";
 
 /**
  * Module planning — ex-Koinonia.

--- a/src/modules/planning/services/event.service.ts
+++ b/src/modules/planning/services/event.service.ts
@@ -1,0 +1,62 @@
+import type { Prisma } from "@/generated/prisma/client";
+import { planningBus } from "../bus";
+
+type TxClient = Prisma.TransactionClient;
+
+interface DeleteEventsCtx {
+  tx: TxClient;
+  churchId: string;
+  userId?: string;
+}
+
+/**
+ * Supprime un ou plusieurs événements en cascade.
+ *
+ * Doit être appelé dans une transaction Prisma existante.
+ *
+ * Ordre :
+ * 1. Émet `planning:event:cancelled` pour chaque eventId (handlers cross-module
+ *    nettoient leurs FK dans la même tx avant la suppression)
+ * 2. Supprime les données planning-owned : Planning, TaskAssignment,
+ *    EventDepartment, EventReport, AnnouncementEvent
+ * 3. Supprime les Event
+ *
+ * Utiliser cette fonction pour toute suppression d'événement — API bulk delete
+ * ET executor de demandes — afin de garantir la cohérence et les émissions bus.
+ */
+export async function deleteEvents(
+  ctx: DeleteEventsCtx,
+  eventIds: string[]
+): Promise<void> {
+  if (eventIds.length === 0) return;
+
+  // 1. Émettre avant la suppression pour que les handlers cross-module
+  //    (ex. discipleship) nettoient leurs FK dans la même transaction.
+  for (const eventId of eventIds) {
+    await planningBus.emit(
+      "planning:event:cancelled",
+      { tx: ctx.tx, churchId: ctx.churchId, userId: ctx.userId },
+      { eventId, churchId: ctx.churchId, cancelledById: ctx.userId ?? "system" }
+    );
+  }
+
+  // 2. Cleanup planning-owned (ordre FK : enfants avant parents)
+  const eventDeptIds = (
+    await ctx.tx.eventDepartment.findMany({
+      where: { eventId: { in: eventIds } },
+      select: { id: true },
+    })
+  ).map((ed) => ed.id);
+
+  if (eventDeptIds.length > 0) {
+    await ctx.tx.planning.deleteMany({ where: { eventDepartmentId: { in: eventDeptIds } } });
+    await ctx.tx.eventDepartment.deleteMany({ where: { id: { in: eventDeptIds } } });
+  }
+
+  await ctx.tx.taskAssignment.deleteMany({ where: { eventId: { in: eventIds } } });
+  await ctx.tx.eventReport.deleteMany({ where: { eventId: { in: eventIds } } });
+  await ctx.tx.announcementEvent.deleteMany({ where: { eventId: { in: eventIds } } });
+
+  // 3. Supprimer les events (FK propres grâce aux étapes précédentes)
+  await ctx.tx.event.deleteMany({ where: { id: { in: eventIds } } });
+}

--- a/src/modules/planning/services/request-executor.ts
+++ b/src/modules/planning/services/request-executor.ts
@@ -1,52 +1,100 @@
 import type { Prisma } from "@/generated/prisma/client";
+import { planningBus } from "../bus";
 
-interface ExecutionResult {
+export interface ExecutionResult {
   success: boolean;
   error?: string;
+  /** ID de la ressource créée ou modifiée (event, role…), si applicable. */
+  resourceId?: string;
   recurrenceTruncated?: boolean;
   maxOccurrences?: number;
+  /** Nombre d'occurrences enfants créées (AJOUT_EVENEMENT récurrent uniquement). */
+  childCount?: number;
 }
 
 type TxClient = Prisma.TransactionClient;
 
 /**
- * Execute the action associated with an approved request.
- * Called within a transaction after status is set to APPROUVEE.
- * On success, sets status to EXECUTEE. On failure, sets ERREUR + executionError.
+ * Exécute l'action associée à une demande approuvée.
+ *
+ * Doit être appelé dans une transaction Prisma.
+ * En cas de succès émet les événements planningBus correspondants.
+ * Retourne `{ success: false, error }` sans throw — l'appelant gère ERREUR vs EXECUTEE.
  */
 export async function executeRequest(
   tx: TxClient,
-  _requestId: string,
+  requestId: string,
   churchId: string,
   type: string,
   payload: Record<string, unknown>,
-  _approvedById: string
+  userId: string
 ): Promise<ExecutionResult> {
+  const ctx = { tx, churchId, userId };
+
   try {
+    let result: ExecutionResult;
+
     switch (type) {
       case "AJOUT_EVENEMENT":
-        return await executeAjoutEvenement(tx, churchId, payload);
-
+        result = await executeAjoutEvenement(tx, churchId, payload);
+        break;
       case "MODIFICATION_EVENEMENT":
-        return await executeModificationEvenement(tx, churchId, payload);
-
+        result = await executeModificationEvenement(tx, churchId, payload);
+        break;
       case "ANNULATION_EVENEMENT":
-        return await executeAnnulationEvenement(tx, churchId, payload);
-
+        result = await executeAnnulationEvenement(tx, churchId, payload);
+        break;
       case "MODIFICATION_PLANNING":
-        return await executeModificationPlanning(tx, churchId, payload);
-
+        result = await executeModificationPlanning(tx, churchId, payload);
+        break;
       case "DEMANDE_ACCES":
-        return await executeDemandeAcces(tx, churchId, payload);
-
+        result = await executeDemandeAcces(tx, churchId, payload);
+        break;
       default:
         return { success: false, error: `Type de demande non exécutable : ${type}` };
     }
+
+    if (!result.success) return result;
+
+    // Événements spécifiques par type
+    if (type === "AJOUT_EVENEMENT" && result.resourceId) {
+      await planningBus.emit("planning:event:created", ctx, {
+        eventId: result.resourceId,
+        churchId,
+        title: payload.eventTitle as string,
+        type: payload.eventType as string,
+        createdById: userId,
+        isRecurrenceParent: !!(payload.recurrenceRule && payload.recurrenceEnd),
+        childCount: result.childCount,
+      });
+    }
+
+    if (type === "ANNULATION_EVENEMENT" && result.resourceId) {
+      await planningBus.emit("planning:event:cancelled", ctx, {
+        eventId: result.resourceId,
+        churchId,
+        cancelledById: userId,
+        requestId,
+      });
+    }
+
+    // Événement générique — émis pour toute exécution réussie
+    await planningBus.emit("planning:request:executed", ctx, {
+      requestId,
+      requestType: type,
+      churchId,
+      executedById: userId,
+      resourceId: result.resourceId,
+    });
+
+    return result;
   } catch (error) {
     const message = error instanceof Error ? error.message : "Erreur inconnue";
     return { success: false, error: message };
   }
 }
+
+// ─── Helpers internes ─────────────────────────────────────────────────────────
 
 function computeDeadlineFromOffset(eventDate: Date, offset: string): Date {
   const result = new Date(eventDate);
@@ -61,7 +109,11 @@ function computeDeadlineFromOffset(eventDate: Date, offset: string): Date {
 
 const MAX_RECURRENCE_OCCURRENCES = 104; // ~2 ans hebdomadaires
 
-function generateRecurrenceDates(startDate: Date, rule: string, endDate: Date): { dates: Date[]; truncated: boolean } {
+function generateRecurrenceDates(
+  startDate: Date,
+  rule: string,
+  endDate: Date
+): { dates: Date[]; truncated: boolean } {
   if (isNaN(endDate.getTime())) return { dates: [], truncated: false };
   const dates: Date[] = [];
   const current = new Date(startDate);
@@ -76,6 +128,8 @@ function generateRecurrenceDates(startDate: Date, rule: string, endDate: Date): 
   const truncated = dates.length === MAX_RECURRENCE_OCCURRENCES && current <= endDate;
   return { dates, truncated };
 }
+
+// ─── Exécuteurs par type ──────────────────────────────────────────────────────
 
 async function executeAjoutEvenement(
   tx: TxClient,
@@ -100,11 +154,8 @@ async function executeAjoutEvenement(
     return { success: false, error: "eventDate invalide" };
   }
 
-  if (recurrenceEnd) {
-    const endDateCheck = new Date(recurrenceEnd);
-    if (isNaN(endDateCheck.getTime())) {
-      return { success: false, error: "recurrenceEnd invalide" };
-    }
+  if (recurrenceEnd && isNaN(new Date(recurrenceEnd).getTime())) {
+    return { success: false, error: "recurrenceEnd invalide" };
   }
 
   if (departmentIds && departmentIds.length > 0) {
@@ -128,15 +179,7 @@ async function executeAjoutEvenement(
     const { dates: childDates, truncated } = generateRecurrenceDates(eventDate, recurrenceRule, endDate);
 
     const parent = await tx.event.create({
-      data: {
-        title,
-        type,
-        date: eventDate,
-        churchId,
-        planningDeadline: deadline,
-        recurrenceRule,
-        isRecurrenceParent: true,
-      },
+      data: { title, type, date: eventDate, churchId, planningDeadline: deadline, recurrenceRule, isRecurrenceParent: true },
     });
 
     if (departmentIds && departmentIds.length > 0) {
@@ -146,22 +189,10 @@ async function executeAjoutEvenement(
     }
 
     for (const childDate of childDates) {
-      const childDeadline = useOffset
-        ? computeDeadlineFromOffset(childDate, deadlineOffset!)
-        : deadline;
-
+      const childDeadline = useOffset ? computeDeadlineFromOffset(childDate, deadlineOffset!) : deadline;
       const child = await tx.event.create({
-        data: {
-          title,
-          type,
-          date: childDate,
-          churchId,
-          planningDeadline: childDeadline,
-          recurrenceRule,
-          seriesId: parent.id,
-        },
+        data: { title, type, date: childDate, churchId, planningDeadline: childDeadline, recurrenceRule, seriesId: parent.id },
       });
-
       if (departmentIds && departmentIds.length > 0) {
         await tx.eventDepartment.createMany({
           data: departmentIds.map((departmentId) => ({ eventId: child.id, departmentId })),
@@ -171,18 +202,14 @@ async function executeAjoutEvenement(
 
     return {
       success: true,
+      resourceId: parent.id,
+      childCount: childDates.length,
       ...(truncated ? { recurrenceTruncated: true, maxOccurrences: MAX_RECURRENCE_OCCURRENCES } : {}),
     };
   }
 
   const event = await tx.event.create({
-    data: {
-      title,
-      type,
-      date: eventDate,
-      churchId,
-      planningDeadline: deadline,
-    },
+    data: { title, type, date: eventDate, churchId, planningDeadline: deadline },
   });
 
   if (departmentIds && departmentIds.length > 0) {
@@ -191,7 +218,7 @@ async function executeAjoutEvenement(
     });
   }
 
-  return { success: true };
+  return { success: true, resourceId: event.id };
 }
 
 async function executeModificationEvenement(
@@ -207,12 +234,8 @@ async function executeModificationEvenement(
   }
 
   const event = await tx.event.findUnique({ where: { id: eventId }, select: { id: true, churchId: true } });
-  if (!event) {
-    return { success: false, error: "Événement introuvable" };
-  }
-  if (event.churchId !== churchId) {
-    return { success: false, error: "Événement hors périmètre" };
-  }
+  if (!event) return { success: false, error: "Événement introuvable" };
+  if (event.churchId !== churchId) return { success: false, error: "Événement hors périmètre" };
 
   await tx.event.update({
     where: { id: eventId },
@@ -226,7 +249,7 @@ async function executeModificationEvenement(
     },
   });
 
-  return { success: true };
+  return { success: true, resourceId: eventId };
 }
 
 async function executeAnnulationEvenement(
@@ -236,20 +259,14 @@ async function executeAnnulationEvenement(
 ): Promise<ExecutionResult> {
   const eventId = payload.eventId as string;
 
-  if (!eventId) {
-    return { success: false, error: "Données manquantes : eventId" };
-  }
+  if (!eventId) return { success: false, error: "Données manquantes : eventId" };
 
   const event = await tx.event.findUnique({
     where: { id: eventId },
     include: { eventDepts: { select: { id: true } } },
   });
-  if (!event) {
-    return { success: false, error: "Événement introuvable" };
-  }
-  if (event.churchId !== churchId) {
-    return { success: false, error: "Événement hors périmètre" };
-  }
+  if (!event) return { success: false, error: "Événement introuvable" };
+  if (event.churchId !== churchId) return { success: false, error: "Événement hors périmètre" };
 
   const edIds = event.eventDepts.map((ed) => ed.id);
   if (edIds.length > 0) {
@@ -259,7 +276,7 @@ async function executeAnnulationEvenement(
   }
   await tx.event.delete({ where: { id: eventId } });
 
-  return { success: true };
+  return { success: true, resourceId: eventId };
 }
 
 async function executeModificationPlanning(
@@ -275,12 +292,8 @@ async function executeModificationPlanning(
   }
 
   const event = await tx.event.findUnique({ where: { id: eventId }, select: { id: true, churchId: true } });
-  if (!event) {
-    return { success: false, error: "Événement introuvable" };
-  }
-  if (event.churchId !== churchId) {
-    return { success: false, error: "Événement hors périmètre" };
-  }
+  if (!event) return { success: false, error: "Événement introuvable" };
+  if (event.churchId !== churchId) return { success: false, error: "Événement hors périmètre" };
 
   if (departmentIds.length > 0) {
     const validDepts = await tx.department.count({
@@ -291,44 +304,30 @@ async function executeModificationPlanning(
     }
   }
 
-  // Fetch current EventDepartment records for this event
   const currentEventDepts = await tx.eventDepartment.findMany({
     where: { eventId },
     select: { id: true, departmentId: true },
   });
 
   const currentDeptIds = currentEventDepts.map((ed) => ed.departmentId);
-  const requestedDeptIds = departmentIds;
+  const toAdd = departmentIds.filter((id) => !currentDeptIds.includes(id));
+  const toRemove = currentEventDepts.filter((ed) => !departmentIds.includes(ed.departmentId));
 
-  // Departments to add: in requested but not in current
-  const toAdd = requestedDeptIds.filter((id) => !currentDeptIds.includes(id));
-
-  // Departments to remove: in current but not in requested
-  const toRemove = currentEventDepts.filter((ed) => !requestedDeptIds.includes(ed.departmentId));
-
-  // Remove departments: cascade delete plannings first, then EventDepartment records
   if (toRemove.length > 0) {
     const removeIds = toRemove.map((ed) => ed.id);
     await tx.planning.deleteMany({ where: { eventDepartmentId: { in: removeIds } } });
     await tx.eventDepartment.deleteMany({ where: { id: { in: removeIds } } });
   }
 
-  // Add new departments
   if (toAdd.length > 0) {
     await tx.eventDepartment.createMany({
       data: toAdd.map((departmentId) => ({ eventId, departmentId })),
     });
   }
 
-  return {
-    success: true,
-    error: undefined,
-  };
+  return { success: true, resourceId: eventId };
 }
 
-// Rôles pouvant être attribués via une DEMANDE_ACCES.
-// SUPER_ADMIN, ADMIN, SECRETARY sont explicitement exclus — ils ne peuvent
-// être assignés que par un super-administrateur via l'interface d'administration.
 const DEMANDE_ACCES_ALLOWED_ROLES = [
   "MINISTER",
   "DEPARTMENT_HEAD",
@@ -354,7 +353,6 @@ async function executeDemandeAcces(
     return { success: false, error: `Rôle non autorisé via demande d'accès : ${role}` };
   }
 
-  // MINISTER et DEPARTMENT_HEAD nécessitent un scope obligatoire
   if (role === "MINISTER" && !ministryId) {
     return { success: false, error: "ministryId requis pour le rôle MINISTER" };
   }
@@ -363,15 +361,11 @@ async function executeDemandeAcces(
   }
 
   const user = await tx.user.findUnique({ where: { id: targetUserId }, select: { id: true } });
-  if (!user) {
-    return { success: false, error: "Utilisateur cible introuvable" };
-  }
+  if (!user) return { success: false, error: "Utilisateur cible introuvable" };
 
   if (ministryId) {
     const validMinistry = await tx.ministry.count({ where: { id: ministryId, churchId } });
-    if (validMinistry === 0) {
-      return { success: false, error: "Ministère invalide ou hors périmètre" };
-    }
+    if (validMinistry === 0) return { success: false, error: "Ministère invalide ou hors périmètre" };
   }
 
   if (departmentIds && departmentIds.length > 0) {
@@ -383,21 +377,18 @@ async function executeDemandeAcces(
     }
   }
 
-  await tx.userChurchRole.create({
+  const ucr = await tx.userChurchRole.create({
     data: {
       userId: targetUserId,
       churchId,
       role: role as "MINISTER" | "DEPARTMENT_HEAD" | "DISCIPLE_MAKER" | "REPORTER",
       ...(role === "MINISTER" && ministryId ? { ministryId } : {}),
       ...(role === "DEPARTMENT_HEAD" && departmentIds?.length
-        ? {
-            departments: {
-              create: departmentIds.map((departmentId) => ({ departmentId })),
-            },
-          }
+        ? { departments: { create: departmentIds.map((departmentId) => ({ departmentId })) } }
         : {}),
     },
+    select: { id: true },
   });
 
-  return { success: true };
+  return { success: true, resourceId: ucr.id };
 }

--- a/src/modules/planning/services/request-executor.ts
+++ b/src/modules/planning/services/request-executor.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from "@/generated/prisma/client";
 import { planningBus } from "../bus";
+import { deleteEvents } from "./event.service";
 
 export interface ExecutionResult {
   success: boolean;
@@ -250,7 +251,7 @@ async function executeAnnulationEvenement(
   churchId: string,
   payload: Record<string, unknown>,
   ctx: { tx: TxClient; churchId: string; userId: string },
-  requestId: string
+  _requestId: string
 ): Promise<ExecutionResult> {
   const eventId = payload.eventId as string;
 
@@ -258,27 +259,14 @@ async function executeAnnulationEvenement(
 
   const event = await tx.event.findUnique({
     where: { id: eventId },
-    include: { eventDepts: { select: { id: true } } },
+    select: { id: true, churchId: true },
   });
   if (!event) return { success: false, error: "Événement introuvable" };
   if (event.churchId !== churchId) return { success: false, error: "Événement hors périmètre" };
 
-  // Émettre AVANT la suppression : les handlers (ex. discipleship) doivent
-  // nettoyer leurs FK dans la même transaction avant que l'event soit supprimé.
-  await planningBus.emit("planning:event:cancelled", ctx, {
-    eventId,
-    churchId,
-    cancelledById: ctx.userId,
-    requestId,
-  });
-
-  const edIds = event.eventDepts.map((ed) => ed.id);
-  if (edIds.length > 0) {
-    await tx.planning.deleteMany({ where: { eventDepartmentId: { in: edIds } } });
-    await tx.taskAssignment.deleteMany({ where: { eventId } });
-    await tx.eventDepartment.deleteMany({ where: { id: { in: edIds } } });
-  }
-  await tx.event.delete({ where: { id: eventId } });
+  // deleteEvents gère : émission bus, cleanup FK (planning + discipleship
+  // via handler + eventReport + announcementEvent), puis suppression.
+  await deleteEvents(ctx, [eventId]);
 
   return { success: true, resourceId: eventId };
 }

--- a/src/modules/planning/services/request-executor.ts
+++ b/src/modules/planning/services/request-executor.ts
@@ -42,7 +42,9 @@ export async function executeRequest(
         result = await executeModificationEvenement(tx, churchId, payload);
         break;
       case "ANNULATION_EVENEMENT":
-        result = await executeAnnulationEvenement(tx, churchId, payload);
+        // ctx + requestId passés pour émettre planning:event:cancelled AVANT la suppression
+        // (les handlers doivent nettoyer les FK avant que l'event soit supprimé)
+        result = await executeAnnulationEvenement(tx, churchId, payload, ctx, requestId);
         break;
       case "MODIFICATION_PLANNING":
         result = await executeModificationPlanning(tx, churchId, payload);
@@ -66,15 +68,6 @@ export async function executeRequest(
         createdById: userId,
         isRecurrenceParent: !!(payload.recurrenceRule && payload.recurrenceEnd),
         childCount: result.childCount,
-      });
-    }
-
-    if (type === "ANNULATION_EVENEMENT" && result.resourceId) {
-      await planningBus.emit("planning:event:cancelled", ctx, {
-        eventId: result.resourceId,
-        churchId,
-        cancelledById: userId,
-        requestId,
       });
     }
 
@@ -255,7 +248,9 @@ async function executeModificationEvenement(
 async function executeAnnulationEvenement(
   tx: TxClient,
   churchId: string,
-  payload: Record<string, unknown>
+  payload: Record<string, unknown>,
+  ctx: { tx: TxClient; churchId: string; userId: string },
+  requestId: string
 ): Promise<ExecutionResult> {
   const eventId = payload.eventId as string;
 
@@ -267,6 +262,15 @@ async function executeAnnulationEvenement(
   });
   if (!event) return { success: false, error: "Événement introuvable" };
   if (event.churchId !== churchId) return { success: false, error: "Événement hors périmètre" };
+
+  // Émettre AVANT la suppression : les handlers (ex. discipleship) doivent
+  // nettoyer leurs FK dans la même transaction avant que l'event soit supprimé.
+  await planningBus.emit("planning:event:cancelled", ctx, {
+    eventId,
+    churchId,
+    cancelledById: ctx.userId,
+    requestId,
+  });
 
   const edIds = event.eventDepts.map((ed) => ed.id);
   if (edIds.length > 0) {


### PR DESCRIPTION
## Résumé

Consolidation des PR #218–#223 en une seule PR ciblant directement `feat/v1.0-platform`.

## Commits inclus

| Commit | Contenu |
|---|---|
| `2238f63` | `hasPermission` → `rolePermissions` dans `src/app/` (15 fichiers) |
| `7a531dd` | `PlanningEvents` + `planningBus = EventBus<PlanningEvents>` |
| `5dd0dbf` | `request-executor` déplacé dans `src/modules/planning/services/` + émissions bus |
| `ed01592` | Premier handler cross-module : `planning:event:cancelled` → cleanup `DiscipleshipAttendance` |
| `ad74bd9` | `deleteEvents` service — centralise la suppression + corrige 2 bugs FK (`EventReport`, `AnnouncementEvent`) |

## Architecture livrée

```
src/modules/planning/
├── index.ts                ← exports : planningBus, PlanningEvents, executeRequest, deleteEvents, ExecutionResult
├── bus.ts                  ← EventBus<PlanningEvents> singleton
├── events.ts               ← PlanningEvents type map (4 événements)
└── services/
    ├── request-executor.ts ← executor demandes approuvées + émissions bus
    └── event.service.ts    ← deleteEvents() : émission + cleanup FK + suppression

src/lib/registry.ts         ← handler cross-module : planning:event:cancelled → discipleship cleanup
```

## Bugs corrigés

- `executeAnnulationEvenement` ne nettoyait pas `EventReport` et `AnnouncementEvent` → FK violation silencieuse
- Deux chemins de suppression (API bulk + executor) avaient des logiques divergentes → centralisés dans `deleteEvents`

## Validations

- `npm run typecheck` ✓
- `npx vitest run` → 220/220 ✓
- `npm run lint:boundaries` → aucune violation ✓

## PRs fermées

Remplace #218, #219, #220, #222, #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)