### PR TITLE
feat(media): droits upload pour la team Communication

### DIFF
--- a/src/app/(auth)/media/events/[id]/page.tsx
+++ b/src/app/(auth)/media/events/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { requireMediaAccess, isProductionMediaMember, resolveChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaAccess, isProductionMediaMember, isCommunicationMember, resolveChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import { rolePermissions } from "@/lib/registry";
@@ -55,7 +55,8 @@ export default async function MediaEventDetailPage({
       .flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const isProductionMember = await isProductionMediaMember(session, churchId!);
-  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember;
+  const isCommMember = await isCommunicationMember(session, churchId!);
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember || isCommMember;
   const canManage = session.user.isSuperAdmin || churchPerms.has("media:manage") || isProductionMember;
 
   return (

--- a/src/app/(auth)/media/events/page.tsx
+++ b/src/app/(auth)/media/events/page.tsx
@@ -1,4 +1,4 @@
-import { requireMediaAccess, isProductionMediaMember, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaAccess, isProductionMediaMember, isCommunicationMember, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
@@ -52,7 +52,8 @@ export default async function MediaEventsPage() {
       .flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const isProductionMember = await isProductionMediaMember(session, churchId);
-  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember;
+  const isCommMember = await isCommunicationMember(session, churchId);
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember || isCommMember;
 
   return (
     <div>

--- a/src/app/(auth)/media/projects/[id]/page.tsx
+++ b/src/app/(auth)/media/projects/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { requireMediaAccess, isProductionMediaMember, resolveChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaAccess, isProductionMediaMember, isCommunicationMember, resolveChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import { rolePermissions } from "@/lib/registry";
@@ -65,7 +65,8 @@ export default async function MediaProjectDetailPage({
       .flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const isProductionMember = await isProductionMediaMember(session, churchId!);
-  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember;
+  const isCommMember = await isCommunicationMember(session, churchId!);
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember || isCommMember;
   const canReview = session.user.isSuperAdmin || churchPerms.has("media:review");
   const canManage = session.user.isSuperAdmin || churchPerms.has("media:manage") || isProductionMember;
 

--- a/src/app/(auth)/media/projects/page.tsx
+++ b/src/app/(auth)/media/projects/page.tsx
@@ -1,4 +1,4 @@
-import { requireMediaAccess, isProductionMediaMember, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaAccess, isProductionMediaMember, isCommunicationMember, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
@@ -50,7 +50,8 @@ export default async function MediaProjectsPage() {
       .flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const isProductionMember = await isProductionMediaMember(session, churchId);
-  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember;
+  const isCommMember = await isCommunicationMember(session, churchId);
+  const canUpload = session.user.isSuperAdmin || churchPerms.has("media:upload") || isProductionMember || isCommMember;
 
   return (
     <div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -489,8 +489,9 @@ export async function requireMediaAccess(churchId: string) {
 
 /**
  * Autorise l'upload et la création de ressources média.
- * Passe si : permission `media:upload` (ADMIN, SECRETARY…) OU membre PRODUCTION_MEDIA.
- * La team Communication n'a pas ce droit.
+ * Passe si : permission `media:upload` (ADMIN, SECRETARY…)
+ *         OU membre PRODUCTION_MEDIA
+ *         OU membre COMMUNICATION.
  */
 export async function requireMediaUploadAccess(churchId: string) {
   const session = await requireAuth();
@@ -502,7 +503,7 @@ export async function requireMediaUploadAccess(churchId: string) {
   const { rolePermissions } = await import("./registry");
   const userPerms = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
 
-  if (userPerms.has("media:upload") || await isProductionMediaMember(session, churchId))
+  if (userPerms.has("media:upload") || await isProductionMediaMember(session, churchId) || await isCommunicationMember(session, churchId))
     return session;
 
   throw new Error("FORBIDDEN");


### PR DESCRIPTION
## Summary

- `isCommunicationMember` ajouté à `canUpload` dans les 4 pages media (events list, event detail, projects list, project detail)
- `requireMediaUploadAccess` mis à jour pour autoriser également les membres Communication
- Les droits de gestion (`canManage`) restent réservés à la Production Média

## Test plan

- [ ] Membre de la team Communication peut uploader dans un événement média
- [ ] Membre de la team Communication peut uploader dans un projet média
- [ ] Membre de la team Communication ne peut pas gérer (modifier statut, supprimer) les fichiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)