### PR TITLE
fix(media): ajouter MEDIA_ALL dans le schéma Zod de création de lien

### DIFF
--- a/src/app/api/media-events/[id]/share/route.ts
+++ b/src/app/api/media-events/[id]/share/route.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 const SENSITIVE_TOKEN_TYPES = ["VALIDATOR", "PREVALIDATOR"] as const;
 
 const createSchema = z.object({
-  type: z.enum(["VALIDATOR", "MEDIA", "PREVALIDATOR", "GALLERY"]),
+  type: z.enum(["VALIDATOR", "MEDIA", "MEDIA_ALL", "PREVALIDATOR", "GALLERY"]),
   label: z.string().optional(),
   expiresInDays: z.number().int().positive().optional(),
   onlyApproved: z.boolean().optional(),

--- a/src/app/api/media-projects/[id]/share/route.ts
+++ b/src/app/api/media-projects/[id]/share/route.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 const SENSITIVE_TOKEN_TYPES = ["VALIDATOR", "PREVALIDATOR"] as const;
 
 const createSchema = z.object({
-  type: z.enum(["VALIDATOR", "MEDIA", "PREVALIDATOR", "GALLERY"]),
+  type: z.enum(["VALIDATOR", "MEDIA", "MEDIA_ALL", "PREVALIDATOR", "GALLERY"]),
   label: z.string().optional(),
   expiresInDays: z.number().int().positive().optional(),
   onlyApproved: z.boolean().optional(),


### PR DESCRIPTION
## Problème

La création d'un lien "Téléchargement (toutes)" (`MEDIA_ALL`) échouait avec "Données invalides" car `MEDIA_ALL` était absent de l'enum Zod côté API, alors qu'il est présent dans le dropdown client et dans le schéma Prisma.

## Fix

Ajout de `"MEDIA_ALL"` dans le `z.enum` des routes :
- `POST /api/media-events/[id]/share`
- `POST /api/media-projects/[id]/share`

🤖 Generated with [Claude Code](https://claude.com/claude-code)