### PR TITLE
feat(mrbs): module optionnel SSO MRBS ↔ Koinonia (v1.2.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,5 +37,13 @@ SMTP_FROM=Koinonia <noreply@votre-domaine.com>  # adresse expediteur
 SMTP_IGNORE_TLS=false                         # mettre "true" pour un relay local (localhost:25) qui annonce STARTTLS avec un cert auto-signé
 SMTP_TLS_REJECT_UNAUTHORIZED=true             # mettre "false" si certificat SMTP auto-signé (serveur distant)
 
+# ─── Module MRBS (optionnel — réservation de salles) ───
+# Activer le module : ajouter "mrbs" dans ENABLED_MODULES (ex: core,planning,discipleship,media,mrbs)
+# Si ENABLED_MODULES est absent, tous les modules sont chargés (y compris mrbs).
+MRBS_API_SECRET=                          # secret partagé avec MRBS PHP (openssl rand -base64 32)
+MRBS_DB_URL=mysql://USER:PASSWORD@localhost:3306/mrbs  # BDD MRBS (lecture seule pour la moulinette)
+MRBS_URL=https://salles.example.com       # URL publique de l'instance MRBS (lien sidebar)
+MRBS_CHURCH_ID=                           # churchId Koinonia servi par cette instance MRBS
+
 # ─── Monitoring ───
 # GET /api/health — public, retourne { status, version, db, uptime }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.2.0] - 2026-04-29
+
+### Ajouté
+
+- Module MRBS (optionnel) : SSO entre Koinonia et MRBS (réservation de salles) — les utilisateurs connectés à Koinonia sont automatiquement reconnus dans MRBS via cookie partagé
+- Module MRBS : mapping automatique des niveaux MRBS (0 lecture, 1 utilisateur, 2 admin) selon le rôle Koinonia
+- Module MRBS : page d'administration `/admin/mrbs-links` pour lier les comptes MRBS aux comptes Koinonia (auto-détection par email, liaison manuelle)
+- Module MRBS : endpoints API `/api/auth/mrbs/*` pour la résolution de session et la récupération des utilisateurs
+- Module MRBS : lien "Salles" dans la sidebar pointant vers l'instance MRBS configurée
+- Migration BDD : table `mrbs_user_links` pour les liaisons manuelles de comptes
+
 ## [v1.1.13] - 2026-04-29
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.1.13",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/migrations/20260429000000_mrbs_user_links/migration.sql
+++ b/prisma/migrations/20260429000000_mrbs_user_links/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE `mrbs_user_links` (
+    `id` VARCHAR(191) NOT NULL,
+    `mrbsUsername` VARCHAR(191) NOT NULL,
+    `userId` VARCHAR(191) NOT NULL,
+    `churchId` VARCHAR(191) NOT NULL,
+    `linkedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `linkedById` VARCHAR(191) NOT NULL,
+
+    UNIQUE INDEX `mrbs_user_links_mrbsUsername_key`(`mrbsUsername`),
+    INDEX `mrbs_user_links_userId_idx`(`userId`),
+    INDEX `mrbs_user_links_churchId_idx`(`churchId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `mrbs_user_links` ADD CONSTRAINT `mrbs_user_links_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `mrbs_user_links` ADD CONSTRAINT `mrbs_user_links_churchId_fkey` FOREIGN KEY (`churchId`) REFERENCES `churches`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `mrbs_user_links` ADD CONSTRAINT `mrbs_user_links_linkedById_fkey` FOREIGN KEY (`linkedById`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,6 +74,8 @@ model Church {
   mediaEvents              MediaEvent[]
   mediaProjects            MediaProject[]
   mediaSettings            MediaSettings?
+  // Module mrbs (optionnel)
+  mrbsUserLinks            MrbsUserLink[]
 
   @@map("churches")
 }
@@ -119,6 +121,9 @@ model User {
   mediaProjectsCreated    MediaProject[]      @relation("MediaProjectCreator")
   mediaFileVersions       MediaFileVersion[]  @relation("MediaFileVersionCreator")
   mediaComments           MediaComment[]      @relation("MediaCommentAuthor")
+  // Module mrbs (optionnel)
+  mrbsUserLinks           MrbsUserLink[]      @relation("MrbsLinkedUser")
+  mrbsUserLinksCreated    MrbsUserLink[]      @relation("MrbsLinkCreator")
 
   @@map("users")
 }
@@ -586,6 +591,29 @@ model Request {
   @@index([churchId, type, status])
   @@index([assignedDeptId, status])
   @@map("requests")
+}
+
+// ============================================================================
+// MODULE MRBS (optionnel — réservation de salles)
+// ============================================================================
+
+/// Liaison entre un compte MRBS (username) et un compte Koinonia (userId).
+/// Utilisée quand le username MRBS n'est pas l'email Koinonia (ex : "jdupont" → jean.dupont@mail.com).
+model MrbsUserLink {
+  id           String   @id @default(cuid())
+  mrbsUsername String   @unique               // mrbs_users.name dans la BDD MRBS
+  userId       String
+  churchId     String
+  linkedAt     DateTime @default(now())
+  linkedById   String
+
+  user     User   @relation("MrbsLinkedUser", fields: [userId], references: [id])
+  church   Church @relation(fields: [churchId], references: [id])
+  linkedBy User   @relation("MrbsLinkCreator", fields: [linkedById], references: [id])
+
+  @@index([userId])
+  @@index([churchId])
+  @@map("mrbs_user_links")
 }
 
 // ============================================================================

--- a/src/app/(auth)/admin/mrbs-links/MrbsLinksManager.tsx
+++ b/src/app/(auth)/admin/mrbs-links/MrbsLinksManager.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useState } from "react";
+import Button from "@/components/ui/Button";
+
+interface MrbsUserRow {
+  mrbsUsername: string;
+  mrbsDisplayName: string;
+  mrbsEmail: string | null;
+  mrbsLevel: number;
+  linkedUserId: string | null;
+  autoMatchUserId: string | null;
+}
+
+interface KoinoniaUser {
+  id: string;
+  email: string | null;
+  name: string | null;
+  displayName: string | null;
+}
+
+interface Props {
+  mrbsUsers: MrbsUserRow[];
+  koinoniaUsers: KoinoniaUser[];
+  linkedByKoinonia: Record<string, string>;
+  churchId: string;
+  hasMrbsDb: boolean;
+}
+
+const LEVEL_LABELS: Record<number, string> = { 0: "Lecture", 1: "Utilisateur", 2: "Admin" };
+const LEVEL_COLORS: Record<number, string> = {
+  0: "bg-gray-100 text-gray-600",
+  1: "bg-blue-100 text-blue-700",
+  2: "bg-purple-100 text-purple-700",
+};
+
+export default function MrbsLinksManager({ mrbsUsers, koinoniaUsers, linkedByKoinonia, hasMrbsDb }: Props) {
+  const [rows, setRows] = useState<MrbsUserRow[]>(mrbsUsers);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const koinoniaLabel = (u: KoinoniaUser) => u.displayName ?? u.name ?? u.email ?? u.id;
+
+  async function link(mrbsUsername: string, userId: string) {
+    setSaving(mrbsUsername);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/mrbs-links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mrbsUsername, userId }),
+      });
+      if (!res.ok) throw new Error((await res.json()).error ?? "Erreur");
+      setRows((prev) =>
+        prev.map((r) => (r.mrbsUsername === mrbsUsername ? { ...r, linkedUserId: userId, autoMatchUserId: null } : r))
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  async function unlink(mrbsUsername: string) {
+    setSaving(mrbsUsername);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/mrbs-links?mrbsUsername=${encodeURIComponent(mrbsUsername)}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error((await res.json()).error ?? "Erreur");
+      setRows((prev) =>
+        prev.map((r) => (r.mrbsUsername === mrbsUsername ? { ...r, linkedUserId: null } : r))
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  async function autoLinkAll() {
+    const toLink = rows.filter((r) => !r.linkedUserId && r.autoMatchUserId);
+    for (const row of toLink) {
+      await link(row.mrbsUsername, row.autoMatchUserId!);
+    }
+  }
+
+  const autoLinkCount = rows.filter((r) => !r.linkedUserId && r.autoMatchUserId).length;
+  const linkedCount = rows.filter((r) => r.linkedUserId).length;
+  const unmatchedCount = rows.filter((r) => !r.linkedUserId && !r.autoMatchUserId).length;
+
+  if (!hasMrbsDb) {
+    return (
+      <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-6 text-sm text-yellow-800">
+        <p className="font-semibold mb-1">Variable MRBS_DB_URL non configurée</p>
+        <p>Sans accès à la base MRBS, la moulinette ne peut pas lire les comptes existants. Configurez <code className="font-mono bg-yellow-100 px-1 rounded">MRBS_DB_URL</code> dans votre fichier <code className="font-mono bg-yellow-100 px-1 rounded">.env</code>.</p>
+        <p className="mt-2 text-yellow-600">Les liaisons manuelles restent possibles via l&apos;API <code className="font-mono">POST /api/admin/mrbs-links</code>.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-3">
+        {[
+          { label: "Liés", value: linkedCount, color: "text-green-700 bg-green-50 border-green-200" },
+          { label: "Auto-détectés", value: autoLinkCount, color: "text-blue-700 bg-blue-50 border-blue-200" },
+          { label: "Sans correspondance", value: unmatchedCount, color: "text-gray-700 bg-gray-50 border-gray-200" },
+        ].map(({ label, value, color }) => (
+          <div key={label} className={`rounded-xl border p-4 text-center ${color}`}>
+            <p className="text-2xl font-bold">{value}</p>
+            <p className="text-xs mt-0.5">{label}</p>
+          </div>
+        ))}
+      </div>
+
+      {error && <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">{error}</p>}
+
+      {autoLinkCount > 0 && (
+        <div className="flex justify-end">
+          <Button onClick={autoLinkAll} disabled={saving !== null} size="sm">
+            Lier automatiquement ({autoLinkCount})
+          </Button>
+        </div>
+      )}
+
+      {rows.length === 0 ? (
+        <p className="text-sm text-gray-400 text-center py-8">Aucun compte MRBS trouvé dans la base de données.</p>
+      ) : (
+        <div className="border border-gray-200 rounded-xl overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Compte MRBS</th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Niveau MRBS</th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Compte Koinonia</th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.map((row) => {
+                const linked = koinoniaUsers.find((u) => u.id === row.linkedUserId);
+                const autoMatch = koinoniaUsers.find((u) => u.id === row.autoMatchUserId);
+                const isSaving = saving === row.mrbsUsername;
+
+                return (
+                  <tr key={row.mrbsUsername} className="hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-3">
+                      <p className="font-medium text-gray-900">{row.mrbsDisplayName}</p>
+                      <p className="text-xs text-gray-400 font-mono">{row.mrbsUsername}</p>
+                      {row.mrbsEmail && row.mrbsEmail !== row.mrbsUsername && (
+                        <p className="text-xs text-gray-400">{row.mrbsEmail}</p>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`text-xs font-medium px-2 py-1 rounded-full ${LEVEL_COLORS[row.mrbsLevel] ?? LEVEL_COLORS[0]}`}>
+                        {LEVEL_LABELS[row.mrbsLevel] ?? "Inconnu"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      {linked ? (
+                        <div className="flex items-center gap-2">
+                          <span className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
+                          <span className="text-gray-800">{koinoniaLabel(linked)}</span>
+                        </div>
+                      ) : autoMatch ? (
+                        <div className="flex items-center gap-2">
+                          <span className="w-2 h-2 rounded-full bg-blue-400 shrink-0" />
+                          <span className="text-blue-700">{koinoniaLabel(autoMatch)}</span>
+                          <span className="text-xs text-blue-500">(email)</span>
+                        </div>
+                      ) : (
+                        <ManualLinkSelect
+                          mrbsUsername={row.mrbsUsername}
+                          koinoniaUsers={koinoniaUsers}
+                          linkedByKoinonia={linkedByKoinonia}
+                          currentLinkedUserId={row.linkedUserId}
+                          onLink={(userId) => link(row.mrbsUsername, userId)}
+                          disabled={isSaving}
+                        />
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right whitespace-nowrap">
+                      {linked ? (
+                        <button
+                          onClick={() => unlink(row.mrbsUsername)}
+                          disabled={isSaving}
+                          className="text-xs text-red-500 hover:text-red-700 border border-red-200 hover:bg-red-50 rounded-lg px-2.5 py-1.5 transition-colors disabled:opacity-50"
+                        >
+                          {isSaving ? "…" : "Délier"}
+                        </button>
+                      ) : autoMatch ? (
+                        <button
+                          onClick={() => link(row.mrbsUsername, row.autoMatchUserId!)}
+                          disabled={isSaving}
+                          className="text-xs text-blue-600 hover:text-blue-800 border border-blue-200 hover:bg-blue-50 rounded-lg px-2.5 py-1.5 transition-colors disabled:opacity-50"
+                        >
+                          {isSaving ? "…" : "Lier"}
+                        </button>
+                      ) : null}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ManualLinkSelect({
+  mrbsUsername,
+  koinoniaUsers,
+  linkedByKoinonia,
+  currentLinkedUserId,
+  onLink,
+  disabled,
+}: {
+  mrbsUsername: string;
+  koinoniaUsers: KoinoniaUser[];
+  linkedByKoinonia: Record<string, string>;
+  currentLinkedUserId: string | null;
+  onLink: (userId: string) => void;
+  disabled: boolean;
+}) {
+  const [value, setValue] = useState(currentLinkedUserId ?? "");
+
+  const available = koinoniaUsers.filter(
+    (u) => !linkedByKoinonia[u.id] || linkedByKoinonia[u.id] === mrbsUsername
+  );
+
+  return (
+    <div className="flex items-center gap-2">
+      <select
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        disabled={disabled}
+        className="text-sm border border-gray-200 rounded-lg px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-icc-violet bg-white w-44"
+      >
+        <option value="">— Sélectionner —</option>
+        {available.map((u) => (
+          <option key={u.id} value={u.id}>
+            {u.displayName ?? u.name ?? u.email ?? u.id}
+          </option>
+        ))}
+      </select>
+      {value && (
+        <button
+          onClick={() => onLink(value)}
+          disabled={disabled}
+          className="text-xs text-icc-violet hover:text-purple-700 border border-icc-violet/40 hover:bg-icc-violet/5 rounded-lg px-2.5 py-1.5 transition-colors disabled:opacity-50"
+        >
+          Lier
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/app/(auth)/admin/mrbs-links/page.tsx
+++ b/src/app/(auth)/admin/mrbs-links/page.tsx
@@ -1,0 +1,91 @@
+import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { registry } from "@/lib/registry";
+import { notFound } from "next/navigation";
+import MrbsLinksManager from "./MrbsLinksManager";
+
+interface MrbsUser {
+  name: string;
+  display_name: string | null;
+  email: string | null;
+  level: number;
+}
+
+async function fetchMrbsUsers(): Promise<MrbsUser[]> {
+  const dbUrl = process.env.MRBS_DB_URL;
+  if (!dbUrl) return [];
+
+  try {
+    const mariadb = await import("mariadb");
+    const conn = await mariadb.createConnection(dbUrl);
+    try {
+      const rows = await conn.query(
+        "SELECT name, display_name, email, level FROM mrbs_users ORDER BY display_name, name"
+      );
+      return rows as MrbsUser[];
+    } finally {
+      await conn.end();
+    }
+  } catch {
+    return [];
+  }
+}
+
+export default async function MrbsLinksPage() {
+  if (!registry.has("mrbs")) notFound();
+
+  const session = await requirePermission("mrbs:manage");
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p>Aucune église sélectionnée.</p>;
+
+  const [mrbsUsers, links, koinoniaUsers] = await Promise.all([
+    fetchMrbsUsers(),
+    prisma.mrbsUserLink.findMany({
+      where: { churchId },
+      select: { mrbsUsername: true, userId: true },
+    }),
+    prisma.user.findMany({
+      orderBy: [{ displayName: "asc" }, { name: "asc" }],
+      select: { id: true, email: true, name: true, displayName: true },
+    }),
+  ]);
+
+  const linkedByMrbs = new Map(links.map((l) => [l.mrbsUsername, l.userId]));
+  const linkedByKoinonia = new Map(links.map((l) => [l.userId, l.mrbsUsername]));
+
+  // Enrichir les MRBS users avec leur statut de liaison
+  const enriched = mrbsUsers.map((u) => {
+    const linkedUserId = linkedByMrbs.get(u.name);
+    const autoMatchUser = !linkedUserId
+      ? koinoniaUsers.find((k) => k.email === u.email || k.email === u.name)
+      : null;
+
+    return {
+      mrbsUsername: u.name,
+      mrbsDisplayName: u.display_name ?? u.name,
+      mrbsEmail: u.email,
+      mrbsLevel: u.level,
+      linkedUserId: linkedUserId ?? null,
+      autoMatchUserId: autoMatchUser?.id ?? null,
+    };
+  });
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Liaison comptes MRBS ↔ Koinonia</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Associer les comptes MRBS existants aux comptes Koinonia pour le SSO.
+          Les comptes dont l&apos;email correspond sont détectés automatiquement.
+        </p>
+      </div>
+      <MrbsLinksManager
+        mrbsUsers={enriched}
+        koinoniaUsers={koinoniaUsers}
+        linkedByKoinonia={Object.fromEntries(linkedByKoinonia)}
+        churchId={churchId}
+        hasMrbsDb={!!process.env.MRBS_DB_URL}
+      />
+    </div>
+  );
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import Image from "next/image";
 import { auth, signOut, getCurrentChurchId } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { rolePermissions } from "@/lib/registry";
+import { rolePermissions, registry } from "@/lib/registry";
 import ChurchSwitcher from "@/components/ChurchSwitcher";
 import AuthLayoutShell from "@/components/AuthLayoutShell";
 import NotificationBell from "@/components/NotificationBell";
@@ -190,6 +190,13 @@ export default async function AuthLayout({
     </footer>
   );
 
+  // ── Module MRBS (optionnel) ───────────────────────────────────────────────
+  const mrbsUrl = registry.has("mrbs") ? (process.env.MRBS_URL ?? null) : null;
+  const mrbsAdminLink =
+    registry.has("mrbs") && userPermissions.has("mrbs:manage")
+      ? "/admin/mrbs-links"
+      : null;
+
   const hasDiscipleship = userPermissions.has("discipleship:view");
   const hasEventsAccess = userPermissions.has("events:view");
   const hasEventsManage = userPermissions.has("events:manage");
@@ -215,6 +222,8 @@ export default async function AuthLayout({
       configLinks={visibleConfigLinks}
       requestLinks={requestLinks}
       mediaLinks={mediaLinks}
+      mrbsUrl={mrbsUrl}
+      mrbsAdminLink={mrbsAdminLink}
       hasDiscipleship={hasDiscipleship}
       hasEventsAccess={hasEventsAccess}
       hasEventsManage={hasEventsManage}

--- a/src/app/api/admin/mrbs-links/route.ts
+++ b/src/app/api/admin/mrbs-links/route.ts
@@ -1,0 +1,78 @@
+import { prisma } from "@/lib/prisma";
+import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { z } from "zod";
+
+const createSchema = z.object({
+  mrbsUsername: z.string().min(1),
+  userId: z.string().min(1),
+});
+
+export async function GET(_request: Request) {
+  try {
+    const session = await requirePermission("mrbs:manage");
+    const churchId = await getCurrentChurchId(session);
+    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+
+    const links = await prisma.mrbsUserLink.findMany({
+      where: { churchId },
+      include: {
+        user: { select: { id: true, email: true, name: true, displayName: true } },
+        linkedBy: { select: { id: true, name: true, displayName: true } },
+      },
+      orderBy: { linkedAt: "desc" },
+    });
+
+    return successResponse(links);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await requirePermission("mrbs:manage");
+    const churchId = await getCurrentChurchId(session);
+    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+
+    const data = createSchema.parse(await request.json());
+
+    const link = await prisma.mrbsUserLink.upsert({
+      where: { mrbsUsername: data.mrbsUsername },
+      create: {
+        mrbsUsername: data.mrbsUsername,
+        userId: data.userId,
+        churchId,
+        linkedById: session.user.id!,
+      },
+      update: {
+        userId: data.userId,
+        linkedById: session.user.id!,
+        linkedAt: new Date(),
+      },
+    });
+
+    return successResponse(link, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const session = await requirePermission("mrbs:manage");
+    const churchId = await getCurrentChurchId(session);
+    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+
+    const mrbsUsername = new URL(request.url).searchParams.get("mrbsUsername");
+    if (!mrbsUsername) throw new ApiError(400, "Paramètre mrbsUsername requis");
+
+    await prisma.mrbsUserLink.deleteMany({
+      where: { mrbsUsername, churchId },
+    });
+
+    return successResponse({ deleted: mrbsUsername });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/auth/mrbs/session/route.ts
+++ b/src/app/api/auth/mrbs/session/route.ts
@@ -1,0 +1,73 @@
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { computeMrbsLevel } from "@/modules/mrbs";
+
+function requireMrbsSecret(request: Request): void {
+  const secret = process.env.MRBS_API_SECRET;
+  if (!secret) throw new ApiError(503, "Module MRBS non configuré");
+  const auth = request.headers.get("authorization") ?? "";
+  if (auth !== `Bearer ${secret}`) throw new ApiError(401, "Secret MRBS invalide");
+}
+
+/**
+ * GET /api/auth/mrbs/session
+ *
+ * Appelé par SessionKoinonia (PHP) à chaque requête MRBS.
+ * Reçoit le session token NextAuth du cookie navigateur et retourne
+ * les infos MRBS de l'utilisateur correspondant.
+ *
+ * Query params :
+ *   token    — valeur du cookie authjs.session-token
+ *   churchId — churchId configuré dans MRBS config.inc.php
+ *
+ * Response : { username, display_name, level, email }
+ */
+export async function GET(request: Request) {
+  try {
+    requireMrbsSecret(request);
+
+    const { searchParams } = new URL(request.url);
+    const token = searchParams.get("token");
+    const churchId = searchParams.get("churchId") ?? process.env.MRBS_CHURCH_ID ?? "";
+
+    if (!token) throw new ApiError(400, "Paramètre 'token' requis");
+    if (!churchId) throw new ApiError(400, "Paramètre 'churchId' requis");
+
+    // Chercher la session en DB (Auth.js database sessions)
+    const session = await prisma.session.findUnique({
+      where: { sessionToken: token },
+      select: {
+        expires: true,
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            displayName: true,
+            isSuperAdmin: true,
+          },
+        },
+      },
+    });
+
+    if (!session || !session.user) throw new ApiError(401, "Session invalide");
+    if (new Date(session.expires) < new Date()) throw new ApiError(401, "Session expirée");
+
+    const { user } = session;
+
+    // Chercher une liaison MRBS explicite (moulinette)
+    const link = await prisma.mrbsUserLink.findFirst({
+      where: { userId: user.id, churchId },
+      select: { mrbsUsername: true },
+    });
+
+    // username = liaison explicite > email Koinonia
+    const username = link?.mrbsUsername ?? user.email ?? user.id;
+    const displayName = user.displayName ?? user.name ?? username;
+    const level = await computeMrbsLevel(user.id, churchId, user.isSuperAdmin);
+
+    return successResponse({ username, display_name: displayName, email: user.email, level });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/auth/mrbs/user/route.ts
+++ b/src/app/api/auth/mrbs/user/route.ts
@@ -1,0 +1,63 @@
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { computeMrbsLevel } from "@/modules/mrbs";
+
+function requireMrbsSecret(request: Request): void {
+  const secret = process.env.MRBS_API_SECRET;
+  if (!secret) throw new ApiError(503, "Module MRBS non configuré");
+  const auth = request.headers.get("authorization") ?? "";
+  if (auth !== `Bearer ${secret}`) throw new ApiError(401, "Secret MRBS invalide");
+}
+
+/**
+ * GET /api/auth/mrbs/user
+ *
+ * Appelé par AuthKoinonia::getUserFresh() pour enrichir un User MRBS.
+ *
+ * Query params :
+ *   username — MRBS username (email ou nom lié via MrbsUserLink)
+ *   churchId — churchId configuré dans MRBS config.inc.php
+ *
+ * Response : { username, display_name, email, level }
+ */
+export async function GET(request: Request) {
+  try {
+    requireMrbsSecret(request);
+
+    const { searchParams } = new URL(request.url);
+    const username = searchParams.get("username");
+    const churchId = searchParams.get("churchId") ?? process.env.MRBS_CHURCH_ID ?? "";
+
+    if (!username) throw new ApiError(400, "Paramètre 'username' requis");
+    if (!churchId) throw new ApiError(400, "Paramètre 'churchId' requis");
+
+    // Chercher d'abord via liaison explicite
+    const link = await prisma.mrbsUserLink.findUnique({
+      where: { mrbsUsername: username },
+      select: {
+        user: {
+          select: { id: true, email: true, name: true, displayName: true, isSuperAdmin: true },
+        },
+      },
+    });
+
+    let user = link?.user ?? null;
+
+    // Fallback : username = email Koinonia
+    if (!user) {
+      user = await prisma.user.findUnique({
+        where: { email: username },
+        select: { id: true, email: true, name: true, displayName: true, isSuperAdmin: true },
+      });
+    }
+
+    if (!user) throw new ApiError(404, "Utilisateur introuvable");
+
+    const displayName = user.displayName ?? user.name ?? username;
+    const level = await computeMrbsLevel(user.id, churchId, user.isSuperAdmin);
+
+    return successResponse({ username, display_name: displayName, email: user.email, level });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/auth/mrbs/users/route.ts
+++ b/src/app/api/auth/mrbs/users/route.ts
@@ -1,0 +1,84 @@
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+
+function requireMrbsSecret(request: Request): void {
+  const secret = process.env.MRBS_API_SECRET;
+  if (!secret) throw new ApiError(503, "Module MRBS non configuré");
+  const auth = request.headers.get("authorization") ?? "";
+  if (auth !== `Bearer ${secret}`) throw new ApiError(401, "Secret MRBS invalide");
+}
+
+/**
+ * GET /api/auth/mrbs/users
+ *
+ * Appelé par AuthKoinonia::getUsernames() pour peupler la liste des
+ * utilisateurs dans l'interface admin MRBS.
+ * Ne retourne que les utilisateurs level ≥ 1 de l'église.
+ *
+ * Query params :
+ *   churchId — churchId configuré dans MRBS config.inc.php
+ *
+ * Response : [{ username, display_name }]
+ */
+export async function GET(request: Request) {
+  try {
+    requireMrbsSecret(request);
+
+    const { searchParams } = new URL(request.url);
+    const churchId = searchParams.get("churchId") ?? process.env.MRBS_CHURCH_ID ?? "";
+    if (!churchId) throw new ApiError(400, "Paramètre 'churchId' requis");
+
+    // 1. Utilisateurs avec un rôle level≥1 dans cette église
+    const churchRoles = await prisma.userChurchRole.findMany({
+      where: {
+        churchId,
+        role: { in: ["SUPER_ADMIN", "ADMIN", "MINISTER", "DEPARTMENT_HEAD"] },
+      },
+      select: {
+        user: { select: { id: true, email: true, name: true, displayName: true } },
+      },
+    });
+
+    // 2. Adjoints (isDeputy) dans cette église
+    const deputies = await prisma.userDepartment.findMany({
+      where: { isDeputy: true, userChurchRole: { churchId } },
+      select: {
+        userChurchRole: {
+          select: {
+            user: { select: { id: true, email: true, name: true, displayName: true } },
+          },
+        },
+      },
+    });
+
+    // 3. Super admins globaux
+    const superAdmins = await prisma.user.findMany({
+      where: { isSuperAdmin: true },
+      select: { id: true, email: true, name: true, displayName: true },
+    });
+
+    // 4. Dédupliquer par id
+    const seen = new Map<string, { id: string; email: string | null; name: string | null; displayName: string | null }>();
+    for (const r of churchRoles) seen.set(r.user.id, r.user);
+    for (const d of deputies) seen.set(d.userChurchRole.user.id, d.userChurchRole.user);
+    for (const u of superAdmins) seen.set(u.id, u);
+
+    // 5. Liaisons MRBS explicites (username override)
+    const links = await prisma.mrbsUserLink.findMany({
+      where: { churchId },
+      select: { mrbsUsername: true, userId: true },
+    });
+    const linkByUserId = new Map(links.map((l) => [l.userId, l.mrbsUsername]));
+
+    const result = [...seen.values()]
+      .map((u) => ({
+        username: linkByUserId.get(u.id) ?? u.email ?? u.id,
+        display_name: u.displayName ?? u.name ?? u.email ?? u.id,
+      }))
+      .sort((a, b) => a.display_name.localeCompare(b.display_name, "fr"));
+
+    return successResponse(result);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/components/AuthLayoutShell.tsx
+++ b/src/components/AuthLayoutShell.tsx
@@ -15,6 +15,8 @@ interface AuthLayoutShellProps {
   configLinks: { href: string; label: string }[];
   requestLinks: { href: string; label: string }[];
   mediaLinks: { href: string; label: string }[];
+  mrbsUrl?: string | null;
+  mrbsAdminLink?: string | null;
   hasDiscipleship: boolean;
   hasEventsAccess: boolean;
   hasEventsManage: boolean;
@@ -42,6 +44,8 @@ export default function AuthLayoutShell({
   configLinks,
   requestLinks,
   mediaLinks,
+  mrbsUrl = null,
+  mrbsAdminLink = null,
   hasDiscipleship,
   hasEventsAccess,
   hasEventsManage,
@@ -91,6 +95,8 @@ export default function AuthLayoutShell({
             configLinks={configLinks}
             requestLinks={requestLinks}
             mediaLinks={mediaLinks}
+            mrbsUrl={mrbsUrl}
+            mrbsAdminLink={mrbsAdminLink}
             hasDiscipleship={hasDiscipleship}
             hasEventsAccess={hasEventsAccess}
             hasEventsManage={hasEventsManage}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,6 +9,8 @@ interface SidebarProps {
   configLinks: { href: string; label: string }[];
   requestLinks: { href: string; label: string }[];
   mediaLinks: { href: string; label: string }[];
+  mrbsUrl?: string | null;
+  mrbsAdminLink?: string | null;
   hasDiscipleship?: boolean;
   hasEventsAccess?: boolean;
   hasEventsManage?: boolean;
@@ -82,6 +84,14 @@ function IconConfig({ className }: { className?: string }) {
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  );
+}
+
+function IconMrbs({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
     </svg>
   );
 }
@@ -277,6 +287,8 @@ export default function Sidebar({
   configLinks,
   requestLinks,
   mediaLinks,
+  mrbsUrl = null,
+  mrbsAdminLink = null,
   hasDiscipleship = false,
   hasEventsAccess = true,
   hasEventsManage = false,
@@ -478,7 +490,37 @@ export default function Sidebar({
         </AccordionSection>
       )}
 
-      {/* 6. Discipolat — lien direct (une seule sous-page) */}
+      {/* 6. Réservation de salles (module MRBS optionnel) */}
+      {(mrbsUrl || mrbsAdminLink) && (
+        <AccordionSection
+          title="Salles"
+          icon={<IconMrbs className="w-4 h-4" />}
+          open={openSection === "mrbs"}
+          onToggle={() => toggle("mrbs")}
+          isActive={pathname.startsWith("/admin/mrbs")}
+          dataTour="sidebar-mrbs"
+        >
+          <nav className="space-y-0.5 pl-6">
+            {mrbsUrl && (
+              <a
+                href={mrbsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block text-sm px-3 py-1.5 rounded-md text-gray-600 hover:text-icc-violet hover:bg-icc-violet/5 transition-colors"
+              >
+                Réserver une salle ↗
+              </a>
+            )}
+            {mrbsAdminLink && (
+              <NavLink href={mrbsAdminLink} active={pathname.startsWith(mrbsAdminLink)} onClose={onClose}>
+                Liaison comptes
+              </NavLink>
+            )}
+          </nav>
+        </AccordionSection>
+      )}
+
+      {/* 7. Discipolat — lien direct (une seule sous-page) */}
       {hasDiscipleship && (
         <Link
           href="/admin/discipleship"

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -4,6 +4,7 @@ import { coreModule } from "@/modules/core";
 import { planningModule, planningBus } from "@/modules/planning";
 import { discipleshipModule } from "@/modules/discipleship";
 import { mediaModule } from "@/modules/media";
+import { mrbsModule } from "@/modules/mrbs";
 
 /**
  * Registry singleton — chargé une fois au démarrage du process.
@@ -12,7 +13,7 @@ import { mediaModule } from "@/modules/media";
  * Source de vérité pour les permissions dans les contrôles d'accès API.
  */
 export const registry = boot({
-  modules: [coreModule, planningModule, discipleshipModule, mediaModule],
+  modules: [coreModule, planningModule, discipleshipModule, mediaModule, mrbsModule],
 });
 
 /**

--- a/src/modules/mrbs/index.ts
+++ b/src/modules/mrbs/index.ts
@@ -1,0 +1,59 @@
+import { defineModule } from "@/core/module-registry";
+
+/**
+ * Module mrbs — optionnel.
+ *
+ * Périmètre :
+ *   - SSO entre Koinonia (NextAuth) et MRBS (réservation de salles)
+ *   - Endpoints API consommés par le plugin AuthKoinonia/SessionKoinonia côté MRBS
+ *   - Page admin de liaison comptes MRBS ↔ Koinonia
+ *
+ * Activation : ajouter "mrbs" dans ENABLED_MODULES (ou retirer pour désactiver).
+ * Dépendances : core uniquement.
+ *
+ * Niveaux MRBS :
+ *   2 (Admin)     — isSuperAdmin ou rôle SUPER_ADMIN / ADMIN
+ *   1 (User)      — rôle MINISTER / DEPARTMENT_HEAD ou isDeputy sur un département
+ *   0 (Read-only) — tous les autres utilisateurs authentifiés
+ */
+export const mrbsModule = defineModule({
+  name: "mrbs",
+  version: "1.0.0",
+  dependsOn: ["core"],
+  permissions: {
+    "mrbs:manage": ["SUPER_ADMIN", "ADMIN"],
+  },
+});
+
+/**
+ * Calcule le niveau MRBS (0/1/2) d'un utilisateur dans une église donnée.
+ * Exporté pour être réutilisé dans les endpoints API.
+ */
+export async function computeMrbsLevel(
+  userId: string,
+  churchId: string,
+  isSuperAdmin: boolean
+): Promise<0 | 1 | 2> {
+  if (isSuperAdmin) return 2;
+
+  const { prisma } = await import("@/lib/prisma");
+
+  const churchRole = await prisma.userChurchRole.findFirst({
+    where: { userId, churchId },
+    select: {
+      role: true,
+      departments: { select: { isDeputy: true } },
+    },
+    orderBy: { role: "asc" },
+  });
+
+  if (!churchRole) return 0;
+
+  const { role, departments } = churchRole;
+
+  if (role === "SUPER_ADMIN" || role === "ADMIN") return 2;
+  if (role === "MINISTER" || role === "DEPARTMENT_HEAD") return 1;
+  if (departments.some((d) => d.isDeputy)) return 1;
+
+  return 0;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,6 +17,10 @@ export function proxy(request: NextRequest) {
         request.nextUrl.pathname.startsWith("/api/media/download/")) {
       return NextResponse.next();
     }
+    // Allow MRBS SSO endpoints (authenticated by Bearer secret, not session cookie)
+    if (request.nextUrl.pathname.startsWith("/api/auth/mrbs/")) {
+      return NextResponse.next();
+    }
     if (request.nextUrl.pathname.startsWith("/api/")) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }


### PR DESCRIPTION
## Résumé

- Intégration optionnelle MRBS (réservation de salles) via SSO cookie + API
- Les utilisateurs Koinonia sont reconnus automatiquement dans MRBS sans re-saisie de mot de passe
- Mapping de niveaux MRBS (0/1/2) selon le rôle Koinonia
- Page admin de liaison de comptes (`/admin/mrbs-links`) avec auto-détection par email
- Migration BDD : table `mrbs_user_links`

## Activation

Ajouter dans `.env` :
```
ENABLED_MODULES=mrbs
MRBS_API_SECRET=<secret partagé avec MRBS>
MRBS_URL=https://salles.example.com
MRBS_CHURCH_ID=<churchId>
```

## Test plan

- [ ] Sans `ENABLED_MODULES=mrbs` : section "Salles" absente de la sidebar
- [ ] Avec le module activé : lien "Salles" visible, `/admin/mrbs-links` accessible aux admins
- [ ] `GET /api/auth/mrbs/session` avec token valide → retourne `username/level/email`
- [ ] `GET /api/auth/mrbs/session` sans `Authorization` → 401
- [ ] Migration `mrbs_user_links` s'applique proprement

🤖 Generated with [Claude Code](https://claude.com/claude-code)