### PR TITLE
chore: release v1.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.1.9] - 2026-04-28
+
+### Corrigé
+
+- Médias : l'upload de photos ne bloque plus sur la limite de 10MB de Next.js (portée à 100MB dans next.config.ts)
+- Médias : correction d'un bug critique — les uploads de photos authentifiés retournaient 400 silencieusement (clé FormData `"file"` → `"files"`, en accord avec le serveur)
+
 ## [v1.1.8] - 2026-04-26
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
+++ b/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
@@ -132,7 +132,7 @@ function PhotoUploadZone({ eventId, onUploaded, onProgressChange }: {
     for (const file of files) {
       try {
         const form = new FormData();
-        form.append("file", file);
+        form.append("files", file);
         const res = await fetch(`/api/media-events/${eventId}/photos`, { method: "POST", body: form });
         const json = await res.json();
         if (!res.ok) errors.push(`${file.name}: ${json.error || "Erreur"}`);


### PR DESCRIPTION
## v1.1.9

### Corrigé
- **Bug critique médias** : les uploads de photos authentifiés retournaient 400 silencieusement — clé FormData `"file"` ne correspondait pas au `getAll("files")` côté serveur
- **Limite body 10MB** : photos de 10-50MB bloquées avant d'atteindre le handler — portée à 100MB (le client envoie une photo à la fois, MAX_PHOTO_SIZE = 50MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)