### PR TITLE
chore: release v1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.2.7] - 2026-05-01
+
+### Corrigé
+
+- Membres : la fusion de comptes échouait avec une violation de clé étrangère quand les deux membres avaient des doublons (planning, tâches, présences discipolat, relation disciple) — les doublons non migrés sont désormais supprimés avant la suppression du membre source
+
 ## [v1.2.6] - 2026-05-01
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v1.2.7

### Corrigé

- Membres : violation de clé étrangère lors de la fusion de comptes quand les deux membres avaient des doublons (#280)

🤖 Generated with [Claude Code](https://claude.com/claude-code)