### PR TITLE
feat(integration): VISUEL → MediaProject via event bus (#211)

### DIFF
--- a/src/app/api/requests/[id]/route.ts
+++ b/src/app/api/requests/[id]/route.ts
@@ -3,7 +3,7 @@ import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { rolePermissions } from "@/lib/registry";
-import { executeRequest } from "@/modules/planning";
+import { executeRequest, planningBus } from "@/modules/planning";
 import { z } from "zod";
 import type { Prisma } from "@/generated/prisma/client";
 
@@ -120,6 +120,7 @@ export async function PATCH(
         churchId: true,
         type: true,
         status: true,
+        title: true,
         announcementId: true,
         payload: true,
       },
@@ -282,6 +283,24 @@ export async function PATCH(
           where: { id: existing.announcementId },
           data: { status: announcementStatus },
         });
+      }
+
+      // Emit status_changed event for cross-module integrations (e.g. media module)
+      if (data.status !== undefined) {
+        await planningBus.emit(
+          "planning:request:status_changed",
+          { tx, churchId: existing.churchId, userId: session.user.id },
+          {
+            requestId: id,
+            requestType: existing.type,
+            churchId: existing.churchId,
+            oldStatus: existing.status,
+            newStatus: data.status,
+            updatedById: session.user.id,
+            title: existing.title,
+            payload: currentPayload,
+          }
+        );
       }
 
       return result;

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -37,3 +37,39 @@ export const rolePermissions = buildRolePermissions(registry);
 planningBus.on("planning:event:cancelled", async ({ tx }, { eventId }) => {
   await tx.discipleshipAttendance.deleteMany({ where: { eventId } });
 });
+
+/**
+ * Media → Planning : quand une Request VISUEL passe en EN_COURS (prise en charge
+ * par la Production Média), créer automatiquement un MediaProject correspondant.
+ *
+ * - Le nom du projet reprend le titre de la Request.
+ * - La description embarque le brief et l'identifiant de la Request (référence loose,
+ *   pas de FK Prisma cross-module — conforme aux règles d'architecture v1.0).
+ *
+ * S'exécute dans la même transaction que la mise à jour du statut.
+ */
+planningBus.on(
+  "planning:request:status_changed",
+  async ({ tx, userId }, { requestType, newStatus, churchId, requestId, title, payload }) => {
+    if (requestType !== "VISUEL" || newStatus !== "EN_COURS") return;
+
+    const brief = typeof payload.brief === "string" ? payload.brief : null;
+    const description = [
+      brief,
+      `[source:request:${requestId}]`,
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+
+    if (!userId) return; // ne devrait pas arriver depuis une route API authentifiée
+
+    await tx.mediaProject.create({
+      data: {
+        name: title,
+        description,
+        churchId,
+        createdById: userId,
+      },
+    });
+  }
+);

--- a/src/modules/planning/events.ts
+++ b/src/modules/planning/events.ts
@@ -47,4 +47,22 @@ export type PlanningEvents = {
     newStatus: string | null;
     changedById: string;
   };
+
+  /**
+   * Le statut d'une Request a changé.
+   * Émis depuis PATCH /api/requests/[id] lors de toute transition de statut.
+   * Utilisé notamment pour déclencher la création d'un MediaProject quand
+   * une Request VISUEL passe en EN_COURS.
+   */
+  "planning:request:status_changed": {
+    requestId: string;
+    requestType: string;
+    churchId: string;
+    oldStatus: string;
+    newStatus: string;
+    updatedById: string;
+    title: string;
+    /** Payload brut de la Request, pour utilisation par les handlers cross-module. */
+    payload: Record<string, unknown>;
+  };
 }


### PR DESCRIPTION
## Summary

Implémente l'intégration cross-module planning → media via le bus d'événements in-process, validant le critère d'acceptation v1.0 (#211) :

> "Un user admin peut créer un événement, déclencher une request visuel, et voir le MediaProject correspondant apparaître **dans la même transaction**"

- **`planning/events.ts`** : nouveau type `planning:request:status_changed` — émis lors de toute transition de statut d'une Request
- **`requests/[id]/route.ts`** : émission de l'événement dans la transaction existante (branche non-exécutable)
- **`registry.ts`** : listener media → planning — crée un `MediaProject` quand `requestType === "VISUEL"` et `newStatus === "EN_COURS"` ; la description embarque le brief + une référence loose `[source:request:<id>]` (pas de FK cross-module)

L'intégration est **loose** : pas de FK Prisma entre `Request` et `MediaProject`, conforme aux règles d'architecture v1.0 (IDs nus sans FK cross-module).

## Test plan

- [ ] Créer une annonce avec canal externe → Request VISUEL EN_ATTENTE créée
- [ ] Depuis `/media/requests`, passer la Request VISUEL en EN_COURS
- [ ] Vérifier qu'un MediaProject apparaît dans `/media/projects` avec le titre et le brief de la Request
- [ ] Vérifier `npm run typecheck` ✅
- [ ] Vérifier `npm run lint:boundaries` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)