### PR TITLE
fix(requests): champ type manquant dans la soumission d'une demande de visuel

### DIFF
--- a/src/app/(auth)/requests/new/RequestForm.tsx
+++ b/src/app/(auth)/requests/new/RequestForm.tsx
@@ -262,6 +262,7 @@ export default function RequestForm({
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         churchId,
+        type: "VISUEL",
         title: visualTitle,
         brief: visualBrief || null,
         format: visualFormat || null,


### PR DESCRIPTION
## Problème

`submitVisual()` n'envoyait pas `type: "VISUEL"` dans le body — l'API Zod rejetait la requête avec `"Type de demande invalide : undefined"`.

## Fix

Ajout de `type: "VISUEL"` dans le JSON envoyé à `POST /api/requests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)