### PR TITLE
fix(members): supprimer les doublons non migrés lors de la fusion de comptes

### DIFF
--- a/src/app/api/admin/members/merge/route.ts
+++ b/src/app/api/admin/members/merge/route.ts
@@ -74,6 +74,8 @@ export async function POST(request: Request) {
         });
         if (!conflict) {
           await tx.planning.update({ where: { id: p.id }, data: { memberId: targetId } });
+        } else {
+          await tx.planning.delete({ where: { id: p.id } });
         }
       }
 
@@ -86,6 +88,8 @@ export async function POST(request: Request) {
         });
         if (!conflict) {
           await tx.taskAssignment.update({ where: { id: t.id }, data: { memberId: targetId } });
+        } else {
+          await tx.taskAssignment.delete({ where: { id: t.id } });
         }
       }
 
@@ -97,6 +101,8 @@ export async function POST(request: Request) {
         });
         if (!conflict) {
           await tx.discipleshipAttendance.update({ where: { id: a.id }, data: { memberId: targetId } });
+        } else {
+          await tx.discipleshipAttendance.delete({ where: { id: a.id } });
         }
       }
 
@@ -108,8 +114,9 @@ export async function POST(request: Request) {
         });
         if (!conflict) {
           await tx.discipleship.update({ where: { id: d.id }, data: { discipleId: targetId } });
+        } else {
+          await tx.discipleship.delete({ where: { id: d.id } });
         }
-        // else: target a déjà un FD dans cette église → on laisse tomber la relation source
       }
 
       // ── Discipleship (en tant que FD et premier FD) ───────────────────────────


### PR DESCRIPTION
## Problème

`member.delete()` levait une FK violation : les enregistrements en doublon (planning, tâches, présences discipolat, relation disciple) étaient ignorés lors du conflit mais restaient en base avec `memberId = sourceId`.

## Fix

Dans chaque bloc de déduplication, le `else` supprime désormais explicitement la ligne source au lieu de la laisser orpheline :

- `Planning` — doublon supprimé (target conserve son statut)
- `TaskAssignment` — doublon supprimé
- `DiscipleshipAttendance` — doublon supprimé
- `Discipleship (disciple)` — relation source supprimée (target conserve son FD)

Les tables avec `onDelete: Cascade` (`MemberDepartment`, `MemberUserLink`) ne sont pas concernées.

## Test plan

- [ ] Fusionner deux membres qui ont des plannings sur les mêmes événements → pas d'erreur FK, fusion réussie
- [ ] Vérifier que le target conserve ses données (statut planning, présences, FD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)