### PR TITLE
docs: mettre à jour la documentation v1.0 (STAR, unified requests, media)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,7 @@ Chaque module expose un **manifeste** (`index.ts`) qui declare ses permissions, 
 | Module | Perimetre |
 |---|---|
 | `core` | Gestion des eglises (`church:manage`) et des utilisateurs (`users:manage`) |
-| `planning` | Evenements, planning, membres, annonces, demandes (Request workflow) |
+| `planning` | Evenements, planning, membres, annonces, demandes (Request workflow), espace STAR |
 | `discipleship` | Suivi discipolat, relations, presences, stats |
 
 **Exports du module `planning` :**
@@ -130,6 +130,7 @@ koinonia/
 │   │   │   ├── layout.tsx         # Auth guard, header, sidebar, footer version
 │   │   │   ├── dashboard/         # Vue planning par departement
 │   │   │   │   └── stats/         # Statistiques par departement
+│   │   │   ├── planning/          # "Mon planning" — espace STAR (role STAR uniquement)
 │   │   │   ├── events/            # Liste et calendrier des evenements
 │   │   │   │   └── calendar/      # Vue calendrier
 │   │   │   ├── profile/           # Profil utilisateur et liaison compte STAR
@@ -139,8 +140,10 @@ koinonia/
 │   │   │   ├── secretariat/
 │   │   │   │   └── requests/      # Dashboard Secretariat (toutes demandes)
 │   │   │   ├── media/
-│   │   │   │   └── requests/      # Dashboard Production Media (VISUEL)
-│   │   │   │       └── new/       # Demande visuel standalone
+│   │   │   │   ├── requests/      # Dashboard Production Media (VISUEL)
+│   │   │   │   │   └── new/       # Demande visuel standalone
+│   │   │   │   ├── events/        # Evenements media (module Media)
+│   │   │   │   └── projects/      # Projets media (phases v/g/d)
 │   │   │   ├── communication/
 │   │   │   │   └── requests/      # Dashboard Communication (RESEAUX_SOCIAUX)
 │   │   │   ├── guide/             # Guide utilisateur par role
@@ -148,7 +151,7 @@ koinonia/
 │   │   │       ├── layout.tsx     # Guard multi-permissions
 │   │   │       ├── churches/      # CRUD eglises
 │   │   │       ├── users/         # Gestion utilisateurs et roles
-│   │   │       ├── access/        # Gestion des acces (ministres, resp. dept, reporters)
+│   │   │       ├── access/        # Gestion des acces (ministres, resp. dept, reporters, STAR)
 │   │   │       ├── ministries/    # CRUD ministeres
 │   │   │       ├── departments/   # CRUD departements
 │   │   │       │   └── functions/ # Config fonctions departementales

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -38,6 +38,29 @@ session.user.churchRoles = [
 ]
 ```
 
+#### Chargement des departements STAR
+
+Pour les roles `STAR`, le callback `session` ne consulte pas `user_departments` (vide par design) mais derive les departements depuis la liaison membre :
+
+```typescript
+// Pseudo-code du callback session (src/lib/auth.ts)
+if (cr.role === "STAR") {
+  const link = await prisma.memberUserLink.findUnique({
+    where: { userId_churchId: { userId, churchId: cr.churchId } },
+    include: { member: { include: { departments: { include: { department: true } } } } },
+  });
+  // departments = link.member.departments.map(d => d.department)
+}
+```
+
+Cela permet d'assigner le role STAR sans aucune entree `user_departments` : les departements visibles suivent automatiquement le profil membre.
+
+#### Notifications de liaison
+
+- Soumission d'une `MemberLinkRequest` → notification `MEMBER_LINK_REQUEST` envoyee a tous les utilisateurs avec role `ADMIN`, `SECRETARY` ou `SUPER_ADMIN` dans l'eglise concernee
+- Approbation → notification `MEMBER_LINK_APPROVED` au demandeur (lien : `/planning`)
+- Rejet → notification `MEMBER_LINK_REJECTED` au demandeur avec le motif (lien : `/profile`)
+
 ### Protection des routes
 
 **Middleware** (`src/proxy.ts`, ex `src/middleware.ts`) :
@@ -71,6 +94,7 @@ session.user.churchRoles = [
 | Responsable departement | `DEPARTMENT_HEAD` | Un ou plusieurs departements |
 | Accompagnateur discipolat | `DISCIPLE_MAKER` | Suivi des relations de discipolat et gestion des presences |
 | Rapporteur | `REPORTER` | Acces en lecture/ecriture aux comptes rendus d'evenements |
+| Membre actif | `STAR` | Consultation du planning personnel uniquement |
 
 Un utilisateur peut avoir **plusieurs roles** dans **plusieurs eglises** via la table `user_church_roles`.
 
@@ -79,6 +103,7 @@ Un utilisateur peut avoir **plusieurs roles** dans **plusieurs eglises** via la 
 - **Super Admin** : automatique a la premiere connexion si l'email est dans `SUPER_ADMIN_EMAILS`
 - **Autres roles** : via l'interface admin (`/admin/users`), avec affectation optionnelle de ministere (MINISTER) ou departements (DEPARTMENT_HEAD)
 - **isDeputy** : la table `user_departments` (liaison `DEPARTMENT_HEAD` ↔ departements) dispose d'un flag `isDeputy` pour distinguer le responsable principal du responsable adjoint (deputy)
+- **STAR** : attribue depuis `/admin/access` (onglet STAR) ; les departements visibles sont derives automatiquement depuis `MemberUserLink → Member → MemberDepartment` — aucune entree `user_departments` n'est creee
 
 ---
 
@@ -98,23 +123,23 @@ const userPermissions = new Set(
 
 Matrice resultante :
 
-| Permission | Super Admin | Admin | Secrétaire | Ministre | Resp. département | Disciple Maker | Reporter |
-|---|---|---|---|---|---|---|---|
-| `planning:view` | x | x | x | x | x | | |
-| `planning:edit` | x | x | | x | x | | |
-| `members:view` | x | x | x | x | x | | |
-| `members:manage` | x | x | | x | x | | |
-| `events:view` | x | x | x | x | x | | x |
-| `events:manage` | x | x | x | | | | |
-| `departments:view` | x | x | x | x | x | | |
-| `departments:manage` | x | x | | | | | |
-| `church:manage` | x | | | | | | |
-| `users:manage` | x | | | | | | |
-| `discipleship:view` | x | x | x | | x | x | |
-| `discipleship:manage` | x | x | | | | x | |
-| `discipleship:export` | x | | x | | | | |
-| `reports:view` | x | x | x | | | | x |
-| `reports:edit` | x | x | x | | | | x |
+| Permission | Super Admin | Admin | Secrétaire | Ministre | Resp. département | Disciple Maker | Reporter | STAR |
+|---|---|---|---|---|---|---|---|---|
+| `planning:view` | x | x | x | x | x | | | x |
+| `planning:edit` | x | x | | x | x | | | |
+| `members:view` | x | x | x | x | x | | | |
+| `members:manage` | x | x | | x | x | | | |
+| `events:view` | x | x | x | x | x | | x | |
+| `events:manage` | x | x | x | | | | | |
+| `departments:view` | x | x | x | x | x | | | |
+| `departments:manage` | x | x | | | | | | |
+| `church:manage` | x | | | | | | | |
+| `users:manage` | x | | | | | | | |
+| `discipleship:view` | x | x | x | | x | x | | |
+| `discipleship:manage` | x | x | | | | x | | |
+| `discipleship:export` | x | | x | | | | | |
+| `reports:view` | x | x | x | | | | x | |
+| `reports:edit` | x | x | x | | | | x | |
 
 **Spécificités du Secrétaire** :
 - Voit tous les départements de son église (même périmètre que Admin)
@@ -127,6 +152,13 @@ Matrice resultante :
 **Spécificités du Reporter** :
 - Accès aux événements en lecture (`events:view`) et aux comptes rendus (`reports:view` + `reports:edit`)
 - Pas d'accès au planning, aux membres, au discipolat ni à la section admin
+
+**Spécificités du STAR** :
+- Permission `planning:view` uniquement — accède à son planning personnel via `/planning`
+- Pas d'accès aux sections membres, événements, admin, discipolat
+- Navigation réduite : lien "Mon planning" visible uniquement si `isStarOnly` (`churchRoles.every(r => r.role === "STAR")`)
+- Les départements du STAR sont dérivés automatiquement depuis `MemberUserLink → Member → MemberDepartment` dans le callback de session (pas de `user_departments`)
+- Attribution requiert une liaison compte-membre valide (`MemberUserLink`)
 
 ### Utilisation dans le code
 
@@ -166,5 +198,6 @@ L'endpoint `PATCH /api/departments/[departmentId]` qui assigne une fonction depa
 - **Responsable de département** : voit uniquement les départements qui lui sont assignés via `user_departments`
 - **Disciple Maker** : pas d'accès au planning ni à la grille des départements ; périmètre limité au module discipolat
 - **Reporter** : pas d'accès au planning, aux membres ni à la section admin ; voit uniquement les événements et les comptes rendus qui lui sont accessibles
+- **STAR** : accès à `/planning` uniquement (son planning personnel) ; les départements sont dérivés depuis `MemberUserLink`, pas depuis `user_departments`
 
 Cette logique est implémentée dans `src/app/(auth)/layout.tsx` et `getUserDepartmentScope()` dans `src/lib/auth.ts`.

--- a/docs/database.md
+++ b/docs/database.md
@@ -41,8 +41,8 @@ Tous les IDs sont des `String @default(cuid())`.
 │     │        ├──► discipleship_attendances                          │
 │     │        └──► event_reports ──► event_report_sections           │
 │     │                                          │                     │
-│     ├──► announcements ──► service_requests ───┘                    │
-│     ├──► service_requests                                            │
+│     ├──► announcements ──► requests ───────────┘                    │
+│     ├──► requests                                                    │
 │     ├──► member_user_links                                           │
 │     ├──► member_link_requests                                        │
 │     ├──► discipleships                                               │
@@ -101,7 +101,7 @@ Association utilisateur-eglise-role. Un utilisateur peut avoir plusieurs roles d
 | `id` | String (cuid) | Identifiant unique |
 | `userId` | String | Ref vers `users` |
 | `churchId` | String | Ref vers `churches` |
-| `role` | Role (enum) | `SUPER_ADMIN`, `ADMIN`, `SECRETARY`, `MINISTER`, `DEPARTMENT_HEAD`, `DISCIPLE_MAKER`, `REPORTER` |
+| `role` | Role (enum) | `SUPER_ADMIN`, `ADMIN`, `SECRETARY`, `MINISTER`, `DEPARTMENT_HEAD`, `DISCIPLE_MAKER`, `REPORTER`, `STAR` |
 | `ministryId` | String? | Ref vers `ministries` (pour MINISTER) |
 
 Contrainte unique : `[userId, churchId, role]`
@@ -136,7 +136,7 @@ Departements d'un ministere (Choristes, Musiciens, Son...).
 |---|---|---|
 | `name` | String | Nom du departement |
 | `ministryId` | String | Ref vers `ministries` |
-| `function` | DepartmentFunction? | Fonction speciale : `SECRETARIAT`, `COMMUNICATION`, `PRODUCTION_MEDIA` (nullable) |
+| `function` | String? | Fonction speciale : `SECRETARIAT`, `COMMUNICATION`, `PRODUCTION_MEDIA`, ou valeur personnalisee (nullable) |
 
 #### `members`
 
@@ -355,30 +355,29 @@ Table de jointure Announcement ↔ Event (evenements cibles par l'annonce).
 
 Cle primaire composite : `[announcementId, eventId]`
 
-#### `service_requests`
+#### `requests`
 
-Demandes de service generees automatiquement lors de la soumission d'une annonce, ou creees manuellement (visuels standalone).
+Modele unifie pour toutes les demandes : annonces (DIFFUSION_INTERNE, RESEAUX_SOCIAUX, VISUEL) et demandes metier (AJOUT_EVENEMENT, MODIFICATION_EVENEMENT, ANNULATION_EVENEMENT, MODIFICATION_PLANNING, DEMANDE_ACCES).
 
 | Champ | Type | Description |
 |---|---|---|
 | `id` | String (cuid) | Identifiant unique |
 | `churchId` | String | Ref vers `churches` |
-| `type` | ServiceRequestType | `VISUEL`, `DIFFUSION_INTERNE`, `RESEAUX_SOCIAUX` |
+| `type` | RequestType | Type de demande (voir enum ci-dessous) |
+| `status` | RequestStatus | Statut (voir enum ci-dessous) |
+| `title` | String | Titre de la demande |
+| `payload` | Json | Donnees specifiques au type (brief, eventId, changes, etc.) |
 | `submittedById` | String | Ref vers `users` (soumetteur) |
-| `departmentId` | String? | Departement soumetteur (optionnel) |
-| `ministryId` | String? | Ministere soumetteur (optionnel) |
-| `assignedDeptId` | String? | Departement traitant (resolu via `DepartmentFunction`) |
-| `announcementId` | String? | Ref vers `announcements` (si generee depuis une annonce) |
-| `parentRequestId` | String? | Ref vers `service_requests` (auto-referentiel : lie un VISUEL a son canal parent) |
-| `title` | String | Titre |
-| `brief` | String? (Text) | Description / brief |
-| `format` | String? | Format attendu (ex: Slide/Affiche, Story/Post) |
-| `deadline` | DateTime? | Echeance |
-| `status` | ServiceRequestStatus | `EN_ATTENTE`, `EN_COURS`, `LIVRE`, `ANNULE` |
-| `deliveryLink` | String? | Lien de livraison |
-| `reviewNotes` | String? | Notes de revue |
-| `reviewedById` | String? | Ref vers `users` (revieweur) |
-| `reviewedAt` | DateTime? | Date de revue |
+| `departmentId` | String? | Ref vers `departments` (departement source) |
+| `ministryId` | String? | Ref vers `ministries` (ministere source) |
+| `assignedDeptId` | String? | Ref vers `departments` (departement traitant, resolu via fonction) |
+| `announcementId` | String? | Ref vers `announcements` (si liee a une annonce) |
+| `parentRequestId` | String? | Ref vers `requests` (auto-referentiel : lie un VISUEL a son canal parent) |
+| `reviewNotes` | String? (Text) | Notes du traitant |
+| `reviewedById` | String? | Ref vers `users` (traitant) |
+| `reviewedAt` | DateTime? | Date de traitement |
+| `executedAt` | DateTime? | Date d'execution automatique (demandes metier) |
+| `executionError` | String? (Text) | Message d'erreur si execution echouee |
 | `submittedAt` | DateTime | Date de soumission |
 | `updatedAt` | DateTime | Derniere modification |
 
@@ -396,6 +395,7 @@ MINISTER         # Responsable d'un ministere
 DEPARTMENT_HEAD  # Responsable d'un ou plusieurs departements
 DISCIPLE_MAKER   # Faiseur de disciples (acces aux fonctionnalites de discipolat)
 REPORTER         # Rapporteur (acces a la saisie des comptes-rendus)
+STAR             # Membre actif (acces uniquement a son planning personnel via MemberUserLink)
 ```
 
 #### `ServiceStatus`
@@ -407,15 +407,17 @@ INDISPONIBLE        # Absent
 REMPLACANT          # Remplace un membre indisponible
 ```
 
-#### `DepartmentFunction`
+#### Fonctions departementales (`department.function`)
+
+Champ `String?` sur le modele `Department` (plus un enum Prisma depuis v1.0). Valeurs conventionnelles :
 
 ```
-SECRETARIAT       # Departement traitant les diffusions internes
+SECRETARIAT       # Departement traitant les diffusions internes et demandes
 COMMUNICATION     # Departement traitant les publications reseaux sociaux
 PRODUCTION_MEDIA  # Departement traitant les demandes de visuels
 ```
 
-Un seul departement par fonction et par eglise. Assigne via `PATCH /api/departments/[id]`.
+Des valeurs personnalisees sont possibles. Un seul departement par fonction et par eglise. Assigne via `PATCH /api/departments/[id]`. Constantes definies dans `src/lib/department-functions.ts`.
 
 #### `MemberLinkRequestStatus`
 
@@ -434,21 +436,30 @@ TRAITEE     # Traitement termine
 ANNULEE     # Annulee
 ```
 
-#### `ServiceRequestType`
+#### `RequestType`
 
 ```
-VISUEL             # Creation d'un visuel (Production Media)
-DIFFUSION_INTERNE  # Diffusion interne (Secretariat)
-RESEAUX_SOCIAUX    # Publication reseaux sociaux (Communication)
+DIFFUSION_INTERNE      # Annonce : diffusion interne (Secretariat)
+RESEAUX_SOCIAUX        # Annonce : publication reseaux sociaux (Communication)
+VISUEL                 # Annonce : creation d'un visuel (Production Media) — enfant auto
+AJOUT_EVENEMENT        # Demande : ajouter un evenement au planning
+MODIFICATION_EVENEMENT # Demande : modifier un evenement existant
+ANNULATION_EVENEMENT   # Demande : annuler un evenement
+MODIFICATION_PLANNING  # Demande : modifier le statut d'un membre dans un planning
+DEMANDE_ACCES          # Demande : attribuer un role a un utilisateur
 ```
 
-#### `ServiceRequestStatus`
+#### `RequestStatus`
 
 ```
-EN_ATTENTE  # Demande recue, en attente
-EN_COURS    # En cours de traitement
-LIVRE       # Livre (avec lien de livraison)
-ANNULE      # Annulee
+EN_ATTENTE   # Recue, en attente de traitement
+EN_COURS     # Traitement en cours (annonces)
+APPROUVEE    # Validee (demandes metier, avant execution)
+EXECUTEE     # Execution automatique reussie
+LIVRE        # Livree manuellement (annonces)
+REFUSEE      # Refusee (note obligatoire)
+ANNULE       # Annulee par le soumetteur ou en cascade
+ERREUR       # Echec de l'execution automatique
 ```
 
 ## Seed (donnees initiales)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,17 +1,22 @@
 # Roadmap
 
-## Annonces et production media
+## Demandes et production media (systeme unifie)
 
-- [x] Module annonces : soumission par les referents (`/announcements/new`)
-- [x] Liste des annonces du referent (`/announcements`)
-- [x] Generation automatique des ServiceRequests selon les canaux (INTERNE/EXTERNE)
-- [x] Dashboard Secretariat (`/secretariat/announcements`) — traitement des DIFFUSION_INTERNE
+- [x] Systeme unifie de demandes (`Request`) : annonces + evenements + acces dans un seul modele
+- [x] Migration `ServiceRequest` → `Request` avec payload JSON type-specifique
+- [x] `DepartmentFunction` : enum → `String?` (flexible, extensible)
+- [x] "Mes demandes" (`/requests`) : liste unifiee annonces + demandes pour le soumetteur
+- [x] Formulaire unifie (`/requests/new`) : cartes par type, champs dynamiques
+- [x] Dashboard Secretariat (`/secretariat/requests`) — traitement de toutes les demandes
 - [x] Dashboard Production Media (`/media/requests`) — traitement des VISUEL
 - [x] Dashboard Communication (`/communication/requests`) — traitement des RESEAUX_SOCIAUX
 - [x] Demande visuel standalone sans annonce (`/media/requests/new`)
 - [x] Configuration des fonctions departementales (`/admin/departments/functions`)
 - [x] Flag `allowAnnouncements` sur les evenements
 - [x] Relation auto-referentielle VISUEL → canal parent (format contextualise)
+- [x] Execution automatique des demandes approuvees (`executeRequest()` dans `request-executor.ts`)
+- [x] Module Media : evenements, projets, pages publiques (`/media/*`)
+- [x] Module Media : gestion des phases (v/g/d) par projet
 
 ## Interface utilisateur
 
@@ -108,7 +113,8 @@
 - [x] Page /admin/access : attribution des ministres et responsables de departement
 - [x] Distinction principal/adjoint (isDeputy) sur les responsables de departement
 - [x] Onglet Comptes rendus : toggle REPORTER par utilisateur
-- [x] Reorganisation du menu sidebar en 6 sections (Planning, Evenements, Membres, Annonces, Discipolat, Configuration)
+- [x] Onglet STAR : visualisation du statut de liaison compte-membre, toggle role STAR
+- [x] Reorganisation du menu sidebar en 6 sections (Planning, Evenements, Membres, Demandes, Discipolat, Configuration)
 
 ## Liaison compte STAR
 
@@ -116,7 +122,18 @@
 - [x] Page profil /profile : visualisation et demande de liaison
 - [x] Interface admin : colonne Compte et bouton Lier sur la page membres
 - [x] Liaison independante de l'attribution de role
-- [ ] Notification au responsable lors d'une nouvelle demande de liaison
+- [x] Notification aux admins/secretaires lors d'une nouvelle demande de liaison
+- [x] Notification au demandeur lors de l'approbation ou du rejet de sa demande
+- [x] Attribution du role STAR depuis /admin/access (onglet dedie)
+
+## Espace STAR (membre actif)
+
+- [x] Role `STAR` dans l'enum `Role` Prisma
+- [x] Session callback : departements du STAR derives automatiquement depuis `MemberUserLink → Member → MemberDepartment` (sans `user_departments`)
+- [x] Page "Mon planning" (`/planning`) : liste des services futurs et passes du membre lie
+- [x] Sidebar : lien "Mon planning" visible uniquement pour les utilisateurs STAR-only
+- [x] Guide utilisateur : onglet et description pour le role STAR
+- [x] `isStarOnly` flag dans le layout pour conditionner la navigation
 
 ## Guide utilisateur
 


### PR DESCRIPTION
## Summary

- **roadmap.md** : section "Annonces" renommée en "Demandes unifié" avec les nouvelles entrées (Request workflow, module media) ; nouvelle section "Espace STAR" ; notifications liaison STAR marquées comme faites ; onglet STAR dans /admin/access
- **architecture.md** : route `/planning` ajoutée dans l'arborescence, `media/events` et `media/projects`, description `/admin/access` et périmètre module planning mis à jour
- **database.md** : `service_requests` → `requests` (modèle unifié avec payload JSON), enum `Role` + `STAR`, `DepartmentFunction` → `String?`, enums `RequestType` / `RequestStatus` remplacent `ServiceRequestType` / `ServiceRequestStatus`
- **auth.md** : rôle `STAR` dans la hiérarchie et la matrice de permissions, documentation du chargement de session depuis `MemberUserLink`, notifications de liaison (soumission / approbation / rejet)

## Test plan

- [ ] Vérifier que les liens internes entre docs sont cohérents
- [ ] Vérifier que la matrice de permissions correspond à `src/modules/planning/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)