### PR TITLE
feat(sidebar): réorganisation menu — Demandes / Médias séparés, Discipolat lien direct

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ koinonia/
 │   │       ├── notifications/
 │   │       └── users/           # CRUD + [userId]/roles POST/PATCH/DELETE
 │   ├── components/
-│   │   ├── Sidebar.tsx          # Sidebar (sections : Planning, Evenements, Membres, Demandes, Discipolat, Configuration)
+│   │   ├── Sidebar.tsx          # Sidebar (sections : Planning, Evenements, Membres, Demandes, Medias, Discipolat, Configuration)
 │   │   ├── AuthLayoutShell.tsx  # Shell layout authentifie (sidebar + bottom nav + contenu)
 │   │   ├── BottomNav.tsx        # Navigation mobile fixe en bas
 │   │   ├── NotificationBell.tsx # Cloche de notifications avec badge

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,7 +180,7 @@ koinonia/
 │   ├── components/
 │   │   ├── AuthLayoutShell.tsx    # Shell layout authentifie (header, sidebar)
 │   │   ├── BottomNav.tsx          # Navigation mobile bas d'ecran
-│   │   ├── Sidebar.tsx            # Sidebar unifiee
+│   │   ├── Sidebar.tsx            # Sidebar (Planning, Evenements, Membres, Demandes, Medias, Discipolat, Configuration)
 │   │   ├── PlanningGrid.tsx       # Grille planning interactive (auto-save)
 │   │   ├── EventSelector.tsx      # Selecteur d'evenement
 │   │   ├── MonthlyPlanningView.tsx

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,7 +114,10 @@
 - [x] Distinction principal/adjoint (isDeputy) sur les responsables de departement
 - [x] Onglet Comptes rendus : toggle REPORTER par utilisateur
 - [x] Onglet STAR : visualisation du statut de liaison compte-membre, toggle role STAR
-- [x] Reorganisation du menu sidebar en 6 sections (Planning, Evenements, Membres, Demandes, Discipolat, Configuration)
+- [x] Reorganisation du menu sidebar en 7 sections (Planning, Evenements, Membres, Demandes, Medias, Discipolat, Configuration)
+- [x] Sidebar : section "Demandes" limitee aux flux de requetes (Mes demandes + Gestion secrétariat)
+- [x] Sidebar : section "Medias" separee (Evenements, Projets, Visuels, Communication) — visible selon permissions media:view ou appartenance au departement
+- [x] Sidebar : "Discipolat" passe en lien direct (suppression de l'accordéon superflu)
 
 ## Liaison compte STAR
 

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -81,13 +81,15 @@ export default async function AuthLayout({
     .filter((link) => link.permissions.some((p) => userPermissions.has(p)))
     .map(({ href, label }) => ({ href, label }));
 
-  // Compute service links (demandes)
-  // Dashboards opérationnels restreints aux membres du département concerné + events:manage
-  const serviceLinks: { href: string; label: string }[] = [];
+  // ── Section "Demandes" (workflow requêtes) ──────────────────────────────────
+  const requestLinks: { href: string; label: string }[] = [];
 
   if (userPermissions.has("planning:view")) {
-    serviceLinks.push({ href: "/requests", label: "Mes demandes" });
+    requestLinks.push({ href: "/requests", label: "Mes demandes" });
   }
+
+  // ── Section "Médias" (module Media + dashboards production) ─────────────────
+  const mediaLinks: { href: string; label: string }[] = [];
 
   if (currentChurchId && userPermissions.has("planning:view")) {
     const isGlobalManager = userPermissions.has("events:manage");
@@ -112,17 +114,16 @@ export default async function AuthLayout({
       serviceDepts.some((d) => d.function === fn && userDeptIds.has(d.id));
 
     if (isMemberOf("SECRETARIAT"))
-      serviceLinks.push({ href: "/secretariat/requests", label: "Gestion" });
+      requestLinks.push({ href: "/secretariat/requests", label: "Gestion" });
     if (isMemberOf("PRODUCTION_MEDIA"))
-      serviceLinks.push({ href: "/media/requests", label: "Visuels" });
+      mediaLinks.push({ href: "/media/requests", label: "Visuels" });
     if (isMemberOf("COMMUNICATION"))
-      serviceLinks.push({ href: "/communication/requests", label: "Communication" });
+      mediaLinks.push({ href: "/communication/requests", label: "Communication" });
   }
 
-  // Media module links
   if (userPermissions.has("media:view")) {
-    serviceLinks.push({ href: "/media/events", label: "Événements médias" });
-    serviceLinks.push({ href: "/media/projects", label: "Projets médias" });
+    mediaLinks.push({ href: "/media/events", label: "Événements" });
+    mediaLinks.push({ href: "/media/projects", label: "Projets" });
   }
 
   const headerContent = (
@@ -211,7 +212,8 @@ export default async function AuthLayout({
     <AuthLayoutShell
       departments={allDepartments}
       configLinks={visibleConfigLinks}
-      serviceLinks={serviceLinks}
+      requestLinks={requestLinks}
+      mediaLinks={mediaLinks}
       hasDiscipleship={hasDiscipleship}
       hasEventsAccess={hasEventsAccess}
       hasEventsManage={hasEventsManage}

--- a/src/components/AuthLayoutShell.tsx
+++ b/src/components/AuthLayoutShell.tsx
@@ -12,7 +12,8 @@ type RoleKey = "SUPER_ADMIN" | "ADMIN" | "SECRETARY" | "MINISTER" | "DEPARTMENT_
 interface AuthLayoutShellProps {
   departments: { id: string; name: string; ministryName?: string }[];
   configLinks: { href: string; label: string }[];
-  serviceLinks: { href: string; label: string }[];
+  requestLinks: { href: string; label: string }[];
+  mediaLinks: { href: string; label: string }[];
   hasDiscipleship: boolean;
   hasEventsAccess: boolean;
   hasEventsManage: boolean;
@@ -45,7 +46,8 @@ function IconClose({ className }: { className?: string }) {
 export default function AuthLayoutShell({
   departments,
   configLinks,
-  serviceLinks,
+  requestLinks,
+  mediaLinks,
   hasDiscipleship,
   hasEventsAccess,
   hasEventsManage,
@@ -114,7 +116,8 @@ export default function AuthLayoutShell({
             <Sidebar
               departments={departments}
               configLinks={configLinks}
-              serviceLinks={serviceLinks}
+              requestLinks={requestLinks}
+              mediaLinks={mediaLinks}
               hasDiscipleship={hasDiscipleship}
               hasEventsAccess={hasEventsAccess}
               hasEventsManage={hasEventsManage}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,7 +7,8 @@ import { useSearchParams, usePathname } from "next/navigation";
 interface SidebarProps {
   departments: { id: string; name: string; ministryName?: string }[];
   configLinks: { href: string; label: string }[];
-  serviceLinks: { href: string; label: string }[];
+  requestLinks: { href: string; label: string }[];
+  mediaLinks: { href: string; label: string }[];
   hasDiscipleship?: boolean;
   hasEventsAccess?: boolean;
   hasEventsManage?: boolean;
@@ -56,6 +57,14 @@ function IconDiscipleship({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+    </svg>
+  );
+}
+
+function IconMedia({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
     </svg>
   );
 }
@@ -258,7 +267,8 @@ function NavLink({
 export default function Sidebar({
   departments,
   configLinks,
-  serviceLinks,
+  requestLinks,
+  mediaLinks,
   hasDiscipleship = false,
   hasEventsAccess = true,
   hasEventsManage = false,
@@ -280,9 +290,10 @@ export default function Sidebar({
     pathname.startsWith("/admin/events") ||
     pathname.startsWith("/admin/reports");
   const isMembersActive = pathname.startsWith("/admin/members");
-  const isServiceActive =
+  const isRequestsActive =
     pathname.startsWith("/requests") ||
-    pathname.startsWith("/secretariat") ||
+    pathname.startsWith("/secretariat");
+  const isMediaActive =
     pathname.startsWith("/media") ||
     pathname.startsWith("/communication");
   const isDiscipleshipActive = pathname.startsWith("/admin/discipleship");
@@ -296,8 +307,8 @@ export default function Sidebar({
   function activeSection() {
     if (isEventsActive) return "events";
     if (isMembersActive) return "members";
-    if (isServiceActive) return "service";
-    if (isDiscipleshipActive) return "discipleship";
+    if (isRequestsActive) return "requests";
+    if (isMediaActive) return "media";
     if (isConfigActive) return "config";
     return "planning";
   }
@@ -315,7 +326,8 @@ export default function Sidebar({
 
   return (
     <aside className="w-64 min-h-0 md:min-h-[calc(100vh-73px)] bg-white border-r border-gray-200 p-4 pb-20 md:pb-4 space-y-1 overflow-y-auto">
-      {/* 0. Mon planning (STAR only) */}
+
+      {/* 0. Mon planning (STAR uniquement) */}
       {hasMyPlanning && (
         <Link
           href="/planning"
@@ -418,18 +430,18 @@ export default function Sidebar({
         </Link>
       )}
 
-      {/* 4. Annonces */}
-      {serviceLinks.length > 0 && (
+      {/* 4. Demandes */}
+      {requestLinks.length > 0 && (
         <AccordionSection
           title="Demandes"
           icon={<IconMegaphone className="w-4 h-4" />}
-          open={openSection === "service"}
-          onToggle={() => toggle("service")}
-          isActive={isServiceActive}
+          open={openSection === "requests"}
+          onToggle={() => toggle("requests")}
+          isActive={isRequestsActive}
           dataTour="sidebar-service"
         >
           <nav className="space-y-0.5 pl-6">
-            {serviceLinks.map((link) => (
+            {requestLinks.map((link) => (
               <NavLink key={link.href} href={link.href} active={pathname.startsWith(link.href)} onClose={onClose}>
                 {link.label}
               </NavLink>
@@ -438,25 +450,40 @@ export default function Sidebar({
         </AccordionSection>
       )}
 
-      {/* 5. Discipolat */}
-      {hasDiscipleship && (
+      {/* 5. Médias */}
+      {mediaLinks.length > 0 && (
         <AccordionSection
-          title="Discipolat"
-          icon={<IconDiscipleship className="w-4 h-4" />}
-          open={openSection === "discipleship"}
-          onToggle={() => toggle("discipleship")}
-          isActive={isDiscipleshipActive}
-          dataTour="sidebar-discipleship"
+          title="Médias"
+          icon={<IconMedia className="w-4 h-4" />}
+          open={openSection === "media"}
+          onToggle={() => toggle("media")}
+          isActive={isMediaActive}
+          dataTour="sidebar-media"
         >
           <nav className="space-y-0.5 pl-6">
-            <NavLink href="/admin/discipleship" active={pathname === "/admin/discipleship"} onClose={onClose}>
-              Tableau de bord
-            </NavLink>
+            {mediaLinks.map((link) => (
+              <NavLink key={link.href} href={link.href} active={pathname.startsWith(link.href)} onClose={onClose}>
+                {link.label}
+              </NavLink>
+            ))}
           </nav>
         </AccordionSection>
       )}
 
-      {/* 6. Configuration */}
+      {/* 6. Discipolat — lien direct (une seule sous-page) */}
+      {hasDiscipleship && (
+        <Link
+          href="/admin/discipleship"
+          onClick={onClose}
+          data-tour="sidebar-discipleship"
+          className={`${sectionHeaderBase} ${isDiscipleshipActive ? sectionHeaderActive : sectionHeaderIdle} rounded-md`}
+        >
+          <IconDiscipleship className="w-4 h-4 shrink-0" />
+          <span className="flex-1">Discipolat</span>
+        </Link>
+      )}
+
+      {/* 7. Configuration */}
       {configLinks.length > 0 && (
         <AccordionSection
           title="Configuration"


### PR DESCRIPTION
## Résumé

Réorganisation de la sidebar selon la proposition validée :

### Avant → Après

**Section "Demandes"** (anciennement fourre-tout) :
- Avant : Mes demandes + Gestion + Visuels + Communication + Événements médias + Projets médias
- Après : Mes demandes + Gestion (secrétariat uniquement)

**Nouvelle section "Médias"** :
- Visuels (Production Média), Communication, Événements, Projets
- Visible uniquement si `media:view` ou membre d'un département PRODUCTION_MEDIA/COMMUNICATION

**Discipolat** :
- Avant : accordéon avec une seule sous-page ("Tableau de bord")
- Après : lien direct `/admin/discipleship` — un clic de moins

### Changements techniques

- `layout.tsx` : `serviceLinks` → `requestLinks` + `mediaLinks`
- `AuthLayoutShell.tsx` : propagation des nouvelles props
- `Sidebar.tsx` : nouvelle icône `IconMedia`, sections recalculées, `isRequestsActive` / `isMediaActive`

## Test plan

- [ ] Admin : voir Planning / Événements / Membres / Demandes (Mes demandes + Gestion) / Médias (Événements + Projets + Visuels + Communication) / Discipolat (lien direct) / Configuration
- [ ] Responsable de département : Planning / Événements / Membres / Demandes (Mes demandes) — pas de Médias
- [ ] Reporter : Événements / Demandes (Mes demandes)
- [ ] STAR : "Mon planning" uniquement
- [ ] Navigation active : chaque section s'ouvre automatiquement sur la page correspondante
- [ ] `npm run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)