### PR TITLE
chore: release v1.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.1.13] - 2026-04-29
+
+### Corrigé
+
+- Médias : création d'un lien "Téléchargement (toutes)" (`MEDIA_ALL`) échouait avec "Données invalides" — `MEDIA_ALL` était absent du schéma de validation côté API
+
 ## [v1.1.12] - 2026-04-29
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Release v1.1.13

### Corrigé
- Médias : création d'un lien `MEDIA_ALL` échouait avec "Données invalides"

🤖 Generated with [Claude Code](https://claude.com/claude-code)