### PR TITLE
feat(media): token MEDIA_ALL — téléchargement toutes photos (#268)

### DIFF
--- a/prisma/migrations/20260428000000_add_media_token_type_media_all/migration.sql
+++ b/prisma/migrations/20260428000000_add_media_token_type_media_all/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: add MEDIA_ALL to MediaTokenType enum
+ALTER TABLE `media_share_tokens` MODIFY COLUMN `type` ENUM('VALIDATOR', 'MEDIA', 'MEDIA_ALL', 'PREVALIDATOR', 'GALLERY') NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -632,7 +632,8 @@ enum MediaCommentType {
 
 enum MediaTokenType {
   VALIDATOR    // Accès validation (lecture + modification status)
-  MEDIA        // Accès téléchargement (lecture photos validées uniquement)
+  MEDIA        // Accès téléchargement (photos approuvées uniquement)
+  MEDIA_ALL    // Accès téléchargement (toutes photos, validées ou non)
   PREVALIDATOR // Accès prévalidation (filtrage avant validation finale)
   GALLERY      // Accès galerie (téléchargement photo par photo)
 }

--- a/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
+++ b/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
@@ -70,7 +70,8 @@ const PHOTO_STATUS_COLORS: Record<MediaPhotoStatus, string> = {
 const TOKEN_TYPE_LABELS: Record<MediaTokenType, string> = {
   VALIDATOR:    "Validateur",
   PREVALIDATOR: "Pré-validateur",
-  MEDIA:        "Téléchargement",
+  MEDIA:        "Téléchargement (validées)",
+  MEDIA_ALL:    "Téléchargement (toutes)",
   GALLERY:      "Galerie",
 };
 
@@ -78,6 +79,7 @@ const TOKEN_TYPE_ICONS: Record<MediaTokenType, string> = {
   VALIDATOR:    "✅",
   PREVALIDATOR: "👁",
   MEDIA:        "⬇️",
+  MEDIA_ALL:    "📦",
   GALLERY:      "🖼️",
 };
 
@@ -271,7 +273,7 @@ function ShareTokenSection({ eventId, tokens, onRefresh }: {
   }
 
   function getTokenUrl(token: ShareToken) {
-    const paths: Record<MediaTokenType, string> = { VALIDATOR: "v", PREVALIDATOR: "v", MEDIA: "d", GALLERY: "g" };
+    const paths: Record<MediaTokenType, string> = { VALIDATOR: "v", PREVALIDATOR: "v", MEDIA: "d", MEDIA_ALL: "d", GALLERY: "g" };
     return `${origin}/media/${paths[token.type]}/${token.token}`;
   }
 

--- a/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
+++ b/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
@@ -115,7 +115,8 @@ const FILE_TYPE_LABELS: Record<MediaFileType, string> = {
 const TOKEN_TYPE_LABELS: Record<MediaTokenType, string> = {
   VALIDATOR:    "Validateur",
   PREVALIDATOR: "Pré-validateur",
-  MEDIA:        "Téléchargement",
+  MEDIA:        "Téléchargement (validées)",
+  MEDIA_ALL:    "Téléchargement (toutes)",
   GALLERY:      "Galerie",
 };
 
@@ -123,6 +124,7 @@ const TOKEN_TYPE_ICONS: Record<MediaTokenType, string> = {
   VALIDATOR:    "✅",
   PREVALIDATOR: "👁",
   MEDIA:        "⬇️",
+  MEDIA_ALL:    "📦",
   GALLERY:      "🖼️",
 };
 
@@ -265,7 +267,7 @@ function ShareTokenSection({ projectId, tokens, onRefresh }: {
   }
 
   function getTokenUrl(token: ShareToken) {
-    const paths: Record<MediaTokenType, string> = { VALIDATOR: "v", PREVALIDATOR: "v", MEDIA: "d", GALLERY: "g" };
+    const paths: Record<MediaTokenType, string> = { VALIDATOR: "v", PREVALIDATOR: "v", MEDIA: "d", MEDIA_ALL: "d", GALLERY: "g" };
     return `${origin}/media/${paths[token.type]}/${token.token}`;
   }
 

--- a/src/app/api/media/download/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/download/[token]/photo/[photoId]/route.ts
@@ -12,7 +12,7 @@ export async function GET(
 ) {
   try {
     const { token, photoId } = await params;
-    const shareToken = await validateMediaShareToken(token, "MEDIA");
+    const shareToken = await validateMediaShareToken(token, ["MEDIA", "MEDIA_ALL"]);
 
     const photo = await prisma.mediaPhoto.findUnique({
       where: { id: photoId },
@@ -23,7 +23,9 @@ export async function GET(
     if (shareToken.mediaEventId && photo.mediaEventId !== shareToken.mediaEventId) {
       throw new ApiError(403, "Photo hors périmètre");
     }
-    if (photo.status !== "APPROVED") throw new ApiError(403, "Photo non approuvée");
+    if (shareToken.type === "MEDIA" && photo.status !== "APPROVED") {
+      throw new ApiError(403, "Photo non approuvée");
+    }
 
     const downloadUrl = await getSignedDownloadUrl(photo.originalKey, photo.filename);
 

--- a/src/app/api/media/download/[token]/route.ts
+++ b/src/app/api/media/download/[token]/route.ts
@@ -12,13 +12,15 @@ export async function GET(
 ) {
   try {
     const { token } = await params;
-    const shareToken = await validateMediaShareToken(token, "MEDIA");
+    const shareToken = await validateMediaShareToken(token, ["MEDIA", "MEDIA_ALL"]);
     const event = shareToken.mediaEvent;
 
     if (!event) return successResponse({ token: shareToken, photos: [] });
 
+    const allStatuses = shareToken.type === "MEDIA_ALL";
+
     const photos = await prisma.mediaPhoto.findMany({
-      where: { mediaEventId: event.id, status: "APPROVED" },
+      where: { mediaEventId: event.id, ...(!allStatuses && { status: "APPROVED" }) },
       orderBy: { uploadedAt: "asc" },
     });
 
@@ -29,6 +31,7 @@ export async function GET(
         size: p.size,
         width: p.width,
         height: p.height,
+        status: p.status,
         thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
       }))
     );

--- a/src/app/api/media/download/[token]/zip/route.ts
+++ b/src/app/api/media/download/[token]/zip/route.ts
@@ -22,15 +22,16 @@ export async function POST(
 ) {
   try {
     const { token } = await params;
-    const shareToken = await validateMediaShareToken(token, "MEDIA");
+    const shareToken = await validateMediaShareToken(token, ["MEDIA", "MEDIA_ALL"]);
     const event = shareToken.mediaEvent;
     if (!event) throw new ApiError(404, "Événement introuvable");
 
     const body = bodySchema.parse(await request.json().catch(() => ({})));
+    const allStatuses = shareToken.type === "MEDIA_ALL";
 
     const where = {
       mediaEventId: event.id,
-      status: "APPROVED" as const,
+      ...(!allStatuses && { status: "APPROVED" as const }),
       ...(body.photoIds?.length ? { id: { in: body.photoIds } } : {}),
     };
 
@@ -40,7 +41,7 @@ export async function POST(
       orderBy: { uploadedAt: "asc" },
     });
 
-    if (photos.length === 0) throw new ApiError(404, "Aucune photo approuvée");
+    if (photos.length === 0) throw new ApiError(404, "Aucune photo disponible");
 
     // Nom du fichier ZIP : nom événement sanitisé
     const safeName = event.name.replace(/[^a-z0-9\-_]/gi, "_").slice(0, 60);

--- a/src/app/media/d/[token]/DownloadView.tsx
+++ b/src/app/media/d/[token]/DownloadView.tsx
@@ -9,6 +9,7 @@ type Photo = {
   size: number;
   width: number | null;
   height: number | null;
+  status: string;
 };
 
 type DownloadData = {
@@ -98,7 +99,13 @@ export default function DownloadView({
           {data.token.label && <p className="text-xs text-gray-400 mt-0.5">{data.token.label}</p>}
           <div className="flex items-center justify-between mt-2 flex-wrap gap-2">
             <p className="text-sm text-gray-600">
-              {photos.length} photo{photos.length !== 1 ? "s" : ""} approuvée{photos.length !== 1 ? "s" : ""} · {formatSize(totalSize)}
+              {photos.length} photo{photos.length !== 1 ? "s" : ""}
+              {data.token.type === "MEDIA_ALL" && photos.some((p) => p.status !== "APPROVED") && (
+                <span className="ml-1.5 text-xs text-yellow-700 bg-yellow-50 border border-yellow-200 rounded-full px-2 py-0.5">
+                  dont {photos.filter((p) => p.status !== "APPROVED").length} non validée{photos.filter((p) => p.status !== "APPROVED").length > 1 ? "s" : ""}
+                </span>
+              )}
+              {" · "}{formatSize(totalSize)}
             </p>
             {photos.length > 0 && (
               <button
@@ -178,6 +185,11 @@ export default function DownloadView({
                   />
                 </div>
                 <div className="p-1.5">
+                            {photo.status !== "APPROVED" && (
+                    <span className="inline-block text-xs text-yellow-700 bg-yellow-50 border border-yellow-200 rounded-full px-1.5 py-0.5 mb-0.5">
+                      Non validée
+                    </span>
+                  )}
                   <p className="text-xs text-gray-500 truncate">{photo.filename}</p>
                   <p className="text-xs text-gray-400">{formatSize(photo.size)}</p>
                   <button

--- a/src/app/media/d/[token]/page.tsx
+++ b/src/app/media/d/[token]/page.tsx
@@ -9,13 +9,15 @@ import DownloadView from "./DownloadView";
 
 async function fetchDownloadData(token: string) {
   try {
-    const shareToken = await validateMediaShareToken(token, "MEDIA");
+    const shareToken = await validateMediaShareToken(token, ["MEDIA", "MEDIA_ALL"]);
     const event = shareToken.mediaEvent;
 
     if (!event) return { token: shareToken, event: null, photos: [] };
 
+    const allStatuses = shareToken.type === "MEDIA_ALL";
+
     const photos = await prisma.mediaPhoto.findMany({
-      where: { mediaEventId: event.id, status: "APPROVED" },
+      where: { mediaEventId: event.id, ...(!allStatuses && { status: "APPROVED" }) },
       orderBy: { uploadedAt: "asc" },
     });
 
@@ -26,6 +28,7 @@ async function fetchDownloadData(token: string) {
         size: p.size,
         width: p.width,
         height: p.height,
+        status: p.status,
         thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
       }))
     );

--- a/src/modules/media/services/tokens.ts
+++ b/src/modules/media/services/tokens.ts
@@ -14,7 +14,7 @@ export function isTokenExpired(expiresAt: Date | null): boolean {
 
 /** URL path segment par type de token (pour les liens publics). */
 export function getTokenUrlPath(type: MediaTokenType): string {
-  if (type === "MEDIA") return "d";
+  if (type === "MEDIA" || type === "MEDIA_ALL") return "d";
   if (type === "GALLERY") return "g";
   return "v";
 }


### PR DESCRIPTION
## Summary

- Nouveau type de token **MEDIA_ALL** : même interface de téléchargement que MEDIA, mais inclut toutes les photos quelle que soit leur status (PENDING, APPROVED, REJECTED…)
- Badge **"Non validée"** affiché sur chaque photo non approuvée dans la vue téléchargement
- Compteur en en-tête : "X photos · dont Y non validées"
- Migration : `ALTER TABLE media_share_tokens MODIFY COLUMN type ENUM(... 'MEDIA_ALL' ...)`

## Cas d'usage

Partager toutes les photos d'un événement avec une équipe externe (ex. Laval) avant que la validation interne soit terminée.

## Après merge

```bash
git checkout main && git pull
git tag v1.1.11 && git push origin v1.1.11
gh release create v1.1.11 --title "v1.1.11" --notes "Token MEDIA_ALL : téléchargement de toutes les photos y compris non validées"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)