### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.1.0] - 2026-04-23
+
+### Ajouté
+
+- Comptes rendus : statistiques Sainte Cène (supports utilisés/restants) dans l'onglet Statistiques et l'export Excel
+- Comptes rendus : section Navette (H/F/Enfants/Total) dans la saisie, les statistiques et l'export Excel
+- Médias : édition d'un événement média (renommage et liaison à un événement planning)
+- Admin : UI de gestion des sauvegardes (liste, déclenchement manuel, restauration avec double confirmation)
+
+### Mis à jour
+
+- Dépendances npm (minor/patch) — next-auth beta.31
+
 ## [v1.0.0] - 2026-04-17
 
 ### Sécurité — audit pré-v1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v1.1.0

### Ajouté
- Comptes rendus : statistiques Sainte Cène (supports utilisés/restants) dans l'onglet Statistiques et l'export Excel
- Comptes rendus : section Navette (H/F/Enfants/Total) dans la saisie, les statistiques et l'export Excel
- Médias : édition d'un événement média (renommage et liaison à un événement planning)
- Admin : UI de gestion des sauvegardes (liste, déclenchement manuel, restauration avec double confirmation)

### Mis à jour
- Dépendances npm (minor/patch) — next-auth beta.31

🤖 Generated with [Claude Code](https://claude.com/claude-code)