### PR TITLE
fix(mrbs): gérer les utilisateurs avec plusieurs rôles pour le niveau MRBS

### DIFF
--- a/src/modules/mrbs/index.ts
+++ b/src/modules/mrbs/index.ts
@@ -38,22 +38,25 @@ export async function computeMrbsLevel(
 
   const { prisma } = await import("@/lib/prisma");
 
-  const churchRole = await prisma.userChurchRole.findFirst({
+  const churchRoles = await prisma.userChurchRole.findMany({
     where: { userId, churchId },
     select: {
       role: true,
       departments: { select: { isDeputy: true } },
     },
-    orderBy: { role: "asc" },
   });
 
-  if (!churchRole) return 0;
+  if (churchRoles.length === 0) return 0;
 
-  const { role, departments } = churchRole;
+  const isDeputy = churchRoles.some((r) => r.departments.some((d) => d.isDeputy));
 
-  if (role === "SUPER_ADMIN" || role === "ADMIN" || role === "SECRETARY") return 2;
-  if (role === "MINISTER" || role === "DEPARTMENT_HEAD") return 1;
-  if (departments.some((d) => d.isDeputy)) return 1;
+  for (const { role } of churchRoles) {
+    if (role === "SUPER_ADMIN" || role === "ADMIN" || role === "SECRETARY") return 2;
+  }
+  for (const { role } of churchRoles) {
+    if (role === "MINISTER" || role === "DEPARTMENT_HEAD") return 1;
+  }
+  if (isDeputy) return 1;
 
   return 0;
 }


### PR DESCRIPTION
## Summary

- `computeMrbsLevel` utilisait `findFirst` avec `orderBy: { role: 'asc' }` — un utilisateur avec plusieurs `UserChurchRole` dans la même église pouvait avoir un niveau MRBS sous-estimé si son rôle le plus "petit" était retourné en premier
- Remplacé par `findMany` + itération sur tous les rôles : le niveau le plus élevé gagne

## Test plan

- [ ] Vérifier qu'un utilisateur ADMIN + STAR dans la même église obtient le niveau 2
- [ ] Vérifier qu'un utilisateur avec un seul rôle obtient toujours le bon niveau

🤖 Generated with [Claude Code](https://claude.com/claude-code)