### PR TITLE
fix(media): PRODUCTION_MEDIA peut gérer les tokens VALIDATOR/PREVALIDATOR

### DIFF
--- a/src/app/api/media-events/[id]/share/__tests__/security.test.ts
+++ b/src/app/api/media-events/[id]/share/__tests__/security.test.ts
@@ -13,12 +13,16 @@ import { createAdminSession, createDepartmentHeadSession } from "@/__mocks__/aut
 const mockRequireChurchPermission = vi.fn();
 const mockRequireMediaAccess = vi.fn();
 const mockRequireMediaUploadAccess = vi.fn();
+const mockRequireMediaManageAccess = vi.fn();
+const mockIsProductionMediaMember = vi.fn().mockResolvedValue(false);
 const mockResolveChurchId = vi.fn().mockResolvedValue("church-1");
 
 vi.mock("@/lib/auth", () => ({
   requireChurchPermission: (...args: unknown[]) => mockRequireChurchPermission(...args),
   requireMediaAccess: (...args: unknown[]) => mockRequireMediaAccess(...args),
   requireMediaUploadAccess: (...args: unknown[]) => mockRequireMediaUploadAccess(...args),
+  requireMediaManageAccess: (...args: unknown[]) => mockRequireMediaManageAccess(...args),
+  isProductionMediaMember: (...args: unknown[]) => mockIsProductionMediaMember(...args),
   resolveChurchId: (...args: unknown[]) => mockResolveChurchId(...args),
 }));
 
@@ -45,6 +49,7 @@ const makeParams = (id: string) => Promise.resolve({ id });
 describe("GET /api/media-events/[id]/share — P0-1 token visibility", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsProductionMediaMember.mockResolvedValue(false);
     prismaMock.mediaShareToken.findMany.mockResolvedValue([
       {
         id: "tok-1",
@@ -112,12 +117,12 @@ describe("GET /api/media-events/[id]/share — P0-1 token visibility", () => {
 describe("POST /api/media-events/[id]/share — P0-1 token creation RBAC", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsProductionMediaMember.mockResolvedValue(false);
   });
 
-  it("refuse la création d'un token VALIDATOR sans media:manage", async () => {
-    // Premier appel (media:upload) passe, mais le second (media:manage) pour VALIDATOR doit rejeter
-    mockRequireMediaUploadAccess.mockResolvedValueOnce(createDepartmentHeadSession([{ id: "dept-1", name: "Son" }])); // upload ok
-    mockRequireChurchPermission.mockRejectedValueOnce(Object.assign(new Error("FORBIDDEN"), { code: "FORBIDDEN", status: 403 })); // media:manage rejeté
+  it("refuse la création d'un token VALIDATOR sans media:manage ni PRODUCTION_MEDIA", async () => {
+    mockRequireMediaUploadAccess.mockResolvedValueOnce(createDepartmentHeadSession([{ id: "dept-1", name: "Son" }]));
+    mockRequireMediaManageAccess.mockRejectedValueOnce(Object.assign(new Error("FORBIDDEN"), { code: "FORBIDDEN", status: 403 }));
 
     const request = new Request("http://localhost/api/media-events/ev-1/share", {
       method: "POST",
@@ -131,7 +136,7 @@ describe("POST /api/media-events/[id]/share — P0-1 token creation RBAC", () =>
   it("autorise la création d'un token VALIDATOR avec media:manage", async () => {
     prismaMock.mediaShareToken.count.mockResolvedValue(0);
     mockRequireMediaUploadAccess.mockResolvedValue(createAdminSession());
-    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockRequireMediaManageAccess.mockResolvedValue(createAdminSession());
 
     const request = new Request("http://localhost/api/media-events/ev-1/share", {
       method: "POST",
@@ -160,15 +165,16 @@ describe("POST /api/media-events/[id]/share — P0-1 token creation RBAC", () =>
 describe("DELETE /api/media-events/[id]/share — P0-1 token deletion RBAC", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsProductionMediaMember.mockResolvedValue(false);
   });
 
-  it("refuse la suppression d'un token VALIDATOR sans media:manage", async () => {
+  it("refuse la suppression d'un token VALIDATOR sans media:manage ni PRODUCTION_MEDIA", async () => {
     prismaMock.mediaShareToken.findUnique.mockResolvedValue({
       id: "tok-1",
       type: "VALIDATOR",
     } as never);
-    mockRequireMediaUploadAccess.mockResolvedValueOnce(createDepartmentHeadSession([{ id: "dept-1", name: "Son" }])); // upload ok
-    mockRequireChurchPermission.mockRejectedValueOnce(Object.assign(new Error("FORBIDDEN"), { code: "FORBIDDEN", status: 403 })); // media:manage rejeté
+    mockRequireMediaUploadAccess.mockResolvedValueOnce(createDepartmentHeadSession([{ id: "dept-1", name: "Son" }]));
+    mockRequireMediaManageAccess.mockRejectedValueOnce(Object.assign(new Error("FORBIDDEN"), { code: "FORBIDDEN", status: 403 }));
 
     const url = "http://localhost/api/media-events/ev-1/share?tokenId=tok-1";
     const res = await DELETE(new Request(url, { method: "DELETE" }), {

--- a/src/app/api/media-events/[id]/share/route.ts
+++ b/src/app/api/media-events/[id]/share/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess, requireMediaManageAccess, isProductionMediaMember, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { createMediaShareToken, getTokenUrlPath } from "@/modules/media";
 import { z } from "zod";
@@ -29,16 +29,15 @@ export async function GET(
 
     const baseUrl = process.env.APP_URL ?? process.env.NEXTAUTH_URL ?? "http://localhost:3000";
 
-    // Vérifier si l'utilisateur a la permission media:manage pour voir les tokens sensibles
+    // Vérifier si l'utilisateur peut voir les tokens sensibles (media:manage OU PRODUCTION_MEDIA)
     const { rolePermissions } = await import("@/lib/registry");
     const userRoles = session.user.churchRoles
       .filter((r) => r.churchId === churchId)
       .map((r) => r.role);
     const canManage =
       session.user.isSuperAdmin ||
-      userRoles.some((role) =>
-        (rolePermissions[role] ?? []).includes("media:manage")
-      );
+      userRoles.some((role) => (rolePermissions[role] ?? []).includes("media:manage")) ||
+      await isProductionMediaMember(session, churchId);
 
     return successResponse(
       tokens.map((t) => {
@@ -71,7 +70,7 @@ export async function POST(
     // Les tokens VALIDATOR et PREVALIDATOR donnent accès à des actions d'approbation :
     // exiger media:manage
     if ((SENSITIVE_TOKEN_TYPES as readonly string[]).includes(data.type)) {
-      await requireChurchPermission("media:manage", churchId);
+      await requireMediaManageAccess(churchId);
     }
 
     // Rule: only one PREVALIDATOR per event
@@ -137,7 +136,7 @@ export async function DELETE(
 
     // Les tokens sensibles (VALIDATOR/PREVALIDATOR) nécessitent media:manage
     if ((SENSITIVE_TOKEN_TYPES as readonly string[]).includes(existingToken.type)) {
-      await requireChurchPermission("media:manage", churchId);
+      await requireMediaManageAccess(churchId);
     }
 
     await prisma.mediaShareToken.delete({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -485,6 +485,26 @@ export async function requireMediaUploadAccess(churchId: string) {
   throw new Error("FORBIDDEN");
 }
 
+/**
+ * Autorise la gestion des ressources média (liens de partage, tokens sensibles…).
+ * Passe si : permission `media:manage` (ADMIN…) OU membre d'un département PRODUCTION_MEDIA.
+ */
+export async function requireMediaManageAccess(churchId: string) {
+  const session = await requireAuth();
+  if (session.user.isSuperAdmin) return session;
+
+  const roles = session.user.churchRoles.filter((r) => r.churchId === churchId);
+  if (roles.length === 0) throw new Error("FORBIDDEN");
+
+  const { rolePermissions } = await import("./registry");
+  const userPerms = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
+
+  if (userPerms.has("media:manage") || await isProductionMediaMember(session, churchId))
+    return session;
+
+  throw new Error("FORBIDDEN");
+}
+
 export async function getCurrentChurchId(
   session: Session
 ): Promise<string | undefined> {


### PR DESCRIPTION
## Résumé

- Ajoute `requireMediaManageAccess` dans `src/lib/auth.ts` : passe si `media:manage` (ADMIN…) **OU** membre d'un département `PRODUCTION_MEDIA`
- Remplace `requireChurchPermission("media:manage")` par `requireMediaManageAccess` dans la route `POST/DELETE /api/media-events/[id]/share` (création/suppression de tokens sensibles)
- Idem pour la visibilité des tokens dans `GET` (champ `token` et `url` des VALIDATOR/PREVALIDATOR)
- Tests mis à jour en conséquence (267/267 ✓)

## Plan de test

- [ ] Membre PRODUCTION_MEDIA : peut créer un token VALIDATOR → 201
- [ ] Membre PRODUCTION_MEDIA : peut supprimer un token VALIDATOR → 200
- [ ] Membre PRODUCTION_MEDIA : voit le token VALIDATOR dans la liste → token non masqué
- [ ] DEPARTMENT_HEAD sans PRODUCTION_MEDIA : ne peut pas créer un token VALIDATOR → 403
- [ ] ADMIN : comportement inchangé → 201/200

🤖 Generated with [Claude Code](https://claude.com/claude-code)