### PR TITLE
feat(notif): notifications demande de liaison membre (#152)

### DIFF
--- a/src/app/api/member-link-requests/[id]/route.ts
+++ b/src/app/api/member-link-requests/[id]/route.ts
@@ -48,6 +48,20 @@ export async function PATCH(
         },
       });
       await logAudit({ userId: session.user.id, churchId, action: "UPDATE", entityType: "MemberLinkRequest", entityId: id, details: { action: "reject" } });
+
+      // Notify the requester that their request was rejected
+      await prisma.notification.create({
+        data: {
+          userId: linkRequest.userId,
+          type: "MEMBER_LINK_REJECTED",
+          title: "Demande de liaison refusée",
+          message: rejectReason
+            ? `Votre demande de liaison a été refusée : ${rejectReason}`
+            : "Votre demande de liaison compte STAR a été refusée.",
+          link: "/profile",
+        },
+      });
+
       return successResponse(updated);
     }
 
@@ -212,6 +226,18 @@ export async function PATCH(
     });
 
     await logAudit({ userId: session.user.id, churchId, action: "UPDATE", entityType: "MemberLinkRequest", entityId: id, details: { action: "approve", requestedRole } });
+
+    // Notify the requester that their request was approved
+    await prisma.notification.create({
+      data: {
+        userId: linkRequest.userId,
+        type: "MEMBER_LINK_APPROVED",
+        title: "Demande de liaison approuvée",
+        message: "Votre compte a été lié à votre fiche STAR. Vous pouvez maintenant accéder à votre planning.",
+        link: "/planning",
+      },
+    });
+
     return successResponse({ approved: true });
   } catch (error) {
     return errorResponse(error);

--- a/src/app/api/member-link-requests/route.ts
+++ b/src/app/api/member-link-requests/route.ts
@@ -72,12 +72,11 @@ export async function POST(request: Request) {
       ministryId: ("ministryId" in data ? data.ministryId : undefined) ?? undefined,
     };
 
-    if (data.type === "no_star") {
-      const req = await prisma.memberLinkRequest.create({ data: commonFields });
-      return successResponse(req, 201);
-    }
+    let req;
 
-    if (data.type === "existing") {
+    if (data.type === "no_star") {
+      req = await prisma.memberLinkRequest.create({ data: commonFields });
+    } else if (data.type === "existing") {
       const member = await prisma.member.findUnique({
         where: { id: data.memberId },
         include: {
@@ -96,21 +95,45 @@ export async function POST(request: Request) {
         throw new ApiError(400, "Ce STAR n'appartient pas à cette église");
       }
 
-      const req = await prisma.memberLinkRequest.create({
+      req = await prisma.memberLinkRequest.create({
         data: { ...commonFields, memberId: data.memberId },
       });
-      return successResponse(req, 201);
+    } else {
+      // type === "new"
+      req = await prisma.memberLinkRequest.create({
+        data: {
+          ...commonFields,
+          firstName: data.firstName,
+          lastName: data.lastName,
+          phone: data.phone ?? undefined,
+        },
+      });
     }
 
-    // type === "new"
-    const req = await prisma.memberLinkRequest.create({
-      data: {
-        ...commonFields,
-        firstName: data.firstName,
-        lastName: data.lastName,
-        phone: data.phone ?? undefined,
+    // Notify all admins/secretaries in the church about the new link request
+    const requesterName =
+      session.user.displayName || session.user.name || session.user.email;
+    const adminRoles = await prisma.userChurchRole.findMany({
+      where: {
+        churchId: data.churchId,
+        role: { in: ["SUPER_ADMIN", "ADMIN", "SECRETARY"] },
       },
+      select: { userId: true },
+      distinct: ["userId"],
     });
+    if (adminRoles.length > 0) {
+      await prisma.notification.createMany({
+        data: adminRoles.map((r) => ({
+          userId: r.userId,
+          type: "MEMBER_LINK_REQUEST",
+          title: "Nouvelle demande de liaison",
+          message: `${requesterName} a soumis une demande de liaison compte STAR.`,
+          link: "/admin/access",
+        })),
+        skipDuplicates: true,
+      });
+    }
+
     return successResponse(req, 201);
   } catch (error) {
     return errorResponse(error);


### PR DESCRIPTION
## Summary

Ferme la boucle du flux STAR : les parties prenantes sont notifiées à chaque étape.

- **Soumission** → notifie tous les ADMIN/SECRETARY/SUPER_ADMIN de l'église (`MEMBER_LINK_REQUEST`, lien `/admin/access`)
- **Approbation** → notifie le demandeur (`MEMBER_LINK_APPROVED`, lien `/planning`)
- **Refus** → notifie le demandeur avec la raison si fournie (`MEMBER_LINK_REJECTED`, lien `/profile`)

## Test plan

- [ ] Soumettre une demande de liaison depuis `/profile` → badge notification visible pour les admins
- [ ] Approuver la demande → demandeur reçoit une notification avec lien vers `/planning`
- [ ] Refuser la demande avec note → demandeur reçoit la raison dans la notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)