### PR TITLE
chore: release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.1.3] - 2026-04-24
+
+### Corrigé
+
+- Médias : la team PRODUCTION_MEDIA peut désormais créer, voir et supprimer les tokens VALIDATOR/PREVALIDATOR (liens de validation)
+
 ## [v1.1.2] - 2026-04-23
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v1.1.3

### Corrigé
- Médias : la team PRODUCTION_MEDIA peut désormais créer, voir et supprimer les tokens VALIDATOR/PREVALIDATOR (liens de validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)