### PR TITLE
fix(cron): log actual error message in email send failures

### DIFF
--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -74,8 +74,8 @@ async function runReminders() {
               try {
                 await sendEmail({ to: member.email, subject, html });
                 emailsSent++;
-              } catch {
-                console.error("Failed to send reminder email (recipient redacted)");
+              } catch (err) {
+                console.error("Failed to send reminder email (recipient redacted):", err instanceof Error ? err.message : err);
               }
             }
 
@@ -186,8 +186,8 @@ async function runPlanningDigest() {
       try {
         await sendEmail({ to: church.secretariatEmail, subject, html });
         digestsSent++;
-      } catch {
-        console.error(`Failed to send planning digest for church ${church.id}`);
+      } catch (err) {
+        console.error(`Failed to send planning digest for church ${church.id}:`, err instanceof Error ? err.message : err);
       }
     }
 


### PR DESCRIPTION
## Summary

- `runReminders()` and `runPlanningDigest()` were catching email errors but only logging a static message, hiding the actual failure reason
- Now logs `err.message` (or the raw error if not an Error instance) so SMTP failures are diagnosable from production logs

## Test plan

- [ ] Trigger the cron endpoint with a bad SMTP config — confirm the real error appears in logs