### PR TITLE
feat(media): module média — Phase 3 v1.0 (ex-Mediaflow)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@auth/prisma-adapter": "^2.7.4",
         "@aws-sdk/client-s3": "^3.1029.0",
+        "@aws-sdk/s3-request-presigner": "^3.1030.0",
         "@prisma/adapter-mariadb": "^7.7.0",
         "@prisma/client": "^7.7.0",
         "@tailwindcss/postcss": "^4.2.2",
@@ -23,6 +24,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "recharts": "^3.8.1",
+        "sharp": "^0.34.5",
         "tailwindcss": "^4.0.0",
         "xlsx": "^0.18.5",
         "zod": "^3.24.0"
@@ -798,6 +800,25 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1030.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1030.0.tgz",
+      "integrity": "sha512-rLM1DjBb9QlQwijKGtVSfWGi2gEz8yYj244RRWsPoGAhl57xKS0OGq6MygP/UYTPVc6r5qr4a8Gq1wos4QxnVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "^3.996.16",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-format-url": "^3.972.9",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.996.16",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.16.tgz",
@@ -868,6 +889,21 @@
         "@smithy/types": "^4.14.0",
         "@smithy/url-parser": "^4.2.13",
         "@smithy/util-endpoints": "^3.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.9.tgz",
+      "integrity": "sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1984,7 +2020,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -10752,7 +10787,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10822,7 +10856,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",
     "@aws-sdk/client-s3": "^3.1029.0",
+    "@aws-sdk/s3-request-presigner": "^3.1030.0",
     "@prisma/adapter-mariadb": "^7.7.0",
     "@prisma/client": "^7.7.0",
     "@tailwindcss/postcss": "^4.2.2",
@@ -34,6 +35,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "recharts": "^3.8.1",
+    "sharp": "^0.34.5",
     "tailwindcss": "^4.0.0",
     "xlsx": "^0.18.5",
     "zod": "^3.24.0"

--- a/prisma/migrations/20260413000000_media_module/migration.sql
+++ b/prisma/migrations/20260413000000_media_module/migration.sql
@@ -1,0 +1,228 @@
+-- Migration: module media (ex-Mediaflow)
+-- Ajoute les tables du module média préfixées media_*.
+-- Les colonnes User.mediaEventsCreated, Church.mediaEvents etc. sont des
+-- relations Prisma-only (pas de colonnes BDD ajoutées côté parent).
+
+-- ─── Enums ───────────────────────────────────────────────────────────────
+
+-- Pas de création d'enums explicite en MariaDB/MySQL : Prisma les inline
+-- dans les colonnes ENUM(…) directement.
+
+-- ─── media_events ────────────────────────────────────────────────────────
+
+CREATE TABLE `media_events` (
+    `id`              VARCHAR(191) NOT NULL,
+    `name`            VARCHAR(255) NOT NULL,
+    `date`            DATETIME(3)  NOT NULL,
+    `description`     TEXT         NULL,
+    `status`          ENUM('DRAFT','PENDING_REVIEW','REVIEWED','ARCHIVED') NOT NULL DEFAULT 'DRAFT',
+    `planningEventId` VARCHAR(191) NULL,
+    `churchId`        VARCHAR(191) NOT NULL,
+    `createdById`     VARCHAR(191) NOT NULL,
+    `createdAt`       DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt`       DATETIME(3)  NOT NULL,
+
+    INDEX `media_events_churchId_idx`(`churchId`),
+    INDEX `media_events_createdById_idx`(`createdById`),
+    INDEX `media_events_status_idx`(`status`),
+    INDEX `media_events_date_idx`(`date`),
+    INDEX `media_events_planningEventId_idx`(`planningEventId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ─── media_projects ───────────────────────────────────────────────────────
+
+CREATE TABLE `media_projects` (
+    `id`          VARCHAR(191) NOT NULL,
+    `name`        VARCHAR(255) NOT NULL,
+    `description` TEXT         NULL,
+    `churchId`    VARCHAR(191) NOT NULL,
+    `createdById` VARCHAR(191) NOT NULL,
+    `createdAt`   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt`   DATETIME(3)  NOT NULL,
+
+    INDEX `media_projects_churchId_idx`(`churchId`),
+    INDEX `media_projects_createdById_idx`(`createdById`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ─── media_photos ─────────────────────────────────────────────────────────
+
+CREATE TABLE `media_photos` (
+    `id`           VARCHAR(191)  NOT NULL,
+    `filename`     VARCHAR(255)  NOT NULL,
+    `originalKey`  VARCHAR(512)  NOT NULL,
+    `thumbnailKey` VARCHAR(512)  NOT NULL,
+    `mimeType`     VARCHAR(100)  NOT NULL,
+    `size`         INT           NOT NULL,
+    `width`        INT           NULL,
+    `height`       INT           NULL,
+    `status`       ENUM('PENDING','APPROVED','REJECTED','PREVALIDATED','PREREJECTED') NOT NULL DEFAULT 'PENDING',
+    `validatedAt`  DATETIME(3)   NULL,
+    `validatedBy`  VARCHAR(255)  NULL,
+    `mediaEventId` VARCHAR(191)  NOT NULL,
+    `uploadedAt`   DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `media_photos_mediaEventId_idx`(`mediaEventId`),
+    INDEX `media_photos_status_idx`(`status`),
+    INDEX `media_photos_mediaEventId_status_idx`(`mediaEventId`, `status`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ─── media_files ──────────────────────────────────────────────────────────
+
+CREATE TABLE `media_files` (
+    `id`                  VARCHAR(191) NOT NULL,
+    `type`                ENUM('PHOTO','VISUAL','VIDEO') NOT NULL,
+    `status`              ENUM('PENDING','APPROVED','REJECTED','PREVALIDATED','PREREJECTED','DRAFT','IN_REVIEW','REVISION_REQUESTED','FINAL_APPROVED') NOT NULL DEFAULT 'PENDING',
+    `filename`            VARCHAR(255) NOT NULL,
+    `mimeType`            VARCHAR(100) NOT NULL,
+    `size`                INT          NOT NULL,
+    `width`               INT          NULL,
+    `height`              INT          NULL,
+    `duration`            INT          NULL,
+    `scheduledDeletionAt` DATETIME(3)  NULL,
+    `mediaEventId`        VARCHAR(191) NULL,
+    `mediaProjectId`      VARCHAR(191) NULL,
+    `createdAt`           DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt`           DATETIME(3)  NOT NULL,
+
+    INDEX `media_files_mediaEventId_idx`(`mediaEventId`),
+    INDEX `media_files_mediaProjectId_idx`(`mediaProjectId`),
+    INDEX `media_files_type_idx`(`type`),
+    INDEX `media_files_status_idx`(`status`),
+    INDEX `media_files_scheduledDeletionAt_idx`(`scheduledDeletionAt`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ─── media_file_versions ──────────────────────────────────────────────────
+
+CREATE TABLE `media_file_versions` (
+    `id`            VARCHAR(191) NOT NULL,
+    `versionNumber` INT          NOT NULL DEFAULT 1,
+    `originalKey`   VARCHAR(512) NOT NULL,
+    `thumbnailKey`  VARCHAR(512) NOT NULL,
+    `notes`         TEXT         NULL,
+    `mediaFileId`   VARCHAR(191) NOT NULL,
+    `createdById`   VARCHAR(191) NOT NULL,
+    `createdAt`     DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `media_file_versions_mediaFileId_versionNumber_key`(`mediaFileId`, `versionNumber`),
+    INDEX `media_file_versions_mediaFileId_idx`(`mediaFileId`),
+    INDEX `media_file_versions_createdById_idx`(`createdById`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ─── media_comments ───────────────────────────────────────────────────────
+
+CREATE TABLE `media_comments` (
+    `id`          VARCHAR(191) NOT NULL,
+    `type`        ENUM('GENERAL','TIMECODE') NOT NULL DEFAULT 'GENERAL',
+    `content`     TEXT         NOT NULL,
+    `authorName`  VARCHAR(255) NULL,
+    `authorImage` TEXT         NULL,
+    `timecode`    INT          NULL,
+    `parentId`    VARCHAR(191) NULL,
+    `mediaFileId` VARCHAR(191) NOT NULL,
+    `authorId`    VARCHAR(191) NULL,
+    `createdAt`   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt`   DATETIME(3)  NOT NULL,
+
+    INDEX `media_comments_mediaFileId_idx`(`mediaFileId`),
+    INDEX `media_comments_authorId_idx`(`authorId`),
+    INDEX `media_comments_parentId_idx`(`parentId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ─── media_share_tokens ───────────────────────────────────────────────────
+
+CREATE TABLE `media_share_tokens` (
+    `id`             VARCHAR(191) NOT NULL,
+    `token`          VARCHAR(64)  NOT NULL,
+    `type`           ENUM('VALIDATOR','MEDIA','PREVALIDATOR','GALLERY') NOT NULL,
+    `label`          VARCHAR(255) NULL,
+    `config`         JSON         NULL,
+    `expiresAt`      DATETIME(3)  NULL,
+    `lastUsedAt`     DATETIME(3)  NULL,
+    `usageCount`     INT          NOT NULL DEFAULT 0,
+    `mediaEventId`   VARCHAR(191) NULL,
+    `mediaProjectId` VARCHAR(191) NULL,
+    `createdAt`      DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `media_share_tokens_token_key`(`token`),
+    INDEX `media_share_tokens_mediaEventId_idx`(`mediaEventId`),
+    INDEX `media_share_tokens_mediaProjectId_idx`(`mediaProjectId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ─── media_zip_jobs ───────────────────────────────────────────────────────
+
+CREATE TABLE `media_zip_jobs` (
+    `id`           VARCHAR(191) NOT NULL,
+    `status`       ENUM('PENDING','PROCESSING','COMPLETED','FAILED') NOT NULL DEFAULT 'PENDING',
+    `progress`     INT          NOT NULL DEFAULT 0,
+    `downloadKey`  VARCHAR(512) NULL,
+    `expiresAt`    DATETIME(3)  NULL,
+    `error`        TEXT         NULL,
+    `mediaEventId` VARCHAR(191) NOT NULL,
+    `photoIds`     JSON         NOT NULL,
+    `tokenId`      VARCHAR(191) NOT NULL,
+    `createdAt`    DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `completedAt`  DATETIME(3)  NULL,
+
+    INDEX `media_zip_jobs_status_idx`(`status`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ─── media_settings ───────────────────────────────────────────────────────
+
+CREATE TABLE `media_settings` (
+    `id`              VARCHAR(191) NOT NULL DEFAULT 'default',
+    `logoKey`         VARCHAR(512) NULL,
+    `faviconKey`      VARCHAR(512) NULL,
+    `logoFilename`    VARCHAR(255) NULL,
+    `faviconFilename` VARCHAR(255) NULL,
+    `retentionDays`   INT          NOT NULL DEFAULT 30,
+    `createdAt`       DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt`       DATETIME(3)  NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- ─── Foreign keys ─────────────────────────────────────────────────────────
+
+-- media_events
+ALTER TABLE `media_events`
+  ADD CONSTRAINT `media_events_planningEventId_fkey` FOREIGN KEY (`planningEventId`) REFERENCES `events`(`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT `media_events_churchId_fkey`        FOREIGN KEY (`churchId`)        REFERENCES `churches`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT `media_events_createdById_fkey`     FOREIGN KEY (`createdById`)     REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- media_projects
+ALTER TABLE `media_projects`
+  ADD CONSTRAINT `media_projects_churchId_fkey`    FOREIGN KEY (`churchId`)    REFERENCES `churches`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT `media_projects_createdById_fkey` FOREIGN KEY (`createdById`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- media_photos
+ALTER TABLE `media_photos`
+  ADD CONSTRAINT `media_photos_mediaEventId_fkey` FOREIGN KEY (`mediaEventId`) REFERENCES `media_events`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- media_files
+ALTER TABLE `media_files`
+  ADD CONSTRAINT `media_files_mediaEventId_fkey`   FOREIGN KEY (`mediaEventId`)   REFERENCES `media_events`(`id`)   ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `media_files_mediaProjectId_fkey` FOREIGN KEY (`mediaProjectId`) REFERENCES `media_projects`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- media_file_versions
+ALTER TABLE `media_file_versions`
+  ADD CONSTRAINT `media_file_versions_mediaFileId_fkey`   FOREIGN KEY (`mediaFileId`)   REFERENCES `media_files`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `media_file_versions_createdById_fkey`   FOREIGN KEY (`createdById`)   REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- media_comments
+ALTER TABLE `media_comments`
+  ADD CONSTRAINT `media_comments_parentId_fkey`    FOREIGN KEY (`parentId`)    REFERENCES `media_comments`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `media_comments_mediaFileId_fkey` FOREIGN KEY (`mediaFileId`) REFERENCES `media_files`(`id`)    ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `media_comments_authorId_fkey`    FOREIGN KEY (`authorId`)    REFERENCES `users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- media_share_tokens
+ALTER TABLE `media_share_tokens`
+  ADD CONSTRAINT `media_share_tokens_mediaEventId_fkey`   FOREIGN KEY (`mediaEventId`)   REFERENCES `media_events`(`id`)   ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `media_share_tokens_mediaProjectId_fkey` FOREIGN KEY (`mediaProjectId`) REFERENCES `media_projects`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,9 @@ model Church {
   memberLinkRequests       MemberLinkRequest[]
   discipleships            Discipleship[]
   eventReports             EventReport[]
+  // Module media
+  mediaEvents              MediaEvent[]
+  mediaProjects            MediaProject[]
 
   @@map("churches")
 }
@@ -109,6 +112,11 @@ model User {
   reviewedLinkRequests    MemberLinkRequest[] @relation("LinkRequestReviewer")
   eventReports            EventReport[]       @relation("ReportAuthor")
   departmentNotices       DepartmentNotice[]
+  // Module media
+  mediaEventsCreated      MediaEvent[]        @relation("MediaEventCreator")
+  mediaProjectsCreated    MediaProject[]      @relation("MediaProjectCreator")
+  mediaFileVersions       MediaFileVersion[]  @relation("MediaFileVersionCreator")
+  mediaComments           MediaComment[]      @relation("MediaCommentAuthor")
 
   @@map("users")
 }
@@ -319,6 +327,8 @@ model Event {
   discipleshipAttendances    DiscipleshipAttendance[]
   report                     EventReport?
   departmentNotices          DepartmentNotice[]
+  // Module media : galeries photos liées à cet événement planning
+  mediaEvents                MediaEvent[]
 
   @@map("events")
 }
@@ -574,4 +584,290 @@ model Request {
   @@index([churchId, type, status])
   @@index([assignedDeptId, status])
   @@map("requests")
+}
+
+// ============================================================================
+// MODULE MEDIA (ex-Mediaflow)
+// ============================================================================
+
+enum MediaEventStatus {
+  DRAFT          // En cours d'upload
+  PENDING_REVIEW // En attente de validation
+  REVIEWED       // Validation terminée
+  ARCHIVED       // Archivé
+}
+
+enum MediaPhotoStatus {
+  PENDING      // En attente de validation
+  APPROVED     // Validée
+  REJECTED     // Rejetée
+  PREVALIDATED // Pré-validée (filtrée par le prévalidateur)
+  PREREJECTED  // Écartée par le prévalidateur
+}
+
+enum MediaFileType {
+  PHOTO  // Images événements
+  VISUAL // Visuels (PNG, SVG, PDF)
+  VIDEO  // Vidéos (MP4, MOV)
+}
+
+enum MediaFileStatus {
+  PENDING            // Photos: en attente
+  APPROVED           // Photos: validée
+  REJECTED           // Rejetée (photos et médias)
+  PREVALIDATED       // Photos: pré-validée
+  PREREJECTED        // Photos: écartée
+  DRAFT              // Médias: brouillon
+  IN_REVIEW          // Médias: en révision
+  REVISION_REQUESTED // Médias: révision demandée
+  FINAL_APPROVED     // Médias: approuvé définitivement
+}
+
+enum MediaCommentType {
+  GENERAL  // Commentaire général
+  TIMECODE // Commentaire avec timecode (vidéos)
+}
+
+enum MediaTokenType {
+  VALIDATOR    // Accès validation (lecture + modification status)
+  MEDIA        // Accès téléchargement (lecture photos validées uniquement)
+  PREVALIDATOR // Accès prévalidation (filtrage avant validation finale)
+  GALLERY      // Accès galerie (téléchargement photo par photo)
+}
+
+enum MediaJobStatus {
+  PENDING
+  PROCESSING
+  COMPLETED
+  FAILED
+}
+
+/// Événement média (galerie photos / médias Mediaflow).
+/// Distinct de l'Event planning — peut être lié à un Event planning via planningEventId.
+model MediaEvent {
+  id          String           @id @default(cuid())
+  name        String           @db.VarChar(255)
+  date        DateTime
+  description String?          @db.Text
+  status      MediaEventStatus @default(DRAFT)
+
+  // Lien optionnel vers l'événement planning correspondant
+  planningEventId String?
+  planningEvent   Event?  @relation(fields: [planningEventId], references: [id], onDelete: SetNull)
+
+  // Multi-tenant
+  churchId    String
+  church      Church @relation(fields: [churchId], references: [id])
+
+  // Créateur (utilisateur Koinonia)
+  createdById String
+  createdBy   User   @relation("MediaEventCreator", fields: [createdById], references: [id])
+
+  photos      MediaPhoto[]
+  files       MediaFile[]
+  shareTokens MediaShareToken[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([churchId])
+  @@index([createdById])
+  @@index([status])
+  @@index([date])
+  @@index([planningEventId])
+  @@map("media_events")
+}
+
+/// Projet média (conteneur alternatif sans lien événement planning).
+model MediaProject {
+  id          String  @id @default(cuid())
+  name        String  @db.VarChar(255)
+  description String? @db.Text
+
+  churchId    String
+  church      Church @relation(fields: [churchId], references: [id])
+
+  createdById String
+  createdBy   User   @relation("MediaProjectCreator", fields: [createdById], references: [id])
+
+  files       MediaFile[]
+  shareTokens MediaShareToken[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([churchId])
+  @@index([createdById])
+  @@map("media_projects")
+}
+
+/// Photo associée à un événement média.
+model MediaPhoto {
+  id           String           @id @default(cuid())
+  filename     String           @db.VarChar(255)
+  originalKey  String           @db.VarChar(512)
+  thumbnailKey String           @db.VarChar(512)
+  mimeType     String           @db.VarChar(100)
+  size         Int
+  width        Int?
+  height       Int?
+
+  status      MediaPhotoStatus @default(PENDING)
+  validatedAt DateTime?
+  validatedBy String?          @db.VarChar(255)
+
+  mediaEventId String
+  mediaEvent   MediaEvent @relation(fields: [mediaEventId], references: [id], onDelete: Cascade)
+
+  uploadedAt DateTime @default(now())
+
+  @@index([mediaEventId])
+  @@index([status])
+  @@index([mediaEventId, status])
+  @@map("media_photos")
+}
+
+/// Fichier média (visuel, vidéo, etc.) avec versionnage.
+model MediaFile {
+  id       String          @id @default(cuid())
+  type     MediaFileType
+  status   MediaFileStatus @default(PENDING)
+  filename String          @db.VarChar(255)
+  mimeType String          @db.VarChar(100)
+  size     Int
+  width    Int?
+  height   Int?
+  duration Int?            // Durée en secondes (vidéos)
+
+  scheduledDeletionAt DateTime?
+
+  // Relations (mutuellement exclusives)
+  mediaEventId   String?
+  mediaEvent     MediaEvent?   @relation(fields: [mediaEventId], references: [id], onDelete: Cascade)
+  mediaProjectId String?
+  mediaProject   MediaProject? @relation(fields: [mediaProjectId], references: [id], onDelete: Cascade)
+
+  versions MediaFileVersion[]
+  comments MediaComment[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([mediaEventId])
+  @@index([mediaProjectId])
+  @@index([type])
+  @@index([status])
+  @@index([scheduledDeletionAt])
+  @@map("media_files")
+}
+
+/// Version d'un fichier média.
+model MediaFileVersion {
+  id            String @id @default(cuid())
+  versionNumber Int    @default(1)
+  originalKey   String @db.VarChar(512)
+  thumbnailKey  String @db.VarChar(512)
+  notes         String? @db.Text
+
+  mediaFileId String
+  mediaFile   MediaFile @relation(fields: [mediaFileId], references: [id], onDelete: Cascade)
+  createdById String
+  createdBy   User      @relation("MediaFileVersionCreator", fields: [createdById], references: [id])
+
+  createdAt DateTime @default(now())
+
+  @@unique([mediaFileId, versionNumber])
+  @@index([mediaFileId])
+  @@index([createdById])
+  @@map("media_file_versions")
+}
+
+/// Commentaire sur un fichier média.
+model MediaComment {
+  id      String           @id @default(cuid())
+  type    MediaCommentType @default(GENERAL)
+  content String           @db.Text
+
+  authorName  String? @db.VarChar(255)
+  authorImage String? @db.Text
+  timecode    Int?
+
+  parentId String?
+  parent   MediaComment?  @relation("MediaCommentReplies", fields: [parentId], references: [id], onDelete: Cascade)
+  replies  MediaComment[] @relation("MediaCommentReplies")
+
+  mediaFileId String
+  mediaFile   MediaFile @relation(fields: [mediaFileId], references: [id], onDelete: Cascade)
+  authorId    String?
+  author      User?     @relation("MediaCommentAuthor", fields: [authorId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([mediaFileId])
+  @@index([authorId])
+  @@index([parentId])
+  @@map("media_comments")
+}
+
+/// Token de partage pour accès sans authentification (galerie, validation, téléchargement).
+model MediaShareToken {
+  id     String         @id @default(cuid())
+  token  String         @unique @db.VarChar(64)
+  type   MediaTokenType
+  label  String?        @db.VarChar(255)
+  config Json?
+
+  expiresAt  DateTime?
+  lastUsedAt DateTime?
+  usageCount Int       @default(0)
+
+  // Relations (mutuellement exclusives)
+  mediaEventId   String?
+  mediaEvent     MediaEvent?   @relation(fields: [mediaEventId], references: [id], onDelete: Cascade)
+  mediaProjectId String?
+  mediaProject   MediaProject? @relation(fields: [mediaProjectId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@index([token])
+  @@index([mediaEventId])
+  @@index([mediaProjectId])
+  @@map("media_share_tokens")
+}
+
+/// Job de génération ZIP asynchrone.
+model MediaZipJob {
+  id       String         @id @default(cuid())
+  status   MediaJobStatus @default(PENDING)
+  progress Int            @default(0)
+
+  downloadKey String?   @db.VarChar(512)
+  expiresAt   DateTime?
+  error       String?   @db.Text
+
+  mediaEventId String
+  photoIds     Json
+  tokenId      String
+
+  createdAt   DateTime  @default(now())
+  completedAt DateTime?
+
+  @@index([status])
+  @@map("media_zip_jobs")
+}
+
+/// Paramètres du module média (logo, favicon, rétention).
+model MediaSettings {
+  id              String   @id @default("default")
+  logoKey         String?  @db.VarChar(512)
+  faviconKey      String?  @db.VarChar(512)
+  logoFilename    String?  @db.VarChar(255)
+  faviconFilename String?  @db.VarChar(255)
+  retentionDays   Int      @default(30)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("media_settings")
 }

--- a/src/app/api/media-events/[id]/photos/route.ts
+++ b/src/app/api/media-events/[id]/photos/route.ts
@@ -1,0 +1,132 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import {
+  processImage,
+  validatePhotoFile,
+  getExtensionFromMimeType,
+  uploadMediaFile,
+  getPhotoOriginalKey,
+  getPhotoThumbnailKey,
+} from "@/modules/media";
+import { z } from "zod";
+
+const patchSchema = z.object({
+  photoIds: z.array(z.string()).min(1),
+  status: z.enum(["APPROVED", "REJECTED", "PREVALIDATED", "PREREJECTED"]),
+});
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    await requireChurchPermission("media:view", churchId);
+
+    const photos = await prisma.mediaPhoto.findMany({
+      where: { mediaEventId: id },
+      orderBy: { uploadedAt: "desc" },
+    });
+
+    return successResponse(photos);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+/** POST — upload de photos (multipart/form-data, champ "files[]"). */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    await requireChurchPermission("media:upload", churchId);
+
+    const formData = await request.formData();
+    const files = formData.getAll("files") as File[];
+
+    if (!files || files.length === 0) throw new ApiError(400, "Aucun fichier fourni");
+
+    const uploaded: { id: string; filename: string }[] = [];
+    const errors: { filename: string; error: string }[] = [];
+
+    for (const file of files) {
+      try {
+        validatePhotoFile(file.name, file.type, file.size);
+
+        const buffer = Buffer.from(await file.arrayBuffer());
+        const processed = await processImage(buffer);
+        const ext = getExtensionFromMimeType(file.type);
+
+        const photo = await prisma.mediaPhoto.create({
+          data: {
+            filename: file.name,
+            mimeType: file.type,
+            size: file.size,
+            width: processed.metadata.width,
+            height: processed.metadata.height,
+            mediaEventId: id,
+            originalKey: "", // placeholders, updated below
+            thumbnailKey: "",
+            status: "PENDING",
+          },
+        });
+
+        const originalKey = getPhotoOriginalKey(id, photo.id, ext);
+        const thumbnailKey = getPhotoThumbnailKey(id, photo.id);
+
+        await Promise.all([
+          uploadMediaFile(originalKey, processed.original, "image/jpeg"),
+          uploadMediaFile(thumbnailKey, processed.thumbnail, "image/webp"),
+        ]);
+
+        await prisma.mediaPhoto.update({
+          where: { id: photo.id },
+          data: { originalKey, thumbnailKey },
+        });
+
+        uploaded.push({ id: photo.id, filename: file.name });
+      } catch (err) {
+        errors.push({
+          filename: file.name,
+          error: err instanceof Error ? err.message : "Erreur inconnue",
+        });
+      }
+    }
+
+    return successResponse({ uploaded, errors }, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+/** PATCH — mise à jour de statut en masse (validation/rejet). */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    await requireChurchPermission("media:review", churchId);
+
+    const body = await request.json();
+    const data = patchSchema.parse(body);
+
+    const result = await prisma.mediaPhoto.updateMany({
+      where: { mediaEventId: id, id: { in: data.photoIds } },
+      data: {
+        status: data.status,
+        validatedAt: new Date(),
+      },
+    });
+
+    return successResponse({ updated: result.count });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media-events/[id]/route.ts
+++ b/src/app/api/media-events/[id]/route.ts
@@ -1,0 +1,144 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
+import { deleteFiles } from "@/lib/s3";
+import { z } from "zod";
+
+const patchSchema = z.object({
+  name: z.string().min(1).optional(),
+  date: z.string().optional(),
+  description: z.string().nullable().optional(),
+  status: z.enum(["DRAFT", "PENDING_REVIEW", "REVIEWED", "ARCHIVED"]).optional(),
+  planningEventId: z.string().nullable().optional(),
+});
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    await requireChurchPermission("media:view", churchId);
+
+    const event = await prisma.mediaEvent.findUnique({
+      where: { id },
+      include: {
+        church: { select: { id: true, name: true } },
+        createdBy: { select: { id: true, name: true, displayName: true } },
+        planningEvent: { select: { id: true, title: true, type: true, date: true } },
+        _count: { select: { photos: true, files: true, shareTokens: true } },
+        photos: {
+          select: { status: true },
+        },
+      },
+    });
+
+    if (!event) throw new ApiError(404, "Événement média introuvable");
+    return successResponse(event);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    const session = await requireChurchPermission("media:upload", churchId);
+
+    const body = await request.json();
+    const data = patchSchema.parse(body);
+
+    if (data.planningEventId) {
+      const pe = await prisma.event.findUnique({
+        where: { id: data.planningEventId },
+        select: { churchId: true },
+      });
+      if (!pe || pe.churchId !== churchId) {
+        throw new ApiError(400, "Événement planning invalide ou hors périmètre");
+      }
+    }
+
+    const event = await prisma.mediaEvent.update({
+      where: { id },
+      data: {
+        ...(data.name !== undefined && { name: data.name }),
+        ...(data.date !== undefined && { date: new Date(data.date) }),
+        ...(data.description !== undefined && { description: data.description }),
+        ...(data.status !== undefined && { status: data.status }),
+        ...(data.planningEventId !== undefined && { planningEventId: data.planningEventId }),
+      },
+      include: {
+        church: { select: { id: true, name: true } },
+        createdBy: { select: { id: true, name: true, displayName: true } },
+        planningEvent: { select: { id: true, title: true, type: true, date: true } },
+      },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "UPDATE",
+      entityType: "MediaEvent",
+      entityId: id,
+      details: data,
+    });
+
+    return successResponse(event);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    const session = await requireChurchPermission("media:manage", churchId);
+
+    // Load all S3 keys before deletion
+    const event = await prisma.mediaEvent.findUnique({
+      where: { id },
+      include: {
+        photos: { select: { originalKey: true, thumbnailKey: true } },
+        files: {
+          include: { versions: { select: { originalKey: true, thumbnailKey: true } } },
+        },
+      },
+    });
+
+    if (!event) throw new ApiError(404, "Événement média introuvable");
+
+    const s3Keys = [
+      ...event.photos.flatMap((p) => [p.originalKey, p.thumbnailKey]),
+      ...event.files.flatMap((f) => f.versions.flatMap((v) => [v.originalKey, v.thumbnailKey])),
+    ];
+
+    if (s3Keys.length > 0) {
+      await deleteFiles(s3Keys);
+    }
+
+    // ON DELETE CASCADE handles photos, files, shareTokens
+    await prisma.mediaEvent.delete({ where: { id } });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "DELETE",
+      entityType: "MediaEvent",
+      entityId: id,
+    });
+
+    return successResponse({ deleted: id });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media-events/[id]/share/route.ts
+++ b/src/app/api/media-events/[id]/share/route.ts
@@ -1,0 +1,115 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { createMediaShareToken, getTokenUrlPath } from "@/modules/media";
+import { z } from "zod";
+
+const createSchema = z.object({
+  type: z.enum(["VALIDATOR", "MEDIA", "PREVALIDATOR", "GALLERY"]),
+  label: z.string().optional(),
+  expiresInDays: z.number().int().positive().optional(),
+  onlyApproved: z.boolean().optional(),
+});
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    await requireChurchPermission("media:view", churchId);
+
+    const tokens = await prisma.mediaShareToken.findMany({
+      where: { mediaEventId: id },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const baseUrl = process.env.APP_URL ?? process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+
+    return successResponse(
+      tokens.map((t) => ({
+        ...t,
+        url: `${baseUrl}/media/${getTokenUrlPath(t.type)}/${t.token}`,
+      }))
+    );
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    await requireChurchPermission("media:upload", churchId);
+
+    const body = await request.json();
+    const data = createSchema.parse(body);
+
+    // Rule: only one PREVALIDATOR per event
+    if (data.type === "PREVALIDATOR") {
+      const existing = await prisma.mediaShareToken.count({
+        where: { mediaEventId: id, type: "PREVALIDATOR" },
+      });
+      if (existing > 0) {
+        throw new ApiError(409, "Un lien de prévalidation existe déjà pour cet événement");
+      }
+    }
+
+    // Rule: block VALIDATOR/MEDIA if prevalidation active and pending photos remain
+    if (data.type === "VALIDATOR" || data.type === "MEDIA") {
+      const hasPrevalidator = await prisma.mediaShareToken.count({
+        where: { mediaEventId: id, type: "PREVALIDATOR" },
+      });
+      if (hasPrevalidator > 0) {
+        const pendingCount = await prisma.mediaPhoto.count({
+          where: { mediaEventId: id, status: "PENDING" },
+        });
+        if (pendingCount > 0) {
+          throw new ApiError(
+            409,
+            `La prévalidation est en cours (${pendingCount} photo(s) restante(s)). Terminez la prévalidation avant de créer un lien de validation.`
+          );
+        }
+      }
+    }
+
+    const token = await createMediaShareToken({
+      mediaEventId: id,
+      type: data.type,
+      label: data.label,
+      expiresInDays: data.expiresInDays,
+      onlyApproved: data.onlyApproved,
+    });
+
+    return successResponse(token, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    await requireChurchPermission("media:upload", churchId);
+
+    const tokenId = new URL(request.url).searchParams.get("tokenId");
+    if (!tokenId) throw new ApiError(400, "tokenId requis");
+
+    await prisma.mediaShareToken.delete({
+      where: { id: tokenId, mediaEventId: id },
+    });
+
+    return successResponse({ deleted: tokenId });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media-events/route.ts
+++ b/src/app/api/media-events/route.ts
@@ -1,0 +1,100 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
+import { z } from "zod";
+
+const createSchema = z.object({
+  name: z.string().min(1, "Le nom est requis"),
+  date: z.string().min(1, "La date est requise"),
+  churchId: z.string().min(1, "L'église est requise"),
+  description: z.string().nullable().optional(),
+  planningEventId: z.string().nullable().optional(),
+});
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const churchId = searchParams.get("churchId");
+    if (!churchId) throw new ApiError(400, "churchId requis");
+
+    await requireChurchPermission("media:view", churchId);
+
+    const status = searchParams.get("status");
+    const from = searchParams.get("from");
+    const to = searchParams.get("to");
+
+    const events = await prisma.mediaEvent.findMany({
+      where: {
+        churchId,
+        ...(status ? { status: status as "DRAFT" | "PENDING_REVIEW" | "REVIEWED" | "ARCHIVED" } : {}),
+        ...((from || to) ? {
+          date: {
+            ...(from ? { gte: new Date(from) } : {}),
+            ...(to ? { lte: new Date(to) } : {}),
+          },
+        } : {}),
+      },
+      orderBy: { date: "desc" },
+      include: {
+        church: { select: { id: true, name: true } },
+        createdBy: { select: { id: true, name: true, displayName: true } },
+        planningEvent: { select: { id: true, title: true, type: true, date: true } },
+        _count: { select: { photos: true, files: true } },
+      },
+    });
+
+    return successResponse(events);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const data = createSchema.parse(body);
+
+    const session = await requireChurchPermission("media:upload", data.churchId);
+
+    // Validate planningEventId belongs to same church
+    if (data.planningEventId) {
+      const planningEvent = await prisma.event.findUnique({
+        where: { id: data.planningEventId },
+        select: { churchId: true },
+      });
+      if (!planningEvent || planningEvent.churchId !== data.churchId) {
+        throw new ApiError(400, "Événement planning invalide ou hors périmètre");
+      }
+    }
+
+    const event = await prisma.mediaEvent.create({
+      data: {
+        name: data.name,
+        date: new Date(data.date),
+        churchId: data.churchId,
+        description: data.description ?? null,
+        planningEventId: data.planningEventId ?? null,
+        createdById: session.user.id,
+      },
+      include: {
+        church: { select: { id: true, name: true } },
+        createdBy: { select: { id: true, name: true, displayName: true } },
+        planningEvent: { select: { id: true, title: true, type: true, date: true } },
+      },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId: data.churchId,
+      action: "CREATE",
+      entityType: "MediaEvent",
+      entityId: event.id,
+      details: { name: data.name },
+    });
+
+    return successResponse(event, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media-projects/[id]/route.ts
+++ b/src/app/api/media-projects/[id]/route.ts
@@ -1,0 +1,114 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
+import { deleteFiles } from "@/lib/s3";
+import { z } from "zod";
+
+const patchSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().nullable().optional(),
+});
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaProject", id);
+    await requireChurchPermission("media:view", churchId);
+
+    const project = await prisma.mediaProject.findUnique({
+      where: { id },
+      include: {
+        createdBy: { select: { id: true, name: true, displayName: true } },
+        _count: { select: { files: true, shareTokens: true } },
+      },
+    });
+
+    if (!project) throw new ApiError(404, "Projet média introuvable");
+    return successResponse(project);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaProject", id);
+    const session = await requireChurchPermission("media:upload", churchId);
+
+    const body = await request.json();
+    const data = patchSchema.parse(body);
+
+    const project = await prisma.mediaProject.update({
+      where: { id },
+      data: {
+        ...(data.name !== undefined && { name: data.name }),
+        ...(data.description !== undefined && { description: data.description }),
+      },
+      include: {
+        createdBy: { select: { id: true, name: true, displayName: true } },
+      },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "UPDATE",
+      entityType: "MediaProject",
+      entityId: id,
+      details: data,
+    });
+
+    return successResponse(project);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaProject", id);
+    const session = await requireChurchPermission("media:manage", churchId);
+
+    const project = await prisma.mediaProject.findUnique({
+      where: { id },
+      include: {
+        files: {
+          include: { versions: { select: { originalKey: true, thumbnailKey: true } } },
+        },
+      },
+    });
+
+    if (!project) throw new ApiError(404, "Projet média introuvable");
+
+    const s3Keys = project.files.flatMap((f) =>
+      f.versions.flatMap((v) => [v.originalKey, v.thumbnailKey])
+    );
+    if (s3Keys.length > 0) await deleteFiles(s3Keys);
+
+    await prisma.mediaProject.delete({ where: { id } });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "DELETE",
+      entityType: "MediaProject",
+      entityId: id,
+    });
+
+    return successResponse({ deleted: id });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media-projects/[id]/share/route.ts
+++ b/src/app/api/media-projects/[id]/share/route.ts
@@ -1,0 +1,87 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { createMediaShareToken, getTokenUrlPath } from "@/modules/media";
+import { z } from "zod";
+
+const createSchema = z.object({
+  type: z.enum(["VALIDATOR", "MEDIA", "PREVALIDATOR", "GALLERY"]),
+  label: z.string().optional(),
+  expiresInDays: z.number().int().positive().optional(),
+  onlyApproved: z.boolean().optional(),
+});
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaProject", id);
+    await requireChurchPermission("media:view", churchId);
+
+    const tokens = await prisma.mediaShareToken.findMany({
+      where: { mediaProjectId: id },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const baseUrl = process.env.APP_URL ?? process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+
+    return successResponse(
+      tokens.map((t) => ({
+        ...t,
+        url: `${baseUrl}/media/${getTokenUrlPath(t.type)}/${t.token}`,
+      }))
+    );
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaProject", id);
+    await requireChurchPermission("media:upload", churchId);
+
+    const body = await request.json();
+    const data = createSchema.parse(body);
+
+    const token = await createMediaShareToken({
+      mediaProjectId: id,
+      type: data.type,
+      label: data.label,
+      expiresInDays: data.expiresInDays,
+      onlyApproved: data.onlyApproved,
+    });
+
+    return successResponse(token, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaProject", id);
+    await requireChurchPermission("media:upload", churchId);
+
+    const tokenId = new URL(request.url).searchParams.get("tokenId");
+    if (!tokenId) throw new ApiError(400, "tokenId requis");
+
+    await prisma.mediaShareToken.delete({
+      where: { id: tokenId, mediaProjectId: id },
+    });
+
+    return successResponse({ deleted: tokenId });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media-projects/route.ts
+++ b/src/app/api/media-projects/route.ts
@@ -1,0 +1,68 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
+import { z } from "zod";
+
+const createSchema = z.object({
+  name: z.string().min(1, "Le nom est requis"),
+  churchId: z.string().min(1, "L'église est requise"),
+  description: z.string().nullable().optional(),
+});
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const churchId = searchParams.get("churchId");
+    if (!churchId) throw new ApiError(400, "churchId requis");
+
+    await requireChurchPermission("media:view", churchId);
+
+    const projects = await prisma.mediaProject.findMany({
+      where: { churchId },
+      orderBy: { createdAt: "desc" },
+      include: {
+        createdBy: { select: { id: true, name: true, displayName: true } },
+        _count: { select: { files: true, shareTokens: true } },
+      },
+    });
+
+    return successResponse(projects);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const data = createSchema.parse(body);
+
+    const session = await requireChurchPermission("media:upload", data.churchId);
+
+    const project = await prisma.mediaProject.create({
+      data: {
+        name: data.name,
+        churchId: data.churchId,
+        description: data.description ?? null,
+        createdById: session.user.id,
+      },
+      include: {
+        createdBy: { select: { id: true, name: true, displayName: true } },
+      },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId: data.churchId,
+      action: "CREATE",
+      entityType: "MediaProject",
+      entityId: project.id,
+      details: { name: data.name },
+    });
+
+    return successResponse(project, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/download/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/download/[token]/photo/[photoId]/route.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /api/media/download/[token]/photo/[photoId]
+ * Retourne une URL signée pour télécharger une photo approuvée.
+ */
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { validateMediaShareToken, getSignedDownloadUrl } from "@/modules/media";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string; photoId: string }> }
+) {
+  try {
+    const { token, photoId } = await params;
+    const shareToken = await validateMediaShareToken(token, "MEDIA");
+
+    const photo = await prisma.mediaPhoto.findUnique({
+      where: { id: photoId },
+      select: { id: true, filename: true, mediaEventId: true, originalKey: true, status: true },
+    });
+
+    if (!photo) throw new ApiError(404, "Photo introuvable");
+    if (shareToken.mediaEventId && photo.mediaEventId !== shareToken.mediaEventId) {
+      throw new ApiError(403, "Photo hors périmètre");
+    }
+    if (photo.status !== "APPROVED") throw new ApiError(403, "Photo non approuvée");
+
+    const downloadUrl = await getSignedDownloadUrl(photo.originalKey, photo.filename);
+
+    return successResponse({ id: photo.id, filename: photo.filename, downloadUrl });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/download/[token]/route.ts
+++ b/src/app/api/media/download/[token]/route.ts
@@ -1,0 +1,44 @@
+/**
+ * GET /api/media/download/[token]
+ * Retourne les photos approuvées accessibles au téléchargement (token MEDIA).
+ */
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse } from "@/lib/api-utils";
+import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  try {
+    const { token } = await params;
+    const shareToken = await validateMediaShareToken(token, "MEDIA");
+    const event = shareToken.mediaEvent;
+
+    if (!event) return successResponse({ token: shareToken, photos: [] });
+
+    const photos = await prisma.mediaPhoto.findMany({
+      where: { mediaEventId: event.id, status: "APPROVED" },
+      orderBy: { uploadedAt: "asc" },
+    });
+
+    const photosWithUrls = await Promise.all(
+      photos.map(async (p) => ({
+        id: p.id,
+        filename: p.filename,
+        size: p.size,
+        width: p.width,
+        height: p.height,
+        thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
+      }))
+    );
+
+    return successResponse({
+      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label },
+      event: { id: event.id, name: event.name, date: event.date, photoCount: photosWithUrls.length },
+      photos: photosWithUrls,
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/files/[id]/comments/route.ts
+++ b/src/app/api/media/files/[id]/comments/route.ts
@@ -1,0 +1,95 @@
+/**
+ * GET/POST /api/media/files/[id]/comments
+ * Commentaires de révision sur un fichier média.
+ */
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { z } from "zod";
+
+const postSchema = z.object({
+  content: z.string().min(1),
+  type: z.enum(["GENERAL", "TIMECODE"]).default("GENERAL"),
+  timecode: z.number().int().nonnegative().optional(),
+  parentId: z.string().optional(),
+});
+
+async function resolveFileChurchId(fileId: string) {
+  const file = await prisma.mediaFile.findUnique({
+    where: { id: fileId },
+    include: {
+      mediaEvent: { select: { churchId: true } },
+      mediaProject: { select: { churchId: true } },
+    },
+  });
+  if (!file) throw new ApiError(404, "Fichier introuvable");
+  return file.mediaEvent?.churchId ?? file.mediaProject?.churchId ?? (() => { throw new ApiError(500, "Fichier sans conteneur"); })();
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveFileChurchId(id);
+    await requireChurchPermission("media:view", churchId);
+
+    const comments = await prisma.mediaComment.findMany({
+      where: { mediaFileId: id, parentId: null },
+      include: {
+        author: { select: { id: true, name: true, displayName: true } },
+        replies: {
+          include: {
+            author: { select: { id: true, name: true, displayName: true } },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return successResponse(comments);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveFileChurchId(id);
+    const session = await requireChurchPermission("media:view", churchId);
+
+    const body = await request.json();
+    const data = postSchema.parse(body);
+
+    if (data.parentId) {
+      const parent = await prisma.mediaComment.findUnique({ where: { id: data.parentId } });
+      if (!parent || parent.mediaFileId !== id) throw new ApiError(400, "Commentaire parent invalide");
+    }
+
+    const comment = await prisma.mediaComment.create({
+      data: {
+        content: data.content,
+        type: data.type,
+        timecode: data.timecode,
+        parentId: data.parentId,
+        mediaFileId: id,
+        authorId: session.user.id,
+        authorName: session.user.displayName ?? session.user.name ?? null,
+        authorImage: session.user.image ?? null,
+      },
+      include: {
+        author: { select: { id: true, name: true, displayName: true } },
+      },
+    });
+
+    return successResponse(comment, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/files/[id]/route.ts
+++ b/src/app/api/media/files/[id]/route.ts
@@ -1,0 +1,138 @@
+/**
+ * GET/PATCH/DELETE /api/media/files/[id]
+ * CRUD sur un fichier média (visual/vidéo).
+ */
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { deleteFiles } from "@/lib/s3";
+import { z } from "zod";
+
+const patchSchema = z.object({
+  status: z.enum([
+    "PENDING", "APPROVED", "REJECTED", "PREVALIDATED", "PREREJECTED",
+    "DRAFT", "IN_REVIEW", "REVISION_REQUESTED", "FINAL_APPROVED",
+  ]).optional(),
+  filename: z.string().min(1).optional(),
+  // Confirm upload: set key after presigned upload completes
+  originalKey: z.string().optional(),
+  thumbnailKey: z.string().optional(),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
+  duration: z.number().int().positive().optional(),
+});
+
+async function resolveMediaFileChurchId(fileId: string): Promise<string> {
+  const { ApiError } = await import("@/lib/api-utils");
+  const file = await prisma.mediaFile.findUnique({
+    where: { id: fileId },
+    include: {
+      mediaEvent: { select: { churchId: true } },
+      mediaProject: { select: { churchId: true } },
+    },
+  });
+  if (!file) throw new ApiError(404, "Fichier média introuvable");
+  return file.mediaEvent?.churchId ?? file.mediaProject?.churchId ?? (() => { throw new ApiError(500, "Fichier sans conteneur"); })();
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveMediaFileChurchId(id);
+    await requireChurchPermission("media:view", churchId);
+
+    const file = await prisma.mediaFile.findUnique({
+      where: { id },
+      include: {
+        versions: { orderBy: { versionNumber: "desc" } },
+        _count: { select: { comments: true } },
+      },
+    });
+
+    if (!file) throw new ApiError(404, "Fichier média introuvable");
+    return successResponse(file);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveMediaFileChurchId(id);
+    const session = await requireChurchPermission("media:upload", churchId);
+
+    const body = await request.json();
+    const data = patchSchema.parse(body);
+
+    // Status transitions to APPROVED/REJECTED require media:review
+    if (data.status && ["APPROVED", "REJECTED", "FINAL_APPROVED"].includes(data.status)) {
+      await requireChurchPermission("media:review", churchId);
+    }
+
+    const file = await prisma.mediaFile.update({
+      where: { id },
+      data: {
+        ...(data.status !== undefined && { status: data.status }),
+        ...(data.filename !== undefined && { filename: data.filename }),
+        ...(data.width !== undefined && { width: data.width }),
+        ...(data.height !== undefined && { height: data.height }),
+        ...(data.duration !== undefined && { duration: data.duration }),
+      },
+    });
+
+    // If upload confirmed (originalKey provided), create version 1
+    if (data.originalKey) {
+      const existingVersions = await prisma.mediaFileVersion.count({ where: { mediaFileId: id } });
+      if (existingVersions === 0) {
+        await prisma.mediaFileVersion.create({
+          data: {
+            mediaFileId: id,
+            versionNumber: 1,
+            originalKey: data.originalKey,
+            thumbnailKey: data.thumbnailKey ?? data.originalKey,
+            createdById: session.user.id,
+          },
+        });
+        // Update status from DRAFT to IN_REVIEW
+        await prisma.mediaFile.update({ where: { id }, data: { status: "IN_REVIEW" } });
+      }
+    }
+
+    return successResponse(file);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveMediaFileChurchId(id);
+    await requireChurchPermission("media:manage", churchId);
+
+    const file = await prisma.mediaFile.findUnique({
+      where: { id },
+      include: { versions: { select: { originalKey: true, thumbnailKey: true } } },
+    });
+    if (!file) throw new ApiError(404, "Fichier média introuvable");
+
+    const s3Keys = file.versions.flatMap((v) => [v.originalKey, v.thumbnailKey]);
+    if (s3Keys.length > 0) await deleteFiles(s3Keys);
+
+    await prisma.mediaFile.delete({ where: { id } });
+
+    return successResponse({ deleted: id });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/files/[id]/versions/route.ts
+++ b/src/app/api/media/files/[id]/versions/route.ts
@@ -1,0 +1,115 @@
+/**
+ * GET/POST /api/media/files/[id]/versions
+ * GET : liste les versions d'un fichier média.
+ * POST : démarre l'upload d'une nouvelle version (retourne une URL pré-signée).
+ *
+ * Flow :
+ *   1. POST ici → URL pré-signée S3 + version record créé (status DRAFT)
+ *   2. Client upload direct vers S3
+ *   3. PATCH /api/media/files/[id] avec originalKey pour confirmer l'upload
+ */
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { getVersionOriginalKey, getVersionThumbnailKey } from "@/modules/media";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { s3 } from "@/lib/s3";
+import { z } from "zod";
+
+const PRESIGNED_EXPIRY = 3600;
+
+const postSchema = z.object({
+  filename: z.string().min(1),
+  contentType: z.string().min(1),
+  size: z.number().int().positive(),
+  notes: z.string().optional(),
+});
+
+async function resolveFileChurchId(fileId: string) {
+  const file = await prisma.mediaFile.findUnique({
+    where: { id: fileId },
+    include: {
+      mediaEvent: { select: { churchId: true } },
+      mediaProject: { select: { churchId: true } },
+    },
+  });
+  if (!file) throw new ApiError(404, "Fichier introuvable");
+  return { churchId: file.mediaEvent?.churchId ?? file.mediaProject?.churchId!, file };
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const { churchId } = await resolveFileChurchId(id);
+    await requireChurchPermission("media:view", churchId);
+
+    const versions = await prisma.mediaFileVersion.findMany({
+      where: { mediaFileId: id },
+      orderBy: { versionNumber: "desc" },
+      include: {
+        createdBy: { select: { id: true, name: true, displayName: true } },
+      },
+    });
+
+    return successResponse(versions);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const { churchId, file } = await resolveFileChurchId(id);
+    const session = await requireChurchPermission("media:upload", churchId);
+
+    if (file.type === "PHOTO") throw new ApiError(400, "Les photos ne supportent pas le versionnage");
+
+    const body = await request.json();
+    const data = postSchema.parse(body);
+
+    const latestVersion = await prisma.mediaFileVersion.findFirst({
+      where: { mediaFileId: id },
+      orderBy: { versionNumber: "desc" },
+    });
+    const nextVersion = (latestVersion?.versionNumber ?? 0) + 1;
+
+    const ext = data.filename.split(".").pop()?.toLowerCase() ?? "bin";
+    const originalKey = getVersionOriginalKey(id, nextVersion, ext);
+    const thumbnailKey = getVersionThumbnailKey(id, nextVersion);
+
+    const version = await prisma.mediaFileVersion.create({
+      data: {
+        mediaFileId: id,
+        versionNumber: nextVersion,
+        originalKey,
+        thumbnailKey,
+        notes: data.notes,
+        createdById: session.user.id,
+      },
+    });
+
+    // Reset status to IN_REVIEW when new version is uploaded
+    await prisma.mediaFile.update({
+      where: { id },
+      data: { status: "IN_REVIEW", filename: data.filename, mimeType: data.contentType },
+    });
+
+    const uploadUrl = await getSignedUrl(
+      s3,
+      new PutObjectCommand({ Bucket: process.env.S3_BUCKET ?? "", Key: originalKey, ContentType: data.contentType }),
+      { expiresIn: PRESIGNED_EXPIRY }
+    );
+
+    return successResponse({ version, uploadUrl, expiresIn: PRESIGNED_EXPIRY }, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/files/upload/sign/route.ts
+++ b/src/app/api/media/files/upload/sign/route.ts
@@ -1,0 +1,85 @@
+/**
+ * POST /api/media/files/upload/sign
+ * Demande une URL pré-signée pour uploader directement un fichier média vers S3.
+ * Pour les fichiers VISUAL et VIDEO (pas les photos — celles-ci passent par /api/media-events/[id]/photos).
+ */
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
+import { getFileOriginalKey } from "@/modules/media";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { s3 } from "@/lib/s3";
+import { z } from "zod";
+
+const PRESIGNED_EXPIRY = 3600; // 1h
+const MAX_FILE_SIZE = 500 * 1024 * 1024; // 500 MB
+
+const ALLOWED_MIME_TYPES = [
+  // Images / visuels
+  "image/jpeg", "image/png", "image/webp", "image/svg+xml", "application/pdf",
+  // Vidéos
+  "video/mp4", "video/quicktime", "video/webm",
+];
+
+const schema = z.object({
+  filename: z.string().min(1),
+  contentType: z.string().min(1),
+  size: z.number().int().positive(),
+  type: z.enum(["VISUAL", "VIDEO"]),
+  mediaEventId: z.string().optional(),
+  mediaProjectId: z.string().optional(),
+}).refine((d) => d.mediaEventId || d.mediaProjectId, { message: "mediaEventId ou mediaProjectId requis" });
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const data = schema.parse(body);
+
+    if (!ALLOWED_MIME_TYPES.includes(data.contentType)) {
+      throw new ApiError(400, `Type MIME non supporté : ${data.contentType}`);
+    }
+    if (data.size > MAX_FILE_SIZE) {
+      throw new ApiError(400, `Fichier trop lourd (max ${MAX_FILE_SIZE / 1024 / 1024}MB)`);
+    }
+
+    // Resolve church from target
+    const churchId = data.mediaEventId
+      ? await resolveChurchId("mediaEvent", data.mediaEventId)
+      : await resolveChurchId("mediaProject", data.mediaProjectId!);
+
+    const session = await requireChurchPermission("media:upload", churchId);
+    requireRateLimit(request, { prefix: `media:upload:${session.user.id}`, ...RATE_LIMIT_MUTATION });
+
+    const ext = data.filename.split(".").pop()?.toLowerCase() ?? "bin";
+
+    // Pre-create the MediaFile record to get its id (for S3 key)
+    const container = data.mediaEventId ? "media-events" : "media-projects";
+    const containerId = data.mediaEventId ?? data.mediaProjectId!;
+
+    const file = await prisma.mediaFile.create({
+      data: {
+        type: data.type,
+        status: "DRAFT",
+        filename: data.filename,
+        mimeType: data.contentType,
+        size: data.size,
+        ...(data.mediaEventId && { mediaEventId: data.mediaEventId }),
+        ...(data.mediaProjectId && { mediaProjectId: data.mediaProjectId }),
+      },
+    });
+
+    const originalKey = getFileOriginalKey(container, containerId, file.id, 1, ext);
+
+    const url = await getSignedUrl(
+      s3,
+      new PutObjectCommand({ Bucket: process.env.S3_BUCKET ?? "", Key: originalKey, ContentType: data.contentType }),
+      { expiresIn: PRESIGNED_EXPIRY }
+    );
+
+    return successResponse({ fileId: file.id, uploadUrl: url, key: originalKey, expiresIn: PRESIGNED_EXPIRY }, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/gallery/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/gallery/[token]/photo/[photoId]/route.ts
@@ -1,0 +1,38 @@
+/**
+ * GET /api/media/gallery/[token]/photo/[photoId]
+ * Retourne une URL signée pour télécharger une photo depuis la galerie.
+ */
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { validateMediaShareToken, getSignedOriginalUrl } from "@/modules/media";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string; photoId: string }> }
+) {
+  try {
+    const { token, photoId } = await params;
+    const shareToken = await validateMediaShareToken(token, "GALLERY");
+
+    const photo = await prisma.mediaPhoto.findUnique({
+      where: { id: photoId },
+      select: { id: true, filename: true, mediaEventId: true, originalKey: true, status: true },
+    });
+
+    if (!photo) throw new ApiError(404, "Photo introuvable");
+    if (shareToken.mediaEventId && photo.mediaEventId !== shareToken.mediaEventId) {
+      throw new ApiError(403, "Photo hors périmètre");
+    }
+
+    const onlyApproved = (shareToken.config as { onlyApproved?: boolean } | null)?.onlyApproved ?? false;
+    if (onlyApproved && photo.status !== "APPROVED") {
+      throw new ApiError(403, "Cette photo n'est pas approuvée");
+    }
+
+    const downloadUrl = await getSignedOriginalUrl(photo.originalKey);
+
+    return successResponse({ id: photo.id, filename: photo.filename, downloadUrl });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/gallery/[token]/route.ts
+++ b/src/app/api/media/gallery/[token]/route.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /api/media/gallery/[token]
+ * Retourne la galerie photos (photos approuvées) via token GALLERY.
+ */
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse } from "@/lib/api-utils";
+import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  try {
+    const { token } = await params;
+    const shareToken = await validateMediaShareToken(token, "GALLERY");
+
+    const onlyApproved = (shareToken.config as { onlyApproved?: boolean } | null)?.onlyApproved ?? false;
+    const event = shareToken.mediaEvent;
+
+    if (!event) return successResponse({ token: shareToken, photos: [] });
+
+    const photos = await prisma.mediaPhoto.findMany({
+      where: {
+        mediaEventId: event.id,
+        ...(onlyApproved ? { status: "APPROVED" } : {}),
+      },
+      orderBy: { uploadedAt: "asc" },
+    });
+
+    const photosWithUrls = await Promise.all(
+      photos.map(async (p) => ({
+        id: p.id,
+        filename: p.filename,
+        status: p.status,
+        width: p.width,
+        height: p.height,
+        thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
+      }))
+    );
+
+    return successResponse({
+      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label, config: shareToken.config },
+      event: {
+        id: event.id,
+        name: event.name,
+        date: event.date,
+        photoCount: photosWithUrls.length,
+      },
+      photos: photosWithUrls,
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/settings/route.ts
+++ b/src/app/api/media/settings/route.ts
@@ -1,0 +1,60 @@
+/**
+ * GET/PUT /api/media/settings
+ * Paramètres du module média (logo, favicon, rétention).
+ * Accessible aux super admins.
+ */
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { z } from "zod";
+
+const putSchema = z.object({
+  retentionDays: z.number().int().min(1).max(365).optional(),
+  logoKey: z.string().nullable().optional(),
+  faviconKey: z.string().nullable().optional(),
+  logoFilename: z.string().nullable().optional(),
+  faviconFilename: z.string().nullable().optional(),
+});
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const churchId = searchParams.get("churchId");
+    if (!churchId) throw new ApiError(400, "churchId requis");
+
+    await requireChurchPermission("media:manage", churchId);
+
+    const settings = await prisma.mediaSettings.upsert({
+      where: { id: "default" },
+      update: {},
+      create: { id: "default" },
+    });
+
+    return successResponse(settings);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const churchId = searchParams.get("churchId");
+    if (!churchId) throw new ApiError(400, "churchId requis");
+
+    await requireChurchPermission("media:manage", churchId);
+
+    const body = await request.json();
+    const data = putSchema.parse(body);
+
+    const settings = await prisma.mediaSettings.upsert({
+      where: { id: "default" },
+      update: data,
+      create: { id: "default", ...data },
+    });
+
+    return successResponse(settings);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/validate/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/validate/[token]/photo/[photoId]/route.ts
@@ -1,0 +1,54 @@
+/**
+ * PATCH /api/media/validate/[token]/photo/[photoId]
+ * Valide ou rejette une photo individuelle via token de partage.
+ */
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { validateMediaShareToken } from "@/modules/media";
+import { z } from "zod";
+
+const patchSchema = z.object({
+  status: z.enum(["APPROVED", "REJECTED", "PREVALIDATED", "PREREJECTED"]),
+});
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ token: string; photoId: string }> }
+) {
+  try {
+    const { token, photoId } = await params;
+    const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
+
+    const body = await request.json();
+    const { status } = patchSchema.parse(body);
+
+    // Prevalidator can only set PREVALIDATED/PREREJECTED
+    if (shareToken.type === "PREVALIDATOR" && !["PREVALIDATED", "PREREJECTED"].includes(status)) {
+      throw new ApiError(403, "Le prévalidateur ne peut que prévalider ou écarter");
+    }
+
+    // Validator can only set APPROVED/REJECTED
+    if (shareToken.type === "VALIDATOR" && !["APPROVED", "REJECTED"].includes(status)) {
+      throw new ApiError(403, "Le validateur ne peut qu'approuver ou rejeter");
+    }
+
+    const photo = await prisma.mediaPhoto.findUnique({
+      where: { id: photoId },
+      select: { id: true, mediaEventId: true },
+    });
+
+    if (!photo) throw new ApiError(404, "Photo introuvable");
+    if (shareToken.mediaEventId && photo.mediaEventId !== shareToken.mediaEventId) {
+      throw new ApiError(403, "Photo hors périmètre");
+    }
+
+    const updated = await prisma.mediaPhoto.update({
+      where: { id: photoId },
+      data: { status, validatedAt: new Date() },
+    });
+
+    return successResponse(updated);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/validate/[token]/route.ts
+++ b/src/app/api/media/validate/[token]/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET /api/media/validate/[token]
+ * Retourne l'événement média et ses photos pour validation/prévalidation.
+ * Accessible sans authentification via un token de partage VALIDATOR ou PREVALIDATOR.
+ */
+import { successResponse, errorResponse } from "@/lib/api-utils";
+import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  try {
+    const { token } = await params;
+    const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
+
+    const isPrevalidator = shareToken.type === "PREVALIDATOR";
+    const event = shareToken.mediaEvent;
+
+    if (!event) {
+      return successResponse({ token: shareToken, event: null });
+    }
+
+    const hasPrevalidator = event.shareTokens.some((t) => t.type === "PREVALIDATOR");
+
+    // Filtre statuts selon le type de token
+    let statusFilter: string[];
+    if (isPrevalidator) {
+      statusFilter = ["PENDING"];
+    } else if (hasPrevalidator) {
+      statusFilter = ["PREVALIDATED", "APPROVED", "REJECTED"];
+    } else {
+      statusFilter = ["PENDING", "PREVALIDATED", "APPROVED", "REJECTED"];
+    }
+
+    const { prisma } = await import("@/lib/prisma");
+    const photos = await prisma.mediaPhoto.findMany({
+      where: {
+        mediaEventId: event.id,
+        status: { in: statusFilter as ("PENDING" | "APPROVED" | "REJECTED" | "PREVALIDATED" | "PREREJECTED")[] },
+      },
+      orderBy: { uploadedAt: "asc" },
+    });
+
+    const photosWithUrls = await Promise.all(
+      photos.map(async (p) => ({
+        ...p,
+        thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
+      }))
+    );
+
+    return successResponse({
+      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label },
+      event: {
+        id: event.id,
+        name: event.name,
+        date: event.date,
+        status: event.status,
+        isPrevalidator,
+        hasPrevalidator,
+        totalPhotos: event.photos.length,
+        approvedCount: event.photos.filter((p) => p.status === "APPROVED").length,
+        pendingCount: event.photos.filter((p) => p.status === "PENDING").length,
+        rejectedCount: event.photos.filter((p) => p.status === "REJECTED").length,
+        prevalidatedCount: event.photos.filter((p) => p.status === "PREVALIDATED").length,
+        prerejectedCount: event.photos.filter((p) => p.status === "PREREJECTED").length,
+      },
+      photos: photosWithUrls,
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -315,7 +315,7 @@ export async function requireChurchAccess(churchId: string) {
  * Lève une ApiError 404 si la ressource n'existe pas.
  */
 export async function resolveChurchId(
-  resourceType: "event" | "department" | "member" | "request" | "memberLinkRequest" | "announcement" | "ministry",
+  resourceType: "event" | "department" | "member" | "request" | "memberLinkRequest" | "announcement" | "ministry" | "mediaEvent" | "mediaProject",
   resourceId: string
 ): Promise<string> {
   const { ApiError } = await import("./api-utils");
@@ -383,6 +383,22 @@ export async function resolveChurchId(
       });
       if (!ministry) throw new ApiError(404, "Ministère introuvable");
       return ministry.churchId;
+    }
+    case "mediaEvent": {
+      const me = await prisma.mediaEvent.findUnique({
+        where: { id: resourceId },
+        select: { churchId: true },
+      });
+      if (!me) throw new ApiError(404, "Événement média introuvable");
+      return me.churchId;
+    }
+    case "mediaProject": {
+      const mp = await prisma.mediaProject.findUnique({
+        where: { id: resourceId },
+        select: { churchId: true },
+      });
+      if (!mp) throw new ApiError(404, "Projet média introuvable");
+      return mp.churchId;
     }
   }
 }

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -3,6 +3,7 @@ import { buildRolePermissions } from "@/core/permissions";
 import { coreModule } from "@/modules/core";
 import { planningModule, planningBus } from "@/modules/planning";
 import { discipleshipModule } from "@/modules/discipleship";
+import { mediaModule } from "@/modules/media";
 
 /**
  * Registry singleton — chargé une fois au démarrage du process.
@@ -11,7 +12,7 @@ import { discipleshipModule } from "@/modules/discipleship";
  * Source de vérité pour les permissions dans les contrôles d'accès API.
  */
 export const registry = boot({
-  modules: [coreModule, planningModule, discipleshipModule],
+  modules: [coreModule, planningModule, discipleshipModule, mediaModule],
 });
 
 /**

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -1,4 +1,4 @@
-import { S3Client } from "@aws-sdk/client-s3";
+import { S3Client, DeleteObjectsCommand } from "@aws-sdk/client-s3";
 
 const globalForS3 = globalThis as unknown as {
   s3: S3Client | undefined;
@@ -27,3 +27,21 @@ export const s3 =
   });
 
 if (process.env.NODE_ENV !== "production") globalForS3.s3 = s3;
+
+/** Supprime plusieurs objets S3 en une requête batch (max 1000 clés par appel). */
+export async function deleteFiles(keys: string[]): Promise<void> {
+  if (keys.length === 0) return;
+  const bucket = process.env.S3_BUCKET;
+  if (!bucket) return; // S3 non configuré — no-op en dev
+
+  const BATCH = 1000;
+  for (let i = 0; i < keys.length; i += BATCH) {
+    const batch = keys.slice(i, i + BATCH);
+    await s3.send(
+      new DeleteObjectsCommand({
+        Bucket: bucket,
+        Delete: { Objects: batch.map((Key) => ({ Key })) },
+      })
+    );
+  }
+}

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -1,0 +1,37 @@
+import { defineModule } from "@/core/module-registry";
+
+/**
+ * Module media — ex-Mediaflow.
+ *
+ * Périmètre :
+ *   - Galeries photos événements (MediaEvent, MediaPhoto)
+ *   - Projets média (MediaProject)
+ *   - Fichiers média avec versionnage (MediaFile, MediaFileVersion)
+ *   - Commentaires de révision (MediaComment)
+ *   - Tokens de partage sans authentification (MediaShareToken)
+ *   - Jobs ZIP asynchrones (MediaZipJob)
+ *   - Paramètres du module (MediaSettings)
+ *
+ * Dépendances : core (obligatoire), planning (optionnelle — lien MediaEvent → Event planning)
+ */
+export const mediaModule = defineModule({
+  name: "media",
+  version: "1.0.0",
+  dependsOn: ["core"],
+  optionalDependencies: ["planning"],
+
+  permissions: {
+    // Accès en lecture aux galeries et médias
+    "media:view":    ["SUPER_ADMIN", "ADMIN", "SECRETARY"],
+    // Upload, organisation, création de projets et événements médias
+    "media:upload":  ["SUPER_ADMIN", "ADMIN", "SECRETARY"],
+    // Validation/rejet des photos et médias
+    "media:review":  ["SUPER_ADMIN", "ADMIN"],
+    // Administration du module (paramètres, tokens)
+    "media:manage":  ["SUPER_ADMIN", "ADMIN"],
+  },
+
+  navigation: [
+    { label: "Médias", icon: "media", href: "/media", permission: "media:view" },
+  ],
+});

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -1,5 +1,7 @@
 import { defineModule } from "@/core/module-registry";
 
+export { createMediaShareToken, getTokenUrlPath, isTokenExpired, generateToken } from "./services/tokens";
+
 /**
  * Module media — ex-Mediaflow.
  *

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -12,6 +12,8 @@ export {
   getFileOriginalKey,
   getFileThumbnailKey,
   getZipKey,
+  getVersionOriginalKey,
+  getVersionThumbnailKey,
   createMultipartUpload,
   getSignedPartUrl,
   completeMultipartUpload,

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -1,6 +1,22 @@
 import { defineModule } from "@/core/module-registry";
 
-export { createMediaShareToken, getTokenUrlPath, isTokenExpired, generateToken } from "./services/tokens";
+export { createMediaShareToken, validateMediaShareToken, getTokenUrlPath, isTokenExpired, generateToken } from "./services/tokens";
+export { processImage, validatePhotoFile, getExtensionFromMimeType, ALLOWED_PHOTO_MIME_TYPES, MAX_PHOTO_SIZE } from "./services/image";
+export {
+  uploadFile as uploadMediaFile,
+  getSignedThumbnailUrl,
+  getSignedOriginalUrl,
+  getSignedDownloadUrl,
+  getPhotoOriginalKey,
+  getPhotoThumbnailKey,
+  getFileOriginalKey,
+  getFileThumbnailKey,
+  getZipKey,
+  createMultipartUpload,
+  getSignedPartUrl,
+  completeMultipartUpload,
+  abortMultipartUpload,
+} from "./services/s3";
 
 /**
  * Module media — ex-Mediaflow.

--- a/src/modules/media/services/image.ts
+++ b/src/modules/media/services/image.ts
@@ -1,0 +1,52 @@
+import sharp from "sharp";
+import { ApiError } from "@/lib/api-utils";
+
+export const ALLOWED_PHOTO_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
+export const MAX_PHOTO_SIZE = 50 * 1024 * 1024; // 50 MB
+
+export interface ProcessedImage {
+  original: Buffer;
+  thumbnail: Buffer;
+  metadata: { width: number; height: number; format: string };
+}
+
+/** Traite une image : rotation EXIF + JPEG 90% + miniature WebP 1200px. */
+export async function processImage(buffer: Buffer): Promise<ProcessedImage> {
+  const image = sharp(buffer);
+  const metadata = await image.metadata();
+
+  if (!metadata.width || !metadata.height || !metadata.format) {
+    throw new ApiError(400, "Impossible de lire les métadonnées de l'image");
+  }
+
+  const original = await image.rotate().jpeg({ quality: 90 }).toBuffer();
+  const thumbnail = await sharp(buffer)
+    .rotate()
+    .resize(1200, null, { withoutEnlargement: true })
+    .webp({ quality: 80 })
+    .toBuffer();
+
+  return {
+    original,
+    thumbnail,
+    metadata: { width: metadata.width, height: metadata.height, format: metadata.format },
+  };
+}
+
+export function validatePhotoFile(_filename: string, mimeType: string, size: number): void {
+  if (!ALLOWED_PHOTO_MIME_TYPES.includes(mimeType)) {
+    throw new ApiError(400, `Type de fichier non supporté : ${mimeType}`);
+  }
+  if (size > MAX_PHOTO_SIZE) {
+    throw new ApiError(400, `Fichier trop lourd : ${Math.round(size / 1024 / 1024)}MB (max 50MB)`);
+  }
+}
+
+export function getExtensionFromMimeType(mimeType: string): string {
+  const map: Record<string, string> = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+  };
+  return map[mimeType] ?? "jpg";
+}

--- a/src/modules/media/services/s3.ts
+++ b/src/modules/media/services/s3.ts
@@ -1,0 +1,112 @@
+import {
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+  CreateMultipartUploadCommand,
+  UploadPartCommand,
+  CompleteMultipartUploadCommand,
+  AbortMultipartUploadCommand,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { s3 as s3Client } from "@/lib/s3";
+
+const BUCKET = process.env.S3_BUCKET ?? "";
+
+// ─── URL expiry ────────────────────────────────────────────────────────────
+const THUMBNAIL_URL_EXPIRY = 3600;   // 1h
+const ORIGINAL_URL_EXPIRY  = 300;    // 5min
+const DOWNLOAD_URL_EXPIRY  = 600;    // 10min
+
+// ─── Key helpers ──────────────────────────────────────────────────────────
+
+export type MediaContainer = "media-events" | "media-projects";
+
+export function getPhotoOriginalKey(mediaEventId: string, photoId: string, ext: string): string {
+  return `media-events/${mediaEventId}/photos/originals/${photoId}.${ext}`;
+}
+
+export function getPhotoThumbnailKey(mediaEventId: string, photoId: string): string {
+  return `media-events/${mediaEventId}/photos/thumbnails/${photoId}.webp`;
+}
+
+export function getFileOriginalKey(
+  container: MediaContainer,
+  containerId: string,
+  fileId: string,
+  versionNumber: number,
+  ext: string
+): string {
+  return `${container}/${containerId}/files/v${versionNumber}/${fileId}.${ext}`;
+}
+
+export function getFileThumbnailKey(
+  container: MediaContainer,
+  containerId: string,
+  fileId: string,
+  versionNumber: number
+): string {
+  return `${container}/${containerId}/files/v${versionNumber}/${fileId}.webp`;
+}
+
+export function getZipKey(mediaEventId: string, jobId: string): string {
+  return `media-events/${mediaEventId}/zips/${jobId}.zip`;
+}
+
+// ─── Upload ────────────────────────────────────────────────────────────────
+
+export async function uploadFile(key: string, body: Buffer, contentType: string): Promise<void> {
+  await s3Client.send(new PutObjectCommand({ Bucket: BUCKET, Key: key, Body: body, ContentType: contentType }));
+}
+
+// ─── Signed URLs ──────────────────────────────────────────────────────────
+
+export async function getSignedThumbnailUrl(key: string): Promise<string> {
+  return getSignedUrl(s3Client, new GetObjectCommand({ Bucket: BUCKET, Key: key }), { expiresIn: THUMBNAIL_URL_EXPIRY });
+}
+
+export async function getSignedOriginalUrl(key: string): Promise<string> {
+  return getSignedUrl(s3Client, new GetObjectCommand({ Bucket: BUCKET, Key: key }), { expiresIn: ORIGINAL_URL_EXPIRY });
+}
+
+export async function getSignedDownloadUrl(key: string, filename: string): Promise<string> {
+  return getSignedUrl(
+    s3Client,
+    new GetObjectCommand({ Bucket: BUCKET, Key: key, ResponseContentDisposition: `attachment; filename="${filename}"` }),
+    { expiresIn: DOWNLOAD_URL_EXPIRY }
+  );
+}
+
+// ─── Delete ────────────────────────────────────────────────────────────────
+
+export async function deleteMediaFile(key: string): Promise<void> {
+  await s3Client.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: key }));
+}
+
+// ─── Multipart upload ─────────────────────────────────────────────────────
+
+export async function createMultipartUpload(key: string, contentType: string): Promise<string> {
+  const resp = await s3Client.send(new CreateMultipartUploadCommand({ Bucket: BUCKET, Key: key, ContentType: contentType }));
+  if (!resp.UploadId) throw new Error("createMultipartUpload: no UploadId");
+  return resp.UploadId;
+}
+
+export async function getSignedPartUrl(key: string, uploadId: string, partNumber: number, expiresIn: number): Promise<string> {
+  return getSignedUrl(s3Client, new UploadPartCommand({ Bucket: BUCKET, Key: key, UploadId: uploadId, PartNumber: partNumber }), { expiresIn });
+}
+
+export async function completeMultipartUpload(
+  key: string,
+  uploadId: string,
+  parts: { partNumber: number; etag: string }[]
+): Promise<void> {
+  await s3Client.send(new CompleteMultipartUploadCommand({
+    Bucket: BUCKET,
+    Key: key,
+    UploadId: uploadId,
+    MultipartUpload: { Parts: parts.map((p) => ({ PartNumber: p.partNumber, ETag: p.etag })) },
+  }));
+}
+
+export async function abortMultipartUpload(key: string, uploadId: string): Promise<void> {
+  await s3Client.send(new AbortMultipartUploadCommand({ Bucket: BUCKET, Key: key, UploadId: uploadId }));
+}

--- a/src/modules/media/services/s3.ts
+++ b/src/modules/media/services/s3.ts
@@ -52,6 +52,14 @@ export function getZipKey(mediaEventId: string, jobId: string): string {
   return `media-events/${mediaEventId}/zips/${jobId}.zip`;
 }
 
+export function getVersionOriginalKey(fileId: string, versionNumber: number, ext: string): string {
+  return `media-files/${fileId}/v${versionNumber}/original.${ext}`;
+}
+
+export function getVersionThumbnailKey(fileId: string, versionNumber: number): string {
+  return `media-files/${fileId}/v${versionNumber}/thumbnail.webp`;
+}
+
 // ─── Upload ────────────────────────────────────────────────────────────────
 
 export async function uploadFile(key: string, body: Buffer, contentType: string): Promise<void> {

--- a/src/modules/media/services/tokens.ts
+++ b/src/modules/media/services/tokens.ts
@@ -1,0 +1,58 @@
+import { randomBytes } from "crypto";
+import { prisma } from "@/lib/prisma";
+import type { MediaTokenType } from "@/generated/prisma/client";
+
+export function generateToken(): string {
+  return randomBytes(32).toString("hex"); // 64 chars
+}
+
+export function isTokenExpired(expiresAt: Date | null): boolean {
+  if (!expiresAt) return false;
+  return new Date() > expiresAt;
+}
+
+/** URL path segment par type de token (pour les liens publics). */
+export function getTokenUrlPath(type: MediaTokenType): string {
+  if (type === "MEDIA") return "d";
+  if (type === "GALLERY") return "g";
+  return "v";
+}
+
+interface CreateTokenOptions {
+  type: MediaTokenType;
+  label?: string;
+  expiresInDays?: number;
+  onlyApproved?: boolean;
+}
+
+type CreateTokenWithTarget = CreateTokenOptions &
+  ({ mediaEventId: string; mediaProjectId?: never } | { mediaProjectId: string; mediaEventId?: never });
+
+export async function createMediaShareToken(options: CreateTokenWithTarget) {
+  const { type, label, expiresInDays, onlyApproved, mediaEventId, mediaProjectId } = options;
+
+  const token = generateToken();
+  const expiresAt = expiresInDays
+    ? new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
+    : null;
+  const config = type === "GALLERY" ? { onlyApproved: onlyApproved ?? false } : null;
+
+  const shareToken = await prisma.mediaShareToken.create({
+    data: {
+      token,
+      type,
+      label,
+      expiresAt,
+      ...(config && { config }),
+      ...(mediaEventId && { mediaEventId }),
+      ...(mediaProjectId && { mediaProjectId }),
+    },
+  });
+
+  const baseUrl = process.env.APP_URL ?? process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+
+  return {
+    ...shareToken,
+    url: `${baseUrl}/media/${getTokenUrlPath(type)}/${token}`,
+  };
+}

--- a/src/modules/media/services/tokens.ts
+++ b/src/modules/media/services/tokens.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "crypto";
 import { prisma } from "@/lib/prisma";
+import { ApiError } from "@/lib/api-utils";
 import type { MediaTokenType } from "@/generated/prisma/client";
 
 export function generateToken(): string {
@@ -27,6 +28,41 @@ interface CreateTokenOptions {
 
 type CreateTokenWithTarget = CreateTokenOptions &
   ({ mediaEventId: string; mediaProjectId?: never } | { mediaProjectId: string; mediaEventId?: never });
+
+/** Valide un token de partage et retourne ses données + l'événement ou projet lié. */
+export async function validateMediaShareToken(
+  token: string,
+  requiredTypes?: MediaTokenType | MediaTokenType[]
+) {
+  const shareToken = await prisma.mediaShareToken.findUnique({
+    where: { token },
+    include: {
+      mediaEvent: {
+        include: {
+          photos: { select: { status: true } },
+          shareTokens: { select: { type: true } },
+        },
+      },
+      mediaProject: { select: { id: true, name: true, churchId: true } },
+    },
+  });
+
+  if (!shareToken) throw new ApiError(401, "Token invalide");
+  if (isTokenExpired(shareToken.expiresAt)) throw new ApiError(401, "Token expiré");
+
+  if (requiredTypes) {
+    const allowed = Array.isArray(requiredTypes) ? requiredTypes : [requiredTypes];
+    if (!allowed.includes(shareToken.type)) throw new ApiError(403, "Type de token non autorisé");
+  }
+
+  // Update usage stats
+  await prisma.mediaShareToken.update({
+    where: { id: shareToken.id },
+    data: { lastUsedAt: new Date(), usageCount: { increment: 1 } },
+  });
+
+  return shareToken;
+}
 
 export async function createMediaShareToken(options: CreateTokenWithTarget) {
   const { type, label, expiresInDays, onlyApproved, mediaEventId, mediaProjectId } = options;


### PR DESCRIPTION
## Summary

Absorbe Mediaflow dans ICC Platform comme module `media`.

### Schéma Prisma (8 nouveaux modèles)
- `MediaEvent` — galerie photos liée optionnellement à un `Event` planning
- `MediaProject` — conteneur alternatif (projets sans événement)
- `MediaPhoto` — photos avec statuts de validation (pending/prevalidated/approved/rejected)
- `MediaFile` + `MediaFileVersion` — fichiers médias versionnés (visuels, vidéos)
- `MediaComment` — commentaires de révision avec threads et timecodes
- `MediaShareToken` — tokens de partage public (VALIDATOR/PREVALIDATOR/MEDIA/GALLERY)
- `MediaZipJob` — jobs ZIP asynchrones
- `MediaSettings` — paramètres du module (singleton)

### API routes (17 endpoints)
- `GET/POST /api/media-events` — événements médias
- `GET/PATCH/DELETE /api/media-events/[id]`
- `GET/POST/DELETE /api/media-events/[id]/share` — tokens de partage
- `GET/POST/PATCH /api/media-events/[id]/photos` — upload + validation masse
- `GET/POST /api/media-projects` — projets médias
- `GET/PATCH/DELETE /api/media-projects/[id]`
- `GET/POST/DELETE /api/media-projects/[id]/share`
- `GET /api/media/validate/[token]` + `PATCH .../photo/[id]` — validation publique
- `GET /api/media/gallery/[token]` + `GET .../photo/[id]` — galerie publique
- `GET /api/media/download/[token]` + `GET .../photo/[id]` — téléchargement
- `POST /api/media/files/upload/sign` — URL pré-signée S3
- `GET/PATCH/DELETE /api/media/files/[id]`
- `GET/POST /api/media/files/[id]/comments`
- `GET/PUT /api/media/settings`

### Module manifest
- `src/modules/media/index.ts` — permissions media:view/upload/review/manage
- Enregistré dans le registry

### Services internes (`src/modules/media/services/`)
- `tokens.ts` — createMediaShareToken, validateMediaShareToken
- `image.ts` — processImage (Sharp), validatePhotoFile
- `s3.ts` — clés S3, uploadFile, signedUrls, multipart

### Infra
- `src/lib/s3.ts` + deleteFiles() utilitaire batch
- `src/lib/auth.ts` + resolveChurchId() pour mediaEvent/mediaProject
- `npm install sharp @aws-sdk/s3-request-presigner`

## Test plan

- [ ] `npm run typecheck` ✅
- [ ] `npx depcruise src/` ✅ (0 violations)
- [ ] Créer un MediaEvent via `POST /api/media-events`
- [ ] Uploader des photos via `POST /api/media-events/[id]/photos`
- [ ] Créer un token VALIDATOR et valider des photos via le token public
- [ ] Créer un token GALLERY et accéder à la galerie

🤖 Generated with [Claude Code](https://claude.com/claude-code)