### PR TITLE
feat(members): fusion de doublons et assignation automatique du rôle STAR

### DIFF
--- a/src/app/(auth)/admin/members/duplicates/DuplicatesView.tsx
+++ b/src/app/(auth)/admin/members/duplicates/DuplicatesView.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Button from "@/components/ui/Button";
+import Modal from "@/components/ui/Modal";
+
+type MemberSummary = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  phone: string | null;
+  departments: { id: string; name: string; ministryName: string; isPrimary: boolean }[];
+  userLink: { userId: string; name: string | null; email: string } | null;
+  counts: { plannings: number; disciples: number; disciplesMade: number };
+};
+
+type Group = {
+  reason: "same_name" | "same_email" | "both";
+  members: MemberSummary[];
+};
+
+interface Props {
+  groups: Group[];
+  churchId: string;
+}
+
+const REASON_LABEL: Record<Group["reason"], string> = {
+  same_name: "Même nom",
+  same_email: "Même email",
+  both: "Même nom + email",
+};
+
+const REASON_COLOR: Record<Group["reason"], string> = {
+  same_name: "bg-yellow-100 text-yellow-800",
+  same_email: "bg-orange-100 text-orange-800",
+  both: "bg-red-100 text-red-800",
+};
+
+function MemberCard({ member, isSource, label }: { member: MemberSummary; isSource: boolean; label: string }) {
+  return (
+    <div className={`border-2 rounded-lg p-4 ${isSource ? "border-red-200 bg-red-50" : "border-green-200 bg-green-50"}`}>
+      <div className="flex items-center justify-between mb-2">
+        <span className={`text-xs font-semibold px-2 py-0.5 rounded ${isSource ? "bg-red-200 text-red-800" : "bg-green-200 text-green-800"}`}>
+          {label}
+        </span>
+        {member.userLink && (
+          <span className="text-xs bg-icc-violet text-white px-2 py-0.5 rounded">Compte lié</span>
+        )}
+      </div>
+      <p className="font-semibold text-gray-900">{member.firstName} {member.lastName}</p>
+      {member.email && <p className="text-sm text-gray-600">{member.email}</p>}
+      {member.phone && <p className="text-sm text-gray-600">{member.phone}</p>}
+      {member.userLink && <p className="text-xs text-gray-500 mt-1">Compte : {member.userLink.name ?? member.userLink.email}</p>}
+      <div className="mt-2 space-y-0.5">
+        {member.departments.map((d) => (
+          <span key={d.id} className={`inline-block text-xs px-2 py-0.5 rounded mr-1 ${d.isPrimary ? "bg-icc-violet text-white" : "bg-gray-200 text-gray-700"}`}>
+            {d.ministryName} › {d.name}
+          </span>
+        ))}
+      </div>
+      <div className="mt-2 flex gap-3 text-xs text-gray-500">
+        <span>{member.counts.plannings} planning(s)</span>
+        <span>{member.counts.disciples} discipolat(s)</span>
+        <span>{member.counts.disciplesMade} disciple(s)</span>
+      </div>
+    </div>
+  );
+}
+
+type FieldChoice<T> = { value: T; from: "source" | "target" | "manual" };
+
+function FieldPicker<T extends string | null>({
+  label,
+  sourceValue,
+  targetValue,
+  choice,
+  onChange,
+}: {
+  label: string;
+  sourceValue: T;
+  targetValue: T;
+  choice: FieldChoice<T>;
+  onChange: (c: FieldChoice<T>) => void;
+}) {
+  const same = sourceValue === targetValue;
+  if (same) {
+    return (
+      <div className="text-sm text-gray-700">
+        <span className="font-medium text-gray-500">{label} :</span> {sourceValue ?? <em className="text-gray-400">vide</em>}
+      </div>
+    );
+  }
+  return (
+    <div className="border rounded p-2 bg-white">
+      <p className="text-xs font-semibold text-gray-500 mb-1">{label}</p>
+      <label className="flex items-center gap-2 cursor-pointer mb-1">
+        <input type="radio" checked={choice.from === "source"} onChange={() => onChange({ value: sourceValue, from: "source" })} />
+        <span className="text-sm text-red-700">{sourceValue ?? <em className="text-gray-400">vide</em>} <span className="text-xs text-gray-400">(à supprimer)</span></span>
+      </label>
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input type="radio" checked={choice.from === "target"} onChange={() => onChange({ value: targetValue, from: "target" })} />
+        <span className="text-sm text-green-700">{targetValue ?? <em className="text-gray-400">vide</em>} <span className="text-xs text-gray-400">(à conserver)</span></span>
+      </label>
+    </div>
+  );
+}
+
+function MergeModal({
+  group,
+  onClose,
+  onMerged,
+}: {
+  group: Group;
+  onClose: () => void;
+  onMerged: () => void;
+}) {
+  const [sourceIndex, setSourceIndex] = useState(0);
+  const source = group.members[sourceIndex];
+  const target = group.members[sourceIndex === 0 ? 1 : 0];
+
+  const [firstName, setFirstName] = useState<FieldChoice<string>>({
+    value: target.firstName,
+    from: "target",
+  });
+  const [lastName, setLastName] = useState<FieldChoice<string>>({
+    value: target.lastName,
+    from: "target",
+  });
+  const [email, setEmail] = useState<FieldChoice<string | null>>({
+    value: target.email,
+    from: "target",
+  });
+  const [phone, setPhone] = useState<FieldChoice<string | null>>({
+    value: target.phone,
+    from: "target",
+  });
+  const [keepUserId, setKeepUserId] = useState<string | null>(
+    target.userLink?.userId ?? source.userLink?.userId ?? null
+  );
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const bothHaveLink = !!(source.userLink && target.userLink);
+
+  // Reset choices when source/target swap
+  function swap() {
+    setSourceIndex((i) => (i === 0 ? 1 : 0));
+    setFirstName({ value: source.firstName, from: "target" });
+    setLastName({ value: source.lastName, from: "target" });
+    setEmail({ value: source.email, from: "target" });
+    setPhone({ value: source.phone, from: "target" });
+    setKeepUserId(source.userLink?.userId ?? target.userLink?.userId ?? null);
+  }
+
+  async function confirm() {
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/members/merge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sourceId: source.id,
+          targetId: target.id,
+          resolution: {
+            firstName: firstName.value,
+            lastName: lastName.value,
+            email: email.value,
+            phone: phone.value,
+            keepUserId: bothHaveLink ? keepUserId : null,
+          },
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Erreur inconnue");
+      onMerged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur inconnue");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Modal open onClose={onClose} title="Fusionner deux membres">
+      <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">
+        {/* Cartes source/target */}
+        <div className="grid grid-cols-2 gap-3">
+          <MemberCard member={source} isSource label="Sera supprimé" />
+          <MemberCard member={target} isSource={false} label="Sera conservé" />
+        </div>
+
+        <button
+          type="button"
+          onClick={swap}
+          className="text-xs text-icc-violet hover:underline"
+        >
+          ⇄ Inverser source et cible
+        </button>
+
+        {/* Résolution des champs */}
+        <div className="space-y-2">
+          <p className="text-sm font-semibold text-gray-700">Champs à conserver</p>
+          <FieldPicker
+            label="Prénom"
+            sourceValue={source.firstName}
+            targetValue={target.firstName}
+            choice={firstName}
+            onChange={setFirstName}
+          />
+          <FieldPicker
+            label="Nom"
+            sourceValue={source.lastName}
+            targetValue={target.lastName}
+            choice={lastName}
+            onChange={setLastName}
+          />
+          <FieldPicker
+            label="Email"
+            sourceValue={source.email}
+            targetValue={target.email}
+            choice={email}
+            onChange={setEmail}
+          />
+          <FieldPicker
+            label="Téléphone"
+            sourceValue={source.phone}
+            targetValue={target.phone}
+            choice={phone}
+            onChange={setPhone}
+          />
+        </div>
+
+        {/* Conflit de compte lié */}
+        {bothHaveLink && (
+          <div className="border rounded p-3 bg-yellow-50">
+            <p className="text-sm font-semibold text-yellow-800 mb-2">Les deux ont un compte Google lié — lequel conserver ?</p>
+            <label className="flex items-center gap-2 cursor-pointer mb-1">
+              <input
+                type="radio"
+                checked={keepUserId === source.userLink!.userId}
+                onChange={() => setKeepUserId(source.userLink!.userId)}
+              />
+              <span className="text-sm text-red-700">{source.userLink!.name ?? source.userLink!.email} <span className="text-xs text-gray-400">(source)</span></span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                checked={keepUserId === target.userLink!.userId}
+                onChange={() => setKeepUserId(target.userLink!.userId)}
+              />
+              <span className="text-sm text-green-700">{target.userLink!.name ?? target.userLink!.email} <span className="text-xs text-gray-400">(cible)</span></span>
+            </label>
+          </div>
+        )}
+
+        {/* Départements fusionnés */}
+        <div className="bg-gray-50 rounded p-3">
+          <p className="text-xs font-semibold text-gray-500 mb-1">Départements après fusion (union)</p>
+          {[
+            ...new Map(
+              [...source.departments, ...target.departments].map((d) => [d.id, d])
+            ).values(),
+          ].map((d) => (
+            <span key={d.id} className="inline-block text-xs px-2 py-0.5 rounded mr-1 mb-1 bg-gray-200 text-gray-700">
+              {d.ministryName} › {d.name}
+            </span>
+          ))}
+        </div>
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </div>
+
+      <div className="flex justify-end gap-3 mt-4 pt-3 border-t">
+        <Button variant="secondary" onClick={onClose} disabled={loading}>
+          Annuler
+        </Button>
+        <Button variant="danger" onClick={confirm} disabled={loading}>
+          {loading ? "Fusion en cours…" : "Confirmer la fusion"}
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+export default function DuplicatesView({ groups, churchId }: Props) {
+  const router = useRouter();
+  const [mergeGroup, setMergeGroup] = useState<Group | null>(null);
+  const [assigningStars, setAssigningStars] = useState(false);
+  const [assignResult, setAssignResult] = useState<{ assigned: number; total: number } | null>(null);
+
+  async function assignStarRoles() {
+    setAssigningStars(true);
+    try {
+      const res = await fetch("/api/admin/members/assign-star-roles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ churchId }),
+      });
+      const json = await res.json();
+      if (res.ok) setAssignResult(json);
+    } finally {
+      setAssigningStars(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Bulk STAR assign */}
+      <div className="border-2 rounded-lg p-4 bg-icc-violet/5 border-icc-violet/20">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div>
+            <p className="font-semibold text-gray-800">Assigner le rôle STAR aux membres liés sans accès</p>
+            <p className="text-sm text-gray-500 mt-0.5">
+              Attribue automatiquement le rôle STAR (accès planning en lecture) à tous les membres avec un compte Google lié mais aucun rôle.
+            </p>
+          </div>
+          <Button onClick={assignStarRoles} disabled={assigningStars}>
+            {assigningStars ? "En cours…" : "Assigner les rôles STAR"}
+          </Button>
+        </div>
+        {assignResult && (
+          <p className="text-sm text-green-700 mt-2">
+            {assignResult.assigned} rôle(s) STAR assigné(s) sur {assignResult.total} compte(s) lié(s).
+          </p>
+        )}
+      </div>
+
+      {/* Liste doublons */}
+      {groups.length === 0 ? (
+        <div className="text-center py-12 text-gray-500">
+          <p className="text-lg">Aucun doublon détecté</p>
+          <p className="text-sm mt-1">Tous les membres ont des noms et emails uniques.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">{groups.length} groupe(s) de doublons potentiels détecté(s)</p>
+          {groups.map((group, i) => (
+            <div key={i} className="border-2 rounded-lg p-4">
+              <div className="flex items-center justify-between mb-3">
+                <span className={`text-xs font-semibold px-2 py-1 rounded ${REASON_COLOR[group.reason]}`}>
+                  {REASON_LABEL[group.reason]}
+                </span>
+                <Button
+                  onClick={() => setMergeGroup(group)}
+                  className="text-sm"
+                >
+                  Fusionner
+                </Button>
+              </div>
+              <div className="grid gap-3" style={{ gridTemplateColumns: `repeat(${group.members.length}, minmax(0, 1fr))` }}>
+                {group.members.map((m) => (
+                  <div key={m.id} className="border rounded p-3 bg-gray-50">
+                    <p className="font-semibold text-gray-900">{m.firstName} {m.lastName}</p>
+                    {m.email && <p className="text-sm text-gray-600">{m.email}</p>}
+                    {m.phone && <p className="text-sm text-gray-600">{m.phone}</p>}
+                    {m.userLink && (
+                      <p className="text-xs text-icc-violet mt-1">Compte : {m.userLink.name ?? m.userLink.email}</p>
+                    )}
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {m.departments.map((d) => (
+                        <span key={d.id} className={`text-xs px-1.5 py-0.5 rounded ${d.isPrimary ? "bg-icc-violet text-white" : "bg-gray-200 text-gray-600"}`}>
+                          {d.name}
+                        </span>
+                      ))}
+                    </div>
+                    <p className="text-xs text-gray-400 mt-1">
+                      {m.counts.plannings} planning · {m.counts.disciples + m.counts.disciplesMade} discipolat
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {mergeGroup && (
+        <MergeModal
+          group={mergeGroup}
+          onClose={() => setMergeGroup(null)}
+          onMerged={() => {
+            setMergeGroup(null);
+            router.refresh();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(auth)/admin/members/duplicates/page.tsx
+++ b/src/app/(auth)/admin/members/duplicates/page.tsx
@@ -1,0 +1,103 @@
+import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
+import DuplicatesView from "./DuplicatesView";
+
+export default async function DuplicatesPage() {
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p className="text-gray-500">Aucune église sélectionnée.</p>;
+  await requireChurchPermission("members:manage", churchId);
+
+  const members = await prisma.member.findMany({
+    where: { departments: { some: { department: { ministry: { churchId } } } } },
+    include: {
+      departments: {
+        include: {
+          department: { select: { id: true, name: true, ministry: { select: { name: true } } } },
+        },
+        orderBy: { isPrimary: "desc" },
+      },
+      userLink: { select: { userId: true, user: { select: { name: true, email: true } } } },
+      _count: { select: { plannings: true, discipleships: true, disciplesMade: true } },
+    },
+  });
+
+  // Détection doublons : même nom normalisé ou même email
+  type MemberRow = (typeof members)[number];
+  type DuplicateGroup = { reason: "same_name" | "same_email" | "both"; members: MemberRow[] };
+
+  const byName = new Map<string, MemberRow[]>();
+  for (const m of members) {
+    const key = `${m.firstName.trim().toLowerCase()} ${m.lastName.trim().toLowerCase()}`;
+    const b = byName.get(key) ?? [];
+    b.push(m);
+    byName.set(key, b);
+  }
+
+  const byEmail = new Map<string, MemberRow[]>();
+  for (const m of members) {
+    if (!m.email) continue;
+    const key = m.email.trim().toLowerCase();
+    const b = byEmail.get(key) ?? [];
+    b.push(m);
+    byEmail.set(key, b);
+  }
+
+  const pairKey = (ids: string[]) => [...ids].sort().join("|");
+  const groups: DuplicateGroup[] = [];
+  const seen = new Set<string>();
+
+  for (const bucket of byName.values()) {
+    if (bucket.length < 2) continue;
+    const key = pairKey(bucket.map((m) => m.id));
+    if (seen.has(key)) continue;
+    seen.add(key);
+    groups.push({ reason: "same_name", members: bucket });
+  }
+
+  for (const bucket of byEmail.values()) {
+    if (bucket.length < 2) continue;
+    const key = pairKey(bucket.map((m) => m.id));
+    const existing = groups.find((g) => pairKey(g.members.map((m) => m.id)) === key);
+    if (existing) {
+      existing.reason = "both";
+    } else if (!seen.has(key)) {
+      seen.add(key);
+      groups.push({ reason: "same_email", members: bucket });
+    }
+  }
+
+  const serialized = groups.map((g) => ({
+    reason: g.reason,
+    members: g.members.map((m) => ({
+      id: m.id,
+      firstName: m.firstName,
+      lastName: m.lastName,
+      email: m.email,
+      phone: m.phone,
+      departments: m.departments.map((d) => ({
+        id: d.department.id,
+        name: d.department.name,
+        ministryName: d.department.ministry.name,
+        isPrimary: d.isPrimary,
+      })),
+      userLink: m.userLink
+        ? { userId: m.userLink.userId, name: m.userLink.user.name, email: m.userLink.user.email }
+        : null,
+      counts: { plannings: m._count.plannings, disciples: m._count.discipleships, disciplesMade: m._count.disciplesMade },
+    })),
+  }));
+
+  return (
+    <div>
+      <div className="flex items-center gap-4 mb-6">
+        <Link href="/admin/members" className="text-sm text-icc-violet hover:underline">
+          ← Retour
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900">Doublons potentiels</h1>
+      </div>
+      <DuplicatesView groups={serialized} churchId={churchId} />
+    </div>
+  );
+}

--- a/src/app/(auth)/admin/members/page.tsx
+++ b/src/app/(auth)/admin/members/page.tsx
@@ -1,6 +1,7 @@
 import { requireAuth, getCurrentChurchId, requireChurchPermission, getUserDepartmentScope } from "@/lib/auth";
 import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
+import Link from "next/link";
 import MembersClient from "./MembersClient";
 import LinkRequestsClient from "./LinkRequestsClient";
 
@@ -75,7 +76,17 @@ export default async function MembersPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">STAR</h1>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">STAR</h1>
+        {canManage && (
+          <Link
+            href="/admin/members/duplicates"
+            className="text-sm text-icc-violet hover:underline font-medium"
+          >
+            Doublons potentiels →
+          </Link>
+        )}
+      </div>
 
       {pendingRequests.length > 0 && (
         <div className="mb-8">

--- a/src/app/api/admin/members/assign-star-roles/route.ts
+++ b/src/app/api/admin/members/assign-star-roles/route.ts
@@ -1,0 +1,37 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse } from "@/lib/api-utils";
+import { z } from "zod";
+
+const schema = z.object({ churchId: z.string().min(1) });
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { churchId } = schema.parse(body);
+    await requireChurchPermission("members:manage", churchId);
+
+    // Tous les MemberUserLink de cette église
+    const links = await prisma.memberUserLink.findMany({
+      where: { churchId },
+      select: { userId: true },
+    });
+
+    let assigned = 0;
+    for (const { userId } of links) {
+      const hasRole = await prisma.userChurchRole.findFirst({
+        where: { userId, churchId },
+      });
+      if (!hasRole) {
+        await prisma.userChurchRole.create({
+          data: { userId, churchId, role: "STAR" },
+        });
+        assigned++;
+      }
+    }
+
+    return successResponse({ assigned, total: links.length });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/admin/members/duplicates/route.ts
+++ b/src/app/api/admin/members/duplicates/route.ts
@@ -1,0 +1,79 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const churchId = searchParams.get("churchId");
+    if (!churchId) throw new ApiError(400, "churchId requis");
+    await requireChurchPermission("members:manage", churchId);
+
+    const members = await prisma.member.findMany({
+      where: { departments: { some: { department: { ministry: { churchId } } } } },
+      include: {
+        departments: {
+          include: {
+            department: { select: { id: true, name: true, ministry: { select: { id: true, name: true } } } },
+          },
+          orderBy: { isPrimary: "desc" },
+        },
+        userLink: { select: { userId: true, user: { select: { name: true, email: true } } } },
+        _count: { select: { plannings: true, discipleships: true, disciplesMade: true } },
+      },
+    });
+
+    // Group by normalized name
+    const byName = new Map<string, typeof members>();
+    for (const m of members) {
+      const key = `${m.firstName.trim().toLowerCase()} ${m.lastName.trim().toLowerCase()}`;
+      const bucket = byName.get(key) ?? [];
+      bucket.push(m);
+      byName.set(key, bucket);
+    }
+
+    // Group by email (non-null)
+    const byEmail = new Map<string, typeof members>();
+    for (const m of members) {
+      if (!m.email) continue;
+      const key = m.email.trim().toLowerCase();
+      const bucket = byEmail.get(key) ?? [];
+      bucket.push(m);
+      byEmail.set(key, bucket);
+    }
+
+    type DuplicateGroup = {
+      reason: "same_name" | "same_email" | "both";
+      members: typeof members;
+    };
+
+    const groups: DuplicateGroup[] = [];
+    const seen = new Set<string>();
+
+    const pairKey = (ids: string[]) => [...ids].sort().join("|");
+
+    for (const bucket of byName.values()) {
+      if (bucket.length < 2) continue;
+      const key = pairKey(bucket.map((m) => m.id));
+      if (seen.has(key)) continue;
+      seen.add(key);
+      groups.push({ reason: "same_name", members: bucket });
+    }
+
+    for (const bucket of byEmail.values()) {
+      if (bucket.length < 2) continue;
+      const key = pairKey(bucket.map((m) => m.id));
+      const existing = groups.find((g) => pairKey(g.members.map((m) => m.id)) === key);
+      if (existing) {
+        existing.reason = "both";
+      } else {
+        seen.add(key);
+        groups.push({ reason: "same_email", members: bucket });
+      }
+    }
+
+    return successResponse(groups);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/admin/members/merge/route.ts
+++ b/src/app/api/admin/members/merge/route.ts
@@ -1,0 +1,159 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
+import { z } from "zod";
+
+const schema = z.object({
+  sourceId: z.string().min(1),
+  targetId: z.string().min(1),
+  resolution: z.object({
+    firstName: z.string().min(1),
+    lastName: z.string().min(1),
+    email: z.string().nullable().optional(),
+    phone: z.string().nullable().optional(),
+    // userId du compte à conserver si les deux ont un lien ; null = garder celui du target
+    keepUserId: z.string().nullable().optional(),
+  }),
+});
+
+async function getMemberChurchId(memberId: string): Promise<string | null> {
+  const m = await prisma.member.findUnique({
+    where: { id: memberId },
+    include: {
+      departments: {
+        where: { isPrimary: true },
+        include: { department: { include: { ministry: { select: { churchId: true } } } } },
+      },
+    },
+  });
+  if (!m) return null;
+  return m.departments[0]?.department.ministry.churchId ?? null;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { sourceId, targetId, resolution } = schema.parse(body);
+
+    if (sourceId === targetId) throw new ApiError(400, "Source et cible identiques");
+
+    const [srcChurchId, tgtChurchId] = await Promise.all([
+      getMemberChurchId(sourceId),
+      getMemberChurchId(targetId),
+    ]);
+
+    if (!srcChurchId) throw new ApiError(404, "Membre source introuvable");
+    if (!tgtChurchId) throw new ApiError(404, "Membre cible introuvable");
+    if (srcChurchId !== tgtChurchId) throw new ApiError(400, "Les membres n'appartiennent pas à la même église");
+
+    const session = await requireChurchPermission("members:manage", srcChurchId);
+
+    await prisma.$transaction(async (tx) => {
+      // ── Départements ──────────────────────────────────────────────────────────
+      const sourceDepts = await tx.memberDepartment.findMany({ where: { memberId: sourceId } });
+      const targetDeptIds = new Set(
+        (await tx.memberDepartment.findMany({ where: { memberId: targetId } })).map((d) => d.departmentId)
+      );
+      for (const sd of sourceDepts) {
+        if (!targetDeptIds.has(sd.departmentId)) {
+          await tx.memberDepartment.update({
+            where: { id: sd.id },
+            data: { memberId: targetId },
+          });
+        }
+        // else: doublon → sera supprimé via cascade sur la source
+      }
+
+      // ── Planning ──────────────────────────────────────────────────────────────
+      await tx.planning.updateMany({ where: { memberId: sourceId }, data: { memberId: targetId } });
+
+      // ── TaskAssignment ────────────────────────────────────────────────────────
+      // Unique constraint: (taskId, eventId, memberId) — dédupliquer
+      const srcTasks = await tx.taskAssignment.findMany({ where: { memberId: sourceId } });
+      for (const t of srcTasks) {
+        const conflict = await tx.taskAssignment.findFirst({
+          where: { taskId: t.taskId, eventId: t.eventId, memberId: targetId },
+        });
+        if (!conflict) {
+          await tx.taskAssignment.update({ where: { id: t.id }, data: { memberId: targetId } });
+        }
+      }
+
+      // ── DiscipleshipAttendance ────────────────────────────────────────────────
+      const srcAttendances = await tx.discipleshipAttendance.findMany({ where: { memberId: sourceId } });
+      for (const a of srcAttendances) {
+        const conflict = await tx.discipleshipAttendance.findFirst({
+          where: { memberId: targetId, eventId: a.eventId },
+        });
+        if (!conflict) {
+          await tx.discipleshipAttendance.update({ where: { id: a.id }, data: { memberId: targetId } });
+        }
+      }
+
+      // ── Discipleship (en tant que disciple) ───────────────────────────────────
+      const srcDiscipleships = await tx.discipleship.findMany({ where: { discipleId: sourceId } });
+      for (const d of srcDiscipleships) {
+        const conflict = await tx.discipleship.findFirst({
+          where: { discipleId: targetId, churchId: d.churchId },
+        });
+        if (!conflict) {
+          await tx.discipleship.update({ where: { id: d.id }, data: { discipleId: targetId } });
+        }
+        // else: target a déjà un FD dans cette église → on laisse tomber la relation source
+      }
+
+      // ── Discipleship (en tant que FD et premier FD) ───────────────────────────
+      await tx.discipleship.updateMany({ where: { discipleMakerId: sourceId }, data: { discipleMakerId: targetId } });
+      await tx.discipleship.updateMany({ where: { firstMakerId: sourceId }, data: { firstMakerId: targetId } });
+
+      // ── MemberLinkRequest ────────────────────────────────────────────────────
+      await tx.memberLinkRequest.updateMany({ where: { memberId: sourceId }, data: { memberId: targetId } });
+
+      // ── MemberUserLink ────────────────────────────────────────────────────────
+      const srcLink = await tx.memberUserLink.findUnique({ where: { memberId: sourceId } });
+      const tgtLink = await tx.memberUserLink.findUnique({ where: { memberId: targetId } });
+
+      if (srcLink && tgtLink) {
+        // Les deux ont un compte lié — garder celui choisi, supprimer l'autre
+        const userIdToRemove = resolution.keepUserId === srcLink.userId ? tgtLink.userId : srcLink.userId;
+        const memberIdToRemove = userIdToRemove === srcLink.userId ? sourceId : targetId;
+        await tx.memberUserLink.delete({ where: { memberId: memberIdToRemove } });
+        // Déplacer le lien source vers le target si c'est le lien source qu'on conserve
+        if (resolution.keepUserId === srcLink.userId) {
+          await tx.memberUserLink.update({ where: { memberId: sourceId }, data: { memberId: targetId } });
+        }
+      } else if (srcLink && !tgtLink) {
+        await tx.memberUserLink.update({ where: { memberId: sourceId }, data: { memberId: targetId } });
+      }
+      // else: tgtLink && !srcLink → rien à faire (target garde son lien)
+
+      // ── Mettre à jour les champs scalaires du target ──────────────────────────
+      await tx.member.update({
+        where: { id: targetId },
+        data: {
+          firstName: resolution.firstName,
+          lastName: resolution.lastName,
+          ...(resolution.email !== undefined && { email: resolution.email }),
+          ...(resolution.phone !== undefined && { phone: resolution.phone }),
+        },
+      });
+
+      // ── Supprimer la source (cascade: MemberDepartment restants, etc.) ────────
+      await tx.member.delete({ where: { id: sourceId } });
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId: srcChurchId,
+      action: "DELETE",
+      entityType: "Member",
+      entityId: sourceId,
+      details: { mergedInto: targetId, resolution },
+    });
+
+    return successResponse({ merged: true, targetId });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/member-link-requests/[id]/route.ts
+++ b/src/app/api/member-link-requests/[id]/route.ts
@@ -213,6 +213,18 @@ export async function PATCH(
         }
       }
 
+      // ── Auto-assigner le rôle STAR si aucun rôle dans l'église ─────────────
+      if (!isNoStarRole && memberId) {
+        const hasAnyRole = await tx.userChurchRole.findFirst({
+          where: { userId: linkRequest.userId, churchId: linkRequest.churchId },
+        });
+        if (!hasAnyRole) {
+          await tx.userChurchRole.create({
+            data: { userId: linkRequest.userId, churchId: linkRequest.churchId, role: "STAR" },
+          });
+        }
+      }
+
       // ── Mettre à jour la demande ──────────────────────────────────────────────
       await tx.memberLinkRequest.update({
         where: { id },


### PR DESCRIPTION
## Résumé

### Auto-assign rôle STAR
- À l'approbation d'une demande de liaison (`PATCH /api/member-link-requests/[id]`), si l'utilisateur n'a aucun rôle dans l'église, le rôle `STAR` (accès planning en lecture) est automatiquement créé
- Évite le cas où un membre lie son compte mais ne peut rien voir faute de rôle

### Bulk retroactif
- `POST /api/admin/members/assign-star-roles` : parcourt tous les `MemberUserLink` de l'église et crée le rôle `STAR` pour ceux sans aucun rôle — à utiliser une fois pour corriger l'existant

### Détection de doublons
- Page `/admin/members/duplicates` accessible depuis la liste STAR (lien "Doublons potentiels →")
- Groupes par nom normalisé (insensible à la casse) et/ou même email
- Badge de raison : "Même nom" / "Même email" / "Même nom + email"

### Fusion avec résolution de conflits
- Modal côte à côte : source (à supprimer) vs cible (à conserver)
- Bouton ⇄ pour inverser source et cible
- Résolution champ par champ : prénom, nom, email, téléphone
- Si les deux ont un compte Google lié : choix du compte à conserver
- Aperçu des départements après fusion (union des deux listes)
- Transaction Prisma atomique : Planning, TaskAssignment, DiscipleshipAttendance, Discipleship (×3), MemberDepartment (déduplication), MemberUserLink, MemberLinkRequest — puis suppression de la source

## Plan de test
- [ ] Approuver une demande de liaison sans `requestedRole` → vérifier que le rôle STAR est créé
- [ ] Approuver avec `requestedRole: DEPARTMENT_HEAD` → vérifier qu'aucun STAR n'est créé en doublon
- [ ] Cliquer "Assigner les rôles STAR" → vérifier le compte `assigned`
- [ ] Créer deux membres avec le même nom → vérifier qu'ils apparaissent dans /admin/members/duplicates
- [ ] Fusionner deux membres sans compte lié → vérifier la disparition de la source et l'union des départements
- [ ] Fusionner deux membres ayant chacun un compte Google lié → vérifier que le compte non choisi est détaché

🤖 Generated with [Claude Code](https://claude.com/claude-code)