### PR TITLE
fix(auth): OAuthAccountNotLinked pour les utilisateurs migrés

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -49,6 +49,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      allowDangerousEmailAccountLinking: true,
     }),
   ],
   pages: {


### PR DESCRIPTION
## Problème

Les utilisateurs importés depuis Mediaflow existent dans la table `users` (email connu) mais sans entrée dans la table `accounts` (aucune liaison OAuth enregistrée). Lors de la connexion avec Google, le PrismaAdapter refusait de créer la liaison automatiquement, provoquant l'erreur `OAuthAccountNotLinked`.

## Fix

Ajout de `allowDangerousEmailAccountLinking: true` sur le provider Google. NextAuth lie automatiquement le compte Google à l'utilisateur existant par email.

**Pourquoi c'est safe ici** : Koinonia n'utilise que Google OAuth, il n'y a pas d'autre provider ni auth par mot de passe — le risque de détournement de compte par email est inexistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)