### PR TITLE
fix(members): éviter la contrainte unique lors de la fusion de comptes

### DIFF
--- a/src/app/api/admin/members/merge/route.ts
+++ b/src/app/api/admin/members/merge/route.ts
@@ -66,7 +66,16 @@ export async function POST(request: Request) {
       }
 
       // ── Planning ──────────────────────────────────────────────────────────────
-      await tx.planning.updateMany({ where: { memberId: sourceId }, data: { memberId: targetId } });
+      // Unique constraint: (eventDepartmentId, memberId) — dédupliquer
+      const srcPlannings = await tx.planning.findMany({ where: { memberId: sourceId } });
+      for (const p of srcPlannings) {
+        const conflict = await tx.planning.findFirst({
+          where: { eventDepartmentId: p.eventDepartmentId, memberId: targetId },
+        });
+        if (!conflict) {
+          await tx.planning.update({ where: { id: p.id }, data: { memberId: targetId } });
+        }
+      }
 
       // ── TaskAssignment ────────────────────────────────────────────────────────
       // Unique constraint: (taskId, eventId, memberId) — dédupliquer


### PR DESCRIPTION
## Summary

- `planning.updateMany()` pouvait lever `Unique constraint failed on plannings_eventDepartmentId_memberId_key` quand source et target avaient tous les deux un planning pour le même `eventDepartmentId`
- Remplacé par un parcours individuel avec vérification de doublon, identique au pattern déjà appliqué pour `TaskAssignment` et `DiscipleshipAttendance`
- Les plannings en doublon (target en possède déjà un) sont abandonnés silencieusement — seuls les plannings sans conflit sont réaffectés

## Test plan

- [ ] Fusionner deux membres qui ont des plannings sur des événements distincts → tous les plannings du source passent au target
- [ ] Fusionner deux membres qui ont un planning sur le même événement/département → aucune erreur, le planning du target est conservé

🤖 Generated with [Claude Code](https://claude.com/claude-code)