### PR TITLE
feat(requests): indicateur d'urgence sur les demandes de visuels < 48h

### DIFF
--- a/src/app/(auth)/media/requests/MediaDashboard.tsx
+++ b/src/app/(auth)/media/requests/MediaDashboard.tsx
@@ -53,6 +53,22 @@ const PARENT_TYPE_LABEL: Record<string, string> = {
   VISUEL: "Visuel",
 };
 
+function isUrgent(deadline: string | null): boolean {
+  if (!deadline) return false;
+  return new Date(deadline + "T23:59:59").getTime() < Date.now() + 48 * 60 * 60 * 1000;
+}
+
+function sortUrgentFirst(list: MediaRequest[]): MediaRequest[] {
+  return [...list].sort((a, b) => {
+    const pa = (a.payload ?? {}) as Record<string, unknown>;
+    const pb = (b.payload ?? {}) as Record<string, unknown>;
+    const ua = isUrgent((pa.deadline as string) ?? null);
+    const ub = isUrgent((pb.deadline as string) ?? null);
+    if (ua === ub) return 0;
+    return ua ? -1 : 1;
+  });
+}
+
 export default function MediaDashboard({ requests: initial }: Props) {
   const [requests, setRequests] = useState(initial);
   const [processing, setProcessing] = useState<string | null>(null);
@@ -98,8 +114,8 @@ export default function MediaDashboard({ requests: initial }: Props) {
     }
   }
 
-  const pending = requests.filter((r) => r.status === "EN_ATTENTE");
-  const inProgress = requests.filter((r) => r.status === "EN_COURS");
+  const pending = sortUrgentFirst(requests.filter((r) => r.status === "EN_ATTENTE"));
+  const inProgress = sortUrgentFirst(requests.filter((r) => r.status === "EN_COURS"));
   const done = requests.filter((r) => r.status === "LIVRE" || r.status === "ANNULE");
 
   function renderRequest(req: MediaRequest) {
@@ -110,13 +126,19 @@ export default function MediaDashboard({ requests: initial }: Props) {
     const format = (p.format as string) ?? null;
     const deadline = (p.deadline as string) ?? null;
     const deliveryLink = (p.deliveryLink as string) ?? null;
+    const urgent = isUrgent(deadline);
 
     return (
-      <div key={req.id} className="bg-white rounded-lg shadow p-5 border border-gray-100">
+      <div key={req.id} className={`bg-white rounded-lg shadow p-5 border ${urgent && req.status !== "LIVRE" && req.status !== "ANNULE" ? "border-icc-rouge/40" : "border-gray-100"}`}>
         <div className="flex items-start justify-between gap-4 mb-2">
           <div className="min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
               <h3 className="font-semibold text-gray-900">{req.title}</h3>
+              {urgent && req.status !== "LIVRE" && req.status !== "ANNULE" && (
+                <span className="text-xs font-semibold bg-icc-rouge text-white px-2 py-0.5 rounded-full">
+                  ⚡ Urgent
+                </span>
+              )}
               {format && (
                 <span className="text-xs bg-icc-violet/10 text-icc-violet px-2 py-0.5 rounded-full">
                   {format}

--- a/src/app/(auth)/requests/new/RequestForm.tsx
+++ b/src/app/(auth)/requests/new/RequestForm.tsx
@@ -645,6 +645,14 @@ export default function RequestForm({
             value={visualDeadline}
             onChange={(e) => setVisualDeadline(e.target.value)}
           />
+          {visualDeadline && new Date(visualDeadline + "T23:59:59").getTime() < Date.now() + 48 * 60 * 60 * 1000 && (
+            <div className="flex items-start gap-2 px-3 py-2.5 bg-amber-50 border border-amber-300 rounded-lg text-sm text-amber-800">
+              <span className="shrink-0 mt-0.5">⚠️</span>
+              <span>
+                <strong>Délai inférieur à 48h</strong> — le traitement de cette demande n&apos;est pas garanti et reste à la discrétion de la Production Média.
+              </span>
+            </div>
+          )}
           {sourceOptions.length > 1 && (
             <div className="space-y-1">
               <label className="block text-sm font-medium text-gray-700">Département</label>


### PR DESCRIPTION
## Summary

- **Formulaire** : bandeau d'avertissement non-bloquant affiché si la deadline choisie est dans moins de 48h — *"Délai inférieur à 48h — le traitement n'est pas garanti et reste à la discrétion de la Production Média"*
- **Dashboard Production Média** : badge ⚡ Urgent (rouge) sur les cartes concernées + bordure rouge légère + tri automatique des urgentes en tête des sections "En attente" et "En cours"
- Les demandes livrées ou annulées ne sont pas marquées urgentes

## Test plan

- [ ] Formulaire : choisir une deadline aujourd'hui ou demain → bandeau amber visible ; choisir une date dans 3+ jours → aucun bandeau
- [ ] Dashboard : une demande avec deadline dans < 48h apparaît en tête de section avec badge "⚡ Urgent"

🤖 Generated with [Claude Code](https://claude.com/claude-code)