### PR TITLE
fix(mobile): BottomNav overflow, tabs Accès & rôles, accès média STAR

### DIFF
--- a/src/app/(auth)/admin/access/AccessClient.tsx
+++ b/src/app/(auth)/admin/access/AccessClient.tsx
@@ -562,12 +562,12 @@ export default function AccessClient({ users, ministries, churchId, isSuperAdmin
   return (
     <div>
       {/* Onglets */}
-      <div className="flex gap-1 mb-6 border-b border-gray-200">
+      <div className="flex gap-1 mb-6 border-b border-gray-200 overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0">
         {(["requests", "roles", "transverse", "reporters", "stars"] as Tab[]).map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
-            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors relative ${
+            className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors relative whitespace-nowrap shrink-0 ${
               tab === t
                 ? "border-icc-violet text-icc-violet"
                 : "border-transparent text-gray-500 hover:text-gray-700"

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -120,11 +120,11 @@ export default async function AuthLayout({
       mediaLinks.push({ href: "/media/requests", label: "Visuels" });
     if (isMemberOf("COMMUNICATION"))
       mediaLinks.push({ href: "/communication/requests", label: "Communication" });
-  }
 
-  if (userPermissions.has("media:view")) {
-    mediaLinks.push({ href: "/media/events", label: "Événements" });
-    mediaLinks.push({ href: "/media/projects", label: "Projets" });
+    if (userPermissions.has("media:view") || isMemberOf("PRODUCTION_MEDIA")) {
+      mediaLinks.push({ href: "/media/events", label: "Événements" });
+      mediaLinks.push({ href: "/media/projects", label: "Projets" });
+    }
   }
 
   const headerContent = (

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -177,7 +177,7 @@ export default async function AuthLayout({
   );
 
   const footerContent = (
-    <footer className="py-4 text-center text-xs text-gray-400">
+    <footer className="pt-4 pb-20 md:py-4 text-center text-xs text-gray-400">
       <a
         href="https://github.com/iccbretagne/koinonia"
         target="_blank"

--- a/src/app/(auth)/media/events/[id]/page.tsx
+++ b/src/app/(auth)/media/events/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { requireChurchPermission, resolveChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaAccess, isProductionMediaMember, resolveChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import { rolePermissions } from "@/lib/registry";
@@ -20,7 +20,7 @@ export default async function MediaEventDetailPage({
     notFound();
   }
 
-  await requireChurchPermission("media:view", churchId!);
+  await requireMediaAccess(churchId!);
 
   const event = await prisma.mediaEvent.findUnique({
     where: { id },
@@ -54,7 +54,8 @@ export default async function MediaEventDetailPage({
       .filter((r) => r.churchId === churchId!)
       .flatMap((r) => rolePermissions[r.role] ?? [])
   );
-  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload");
+  const isProductionMember = await isProductionMediaMember(session, churchId!);
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember;
   const canManage = session.user.isSuperAdmin || churchPerms.has("media:manage");
 
   return (

--- a/src/app/(auth)/media/events/new/page.tsx
+++ b/src/app/(auth)/media/events/new/page.tsx
@@ -1,4 +1,4 @@
-import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaUploadAccess, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import NewMediaEventForm from "./NewMediaEventForm";
 
@@ -6,7 +6,7 @@ export default async function NewMediaEventPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
-  await requireChurchPermission("media:upload", churchId);
+  await requireMediaUploadAccess(churchId);
 
   // Load upcoming planning events for linking
   const planningEvents = await prisma.event.findMany({

--- a/src/app/(auth)/media/events/page.tsx
+++ b/src/app/(auth)/media/events/page.tsx
@@ -1,4 +1,4 @@
-import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaAccess, isProductionMediaMember, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
@@ -9,7 +9,7 @@ export default async function MediaEventsPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
-  await requireChurchPermission("media:view", churchId);
+  await requireMediaAccess(churchId);
 
   const [events, photoStatusRows] = await Promise.all([
     prisma.mediaEvent.findMany({
@@ -51,7 +51,8 @@ export default async function MediaEventsPage() {
       .filter((r) => r.churchId === churchId)
       .flatMap((r) => rolePermissions[r.role] ?? [])
   );
-  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload");
+  const isProductionMember = await isProductionMediaMember(session, churchId);
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember;
 
   return (
     <div>

--- a/src/app/(auth)/media/projects/[id]/page.tsx
+++ b/src/app/(auth)/media/projects/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { requireChurchPermission, resolveChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaAccess, isProductionMediaMember, resolveChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import { rolePermissions } from "@/lib/registry";
@@ -20,7 +20,7 @@ export default async function MediaProjectDetailPage({
     notFound();
   }
 
-  await requireChurchPermission("media:view", churchId!);
+  await requireMediaAccess(churchId!);
 
   const project = await prisma.mediaProject.findUnique({
     where: { id },
@@ -64,7 +64,8 @@ export default async function MediaProjectDetailPage({
       .filter((r) => r.churchId === churchId!)
       .flatMap((r) => rolePermissions[r.role] ?? [])
   );
-  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload");
+  const isProductionMember = await isProductionMediaMember(session, churchId!);
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember;
   const canReview = session.user.isSuperAdmin || churchPerms.has("media:review");
   const canManage = session.user.isSuperAdmin || churchPerms.has("media:manage");
 

--- a/src/app/(auth)/media/projects/new/page.tsx
+++ b/src/app/(auth)/media/projects/new/page.tsx
@@ -1,11 +1,11 @@
-import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaUploadAccess, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import NewMediaProjectForm from "./NewMediaProjectForm";
 
 export default async function NewMediaProjectPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
-  await requireChurchPermission("media:upload", churchId);
+  await requireMediaUploadAccess(churchId);
 
   return (
     <div>

--- a/src/app/(auth)/media/projects/page.tsx
+++ b/src/app/(auth)/media/projects/page.tsx
@@ -1,4 +1,4 @@
-import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaAccess, isProductionMediaMember, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
@@ -9,7 +9,7 @@ export default async function MediaProjectsPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
-  await requireChurchPermission("media:view", churchId);
+  await requireMediaAccess(churchId);
 
   const [projects, fileStatusRows] = await Promise.all([
     prisma.mediaProject.findMany({
@@ -49,7 +49,8 @@ export default async function MediaProjectsPage() {
       .filter((r) => r.churchId === churchId)
       .flatMap((r) => rolePermissions[r.role] ?? [])
   );
-  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload");
+  const isProductionMember = await isProductionMediaMember(session, churchId);
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember;
 
   return (
     <div>

--- a/src/app/api/media-events/[id]/photos/route.ts
+++ b/src/app/api/media-events/[id]/photos/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import {
   processImage,
@@ -25,7 +25,7 @@ export async function GET(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaEvent", id);
-    await requireChurchPermission("media:view", churchId);
+    await requireMediaAccess(churchId);
 
     const photos = await prisma.mediaPhoto.findMany({
       where: { mediaEventId: id },
@@ -53,7 +53,7 @@ export async function POST(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaEvent", id);
-    await requireChurchPermission("media:upload", churchId);
+    await requireMediaUploadAccess(churchId);
 
     const formData = await request.formData();
     const files = formData.getAll("files") as File[];
@@ -148,7 +148,7 @@ export async function DELETE(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaEvent", id);
-    await requireChurchPermission("media:upload", churchId);
+    await requireMediaUploadAccess(churchId);
 
     const url = new URL(request.url);
     const raw = url.searchParams.get("photoIds") ?? "";

--- a/src/app/api/media-events/[id]/route.ts
+++ b/src/app/api/media-events/[id]/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { deleteFiles } from "@/lib/s3";
@@ -20,7 +20,7 @@ export async function GET(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaEvent", id);
-    await requireChurchPermission("media:view", churchId);
+    await requireMediaAccess(churchId);
 
     const event = await prisma.mediaEvent.findUnique({
       where: { id },
@@ -49,7 +49,7 @@ export async function PATCH(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaEvent", id);
-    const session = await requireChurchPermission("media:upload", churchId);
+    const session = await requireMediaUploadAccess(churchId);
 
     const body = await request.json();
     const data = patchSchema.parse(body);

--- a/src/app/api/media-events/[id]/share/__tests__/security.test.ts
+++ b/src/app/api/media-events/[id]/share/__tests__/security.test.ts
@@ -11,10 +11,14 @@ import { prismaMock } from "@/__mocks__/prisma";
 import { createAdminSession, createDepartmentHeadSession } from "@/__mocks__/auth";
 
 const mockRequireChurchPermission = vi.fn();
+const mockRequireMediaAccess = vi.fn();
+const mockRequireMediaUploadAccess = vi.fn();
 const mockResolveChurchId = vi.fn().mockResolvedValue("church-1");
 
 vi.mock("@/lib/auth", () => ({
   requireChurchPermission: (...args: unknown[]) => mockRequireChurchPermission(...args),
+  requireMediaAccess: (...args: unknown[]) => mockRequireMediaAccess(...args),
+  requireMediaUploadAccess: (...args: unknown[]) => mockRequireMediaUploadAccess(...args),
   resolveChurchId: (...args: unknown[]) => mockResolveChurchId(...args),
 }));
 
@@ -71,7 +75,7 @@ describe("GET /api/media-events/[id]/share — P0-1 token visibility", () => {
 
   it("masque le token VALIDATOR pour un utilisateur avec media:view uniquement (DEPARTMENT_HEAD)", async () => {
     // DEPARTMENT_HEAD a media:view et media:upload mais pas media:manage
-    mockRequireChurchPermission.mockResolvedValue(
+    mockRequireMediaAccess.mockResolvedValue(
       createDepartmentHeadSession([{ id: "dept-1", name: "Son" }])
     );
 
@@ -91,7 +95,7 @@ describe("GET /api/media-events/[id]/share — P0-1 token visibility", () => {
   });
 
   it("retourne le token VALIDATOR complet pour un ADMIN (media:manage)", async () => {
-    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockRequireMediaAccess.mockResolvedValue(createAdminSession());
 
     const res = await GET(new Request("http://localhost/api/media-events/ev-1/share"), {
       params: makeParams("ev-1"),
@@ -112,9 +116,8 @@ describe("POST /api/media-events/[id]/share — P0-1 token creation RBAC", () =>
 
   it("refuse la création d'un token VALIDATOR sans media:manage", async () => {
     // Premier appel (media:upload) passe, mais le second (media:manage) pour VALIDATOR doit rejeter
-    mockRequireChurchPermission
-      .mockResolvedValueOnce(createDepartmentHeadSession([{ id: "dept-1", name: "Son" }])) // media:upload ok
-      .mockRejectedValueOnce(Object.assign(new Error("FORBIDDEN"), { code: "FORBIDDEN", status: 403 })); // media:manage rejeté
+    mockRequireMediaUploadAccess.mockResolvedValueOnce(createDepartmentHeadSession([{ id: "dept-1", name: "Son" }])); // upload ok
+    mockRequireChurchPermission.mockRejectedValueOnce(Object.assign(new Error("FORBIDDEN"), { code: "FORBIDDEN", status: 403 })); // media:manage rejeté
 
     const request = new Request("http://localhost/api/media-events/ev-1/share", {
       method: "POST",
@@ -127,6 +130,7 @@ describe("POST /api/media-events/[id]/share — P0-1 token creation RBAC", () =>
 
   it("autorise la création d'un token VALIDATOR avec media:manage", async () => {
     prismaMock.mediaShareToken.count.mockResolvedValue(0);
+    mockRequireMediaUploadAccess.mockResolvedValue(createAdminSession());
     mockRequireChurchPermission.mockResolvedValue(createAdminSession());
 
     const request = new Request("http://localhost/api/media-events/ev-1/share", {
@@ -139,7 +143,7 @@ describe("POST /api/media-events/[id]/share — P0-1 token creation RBAC", () =>
   });
 
   it("autorise la création d'un token MEDIA sans media:manage", async () => {
-    mockRequireChurchPermission.mockResolvedValue(
+    mockRequireMediaUploadAccess.mockResolvedValue(
       createDepartmentHeadSession([{ id: "dept-1", name: "Son" }])
     );
 
@@ -163,9 +167,8 @@ describe("DELETE /api/media-events/[id]/share — P0-1 token deletion RBAC", () 
       id: "tok-1",
       type: "VALIDATOR",
     } as never);
-    mockRequireChurchPermission
-      .mockResolvedValueOnce(createDepartmentHeadSession([{ id: "dept-1", name: "Son" }])) // media:upload ok
-      .mockRejectedValueOnce(Object.assign(new Error("FORBIDDEN"), { code: "FORBIDDEN", status: 403 })); // media:manage rejeté
+    mockRequireMediaUploadAccess.mockResolvedValueOnce(createDepartmentHeadSession([{ id: "dept-1", name: "Son" }])); // upload ok
+    mockRequireChurchPermission.mockRejectedValueOnce(Object.assign(new Error("FORBIDDEN"), { code: "FORBIDDEN", status: 403 })); // media:manage rejeté
 
     const url = "http://localhost/api/media-events/ev-1/share?tokenId=tok-1";
     const res = await DELETE(new Request(url, { method: "DELETE" }), {
@@ -181,7 +184,7 @@ describe("DELETE /api/media-events/[id]/share — P0-1 token deletion RBAC", () 
       type: "MEDIA",
     } as never);
     prismaMock.mediaShareToken.delete.mockResolvedValue({ id: "tok-2" } as never);
-    mockRequireChurchPermission.mockResolvedValue(
+    mockRequireMediaUploadAccess.mockResolvedValue(
       createDepartmentHeadSession([{ id: "dept-1", name: "Son" }])
     );
 

--- a/src/app/api/media-events/[id]/share/route.ts
+++ b/src/app/api/media-events/[id]/share/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { createMediaShareToken, getTokenUrlPath } from "@/modules/media";
 import { z } from "zod";
@@ -20,7 +20,7 @@ export async function GET(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaEvent", id);
-    const session = await requireChurchPermission("media:view", churchId);
+    const session = await requireMediaAccess(churchId);
 
     const tokens = await prisma.mediaShareToken.findMany({
       where: { mediaEventId: id },
@@ -63,7 +63,7 @@ export async function POST(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaEvent", id);
-    await requireChurchPermission("media:upload", churchId);
+    await requireMediaUploadAccess(churchId);
 
     const body = await request.json();
     const data = createSchema.parse(body);
@@ -123,7 +123,7 @@ export async function DELETE(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaEvent", id);
-    await requireChurchPermission("media:upload", churchId);
+    await requireMediaUploadAccess(churchId);
 
     const tokenId = new URL(request.url).searchParams.get("tokenId");
     if (!tokenId) throw new ApiError(400, "tokenId requis");

--- a/src/app/api/media-events/route.ts
+++ b/src/app/api/media-events/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { z } from "zod";
@@ -18,7 +18,7 @@ export async function GET(request: Request) {
     const churchId = searchParams.get("churchId");
     if (!churchId) throw new ApiError(400, "churchId requis");
 
-    await requireChurchPermission("media:view", churchId);
+    await requireMediaAccess(churchId);
 
     const status = searchParams.get("status");
     const from = searchParams.get("from");
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const data = createSchema.parse(body);
 
-    const session = await requireChurchPermission("media:upload", data.churchId);
+    const session = await requireMediaUploadAccess(data.churchId);
 
     // Validate planningEventId belongs to same church
     if (data.planningEventId) {

--- a/src/app/api/media-projects/[id]/route.ts
+++ b/src/app/api/media-projects/[id]/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { deleteFiles } from "@/lib/s3";
@@ -17,7 +17,7 @@ export async function GET(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaProject", id);
-    await requireChurchPermission("media:view", churchId);
+    await requireMediaAccess(churchId);
 
     const project = await prisma.mediaProject.findUnique({
       where: { id },
@@ -41,7 +41,7 @@ export async function PATCH(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaProject", id);
-    const session = await requireChurchPermission("media:upload", churchId);
+    const session = await requireMediaUploadAccess(churchId);
 
     const body = await request.json();
     const data = patchSchema.parse(body);

--- a/src/app/api/media-projects/[id]/share/route.ts
+++ b/src/app/api/media-projects/[id]/share/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { createMediaShareToken, getTokenUrlPath } from "@/modules/media";
 import { z } from "zod";
@@ -20,7 +20,7 @@ export async function GET(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaProject", id);
-    const session = await requireChurchPermission("media:view", churchId);
+    const session = await requireMediaAccess(churchId);
 
     const tokens = await prisma.mediaShareToken.findMany({
       where: { mediaProjectId: id },
@@ -63,7 +63,7 @@ export async function POST(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaProject", id);
-    await requireChurchPermission("media:upload", churchId);
+    await requireMediaUploadAccess(churchId);
 
     const body = await request.json();
     const data = createSchema.parse(body);
@@ -95,7 +95,7 @@ export async function DELETE(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaProject", id);
-    await requireChurchPermission("media:upload", churchId);
+    await requireMediaUploadAccess(churchId);
 
     const tokenId = new URL(request.url).searchParams.get("tokenId");
     if (!tokenId) throw new ApiError(400, "tokenId requis");

--- a/src/app/api/media-projects/route.ts
+++ b/src/app/api/media-projects/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { z } from "zod";
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
     const churchId = searchParams.get("churchId");
     if (!churchId) throw new ApiError(400, "churchId requis");
 
-    await requireChurchPermission("media:view", churchId);
+    await requireMediaAccess(churchId);
 
     const projects = await prisma.mediaProject.findMany({
       where: { churchId },
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const data = createSchema.parse(body);
 
-    const session = await requireChurchPermission("media:upload", data.churchId);
+    const session = await requireMediaUploadAccess(data.churchId);
 
     const project = await prisma.mediaProject.create({
       data: {

--- a/src/app/api/media/files/[id]/__tests__/route.test.ts
+++ b/src/app/api/media/files/[id]/__tests__/route.test.ts
@@ -7,9 +7,11 @@ import { prismaMock } from "@/__mocks__/prisma";
 import { createAdminSession } from "@/__mocks__/auth";
 
 const mockRequireChurchPermission = vi.fn();
+const mockRequireMediaUploadAccess = vi.fn();
 
 vi.mock("@/lib/auth", () => ({
   requireChurchPermission: (...args: unknown[]) => mockRequireChurchPermission(...args),
+  requireMediaUploadAccess: (...args: unknown[]) => mockRequireMediaUploadAccess(...args),
 }));
 
 vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
@@ -41,7 +43,7 @@ const mockMediaFile = {
 describe("BLOCKER-3 : PATCH /api/media/files/[id] — clés S3 server-side", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequireChurchPermission.mockResolvedValue(createAdminSession("church-1"));
+    mockRequireMediaUploadAccess.mockResolvedValue(createAdminSession("church-1"));
     mockGetFileOriginalKey.mockReturnValue("media-events/evt-1/files/v1/file-1.jpg");
 
     prismaMock.mediaFile.findUnique.mockResolvedValue(mockMediaFile as never);

--- a/src/app/api/media/files/[id]/comments/route.ts
+++ b/src/app/api/media/files/[id]/comments/route.ts
@@ -3,7 +3,7 @@
  * Commentaires de révision sur un fichier média.
  */
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission } from "@/lib/auth";
+import { requireMediaAccess } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
 
@@ -33,7 +33,7 @@ export async function GET(
   try {
     const { id } = await params;
     const churchId = await resolveFileChurchId(id);
-    await requireChurchPermission("media:view", churchId);
+    await requireMediaAccess(churchId);
 
     const comments = await prisma.mediaComment.findMany({
       where: { mediaFileId: id, parentId: null },
@@ -62,7 +62,7 @@ export async function POST(
   try {
     const { id } = await params;
     const churchId = await resolveFileChurchId(id);
-    const session = await requireChurchPermission("media:view", churchId);
+    const session = await requireMediaAccess(churchId);
 
     const body = await request.json();
     const data = postSchema.parse(body);

--- a/src/app/api/media/files/[id]/route.ts
+++ b/src/app/api/media/files/[id]/route.ts
@@ -3,7 +3,7 @@
  * CRUD sur un fichier média (visual/vidéo).
  */
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { deleteMediaFiles } from "@/lib/s3";
 import { getFileOriginalKey } from "@/modules/media";
@@ -56,7 +56,7 @@ export async function GET(
   try {
     const { id } = await params;
     const { churchId } = await resolveMediaFileChurchId(id);
-    await requireChurchPermission("media:view", churchId);
+    await requireMediaAccess(churchId);
 
     const file = await prisma.mediaFile.findUnique({
       where: { id },
@@ -80,7 +80,7 @@ export async function PATCH(
   try {
     const { id } = await params;
     const { churchId, file: mediaFile } = await resolveMediaFileChurchId(id);
-    const session = await requireChurchPermission("media:upload", churchId);
+    const session = await requireMediaUploadAccess(churchId);
 
     const body = await request.json();
     const data = patchSchema.parse(body);

--- a/src/app/api/media/files/[id]/versions/route.ts
+++ b/src/app/api/media/files/[id]/versions/route.ts
@@ -9,7 +9,7 @@
  *   3. PATCH /api/media/files/[id] avec originalKey pour confirmer l'upload
  */
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { getVersionOriginalKey, getVersionThumbnailKey, getSignedOriginalUrl } from "@/modules/media";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
@@ -47,7 +47,7 @@ export async function GET(
   try {
     const { id } = await params;
     const { churchId } = await resolveFileChurchId(id);
-    await requireChurchPermission("media:view", churchId);
+    await requireMediaAccess(churchId);
 
     const versions = await prisma.mediaFileVersion.findMany({
       where: { mediaFileId: id },
@@ -83,7 +83,7 @@ export async function POST(
   try {
     const { id } = await params;
     const { churchId, file } = await resolveFileChurchId(id);
-    const session = await requireChurchPermission("media:upload", churchId);
+    const session = await requireMediaUploadAccess(churchId);
 
     if (file.type === "PHOTO") throw new ApiError(400, "Les photos ne supportent pas le versionnage");
 

--- a/src/app/api/media/files/upload/__tests__/sign.test.ts
+++ b/src/app/api/media/files/upload/__tests__/sign.test.ts
@@ -10,10 +10,12 @@ import { prismaMock } from "@/__mocks__/prisma";
 import { createAdminSession } from "@/__mocks__/auth";
 
 const mockRequireChurchPermission = vi.fn();
+const mockRequireMediaUploadAccess = vi.fn();
 const mockResolveChurchId = vi.fn().mockResolvedValue("church-1");
 
 vi.mock("@/lib/auth", () => ({
   requireChurchPermission: (...args: unknown[]) => mockRequireChurchPermission(...args),
+  requireMediaUploadAccess: (...args: unknown[]) => mockRequireMediaUploadAccess(...args),
   resolveChurchId: (...args: unknown[]) => mockResolveChurchId(...args),
 }));
 
@@ -49,6 +51,7 @@ describe("POST /api/media/files/upload/sign — P0-5 XOR validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockRequireMediaUploadAccess.mockResolvedValue(createAdminSession());
     prismaMock.mediaFile.create.mockResolvedValue({
       id: "file-1",
       type: "VIDEO",

--- a/src/app/api/media/files/upload/sign/route.ts
+++ b/src/app/api/media/files/upload/sign/route.ts
@@ -4,7 +4,7 @@
  * Pour les fichiers VISUAL et VIDEO (pas les photos — celles-ci passent par /api/media-events/[id]/photos).
  */
 import { prisma } from "@/lib/prisma";
-import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { requireMediaUploadAccess, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { getFileOriginalKey } from "@/modules/media";
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
       ? await resolveChurchId("mediaEvent", data.mediaEventId)
       : await resolveChurchId("mediaProject", data.mediaProjectId!);
 
-    const session = await requireChurchPermission("media:upload", churchId);
+    const session = await requireMediaUploadAccess(churchId);
     requireRateLimit(request, { prefix: `media:upload:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
     const ext = data.filename.split(".").pop()?.toLowerCase() ?? "bin";

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+html {
+  overflow-x: hidden;
+}
+
 @theme {
   --color-icc-violet: #5E17EB;
   --color-icc-violet-dark: #4a12bb;

--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -455,7 +455,7 @@ export default function MobileNavSheet({
     <>
       {/* Backdrop */}
       <div
-        className={`fixed inset-0 z-40 bg-black/50 md:hidden transition-opacity duration-300 ${
+        className={`fixed inset-0 z-[55] bg-black/50 md:hidden transition-opacity duration-300 ${
           open ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
         }`}
         onClick={onClose}
@@ -464,7 +464,7 @@ export default function MobileNavSheet({
 
       {/* Sheet */}
       <div
-        className={`fixed inset-x-0 bottom-0 z-50 md:hidden bg-white rounded-t-2xl shadow-2xl flex flex-col max-h-[85vh] transform transition-transform duration-300 ease-out ${
+        className={`fixed inset-x-0 bottom-0 z-[60] md:hidden bg-white rounded-t-2xl shadow-2xl flex flex-col max-h-[85vh] transform transition-transform duration-300 ease-out ${
           open ? "translate-y-0" : "translate-y-full"
         }`}
         aria-modal="true"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -428,6 +428,63 @@ export async function resolveChurchId(
   }
 }
 
+// ── Media access helpers ──────────────────────────────────────────────────────
+
+/**
+ * Vérifie si l'utilisateur est membre d'un département PRODUCTION_MEDIA dans l'église donnée.
+ * Utilisé pour donner accès aux vues média aux STARs de la team production uniquement.
+ */
+export async function isProductionMediaMember(session: Session, churchId: string): Promise<boolean> {
+  const userDeptIds = session.user.churchRoles
+    .filter((r) => r.churchId === churchId)
+    .flatMap((r) => r.departments.map((d) => d.department.id));
+  if (userDeptIds.length === 0) return false;
+  const count = await prisma.department.count({
+    where: { function: "PRODUCTION_MEDIA", ministry: { churchId }, id: { in: userDeptIds } },
+  });
+  return count > 0;
+}
+
+/**
+ * Autorise l'accès en lecture aux ressources média.
+ * Passe si : permission `media:view` (ADMIN, SECRETARY…) OU membre d'un département PRODUCTION_MEDIA.
+ */
+export async function requireMediaAccess(churchId: string) {
+  const session = await requireAuth();
+  if (session.user.isSuperAdmin) return session;
+
+  const roles = session.user.churchRoles.filter((r) => r.churchId === churchId);
+  if (roles.length === 0) throw new Error("FORBIDDEN");
+
+  const { rolePermissions } = await import("./registry");
+  const userPerms = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
+
+  if (userPerms.has("media:view") || await isProductionMediaMember(session, churchId))
+    return session;
+
+  throw new Error("FORBIDDEN");
+}
+
+/**
+ * Autorise l'upload et la création de ressources média.
+ * Passe si : permission `media:upload` (ADMIN, SECRETARY…) OU membre d'un département PRODUCTION_MEDIA.
+ */
+export async function requireMediaUploadAccess(churchId: string) {
+  const session = await requireAuth();
+  if (session.user.isSuperAdmin) return session;
+
+  const roles = session.user.churchRoles.filter((r) => r.churchId === churchId);
+  if (roles.length === 0) throw new Error("FORBIDDEN");
+
+  const { rolePermissions } = await import("./registry");
+  const userPerms = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
+
+  if (userPerms.has("media:upload") || await isProductionMediaMember(session, churchId))
+    return session;
+
+  throw new Error("FORBIDDEN");
+}
+
 export async function getCurrentChurchId(
   session: Session
 ): Promise<string | undefined> {

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -43,9 +43,9 @@ export const mediaModule = defineModule({
 
   permissions: {
     // Accès en lecture aux galeries et médias
-    "media:view":    ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD", "STAR"],
+    "media:view":    ["SUPER_ADMIN", "ADMIN", "SECRETARY"],
     // Upload, organisation, création de projets et événements médias
-    "media:upload":  ["SUPER_ADMIN", "ADMIN", "SECRETARY", "STAR"],
+    "media:upload":  ["SUPER_ADMIN", "ADMIN", "SECRETARY"],
     // Validation/rejet des photos et médias
     "media:review":  ["SUPER_ADMIN", "ADMIN"],
     // Administration du module (paramètres, tokens)

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -43,9 +43,9 @@ export const mediaModule = defineModule({
 
   permissions: {
     // Accès en lecture aux galeries et médias
-    "media:view":    ["SUPER_ADMIN", "ADMIN", "SECRETARY"],
+    "media:view":    ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD", "STAR"],
     // Upload, organisation, création de projets et événements médias
-    "media:upload":  ["SUPER_ADMIN", "ADMIN", "SECRETARY"],
+    "media:upload":  ["SUPER_ADMIN", "ADMIN", "SECRETARY", "STAR"],
     // Validation/rejet des photos et médias
     "media:review":  ["SUPER_ADMIN", "ADMIN"],
     // Administration du module (paramètres, tokens)


### PR DESCRIPTION
## Problèmes corrigés

### 1. BottomNav fixe qui déborde / bouge sur mobile
- **Cause** : quand une page génère un overflow horizontal, certains navigateurs mobiles traitent le viewport comme plus large → `position: fixed; inset-x: 0` se décale
- **Fix** : `overflow-x: hidden` sur `html` dans `globals.css`
- **Bonus** : `pb-20 md:py-4` sur le footer pour qu'il ne soit pas masqué par la barre du bas lors du scroll jusqu'en bas de pages longues

### 2. Page Accès & rôles — onglets trop larges sur mobile
- **Cause** : 5 onglets dont "Rôles transverses" et "Comptes rendus" = overflow sur écran 360px
- **Fix** : barre d'onglets `overflow-x-auto -mx-4 px-4`, boutons `whitespace-nowrap shrink-0`

### 3. STAR de la team Production Média sans accès à la vue média
- **Cause** : `media:view` et `media:upload` limités à SUPER_ADMIN / ADMIN / SECRETARY
- **Fix** : `media:view` étendu à MINISTER, DEPARTMENT_HEAD, STAR ; `media:upload` étendu à STAR

## Test plan
- [ ] Page Accès & rôles sur mobile : les 5 onglets sont scrollables horizontalement
- [ ] Page Événements (longue) sur mobile : la barre du bas reste fixe, pas de décalage horizontal
- [ ] STAR Production Média : voit les sections "Événements" et "Projets" dans le menu Médias
- [ ] STAR ne voit pas "Révision" ni paramètres du module média

🤖 Generated with [Claude Code](https://claude.com/claude-code)