### PR TITLE
chore: release v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.1.6] - 2026-04-24
+
+### Corrigé
+
+- Médias : les liens de partage s'affichent immédiatement après création ou suppression
+- Médias : correction d'un bug silencieux où `refreshEvent()` pouvait écraser les données photos complètes
+
 ## [v1.1.5] - 2026-04-24
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v1.1.6

### Corrigé
- Médias : liens de partage visibles immédiatement après création/suppression
- Médias : `refreshEvent()` ne corrompt plus les données photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)