### PR TITLE
feat(media): UI événements, projets + pages publiques token

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -119,6 +119,12 @@ export default async function AuthLayout({
       serviceLinks.push({ href: "/communication/requests", label: "Communication" });
   }
 
+  // Media module links
+  if (userPermissions.has("media:view")) {
+    serviceLinks.push({ href: "/media/events", label: "Événements médias" });
+    serviceLinks.push({ href: "/media/projects", label: "Projets médias" });
+  }
+
   const headerContent = (
     <>
       <div className="min-w-0">

--- a/src/app/(auth)/media/events/MediaEventsList.tsx
+++ b/src/app/(auth)/media/events/MediaEventsList.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import type { MediaEventStatus } from "@/generated/prisma/enums";
+
+type MediaEvent = {
+  id: string;
+  name: string;
+  date: Date;
+  description: string | null;
+  status: MediaEventStatus;
+  createdAt: Date;
+  createdBy: { id: string; name: string | null; displayName: string | null };
+  planningEvent: { id: string; title: string; type: string; date: Date } | null;
+  _count: { photos: number; files: number };
+};
+
+const STATUS_LABELS: Record<MediaEventStatus, string> = {
+  DRAFT: "Brouillon",
+  PENDING_REVIEW: "En révision",
+  REVIEWED: "Validé",
+  ARCHIVED: "Archivé",
+};
+
+const STATUS_COLORS: Record<MediaEventStatus, string> = {
+  DRAFT: "bg-gray-100 text-gray-700",
+  PENDING_REVIEW: "bg-yellow-100 text-yellow-800",
+  REVIEWED: "bg-green-100 text-green-800",
+  ARCHIVED: "bg-gray-100 text-gray-500",
+};
+
+function formatDate(d: Date) {
+  return new Date(d).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export default function MediaEventsList({
+  events,
+  canUpload,
+}: {
+  events: MediaEvent[];
+  canUpload: boolean;
+}) {
+  const [statusFilter, setStatusFilter] = useState<MediaEventStatus | "">("");
+  const [search, setSearch] = useState("");
+
+  const filtered = events.filter((e) => {
+    if (statusFilter && e.status !== statusFilter) return false;
+    if (search && !e.name.toLowerCase().includes(search.toLowerCase())) return false;
+    return true;
+  });
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <input
+          type="text"
+          placeholder="Rechercher…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent flex-1"
+        />
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value as MediaEventStatus | "")}
+          className="border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+        >
+          <option value="">Tous les statuts</option>
+          {(Object.keys(STATUS_LABELS) as MediaEventStatus[]).map((s) => (
+            <option key={s} value={s}>{STATUS_LABELS[s]}</option>
+          ))}
+        </select>
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-gray-500">
+          {events.length === 0 ? (
+            <>
+              <p className="text-lg font-medium mb-2">Aucun événement média</p>
+              {canUpload && (
+                <p className="text-sm">
+                  <Link href="/media/events/new" className="text-icc-violet hover:underline">
+                    Créer le premier événement
+                  </Link>
+                </p>
+              )}
+            </>
+          ) : (
+            <p>Aucun événement ne correspond aux filtres.</p>
+          )}
+        </div>
+      )}
+
+      <div className="grid gap-4">
+        {filtered.map((event) => (
+          <Link
+            key={event.id}
+            href={`/media/events/${event.id}`}
+            className="block bg-white border-2 border-gray-200 rounded-lg p-4 hover:border-icc-violet transition-colors"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap mb-1">
+                  <h2 className="font-semibold text-gray-900 truncate">{event.name}</h2>
+                  <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_COLORS[event.status]}`}>
+                    {STATUS_LABELS[event.status]}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-500">{formatDate(event.date)}</p>
+                {event.planningEvent && (
+                  <p className="text-xs text-icc-violet mt-1">
+                    Lié à : {event.planningEvent.title}
+                  </p>
+                )}
+                {event.description && (
+                  <p className="text-sm text-gray-600 mt-1 line-clamp-2">{event.description}</p>
+                )}
+              </div>
+              <div className="flex flex-col items-end gap-1 text-xs text-gray-500 shrink-0">
+                {event._count.photos > 0 && (
+                  <span>{event._count.photos} photo{event._count.photos > 1 ? "s" : ""}</span>
+                )}
+                {event._count.files > 0 && (
+                  <span>{event._count.files} fichier{event._count.files > 1 ? "s" : ""}</span>
+                )}
+                <span className="text-gray-400">
+                  par {event.createdBy.displayName || event.createdBy.name || "—"}
+                </span>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
+++ b/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
@@ -1,0 +1,535 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import type { MediaEventStatus, MediaPhotoStatus, MediaTokenType } from "@/generated/prisma/enums";
+
+type Photo = {
+  id: string;
+  filename: string;
+  originalKey: string;
+  thumbnailKey: string;
+  mimeType: string;
+  size: number;
+  width: number | null;
+  height: number | null;
+  status: MediaPhotoStatus;
+  validatedAt: Date | null;
+  validatedBy: string | null;
+  mediaEventId: string;
+  uploadedAt: Date;
+};
+
+type ShareToken = {
+  id: string;
+  token: string;
+  type: MediaTokenType;
+  label: string | null;
+  expiresAt: Date | null;
+  usageCount: number;
+  createdAt: Date;
+};
+
+type MediaEvent = {
+  id: string;
+  name: string;
+  date: Date;
+  description: string | null;
+  status: MediaEventStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: { id: string; name: string | null; displayName: string | null };
+  planningEvent: { id: string; title: string; type: string; date: Date } | null;
+  photos: Photo[];
+  shareTokens: ShareToken[];
+  _count: { photos: number; files: number };
+};
+
+const PHOTO_STATUS_LABELS: Record<MediaPhotoStatus, string> = {
+  PENDING: "En attente",
+  APPROVED: "Approuvée",
+  REJECTED: "Rejetée",
+  PREVALIDATED: "Pré-validée",
+  PREREJECTED: "Pré-rejetée",
+};
+
+const PHOTO_STATUS_COLORS: Record<MediaPhotoStatus, string> = {
+  PENDING: "bg-yellow-100 text-yellow-800",
+  APPROVED: "bg-green-100 text-green-800",
+  REJECTED: "bg-red-100 text-red-800",
+  PREVALIDATED: "bg-blue-100 text-blue-800",
+  PREREJECTED: "bg-orange-100 text-orange-800",
+};
+
+const TOKEN_TYPE_LABELS: Record<MediaTokenType, string> = {
+  VALIDATOR: "Validateur",
+  PREVALIDATOR: "Pré-validateur",
+  MEDIA: "Téléchargement",
+  GALLERY: "Galerie",
+};
+
+const EVENT_STATUS_LABELS: Record<MediaEventStatus, string> = {
+  DRAFT: "Brouillon",
+  PENDING_REVIEW: "En révision",
+  REVIEWED: "Validé",
+  ARCHIVED: "Archivé",
+};
+
+function formatDate(d: Date) {
+  return new Date(d).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function formatSize(bytes: number) {
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} Ko`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} Mo`;
+}
+
+// ── Upload zone ───────────────────────────────────────────
+
+function PhotoUploadZone({
+  eventId,
+  onUploaded,
+}: {
+  eventId: string;
+  onUploaded: () => void;
+}) {
+  const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function uploadFiles(files: File[]) {
+    setUploading(true);
+    setError(null);
+    setProgress({ done: 0, total: files.length });
+
+    let done = 0;
+    const errors: string[] = [];
+
+    for (const file of files) {
+      try {
+        const form = new FormData();
+        form.append("file", file);
+        const res = await fetch(`/api/media-events/${eventId}/photos`, {
+          method: "POST",
+          body: form,
+        });
+        const json = await res.json();
+        if (!res.ok) errors.push(`${file.name}: ${json.error || "Erreur"}`);
+      } catch {
+        errors.push(`${file.name}: Erreur réseau`);
+      }
+      done++;
+      setProgress({ done, total: files.length });
+    }
+
+    setUploading(false);
+    setProgress(null);
+    if (errors.length > 0) setError(errors.join("\n"));
+    onUploaded();
+  }
+
+  function onDrop(e: React.DragEvent) {
+    e.preventDefault();
+    const files = Array.from(e.dataTransfer.files).filter((f) =>
+      ["image/jpeg", "image/png", "image/webp"].includes(f.type)
+    );
+    if (files.length > 0) uploadFiles(files);
+  }
+
+  function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? []);
+    if (files.length > 0) uploadFiles(files);
+    e.target.value = "";
+  }
+
+  return (
+    <div
+      onDrop={onDrop}
+      onDragOver={(e) => e.preventDefault()}
+      onClick={() => inputRef.current?.click()}
+      className="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center cursor-pointer hover:border-icc-violet transition-colors"
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        multiple
+        className="hidden"
+        onChange={onFileChange}
+      />
+      {uploading && progress ? (
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-gray-700">
+            Upload {progress.done}/{progress.total}…
+          </p>
+          <div className="w-full bg-gray-200 rounded-full h-2">
+            <div
+              className="bg-icc-violet h-2 rounded-full transition-all"
+              style={{ width: `${(progress.done / progress.total) * 100}%` }}
+            />
+          </div>
+        </div>
+      ) : (
+        <>
+          <svg className="w-10 h-10 text-gray-400 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          <p className="text-sm text-gray-600">
+            Glissez des photos ici ou <span className="text-icc-violet font-medium">cliquez pour choisir</span>
+          </p>
+          <p className="text-xs text-gray-400 mt-1">JPEG, PNG, WebP — max 50 Mo par photo</p>
+        </>
+      )}
+      {error && (
+        <p className="mt-2 text-xs text-red-600 whitespace-pre-line">{error}</p>
+      )}
+    </div>
+  );
+}
+
+// ── Share token management ────────────────────────────────
+
+function ShareTokenSection({
+  eventId,
+  tokens,
+  onRefresh,
+}: {
+  eventId: string;
+  tokens: ShareToken[];
+  onRefresh: () => void;
+}) {
+  const [creating, setCreating] = useState(false);
+  const [newType, setNewType] = useState<MediaTokenType>("GALLERY");
+  const [newLabel, setNewLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function createToken() {
+    setError(null);
+    setCreating(true);
+    try {
+      const res = await fetch(`/api/media-events/${eventId}/share`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: newType, label: newLabel || null }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Erreur");
+      setNewLabel("");
+      onRefresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function deleteToken(tokenId: string) {
+    if (!confirm("Supprimer ce lien de partage ?")) return;
+    await fetch(`/api/media-events/${eventId}/share?tokenId=${tokenId}`, { method: "DELETE" });
+    onRefresh();
+  }
+
+  function getTokenUrl(token: ShareToken) {
+    const paths: Record<MediaTokenType, string> = {
+      VALIDATOR: "v",
+      PREVALIDATOR: "v",
+      MEDIA: "d",
+      GALLERY: "g",
+    };
+    return `${window.location.origin}/media/${paths[token.type]}/${token.token}`;
+  }
+
+  return (
+    <div className="space-y-3">
+      {tokens.map((token) => (
+        <div key={token.id} className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg border border-gray-200">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-medium bg-icc-violet/10 text-icc-violet px-2 py-0.5 rounded">
+                {TOKEN_TYPE_LABELS[token.type]}
+              </span>
+              {token.label && <span className="text-sm text-gray-700">{token.label}</span>}
+            </div>
+            <p className="text-xs text-gray-500 mt-1 truncate font-mono">{getTokenUrl(token)}</p>
+            <p className="text-xs text-gray-400 mt-0.5">
+              {token.usageCount} utilisation{token.usageCount > 1 ? "s" : ""}
+              {token.expiresAt && ` · expire le ${formatDate(token.expiresAt)}`}
+            </p>
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <button
+              onClick={() => navigator.clipboard.writeText(getTokenUrl(token))}
+              className="text-xs text-gray-500 hover:text-icc-violet border border-gray-200 rounded px-2 py-1"
+            >
+              Copier
+            </button>
+            <button
+              onClick={() => deleteToken(token.id)}
+              className="text-xs text-red-600 hover:text-red-700 border border-red-200 rounded px-2 py-1"
+            >
+              Suppr.
+            </button>
+          </div>
+        </div>
+      ))}
+
+      <div className="flex gap-2">
+        <select
+          value={newType}
+          onChange={(e) => setNewType(e.target.value as MediaTokenType)}
+          className="border-2 border-gray-200 rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+        >
+          {(Object.keys(TOKEN_TYPE_LABELS) as MediaTokenType[]).map((t) => (
+            <option key={t} value={t}>{TOKEN_TYPE_LABELS[t]}</option>
+          ))}
+        </select>
+        <input
+          type="text"
+          placeholder="Étiquette (optionnel)"
+          value={newLabel}
+          onChange={(e) => setNewLabel(e.target.value)}
+          className="flex-1 border-2 border-gray-200 rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+        />
+        <Button onClick={createToken} disabled={creating} size="sm">
+          {creating ? "…" : "+ Lien"}
+        </Button>
+      </div>
+      {error && <p className="text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────
+
+export default function MediaEventDetail({
+  event: initialEvent,
+  canUpload,
+  canReview,
+  canManage,
+}: {
+  event: MediaEvent;
+  canUpload: boolean;
+  canReview: boolean;
+  canManage: boolean;
+}) {
+  const router = useRouter();
+  const [event, setEvent] = useState(initialEvent);
+  const [selectedPhotoIds, setSelectedPhotoIds] = useState<Set<string>>(new Set());
+  const [photoFilter, setPhotoFilter] = useState<MediaPhotoStatus | "">("");
+  const [bulkLoading, setBulkLoading] = useState(false);
+
+  async function refreshEvent() {
+    const res = await fetch(`/api/media-events/${event.id}`);
+    const json = await res.json();
+    if (res.ok) setEvent({ ...event, ...json.data, photos: json.data.photos ?? event.photos, shareTokens: json.data.shareTokens ?? event.shareTokens });
+    router.refresh();
+  }
+
+  async function refreshPhotos() {
+    const res = await fetch(`/api/media-events/${event.id}/photos`);
+    const json = await res.json();
+    if (res.ok) setEvent((prev) => ({ ...prev, photos: json.data, _count: { ...prev._count, photos: json.data.length } }));
+  }
+
+  const filteredPhotos = event.photos.filter((p) =>
+    !photoFilter || p.status === photoFilter
+  );
+
+  function toggleSelect(id: string) {
+    setSelectedPhotoIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectAll() {
+    if (selectedPhotoIds.size === filteredPhotos.length) {
+      setSelectedPhotoIds(new Set());
+    } else {
+      setSelectedPhotoIds(new Set(filteredPhotos.map((p) => p.id)));
+    }
+  }
+
+  async function bulkAction(status: "APPROVED" | "REJECTED") {
+    if (selectedPhotoIds.size === 0) return;
+    setBulkLoading(true);
+    try {
+      await fetch(`/api/media-events/${event.id}/photos`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ photoIds: Array.from(selectedPhotoIds), status }),
+      });
+      setSelectedPhotoIds(new Set());
+      await refreshPhotos();
+    } finally {
+      setBulkLoading(false);
+    }
+  }
+
+  async function deleteEvent() {
+    if (!confirm(`Supprimer l'événement "${event.name}" et toutes ses photos ?`)) return;
+    await fetch(`/api/media-events/${event.id}`, { method: "DELETE" });
+    router.push("/media/events");
+  }
+
+  const pendingCount = event.photos.filter((p) => p.status === "PENDING").length;
+  const approvedCount = event.photos.filter((p) => p.status === "APPROVED").length;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <Link href="/media/events" className="text-sm text-gray-500 hover:text-gray-700">
+              ← Événements
+            </Link>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">{event.name}</h1>
+          <div className="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-600">
+            <span>{formatDate(event.date)}</span>
+            <span className="text-gray-300">|</span>
+            <span>{EVENT_STATUS_LABELS[event.status]}</span>
+            <span className="text-gray-300">|</span>
+            <span>{event._count.photos} photo{event._count.photos !== 1 ? "s" : ""}</span>
+            {approvedCount > 0 && <span className="text-green-600">({approvedCount} approuvée{approvedCount > 1 ? "s" : ""})</span>}
+            {pendingCount > 0 && <span className="text-yellow-600">({pendingCount} en attente)</span>}
+          </div>
+          {event.planningEvent && (
+            <p className="text-xs text-icc-violet mt-1">Lié à : {event.planningEvent.title}</p>
+          )}
+          {event.description && <p className="text-sm text-gray-600 mt-2">{event.description}</p>}
+        </div>
+        {canManage && (
+          <button
+            onClick={deleteEvent}
+            className="text-sm text-red-600 hover:text-red-700 border border-red-200 rounded-lg px-3 py-1.5 hover:bg-red-50 transition-colors shrink-0"
+          >
+            Supprimer
+          </button>
+        )}
+      </div>
+
+      {/* Upload zone */}
+      {canUpload && (
+        <section>
+          <h2 className="text-lg font-semibold text-gray-900 mb-3">Ajouter des photos</h2>
+          <PhotoUploadZone eventId={event.id} onUploaded={refreshPhotos} />
+        </section>
+      )}
+
+      {/* Photos */}
+      <section>
+        <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
+          <h2 className="text-lg font-semibold text-gray-900">
+            Photos ({event._count.photos})
+          </h2>
+          <div className="flex items-center gap-2">
+            <select
+              value={photoFilter}
+              onChange={(e) => setPhotoFilter(e.target.value as MediaPhotoStatus | "")}
+              className="border-2 border-gray-200 rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+            >
+              <option value="">Tous statuts</option>
+              {(Object.keys(PHOTO_STATUS_LABELS) as MediaPhotoStatus[]).map((s) => (
+                <option key={s} value={s}>{PHOTO_STATUS_LABELS[s]}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Bulk actions */}
+        {canReview && filteredPhotos.length > 0 && (
+          <div className="flex items-center gap-3 mb-3 p-2 bg-gray-50 rounded-lg">
+            <input
+              type="checkbox"
+              checked={selectedPhotoIds.size === filteredPhotos.length && filteredPhotos.length > 0}
+              onChange={toggleSelectAll}
+              className="w-4 h-4 rounded border-gray-300"
+            />
+            <span className="text-sm text-gray-600">
+              {selectedPhotoIds.size > 0 ? `${selectedPhotoIds.size} sélectionnée${selectedPhotoIds.size > 1 ? "s" : ""}` : "Tout sélectionner"}
+            </span>
+            {selectedPhotoIds.size > 0 && (
+              <>
+                <Button
+                  size="sm"
+                  onClick={() => bulkAction("APPROVED")}
+                  disabled={bulkLoading}
+                  className="bg-green-600 hover:bg-green-700"
+                >
+                  Approuver
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => bulkAction("REJECTED")}
+                  disabled={bulkLoading}
+                  variant="danger"
+                >
+                  Rejeter
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+
+        {filteredPhotos.length === 0 ? (
+          <p className="text-gray-500 text-sm py-6 text-center">Aucune photo</p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+            {filteredPhotos.map((photo) => (
+              <div
+                key={photo.id}
+                className={`relative group rounded-lg overflow-hidden border-2 transition-colors ${
+                  selectedPhotoIds.has(photo.id) ? "border-icc-violet" : "border-gray-200"
+                }`}
+              >
+                {canReview && (
+                  <input
+                    type="checkbox"
+                    checked={selectedPhotoIds.has(photo.id)}
+                    onChange={() => toggleSelect(photo.id)}
+                    className="absolute top-2 left-2 z-10 w-4 h-4 rounded border-gray-300 opacity-0 group-hover:opacity-100 transition-opacity"
+                    style={selectedPhotoIds.has(photo.id) ? { opacity: 1 } : {}}
+                  />
+                )}
+                <div className="aspect-square bg-gray-100 flex items-center justify-center">
+                  <svg className="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  </svg>
+                </div>
+                <div className="p-1.5">
+                  <span className={`text-xs px-1.5 py-0.5 rounded-full ${PHOTO_STATUS_COLORS[photo.status]}`}>
+                    {PHOTO_STATUS_LABELS[photo.status]}
+                  </span>
+                  <p className="text-xs text-gray-400 mt-1 truncate">{formatSize(photo.size)}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Share tokens */}
+      {canManage && (
+        <section>
+          <h2 className="text-lg font-semibold text-gray-900 mb-3">Liens de partage</h2>
+          <ShareTokenSection
+            eventId={event.id}
+            tokens={event.shareTokens}
+            onRefresh={refreshEvent}
+          />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/app/(auth)/media/events/[id]/page.tsx
+++ b/src/app/(auth)/media/events/[id]/page.tsx
@@ -1,0 +1,59 @@
+import { requireChurchPermission, resolveChurchId, requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { notFound } from "next/navigation";
+import { rolePermissions } from "@/lib/registry";
+import MediaEventDetail from "./MediaEventDetail";
+
+export default async function MediaEventDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await requireAuth();
+
+  let churchId: string;
+  try {
+    churchId = await resolveChurchId("mediaEvent", id);
+  } catch {
+    notFound();
+  }
+
+  await requireChurchPermission("media:view", churchId!);
+
+  const event = await prisma.mediaEvent.findUnique({
+    where: { id },
+    include: {
+      createdBy: { select: { id: true, name: true, displayName: true } },
+      planningEvent: { select: { id: true, title: true, type: true, date: true } },
+      photos: {
+        orderBy: { uploadedAt: "desc" },
+      },
+      shareTokens: {
+        orderBy: { createdAt: "desc" },
+      },
+      _count: { select: { photos: true, files: true } },
+    },
+  });
+
+  if (!event) notFound();
+
+  const userPermissions = new Set(
+    session.user.isSuperAdmin
+      ? ["media:view", "media:upload", "media:review", "media:manage"]
+      : session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
+  );
+
+  const canUpload = userPermissions.has("media:upload");
+  const canReview = userPermissions.has("media:review");
+  const canManage = userPermissions.has("media:manage");
+
+  return (
+    <MediaEventDetail
+      event={event}
+      canUpload={canUpload}
+      canReview={canReview}
+      canManage={canManage}
+    />
+  );
+}

--- a/src/app/(auth)/media/events/[id]/page.tsx
+++ b/src/app/(auth)/media/events/[id]/page.tsx
@@ -38,15 +38,14 @@ export default async function MediaEventDetailPage({
 
   if (!event) notFound();
 
-  const userPermissions = new Set(
-    session.user.isSuperAdmin
-      ? ["media:view", "media:upload", "media:review", "media:manage"]
-      : session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
+  const churchPerms = new Set(
+    session.user.churchRoles
+      .filter((r) => r.churchId === churchId!)
+      .flatMap((r) => rolePermissions[r.role] ?? [])
   );
-
-  const canUpload = userPermissions.has("media:upload");
-  const canReview = userPermissions.has("media:review");
-  const canManage = userPermissions.has("media:manage");
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload");
+  const canReview = session.user.isSuperAdmin || churchPerms.has("media:review");
+  const canManage = session.user.isSuperAdmin || churchPerms.has("media:manage");
 
   return (
     <MediaEventDetail

--- a/src/app/(auth)/media/events/new/NewMediaEventForm.tsx
+++ b/src/app/(auth)/media/events/new/NewMediaEventForm.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+type PlanningEvent = {
+  id: string;
+  title: string;
+  type: string;
+  date: Date;
+};
+
+function formatDate(d: Date) {
+  return new Date(d).toLocaleDateString("fr-FR", { day: "numeric", month: "short", year: "numeric" });
+}
+
+export default function NewMediaEventForm({
+  churchId,
+  planningEvents,
+}: {
+  churchId: string;
+  planningEvents: PlanningEvent[];
+}) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [date, setDate] = useState("");
+  const [description, setDescription] = useState("");
+  const [planningEventId, setPlanningEventId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Auto-fill name from selected planning event
+  function onPlanningEventChange(id: string) {
+    setPlanningEventId(id);
+    if (id) {
+      const pe = planningEvents.find((e) => e.id === id);
+      if (pe && !name) {
+        setName(pe.title);
+        if (!date) {
+          const d = new Date(pe.date);
+          setDate(d.toISOString().split("T")[0]);
+        }
+      }
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch("/api/media-events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          date,
+          churchId,
+          description: description || null,
+          planningEventId: planningEventId || null,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Erreur lors de la création");
+      router.push(`/media/events/${json.data.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur inconnue");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-lg space-y-5">
+      {planningEvents.length > 0 && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Lier à un événement planning <span className="text-gray-400">(optionnel)</span>
+          </label>
+          <select
+            value={planningEventId}
+            onChange={(e) => onPlanningEventChange(e.target.value)}
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+          >
+            <option value="">— Aucun —</option>
+            {planningEvents.map((pe) => (
+              <option key={pe.id} value={pe.id}>
+                {pe.title} — {formatDate(pe.date)}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Nom de l'événement <span className="text-red-500">*</span>
+        </label>
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          placeholder="Ex: Culte du 20 avril 2026"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Date <span className="text-red-500">*</span>
+        </label>
+        <Input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          required
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Description <span className="text-gray-400">(optionnel)</span>
+        </label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={3}
+          placeholder="Notes ou contexte…"
+          className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent resize-none"
+        />
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          {error}
+        </p>
+      )}
+
+      <div className="flex gap-3">
+        <Button type="submit" disabled={loading}>
+          {loading ? "Création…" : "Créer l'événement"}
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => router.push("/media/events")}
+          disabled={loading}
+        >
+          Annuler
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(auth)/media/events/new/page.tsx
+++ b/src/app/(auth)/media/events/new/page.tsx
@@ -1,0 +1,28 @@
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import NewMediaEventForm from "./NewMediaEventForm";
+
+export default async function NewMediaEventPage() {
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("media:upload", churchId);
+
+  // Load upcoming planning events for linking
+  const planningEvents = await prisma.event.findMany({
+    where: {
+      churchId,
+      date: { gte: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000) },
+    },
+    orderBy: { date: "desc" },
+    select: { id: true, title: true, type: true, date: true },
+    take: 50,
+  });
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Nouvel événement média</h1>
+      <NewMediaEventForm churchId={churchId} planningEvents={planningEvents} />
+    </div>
+  );
+}

--- a/src/app/(auth)/media/events/page.tsx
+++ b/src/app/(auth)/media/events/page.tsx
@@ -2,6 +2,7 @@ import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
+import { rolePermissions } from "@/lib/registry";
 import MediaEventsList from "./MediaEventsList";
 
 export default async function MediaEventsPage() {
@@ -20,9 +21,12 @@ export default async function MediaEventsPage() {
     },
   });
 
-  const canUpload = session.user.isSuperAdmin || session.user.churchRoles.some(
-    (r) => r.churchId === churchId && ["SUPER_ADMIN", "ADMIN", "SECRETARY"].includes(r.role)
+  const churchPerms = new Set(
+    session.user.churchRoles
+      .filter((r) => r.churchId === churchId)
+      .flatMap((r) => rolePermissions[r.role] ?? [])
   );
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload");
 
   return (
     <div>

--- a/src/app/(auth)/media/events/page.tsx
+++ b/src/app/(auth)/media/events/page.tsx
@@ -1,0 +1,40 @@
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import MediaEventsList from "./MediaEventsList";
+
+export default async function MediaEventsPage() {
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("media:view", churchId);
+
+  const events = await prisma.mediaEvent.findMany({
+    where: { churchId },
+    orderBy: { date: "desc" },
+    include: {
+      createdBy: { select: { id: true, name: true, displayName: true } },
+      planningEvent: { select: { id: true, title: true, type: true, date: true } },
+      _count: { select: { photos: true, files: true } },
+    },
+  });
+
+  const canUpload = session.user.isSuperAdmin || session.user.churchRoles.some(
+    (r) => r.churchId === churchId && ["SUPER_ADMIN", "ADMIN", "SECRETARY"].includes(r.role)
+  );
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Événements média</h1>
+        {canUpload && (
+          <Link href="/media/events/new">
+            <Button>+ Nouvel événement</Button>
+          </Link>
+        )}
+      </div>
+      <MediaEventsList events={events} canUpload={canUpload} />
+    </div>
+  );
+}

--- a/src/app/(auth)/media/projects/MediaProjectsList.tsx
+++ b/src/app/(auth)/media/projects/MediaProjectsList.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+type MediaProject = {
+  id: string;
+  name: string;
+  description: string | null;
+  createdAt: Date;
+  createdBy: { id: string; name: string | null; displayName: string | null };
+  _count: { files: number };
+};
+
+function formatDate(d: Date) {
+  return new Date(d).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export default function MediaProjectsList({
+  projects,
+  canUpload,
+}: {
+  projects: MediaProject[];
+  canUpload: boolean;
+}) {
+  const [search, setSearch] = useState("");
+
+  const filtered = projects.filter((p) =>
+    !search || p.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-4">
+      <input
+        type="text"
+        placeholder="Rechercher…"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="w-full sm:w-80 border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+      />
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-gray-500">
+          {projects.length === 0 ? (
+            <>
+              <p className="text-lg font-medium mb-2">Aucun projet média</p>
+              {canUpload && (
+                <p className="text-sm">
+                  <Link href="/media/projects/new" className="text-icc-violet hover:underline">
+                    Créer le premier projet
+                  </Link>
+                </p>
+              )}
+            </>
+          ) : (
+            <p>Aucun projet ne correspond à la recherche.</p>
+          )}
+        </div>
+      )}
+
+      <div className="grid gap-4">
+        {filtered.map((project) => (
+          <Link
+            key={project.id}
+            href={`/media/projects/${project.id}`}
+            className="block bg-white border-2 border-gray-200 rounded-lg p-4 hover:border-icc-violet transition-colors"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex-1 min-w-0">
+                <h2 className="font-semibold text-gray-900 truncate">{project.name}</h2>
+                {project.description && (
+                  <p className="text-sm text-gray-600 mt-1 line-clamp-2">{project.description}</p>
+                )}
+                <p className="text-xs text-gray-400 mt-2">
+                  Créé le {formatDate(project.createdAt)} par{" "}
+                  {project.createdBy.displayName || project.createdBy.name || "—"}
+                </p>
+              </div>
+              <div className="text-sm text-gray-500 shrink-0">
+                {project._count.files} fichier{project._count.files !== 1 ? "s" : ""}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
+++ b/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import type { MediaFileStatus, MediaFileType, MediaTokenType } from "@/generated/prisma/enums";
+
+type FileVersion = {
+  id: string;
+  versionNumber: number;
+  originalKey: string;
+  thumbnailKey: string;
+  notes: string | null;
+  createdAt: Date;
+};
+
+type MediaFile = {
+  id: string;
+  type: MediaFileType;
+  status: MediaFileStatus;
+  filename: string;
+  mimeType: string;
+  size: number;
+  width: number | null;
+  height: number | null;
+  duration: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+  versions: FileVersion[];
+};
+
+type ShareToken = {
+  id: string;
+  token: string;
+  type: MediaTokenType;
+  label: string | null;
+  expiresAt: Date | null;
+  usageCount: number;
+  createdAt: Date;
+};
+
+type MediaProject = {
+  id: string;
+  name: string;
+  description: string | null;
+  createdAt: Date;
+  createdBy: { id: string; name: string | null; displayName: string | null };
+  files: MediaFile[];
+  shareTokens: ShareToken[];
+  _count: { files: number };
+};
+
+const FILE_STATUS_LABELS: Record<MediaFileStatus, string> = {
+  PENDING: "En attente",
+  APPROVED: "Approuvé",
+  REJECTED: "Rejeté",
+  PREVALIDATED: "Pré-validé",
+  PREREJECTED: "Pré-rejeté",
+  DRAFT: "Brouillon",
+  IN_REVIEW: "En révision",
+  REVISION_REQUESTED: "Révision demandée",
+  FINAL_APPROVED: "Validé final",
+};
+
+const FILE_STATUS_COLORS: Record<MediaFileStatus, string> = {
+  PENDING: "bg-yellow-100 text-yellow-800",
+  APPROVED: "bg-green-100 text-green-800",
+  REJECTED: "bg-red-100 text-red-800",
+  PREVALIDATED: "bg-blue-100 text-blue-800",
+  PREREJECTED: "bg-orange-100 text-orange-800",
+  DRAFT: "bg-gray-100 text-gray-700",
+  IN_REVIEW: "bg-purple-100 text-purple-800",
+  REVISION_REQUESTED: "bg-amber-100 text-amber-800",
+  FINAL_APPROVED: "bg-emerald-100 text-emerald-800",
+};
+
+const FILE_TYPE_LABELS: Record<MediaFileType, string> = {
+  PHOTO: "Photo",
+  VISUAL: "Visuel",
+  VIDEO: "Vidéo",
+};
+
+const TOKEN_TYPE_LABELS: Record<MediaTokenType, string> = {
+  VALIDATOR: "Validateur",
+  PREVALIDATOR: "Pré-validateur",
+  MEDIA: "Téléchargement",
+  GALLERY: "Galerie",
+};
+
+function formatDate(d: Date) {
+  return new Date(d).toLocaleDateString("fr-FR", { day: "numeric", month: "short", year: "numeric" });
+}
+
+function formatSize(bytes: number) {
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} Ko`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} Mo`;
+}
+
+export default function MediaProjectDetail({
+  project: initialProject,
+  canUpload: _canUpload,
+  canReview,
+  canManage,
+}: {
+  project: MediaProject;
+  canUpload: boolean;
+  canReview: boolean;
+  canManage: boolean;
+}) {
+  const router = useRouter();
+  const [project, setProject] = useState(initialProject);
+  const [typeFilter, setTypeFilter] = useState<MediaFileType | "">("");
+  const [statusFilter, setStatusFilter] = useState<MediaFileStatus | "">("");
+  const [creatingToken, setCreatingToken] = useState(false);
+  const [newTokenType, setNewTokenType] = useState<MediaTokenType>("GALLERY");
+  const [newTokenLabel, setNewTokenLabel] = useState("");
+  const [tokenError, setTokenError] = useState<string | null>(null);
+
+  async function refreshProject() {
+    const res = await fetch(`/api/media-projects/${project.id}`);
+    const json = await res.json();
+    if (res.ok) setProject(json.data);
+    router.refresh();
+  }
+
+  const filteredFiles = project.files.filter((f) => {
+    if (typeFilter && f.type !== typeFilter) return false;
+    if (statusFilter && f.status !== statusFilter) return false;
+    return true;
+  });
+
+  async function deleteProject() {
+    if (!confirm(`Supprimer le projet "${project.name}" et tous ses fichiers ?`)) return;
+    await fetch(`/api/media-projects/${project.id}`, { method: "DELETE" });
+    router.push("/media/projects");
+  }
+
+  async function reviewFile(fileId: string, status: "APPROVED" | "REJECTED" | "REVISION_REQUESTED" | "FINAL_APPROVED") {
+    await fetch(`/api/media/files/${fileId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
+    });
+    await refreshProject();
+  }
+
+  async function createToken() {
+    setTokenError(null);
+    setCreatingToken(true);
+    try {
+      const res = await fetch(`/api/media-projects/${project.id}/share`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: newTokenType, label: newTokenLabel || null }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Erreur");
+      setNewTokenLabel("");
+      await refreshProject();
+    } catch (err) {
+      setTokenError(err instanceof Error ? err.message : "Erreur");
+    } finally {
+      setCreatingToken(false);
+    }
+  }
+
+  async function deleteToken(tokenId: string) {
+    if (!confirm("Supprimer ce lien de partage ?")) return;
+    await fetch(`/api/media-projects/${project.id}/share?tokenId=${tokenId}`, { method: "DELETE" });
+    await refreshProject();
+  }
+
+  function getTokenUrl(token: ShareToken) {
+    const paths: Record<MediaTokenType, string> = { VALIDATOR: "v", PREVALIDATOR: "v", MEDIA: "d", GALLERY: "g" };
+    return `${window.location.origin}/media/${paths[token.type]}/${token.token}`;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="mb-1">
+            <Link href="/media/projects" className="text-sm text-gray-500 hover:text-gray-700">
+              ← Projets
+            </Link>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">{project.name}</h1>
+          <div className="flex items-center gap-3 mt-2 text-sm text-gray-600">
+            <span>Créé le {formatDate(project.createdAt)}</span>
+            <span className="text-gray-300">|</span>
+            <span>{project._count.files} fichier{project._count.files !== 1 ? "s" : ""}</span>
+          </div>
+          {project.description && <p className="text-sm text-gray-600 mt-2">{project.description}</p>}
+        </div>
+        {canManage && (
+          <button
+            onClick={deleteProject}
+            className="text-sm text-red-600 hover:text-red-700 border border-red-200 rounded-lg px-3 py-1.5 hover:bg-red-50 transition-colors shrink-0"
+          >
+            Supprimer
+          </button>
+        )}
+      </div>
+
+      {/* Files */}
+      <section>
+        <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
+          <h2 className="text-lg font-semibold text-gray-900">Fichiers ({project._count.files})</h2>
+          <div className="flex items-center gap-2">
+            <select
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value as MediaFileType | "")}
+              className="border-2 border-gray-200 rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+            >
+              <option value="">Tous types</option>
+              {(Object.keys(FILE_TYPE_LABELS) as MediaFileType[]).map((t) => (
+                <option key={t} value={t}>{FILE_TYPE_LABELS[t]}</option>
+              ))}
+            </select>
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as MediaFileStatus | "")}
+              className="border-2 border-gray-200 rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+            >
+              <option value="">Tous statuts</option>
+              {(Object.keys(FILE_STATUS_LABELS) as MediaFileStatus[]).map((s) => (
+                <option key={s} value={s}>{FILE_STATUS_LABELS[s]}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {filteredFiles.length === 0 ? (
+          <p className="text-gray-500 text-sm py-6 text-center">
+            {project.files.length === 0 ? "Aucun fichier dans ce projet." : "Aucun fichier ne correspond aux filtres."}
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {filteredFiles.map((file) => (
+              <div key={file.id} className="flex items-center justify-between gap-3 p-3 bg-white border-2 border-gray-200 rounded-lg hover:border-icc-violet transition-colors">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">
+                      {FILE_TYPE_LABELS[file.type]}
+                    </span>
+                    <span className={`text-xs px-1.5 py-0.5 rounded-full ${FILE_STATUS_COLORS[file.status]}`}>
+                      {FILE_STATUS_LABELS[file.status]}
+                    </span>
+                    <span className="text-sm font-medium text-gray-900 truncate">{file.filename}</span>
+                  </div>
+                  <p className="text-xs text-gray-400 mt-1">
+                    {formatSize(file.size)} · v{file.versions[0]?.versionNumber ?? 1} · {formatDate(file.createdAt)}
+                  </p>
+                </div>
+                {canReview && (
+                  <div className="flex gap-1 shrink-0">
+                    {file.status === "IN_REVIEW" && (
+                      <>
+                        <button
+                          onClick={() => reviewFile(file.id, "FINAL_APPROVED")}
+                          className="text-xs text-green-700 border border-green-200 rounded px-2 py-1 hover:bg-green-50"
+                        >
+                          Valider
+                        </button>
+                        <button
+                          onClick={() => reviewFile(file.id, "REVISION_REQUESTED")}
+                          className="text-xs text-amber-700 border border-amber-200 rounded px-2 py-1 hover:bg-amber-50"
+                        >
+                          Révision
+                        </button>
+                        <button
+                          onClick={() => reviewFile(file.id, "REJECTED")}
+                          className="text-xs text-red-700 border border-red-200 rounded px-2 py-1 hover:bg-red-50"
+                        >
+                          Rejeter
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Share tokens */}
+      {canManage && (
+        <section>
+          <h2 className="text-lg font-semibold text-gray-900 mb-3">Liens de partage</h2>
+          <div className="space-y-3">
+            {project.shareTokens.map((token) => (
+              <div key={token.id} className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg border border-gray-200">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs font-medium bg-icc-violet/10 text-icc-violet px-2 py-0.5 rounded">
+                      {TOKEN_TYPE_LABELS[token.type]}
+                    </span>
+                    {token.label && <span className="text-sm text-gray-700">{token.label}</span>}
+                  </div>
+                  <p className="text-xs text-gray-500 mt-1 truncate font-mono">{getTokenUrl(token)}</p>
+                  <p className="text-xs text-gray-400 mt-0.5">
+                    {token.usageCount} utilisation{token.usageCount > 1 ? "s" : ""}
+                    {token.expiresAt && ` · expire le ${formatDate(token.expiresAt)}`}
+                  </p>
+                </div>
+                <div className="flex gap-2 shrink-0">
+                  <button
+                    onClick={() => navigator.clipboard.writeText(getTokenUrl(token))}
+                    className="text-xs text-gray-500 hover:text-icc-violet border border-gray-200 rounded px-2 py-1"
+                  >
+                    Copier
+                  </button>
+                  <button
+                    onClick={() => deleteToken(token.id)}
+                    className="text-xs text-red-600 hover:text-red-700 border border-red-200 rounded px-2 py-1"
+                  >
+                    Suppr.
+                  </button>
+                </div>
+              </div>
+            ))}
+
+            <div className="flex gap-2">
+              <select
+                value={newTokenType}
+                onChange={(e) => setNewTokenType(e.target.value as MediaTokenType)}
+                className="border-2 border-gray-200 rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+              >
+                {(Object.keys(TOKEN_TYPE_LABELS) as MediaTokenType[]).map((t) => (
+                  <option key={t} value={t}>{TOKEN_TYPE_LABELS[t]}</option>
+                ))}
+              </select>
+              <input
+                type="text"
+                placeholder="Étiquette (optionnel)"
+                value={newTokenLabel}
+                onChange={(e) => setNewTokenLabel(e.target.value)}
+                className="flex-1 border-2 border-gray-200 rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent"
+              />
+              <Button onClick={createToken} disabled={creatingToken} size="sm">
+                {creatingToken ? "…" : "+ Lien"}
+              </Button>
+            </div>
+            {tokenError && <p className="text-xs text-red-600">{tokenError}</p>}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/app/(auth)/media/projects/[id]/page.tsx
+++ b/src/app/(auth)/media/projects/[id]/page.tsx
@@ -43,15 +43,14 @@ export default async function MediaProjectDetailPage({
 
   if (!project) notFound();
 
-  const userPermissions = new Set(
-    session.user.isSuperAdmin
-      ? ["media:view", "media:upload", "media:review", "media:manage"]
-      : session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
+  const churchPerms = new Set(
+    session.user.churchRoles
+      .filter((r) => r.churchId === churchId!)
+      .flatMap((r) => rolePermissions[r.role] ?? [])
   );
-
-  const canUpload = userPermissions.has("media:upload");
-  const canReview = userPermissions.has("media:review");
-  const canManage = userPermissions.has("media:manage");
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload");
+  const canReview = session.user.isSuperAdmin || churchPerms.has("media:review");
+  const canManage = session.user.isSuperAdmin || churchPerms.has("media:manage");
 
   return (
     <MediaProjectDetail

--- a/src/app/(auth)/media/projects/[id]/page.tsx
+++ b/src/app/(auth)/media/projects/[id]/page.tsx
@@ -1,0 +1,64 @@
+import { requireChurchPermission, resolveChurchId, requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { notFound } from "next/navigation";
+import { rolePermissions } from "@/lib/registry";
+import MediaProjectDetail from "./MediaProjectDetail";
+
+export default async function MediaProjectDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await requireAuth();
+
+  let churchId: string;
+  try {
+    churchId = await resolveChurchId("mediaProject", id);
+  } catch {
+    notFound();
+  }
+
+  await requireChurchPermission("media:view", churchId!);
+
+  const project = await prisma.mediaProject.findUnique({
+    where: { id },
+    include: {
+      createdBy: { select: { id: true, name: true, displayName: true } },
+      files: {
+        orderBy: { createdAt: "desc" },
+        include: {
+          versions: {
+            orderBy: { versionNumber: "desc" },
+            take: 1,
+          },
+        },
+      },
+      shareTokens: {
+        orderBy: { createdAt: "desc" },
+      },
+      _count: { select: { files: true } },
+    },
+  });
+
+  if (!project) notFound();
+
+  const userPermissions = new Set(
+    session.user.isSuperAdmin
+      ? ["media:view", "media:upload", "media:review", "media:manage"]
+      : session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
+  );
+
+  const canUpload = userPermissions.has("media:upload");
+  const canReview = userPermissions.has("media:review");
+  const canManage = userPermissions.has("media:manage");
+
+  return (
+    <MediaProjectDetail
+      project={project}
+      canUpload={canUpload}
+      canReview={canReview}
+      canManage={canManage}
+    />
+  );
+}

--- a/src/app/(auth)/media/projects/new/NewMediaProjectForm.tsx
+++ b/src/app/(auth)/media/projects/new/NewMediaProjectForm.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+export default function NewMediaProjectForm({ churchId }: { churchId: string }) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch("/api/media-projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, churchId, description: description || null }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Erreur lors de la création");
+      router.push(`/media/projects/${json.data.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur inconnue");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-lg space-y-5">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Nom du projet <span className="text-red-500">*</span>
+        </label>
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          placeholder="Ex: Série de visuels Pâques 2026"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Description <span className="text-gray-400">(optionnel)</span>
+        </label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={3}
+          placeholder="Contexte, objectifs…"
+          className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-transparent resize-none"
+        />
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          {error}
+        </p>
+      )}
+
+      <div className="flex gap-3">
+        <Button type="submit" disabled={loading}>
+          {loading ? "Création…" : "Créer le projet"}
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => router.push("/media/projects")}
+          disabled={loading}
+        >
+          Annuler
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(auth)/media/projects/new/page.tsx
+++ b/src/app/(auth)/media/projects/new/page.tsx
@@ -1,0 +1,16 @@
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import NewMediaProjectForm from "./NewMediaProjectForm";
+
+export default async function NewMediaProjectPage() {
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("media:upload", churchId);
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Nouveau projet média</h1>
+      <NewMediaProjectForm churchId={churchId} />
+    </div>
+  );
+}

--- a/src/app/(auth)/media/projects/page.tsx
+++ b/src/app/(auth)/media/projects/page.tsx
@@ -1,0 +1,39 @@
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import MediaProjectsList from "./MediaProjectsList";
+
+export default async function MediaProjectsPage() {
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("media:view", churchId);
+
+  const projects = await prisma.mediaProject.findMany({
+    where: { churchId },
+    orderBy: { createdAt: "desc" },
+    include: {
+      createdBy: { select: { id: true, name: true, displayName: true } },
+      _count: { select: { files: true } },
+    },
+  });
+
+  const canUpload = session.user.isSuperAdmin || session.user.churchRoles.some(
+    (r) => r.churchId === churchId && ["SUPER_ADMIN", "ADMIN", "SECRETARY"].includes(r.role)
+  );
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Projets média</h1>
+        {canUpload && (
+          <Link href="/media/projects/new">
+            <Button>+ Nouveau projet</Button>
+          </Link>
+        )}
+      </div>
+      <MediaProjectsList projects={projects} canUpload={canUpload} />
+    </div>
+  );
+}

--- a/src/app/(auth)/media/projects/page.tsx
+++ b/src/app/(auth)/media/projects/page.tsx
@@ -2,6 +2,7 @@ import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
+import { rolePermissions } from "@/lib/registry";
 import MediaProjectsList from "./MediaProjectsList";
 
 export default async function MediaProjectsPage() {
@@ -19,9 +20,12 @@ export default async function MediaProjectsPage() {
     },
   });
 
-  const canUpload = session.user.isSuperAdmin || session.user.churchRoles.some(
-    (r) => r.churchId === churchId && ["SUPER_ADMIN", "ADMIN", "SECRETARY"].includes(r.role)
+  const churchPerms = new Set(
+    session.user.churchRoles
+      .filter((r) => r.churchId === churchId)
+      .flatMap((r) => rolePermissions[r.role] ?? [])
   );
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload");
 
   return (
     <div>

--- a/src/app/media/d/[token]/DownloadView.tsx
+++ b/src/app/media/d/[token]/DownloadView.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+
+type Photo = {
+  id: string;
+  filename: string;
+  thumbnailUrl: string;
+  size: number;
+  width: number | null;
+  height: number | null;
+};
+
+type DownloadData = {
+  token: { id: string; type: string; label: string | null };
+  event: { id: string; name: string; date: string; photoCount: number } | null;
+  photos: Photo[];
+};
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" });
+}
+
+function formatSize(bytes: number) {
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} Ko`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} Mo`;
+}
+
+export default function DownloadView({
+  token,
+  data,
+}: {
+  token: string;
+  data: DownloadData;
+}) {
+  const { event, photos } = data;
+  const [downloading, setDownloading] = useState<Record<string, boolean>>({});
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  async function downloadPhoto(photoId: string, filename: string) {
+    setDownloading((prev) => ({ ...prev, [photoId]: true }));
+    try {
+      const res = await fetch(`/api/media/download/${token}/photo/${photoId}`);
+      const json = await res.json();
+      if (!res.ok) return;
+      // Trigger download
+      const a = document.createElement("a");
+      a.href = json.data.downloadUrl;
+      a.download = filename;
+      a.click();
+    } finally {
+      setDownloading((prev) => ({ ...prev, [photoId]: false }));
+    }
+  }
+
+  function toggleSelect(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  const totalSize = photos.reduce((acc, p) => acc + p.size, 0);
+  const selectedSize = photos
+    .filter((p) => selected.has(p.id))
+    .reduce((acc, p) => acc + p.size, 0);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200 px-4 py-5">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-xl font-bold text-gray-900">{event?.name ?? "Téléchargement"}</h1>
+          {event && <p className="text-sm text-gray-500 mt-1">{formatDate(event.date)}</p>}
+          {data.token.label && <p className="text-xs text-gray-400 mt-0.5">{data.token.label}</p>}
+          <p className="text-sm text-gray-600 mt-2">
+            {photos.length} photo{photos.length !== 1 ? "s" : ""} approuvée{photos.length !== 1 ? "s" : ""} · {formatSize(totalSize)}
+          </p>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto p-4 space-y-4">
+        {/* Select all */}
+        {photos.length > 0 && (
+          <div className="flex items-center gap-3 p-3 bg-white rounded-lg border border-gray-200">
+            <input
+              type="checkbox"
+              checked={selected.size === photos.length}
+              onChange={() => {
+                if (selected.size === photos.length) setSelected(new Set());
+                else setSelected(new Set(photos.map((p) => p.id)));
+              }}
+              className="w-4 h-4 rounded border-gray-300"
+            />
+            <span className="text-sm text-gray-600">
+              {selected.size > 0
+                ? `${selected.size} sélectionnée${selected.size > 1 ? "s" : ""} (${formatSize(selectedSize)})`
+                : "Tout sélectionner"}
+            </span>
+            {selected.size > 0 && (
+              <span className="text-xs text-gray-400 ml-auto">
+                Téléchargement individuel uniquement
+              </span>
+            )}
+          </div>
+        )}
+
+        {photos.length === 0 ? (
+          <p className="text-center text-gray-500 py-16">Aucune photo approuvée disponible.</p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            {photos.map((photo) => (
+              <div
+                key={photo.id}
+                className={`rounded-lg overflow-hidden border-2 bg-white transition-colors ${
+                  selected.has(photo.id) ? "border-icc-violet" : "border-gray-200"
+                }`}
+              >
+                <div
+                  className="aspect-square bg-gray-100 cursor-pointer"
+                  onClick={() => toggleSelect(photo.id)}
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={photo.thumbnailUrl}
+                    alt={photo.filename}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+                <div className="p-1.5">
+                  <p className="text-xs text-gray-500 truncate">{photo.filename}</p>
+                  <p className="text-xs text-gray-400">{formatSize(photo.size)}</p>
+                  <button
+                    onClick={() => downloadPhoto(photo.id, photo.filename)}
+                    disabled={downloading[photo.id]}
+                    className="mt-1 w-full text-xs bg-icc-violet text-white py-1 rounded hover:bg-icc-violet/90 disabled:opacity-50 transition-colors"
+                  >
+                    {downloading[photo.id] ? "…" : "Télécharger"}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/media/d/[token]/page.tsx
+++ b/src/app/media/d/[token]/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * Page publique téléchargement de photos.
+ * Accessible via un lien MEDIA sans authentification.
+ */
+import { notFound } from "next/navigation";
+import DownloadView from "./DownloadView";
+
+async function fetchDownloadData(token: string) {
+  const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+  const res = await fetch(`${baseUrl}/api/media/download/${token}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) return null;
+  const json = await res.json();
+  return json.data;
+}
+
+export default async function DownloadPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const data = await fetchDownloadData(token);
+
+  if (!data) notFound();
+
+  return <DownloadView token={token} data={data} />;
+}

--- a/src/app/media/g/[token]/GalleryView.tsx
+++ b/src/app/media/g/[token]/GalleryView.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+
+type Photo = {
+  id: string;
+  filename: string;
+  thumbnailUrl: string;
+  status: string;
+  width: number | null;
+  height: number | null;
+};
+
+type GalleryData = {
+  token: { id: string; type: string; label: string | null };
+  event: { id: string; name: string; date: string; photoCount: number } | null;
+  photos: Photo[];
+};
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" });
+}
+
+export default function GalleryView({ data }: { data: GalleryData }) {
+  const [lightbox, setLightbox] = useState<Photo | null>(null);
+
+  const { event, photos } = data;
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <header className="px-4 py-6 max-w-5xl mx-auto">
+        <h1 className="text-2xl font-bold">{event?.name ?? "Galerie"}</h1>
+        {event && <p className="text-gray-400 text-sm mt-1">{formatDate(event.date)}</p>}
+        {data.token.label && <p className="text-gray-500 text-xs mt-0.5">{data.token.label}</p>}
+        <p className="text-gray-400 text-sm mt-2">{photos.length} photo{photos.length !== 1 ? "s" : ""}</p>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-4 pb-8">
+        {photos.length === 0 ? (
+          <p className="text-center text-gray-500 py-16">Aucune photo disponible.</p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
+            {photos.map((photo) => (
+              <button
+                key={photo.id}
+                onClick={() => setLightbox(photo)}
+                className="aspect-square bg-gray-800 rounded-lg overflow-hidden hover:opacity-90 transition-opacity"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={photo.thumbnailUrl}
+                  alt={photo.filename}
+                  className="w-full h-full object-cover"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+      </main>
+
+      {/* Lightbox */}
+      {lightbox && (
+        <div
+          className="fixed inset-0 bg-black/90 z-50 flex items-center justify-center p-4"
+          onClick={() => setLightbox(null)}
+        >
+          <button
+            className="absolute top-4 right-4 text-white text-2xl hover:text-gray-300"
+            onClick={() => setLightbox(null)}
+          >
+            ✕
+          </button>
+          <div className="max-w-3xl w-full">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={lightbox.thumbnailUrl}
+              alt={lightbox.filename}
+              className="w-full rounded-lg max-h-[80vh] object-contain"
+              onClick={(e) => e.stopPropagation()}
+            />
+            <p className="text-gray-400 text-sm text-center mt-2">{lightbox.filename}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/media/g/[token]/page.tsx
+++ b/src/app/media/g/[token]/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * Page publique galerie photos.
+ * Accessible via un lien GALLERY sans authentification.
+ */
+import { notFound } from "next/navigation";
+import GalleryView from "./GalleryView";
+
+async function fetchGalleryData(token: string) {
+  const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+  const res = await fetch(`${baseUrl}/api/media/gallery/${token}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) return null;
+  const json = await res.json();
+  return json.data;
+}
+
+export default async function GalleryPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const data = await fetchGalleryData(token);
+
+  if (!data) notFound();
+
+  return <GalleryView data={data} />;
+}

--- a/src/app/media/v/[token]/ValidatorView.tsx
+++ b/src/app/media/v/[token]/ValidatorView.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState } from "react";
+
+type Photo = {
+  id: string;
+  filename: string;
+  thumbnailUrl: string;
+  status: string;
+  size: number;
+};
+
+type ValidationData = {
+  token: { id: string; type: string; label: string | null };
+  event: {
+    id: string;
+    name: string;
+    date: string;
+    isPrevalidator: boolean;
+    hasPrevalidator: boolean;
+    photos: Photo[];
+    stats: { total: number; pending: number; approved: number; rejected: number };
+  } | null;
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  PENDING: "border-gray-300",
+  APPROVED: "border-green-500",
+  REJECTED: "border-red-500",
+  PREVALIDATED: "border-blue-400",
+  PREREJECTED: "border-orange-400",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  PENDING: "En attente",
+  APPROVED: "Approuvée",
+  REJECTED: "Rejetée",
+  PREVALIDATED: "Pré-validée",
+  PREREJECTED: "Pré-rejetée",
+};
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" });
+}
+
+export default function ValidatorView({
+  token,
+  data,
+}: {
+  token: string;
+  data: ValidationData;
+}) {
+  const { event } = data;
+  const isPrevalidator = data.token.type === "PREVALIDATOR";
+  const approveStatus = isPrevalidator ? "PREVALIDATED" : "APPROVED";
+  const rejectStatus = isPrevalidator ? "PREREJECTED" : "REJECTED";
+
+  const [photos, setPhotos] = useState<Photo[]>(event?.photos ?? []);
+  const [loading, setLoading] = useState<Record<string, boolean>>({});
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkLoading, setBulkLoading] = useState(false);
+
+  async function setPhotoStatus(photoId: string, status: string) {
+    setLoading((prev) => ({ ...prev, [photoId]: true }));
+    try {
+      const res = await fetch(`/api/media/validate/${token}/photo/${photoId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      if (res.ok) {
+        setPhotos((prev) => prev.map((p) => p.id === photoId ? { ...p, status } : p));
+      }
+    } finally {
+      setLoading((prev) => ({ ...prev, [photoId]: false }));
+    }
+  }
+
+  async function bulkSetStatus(status: string) {
+    if (selected.size === 0) return;
+    setBulkLoading(true);
+    try {
+      await Promise.all(
+        Array.from(selected).map((id) =>
+          fetch(`/api/media/validate/${token}/photo/${id}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ status }),
+          })
+        )
+      );
+      setPhotos((prev) => prev.map((p) => selected.has(p.id) ? { ...p, status } : p));
+      setSelected(new Set());
+    } finally {
+      setBulkLoading(false);
+    }
+  }
+
+  const pendingPhotos = photos.filter((p) => p.status === "PENDING");
+
+  if (!event) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+        <p className="text-gray-600">Aucun événement associé à ce lien.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200 px-4 py-4">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-xl font-bold text-gray-900">{event.name}</h1>
+          <p className="text-sm text-gray-500 mt-1">{formatDate(event.date)}</p>
+          {data.token.label && <p className="text-xs text-gray-400 mt-0.5">{data.token.label}</p>}
+          <div className="flex gap-4 mt-3 text-sm">
+            <span>{photos.length} photo{photos.length !== 1 ? "s" : ""}</span>
+            <span className="text-yellow-600">{pendingPhotos.length} en attente</span>
+            <span className="text-green-600">
+              {photos.filter((p) => p.status === approveStatus || p.status === "APPROVED").length} approuvée{photos.filter((p) => p.status === approveStatus || p.status === "APPROVED").length !== 1 ? "s" : ""}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto p-4 space-y-4">
+        {/* Bulk actions */}
+        {pendingPhotos.length > 0 && (
+          <div className="flex items-center gap-3 p-3 bg-white rounded-lg border border-gray-200">
+            <input
+              type="checkbox"
+              checked={selected.size === pendingPhotos.length && pendingPhotos.length > 0}
+              onChange={() => {
+                if (selected.size === pendingPhotos.length) setSelected(new Set());
+                else setSelected(new Set(pendingPhotos.map((p) => p.id)));
+              }}
+              className="w-4 h-4 rounded border-gray-300"
+            />
+            <span className="text-sm text-gray-600">
+              {selected.size > 0 ? `${selected.size} sélectionnée${selected.size > 1 ? "s" : ""}` : "Sélectionner tout"}
+            </span>
+            {selected.size > 0 && (
+              <>
+                <button
+                  onClick={() => bulkSetStatus(approveStatus)}
+                  disabled={bulkLoading}
+                  className="text-sm bg-green-600 text-white px-3 py-1 rounded-lg hover:bg-green-700 disabled:opacity-50"
+                >
+                  ✓ Approuver
+                </button>
+                <button
+                  onClick={() => bulkSetStatus(rejectStatus)}
+                  disabled={bulkLoading}
+                  className="text-sm bg-red-600 text-white px-3 py-1 rounded-lg hover:bg-red-700 disabled:opacity-50"
+                >
+                  ✗ Rejeter
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+          {photos.map((photo) => {
+            const isPending = photo.status === "PENDING";
+            return (
+              <div
+                key={photo.id}
+                className={`relative rounded-lg overflow-hidden border-2 ${STATUS_COLORS[photo.status] ?? "border-gray-300"} bg-white`}
+              >
+                {isPending && (
+                  <input
+                    type="checkbox"
+                    checked={selected.has(photo.id)}
+                    onChange={() => setSelected((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(photo.id)) next.delete(photo.id);
+                      else next.add(photo.id);
+                      return next;
+                    })}
+                    className="absolute top-2 left-2 z-10 w-4 h-4 rounded border-gray-300"
+                  />
+                )}
+                <div className="aspect-square bg-gray-100 relative">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={photo.thumbnailUrl}
+                    alt={photo.filename}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+                <div className="p-1.5">
+                  <span className="text-xs text-gray-500">{STATUS_LABELS[photo.status] ?? photo.status}</span>
+                  {isPending && (
+                    <div className="flex gap-1 mt-1">
+                      <button
+                        onClick={() => setPhotoStatus(photo.id, approveStatus)}
+                        disabled={loading[photo.id]}
+                        className="flex-1 text-xs bg-green-600 text-white py-1 rounded hover:bg-green-700 disabled:opacity-50"
+                      >
+                        ✓
+                      </button>
+                      <button
+                        onClick={() => setPhotoStatus(photo.id, rejectStatus)}
+                        disabled={loading[photo.id]}
+                        className="flex-1 text-xs bg-red-600 text-white py-1 rounded hover:bg-red-700 disabled:opacity-50"
+                      >
+                        ✗
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {photos.length === 0 && (
+          <p className="text-center text-gray-500 py-12">Aucune photo à valider.</p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/media/v/[token]/page.tsx
+++ b/src/app/media/v/[token]/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * Page publique de validation/pré-validation de photos.
+ * Accessible via un lien VALIDATOR ou PREVALIDATOR sans authentification.
+ */
+import { notFound } from "next/navigation";
+import ValidatorView from "./ValidatorView";
+
+async function fetchValidationData(token: string) {
+  const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+  const res = await fetch(`${baseUrl}/api/media/validate/${token}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) return null;
+  const json = await res.json();
+  return json.data;
+}
+
+export default async function ValidatorPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const data = await fetchValidationData(token);
+
+  if (!data) notFound();
+
+  return <ValidatorView token={token} data={data} />;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,6 +11,12 @@ export function proxy(request: NextRequest) {
     if (request.nextUrl.pathname.startsWith("/api/cron")) {
       return NextResponse.next();
     }
+    // Allow public media token routes (validate, gallery, download — token-based auth)
+    if (request.nextUrl.pathname.startsWith("/api/media/validate/") ||
+        request.nextUrl.pathname.startsWith("/api/media/gallery/") ||
+        request.nextUrl.pathname.startsWith("/api/media/download/")) {
+      return NextResponse.next();
+    }
     if (request.nextUrl.pathname.startsWith("/api/")) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }


### PR DESCRIPTION
## Summary

- **Pages authentifiées** :
  - `/media/events` — liste avec filtres statut/recherche
  - `/media/events/new` — formulaire création (avec liaison événement planning optionnelle)
  - `/media/events/[id]` — détail : upload drag-drop photos, bulk approve/reject, gestion liens de partage
  - `/media/projects` — liste projets
  - `/media/projects/new` — formulaire création
  - `/media/projects/[id]` — détail : liste fichiers avec review (valider/révision/rejeter), tokens partage

- **Pages publiques** (sans auth, token-based) :
  - `/media/v/[token]` — validation / pré-validation photos (approve/reject par photo ou en masse)
  - `/media/g/[token]` — galerie avec lightbox
  - `/media/d/[token]` — téléchargement photos approuvées

- **Layout** : liens "Événements médias" + "Projets médias" dans la section Demandes si `media:view`
- **proxy.ts** : routes API publiques (`/api/media/validate|gallery|download/`) exemptées du guard auth

## Test plan

- [ ] Créer un événement média (avec et sans lien planning)
- [ ] Uploader des photos via drag-drop → vérifier miniatures et statut PENDING
- [ ] Bulk approve/reject photos
- [ ] Créer un lien GALLERY → visiter `/media/g/[token]` sans être connecté
- [ ] Créer un lien VALIDATOR → visiter `/media/v/[token]` → approuver/rejeter des photos
- [ ] Créer un lien MEDIA → visiter `/media/d/[token]` → télécharger une photo approuvée
- [ ] Créer un projet → vérifier liste fichiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)