### PR TITLE
chore: release v1.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.1.11] - 2026-04-29
+
+### Ajouté
+
+- Médias : token `MEDIA_ALL` — lien de téléchargement donnant accès à toutes les photos (validées et non validées), pour l'équipe de Laval
+- Médias : lightbox plein écran dans la vue téléchargement — clic sur une miniature ouvre la photo HD avec navigation ←/→, sélection et téléchargement intégrés
+- Médias : vue de validation iso mediaflow — flux card-swipe photo par photo avec swipe gauche/droite, raccourcis clavier (← X / → V / Espace), toast undo, barre de progression temps réel, stats en bas d'écran
+- Médias : lightbox HD inline dans la validation — touche H / Entrée ou clic sur le bouton HD ouvre l'original avec chargement progressif et boutons valider/rejeter intégrés
+- Médias : bouton "X en attente →" dans le header de validation pour sauter directement au prochain PENDING
+- Médias : récap de validation revu — fond noir cohérent, 3 cartes stats (validées / en attente / rejetées), grille 5 colonnes, badge de statut par miniature, toggle thème clair/sombre
+- Médias : accès en lecture aux événements et projets pour la team Communication (vue uniquement, sans upload ni gestion)
+
+### Corrigé
+
+- Auth : erreur `CallbackRouteError: unexpected "iss"` sur le callback Google OAuth — ajout de `trustHost: true` dans la config NextAuth pour les déploiements derrière reverse proxy (Traefik)
+- Médias : les droits de la team Communication sont limités à la vue uniquement (`requireMediaUploadAccess` et `requireMediaManageAccess` restent réservés à PRODUCTION_MEDIA)
+
 ## [v1.1.10] - 2026-04-28
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v1.1.11

### Ajouté
- Token `MEDIA_ALL` — téléchargement de toutes les photos (validées et non validées)
- Lightbox plein écran dans la vue téléchargement
- Vue de validation iso mediaflow — card-swipe, raccourcis clavier, undo, barre de progression
- Lightbox HD inline dans la validation (H / Entrée)
- Bouton "X en attente →" pour sauter au prochain PENDING
- Récap de validation revu — stats, grille 5 col, toggle thème clair/sombre
- Accès lecture aux événements/projets pour la team Communication

### Corrigé
- Auth : `unexpected "iss"` sur callback Google OAuth (`trustHost: true`)
- Médias : droits Communication limités à la vue uniquement

🤖 Generated with [Claude Code](https://claude.com/claude-code)