### PR TITLE
chore: release v1.1.10 (#267)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,8 @@ SMTP_SECURE=false                         # true pour SSL/TLS natif (port 465)
 SMTP_USER=                                # utilisateur SMTP (laisser vide si pas d'auth)
 SMTP_PASS=                                # mot de passe SMTP
 SMTP_FROM=Koinonia <noreply@votre-domaine.com>  # adresse expediteur
+SMTP_IGNORE_TLS=false                         # mettre "true" pour un relay local (localhost:25) qui annonce STARTTLS avec un cert auto-signé
+SMTP_TLS_REJECT_UNAUTHORIZED=true             # mettre "false" si certificat SMTP auto-signé (serveur distant)
 
 # ─── Monitoring ───
 # GET /api/health — public, retourne { status, version, db, uptime }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [v1.1.10] - 2026-04-28
 
+### Ajouté
+
+- Médias : upload de photos via presigned URL S3 — le fichier transite directement du navigateur vers S3 sans passer par Next.js (endpoints `POST /photos/sign` + `POST /photos/confirm`)
+
 ### Corrigé
 
 - Médias : les uploads de photos > 10MB échouaient toujours via les route handlers — ajout de `middlewareClientMaxBodySize: 100MB` dans next.config.ts (le précédent fix `serverActions.bodySizeLimit` ne couvrait pas les routes API transitant par le middleware)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.1.10] - 2026-04-28
+
+### Corrigé
+
+- Médias : les uploads de photos > 10MB échouaient toujours via les route handlers — ajout de `middlewareClientMaxBodySize: 100MB` dans next.config.ts (le précédent fix `serverActions.bodySizeLimit` ne couvrait pas les routes API transitant par le middleware)
+- Médias : erreur de parsing FormData retourne désormais un 400 explicite au lieu d'une exception non gérée
+- Emails : le digest planning échouait avec `self-signed certificate` sur un relay SMTP local (localhost:25) — ajout de l'option `ignoreTLS` (variable `SMTP_IGNORE_TLS=true`)
+
+### Documentation
+
+- `.env.example` : ajout de `SMTP_IGNORE_TLS` et `SMTP_TLS_REJECT_UNAUTHORIZED`
+
 ## [v1.1.9] - 2026-04-28
 
 ### Corrigé

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,8 @@ const nextConfig: NextConfig = {
     serverActions: {
       bodySizeLimit: "100mb",
     },
+    // Limite la taille du corps transmis à travers le middleware (proxy.ts) vers les route handlers
+    middlewareClientMaxBodySize: 100 * 1024 * 1024, // 100MB
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
+++ b/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
@@ -129,19 +129,41 @@ function PhotoUploadZone({ eventId, onUploaded, onProgressChange }: {
     reportProgress({ done: 0, total: files.length });
     let done = 0;
     const errors: string[] = [];
+
     for (const file of files) {
       try {
-        const form = new FormData();
-        form.append("files", file);
-        const res = await fetch(`/api/media-events/${eventId}/photos`, { method: "POST", body: form });
-        const json = await res.json();
-        if (!res.ok) errors.push(`${file.name}: ${json.error || "Erreur"}`);
-      } catch {
-        errors.push(`${file.name}: Erreur réseau`);
+        // 1 — Demande une presigned PUT URL
+        const signRes = await fetch(`/api/media-events/${eventId}/photos/sign`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ filename: file.name, mimeType: file.type, size: file.size }),
+        });
+        const signJson = await signRes.json();
+        if (!signRes.ok) throw new Error(signJson.error || "Erreur de signature");
+
+        // 2 — Upload direct navigateur → S3 (aucun transit par Next.js)
+        const putRes = await fetch(signJson.url, {
+          method: "PUT",
+          headers: { "Content-Type": file.type },
+          body: file,
+        });
+        if (!putRes.ok) throw new Error("Échec de l'upload S3 — vérifiez la configuration CORS du bucket");
+
+        // 3 — Confirmation : sharp (EXIF + JPEG 90% + thumbnail WebP) + création DB
+        const confirmRes = await fetch(`/api/media-events/${eventId}/photos/confirm`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ quarantineId: signJson.quarantineId, filename: file.name, mimeType: file.type, size: file.size }),
+        });
+        const confirmJson = await confirmRes.json();
+        if (!confirmRes.ok) throw new Error(confirmJson.error || "Erreur de confirmation");
+      } catch (err) {
+        errors.push(`${file.name}: ${err instanceof Error ? err.message : "Erreur réseau"}`);
       }
       done++;
       reportProgress({ done, total: files.length });
     }
+
     setUploading(false);
     reportProgress(null);
     if (errors.length > 0) setError(errors.join("\n"));

--- a/src/app/api/media-events/[id]/photos/confirm/route.ts
+++ b/src/app/api/media-events/[id]/photos/confirm/route.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireMediaUploadAccess, resolveChurchId } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import {
+  validatePhotoFile,
+  getExtensionFromMimeType,
+  getQuarantineKey,
+  fileExists,
+  downloadFile,
+  processImage,
+  uploadMediaFile,
+  getPhotoOriginalKey,
+  getPhotoThumbnailKey,
+  deleteMediaFile,
+} from "@/modules/media";
+
+const confirmSchema = z.object({
+  quarantineId: z.string().uuid(),
+  filename: z.string().min(1),
+  mimeType: z.string(),
+  size: z.number().int().positive(),
+});
+
+/** POST — confirme l'upload S3, traite l'image (sharp) et crée l'entrée DB. */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    await requireMediaUploadAccess(churchId);
+
+    const body = confirmSchema.parse(await request.json());
+    validatePhotoFile(body.filename, body.mimeType, body.size);
+
+    const ext = getExtensionFromMimeType(body.mimeType);
+    const quarantineKey = getQuarantineKey(id, body.quarantineId, ext);
+
+    if (!(await fileExists(quarantineKey))) {
+      throw new ApiError(400, "Fichier introuvable — re-uploadez la photo");
+    }
+
+    const buffer = await downloadFile(quarantineKey);
+    const processed = await processImage(buffer);
+
+    const photo = await prisma.mediaPhoto.create({
+      data: {
+        filename: body.filename,
+        mimeType: body.mimeType,
+        size: body.size,
+        width: processed.metadata.width,
+        height: processed.metadata.height,
+        mediaEventId: id,
+        originalKey: "",
+        thumbnailKey: "",
+        status: "PENDING",
+      },
+    });
+
+    const originalKey = getPhotoOriginalKey(id, photo.id, ext);
+    const thumbnailKey = getPhotoThumbnailKey(id, photo.id);
+
+    await Promise.all([
+      uploadMediaFile(originalKey, processed.original, "image/jpeg"),
+      uploadMediaFile(thumbnailKey, processed.thumbnail, "image/webp"),
+    ]);
+
+    await prisma.mediaPhoto.update({
+      where: { id: photo.id },
+      data: { originalKey, thumbnailKey },
+    });
+
+    // Nettoyage quarantine (best-effort, non bloquant)
+    deleteMediaFile(quarantineKey).catch(() => {});
+
+    return successResponse({ id: photo.id, filename: photo.filename }, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media-events/[id]/photos/route.ts
+++ b/src/app/api/media-events/[id]/photos/route.ts
@@ -55,9 +55,14 @@ export async function POST(
     const churchId = await resolveChurchId("mediaEvent", id);
     await requireMediaUploadAccess(churchId);
 
-    const formData = await request.formData();
-    const files = formData.getAll("files") as File[];
+    let formData: FormData;
+    try {
+      formData = await request.formData();
+    } catch {
+      throw new ApiError(400, "Corps de requête invalide — vérifiez que le fichier ne dépasse pas 50 MB");
+    }
 
+    const files = formData.getAll("files") as File[];
     if (!files || files.length === 0) throw new ApiError(400, "Aucun fichier fourni");
 
     const uploaded: { id: string; filename: string }[] = [];

--- a/src/app/api/media-events/[id]/photos/sign/route.ts
+++ b/src/app/api/media-events/[id]/photos/sign/route.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { requireMediaUploadAccess, resolveChurchId } from "@/lib/auth";
+import { successResponse, errorResponse } from "@/lib/api-utils";
+import {
+  validatePhotoFile,
+  getExtensionFromMimeType,
+  getQuarantineKey,
+  getSignedPutUrl,
+} from "@/modules/media";
+
+const signSchema = z.object({
+  filename: z.string().min(1),
+  mimeType: z.string(),
+  size: z.number().int().positive(),
+});
+
+/** POST — génère une presigned PUT URL pour upload direct navigateur → S3. */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const churchId = await resolveChurchId("mediaEvent", id);
+    await requireMediaUploadAccess(churchId);
+
+    const body = signSchema.parse(await request.json());
+    validatePhotoFile(body.filename, body.mimeType, body.size);
+
+    const quarantineId = crypto.randomUUID();
+    const ext = getExtensionFromMimeType(body.mimeType);
+    const quarantineKey = getQuarantineKey(id, quarantineId, ext);
+
+    const url = await getSignedPutUrl(quarantineKey, body.mimeType);
+
+    return successResponse({ quarantineId, url });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -19,6 +19,12 @@ const transporter = nodemailer.createTransport({
         pass: process.env.SMTP_PASS,
       }
     : undefined,
+  // ignoreTLS : désactive STARTTLS même si le serveur l'annonce (relay local port 25)
+  ignoreTLS: process.env.SMTP_IGNORE_TLS === "true",
+  tls: {
+    // Mettre à "false" si le serveur SMTP utilise un certificat auto-signé
+    rejectUnauthorized: process.env.SMTP_TLS_REJECT_UNAUTHORIZED !== "false",
+  },
 });
 
 interface SendEmailOptions {

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -20,6 +20,10 @@ export {
   getSignedPartUrl,
   completeMultipartUpload,
   abortMultipartUpload,
+  getQuarantineKey,
+  getSignedPutUrl,
+  fileExists,
+  downloadFile,
 } from "./services/s3";
 
 /**

--- a/src/modules/media/services/s3.ts
+++ b/src/modules/media/services/s3.ts
@@ -2,6 +2,7 @@ import {
   PutObjectCommand,
   GetObjectCommand,
   DeleteObjectCommand,
+  HeadObjectCommand,
   CreateMultipartUploadCommand,
   UploadPartCommand,
   CompleteMultipartUploadCommand,
@@ -56,6 +57,41 @@ export function getVersionOriginalKey(fileId: string, versionNumber: number, ext
 
 export function getVersionThumbnailKey(fileId: string, versionNumber: number): string {
   return `media-files/${fileId}/v${versionNumber}/thumbnail.webp`;
+}
+
+// ─── Quarantine (upload direct navigateur → S3) ───────────────────────────
+
+export function getQuarantineKey(eventId: string, quarantineId: string, ext: string): string {
+  return `quarantine/media-events/${eventId}/${quarantineId}.${ext}`;
+}
+
+const PRESIGNED_PUT_EXPIRY = 300; // 5 min
+
+export async function getSignedPutUrl(key: string, contentType: string, expiresIn = PRESIGNED_PUT_EXPIRY): Promise<string> {
+  return getSignedUrl(
+    s3Client,
+    new PutObjectCommand({ Bucket: BUCKET, Key: key, ContentType: contentType }),
+    { expiresIn, signableHeaders: new Set(["content-type"]) },
+  );
+}
+
+export async function fileExists(key: string): Promise<boolean> {
+  try {
+    await s3Client.send(new HeadObjectCommand({ Bucket: BUCKET, Key: key }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function downloadFile(key: string): Promise<Buffer> {
+  const resp = await s3Client.send(new GetObjectCommand({ Bucket: BUCKET, Key: key }));
+  if (!resp.Body) throw new Error(`S3 object not found: ${key}`);
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of resp.Body as AsyncIterable<Uint8Array>) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
 }
 
 // ─── Upload ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

### Ajouté
- Upload photos via **presigned URL S3** — le fichier transite directement navigateur → S3 sans passer par Next.js
  - `POST /api/media-events/[id]/photos/sign` : valide métadonnées, génère presigned PUT URL (quarantine S3)
  - `POST /api/media-events/[id]/photos/confirm` : télécharge depuis quarantine, run sharp (EXIF + JPEG 90% + WebP thumbnail), upload final, crée `MediaPhoto` en DB
  - Client mis à jour : sign → PUT S3 → confirm

### Corrigé
- `middlewareClientMaxBodySize: 100MB` — les uploads > 10MB via route handlers échouaient toujours (le fix `serverActions.bodySizeLimit` de v1.1.9 ne couvrait pas les routes API transitant par le middleware)
- Erreur de parsing FormData → 400 explicite au lieu d'une exception non gérée
- Digest planning SMTP : `self-signed certificate` sur relay localhost:25 → option `SMTP_IGNORE_TLS`

## Prérequis avant déploiement

**CORS bucket S3** — le PUT direct navigateur → S3 nécessite que le bucket autorise la méthode PUT depuis l'origine de l'app :
```json
[{
  "AllowedHeaders": ["content-type"],
  "AllowedMethods": ["GET", "PUT"],
  "AllowedOrigins": ["https://votre-domaine.fr"],
  "ExposeHeaders": []
}]
```
Sans cette config, les uploads échoueront avec une erreur CORS (message : "Échec de l'upload S3 — vérifiez la configuration CORS du bucket").

**`.env`** — ajouter :
```
SMTP_IGNORE_TLS=true
```

## Après merge

```bash
git checkout main && git pull
git tag v1.1.10 && git push origin v1.1.10
gh release create v1.1.10 --title "v1.1.10" --notes "Upload photos via presigned URL S3 + fix middlewareClientMaxBodySize + fix SMTP ignoreTLS"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)