### PR TITLE
fix(media): liens de partage visibles après création/suppression

### DIFF
--- a/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
+++ b/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
@@ -617,7 +617,14 @@ export default function MediaEventDetail({
   async function refreshEvent() {
     const res = await fetch(`/api/media-events/${event.id}`);
     const json = await res.json();
-    if (res.ok) setEvent({ ...event, ...json, photos: json.photos ?? event.photos, shareTokens: json.shareTokens ?? event.shareTokens });
+    if (res.ok) {
+      setEvent((prev) => ({
+        ...prev,
+        ...json,
+        photos: prev.photos,           // photos complètes gérées par refreshPhotos
+        shareTokens: json.shareTokens ?? prev.shareTokens,
+      }));
+    }
     router.refresh();
   }
 

--- a/src/app/api/media-events/[id]/route.ts
+++ b/src/app/api/media-events/[id]/route.ts
@@ -29,9 +29,8 @@ export async function GET(
         createdBy: { select: { id: true, name: true, displayName: true } },
         planningEvent: { select: { id: true, title: true, type: true, date: true } },
         _count: { select: { photos: true, files: true, shareTokens: true } },
-        photos: {
-          select: { status: true },
-        },
+        photos: { select: { status: true } },
+        shareTokens: { orderBy: { createdAt: "desc" } },
       },
     });
 


### PR DESCRIPTION
## Résumé

- **Bug** : Créer ou supprimer un lien de partage ne mettait pas à jour la liste — `GET /api/media-events/[id]` ne retournait pas les `shareTokens`, donc `refreshEvent()` ne pouvait pas les actualiser
- **Bonus** : `refreshEvent()` écrasait les objets `Photo` complets (avec `id`, `filename`…) par des objets partiels `{ status }` — corrigé en préservant `prev.photos`

🤖 Generated with [Claude Code](https://claude.com/claude-code)