### PR TITLE
fix(media): augmenter la limite de body à 100MB pour l'upload de photos

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,11 @@ const nextConfig: NextConfig = {
       { hostname: "lh3.googleusercontent.com" },
     ],
   },
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "100mb",
+    },
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Problème

En production, l'upload de plusieurs photos simultanément échoue avec :
```
Request body exceeded 10MB for /api/media-events/.../photos.
Unhandled error: Failed to parse body as FormData.
```

Next.js 16 bufferise le body des route handlers et applique un plafond de 10MB par défaut. `MAX_PHOTO_SIZE` étant à 50MB par fichier, le moindre batch de 2-3 photos dépasse ce seuil.

## Fix

`experimental.serverActions.bodySizeLimit: "100mb"` dans `next.config.ts` — s'applique aux route handlers et server actions.

100MB couvre ~10 photos smartphones (8-10MB chacune) en une seule requête.

## Test plan

- [ ] Uploader 3+ photos de taille > 3MB simultanément → doit réussir sans erreur 10MB
- [ ] Le warning ne doit plus apparaître dans les logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)