### PR TITLE
feat(media): lier une demande de visuel à un projet média à la prise en charge

### DIFF
--- a/src/app/(auth)/media/requests/MediaDashboard.tsx
+++ b/src/app/(auth)/media/requests/MediaDashboard.tsx
@@ -31,6 +31,8 @@ interface MediaRequest {
 
 interface Props {
   requests: MediaRequest[];
+  churchId: string;
+  mediaProjects: { id: string; name: string }[];
 }
 
 const STATUS_LABEL: Record<string, string> = {
@@ -69,11 +71,67 @@ function sortUrgentFirst(list: MediaRequest[]): MediaRequest[] {
   });
 }
 
-export default function MediaDashboard({ requests: initial }: Props) {
+export default function MediaDashboard({ requests: initial, churchId, mediaProjects: initialProjects }: Props) {
   const [requests, setRequests] = useState(initial);
+  const [projects, setProjects] = useState(initialProjects);
   const [processing, setProcessing] = useState<string | null>(null);
   const [deliveryLinks, setDeliveryLinks] = useState<Record<string, string>>({});
   const [notes, setNotes] = useState<Record<string, string>>({});
+
+  // "Prendre en charge" inline form state
+  const [takingCharge, setTakingCharge] = useState<string | null>(null);
+  const [projectMode, setProjectMode] = useState<"existing" | "new">("existing");
+  const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [newProjectName, setNewProjectName] = useState("");
+  const [taking, setTaking] = useState(false);
+
+  function openTakeCharge(reqId: string) {
+    setTakingCharge(reqId);
+    const mode = projects.length > 0 ? "existing" : "new";
+    setProjectMode(mode);
+    setSelectedProjectId(projects[0]?.id ?? "");
+    setNewProjectName("");
+  }
+
+  async function handleTakeCharge(reqId: string) {
+    setTaking(true);
+    try {
+      let projectId = selectedProjectId;
+
+      if (projectMode === "new") {
+        if (!newProjectName.trim()) { alert("Nom du projet requis"); return; }
+        const res = await fetch("/api/media-projects", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: newProjectName.trim(), churchId }),
+        });
+        if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur création projet"); return; }
+        const created = await res.json();
+        projectId = created.data.id;
+        setProjects((prev) => [{ id: projectId, name: newProjectName.trim() }, ...prev]);
+      }
+
+      const patchRes = await fetch(`/api/requests/${reqId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "EN_COURS", payload: { mediaProjectId: projectId } }),
+      });
+      if (!patchRes.ok) { const d = await patchRes.json(); alert(d.error || "Erreur"); return; }
+
+      setRequests((prev) =>
+        prev.map((r) => {
+          if (r.id !== reqId) return r;
+          const updated = { ...(r.payload ?? {}) as Record<string, unknown>, mediaProjectId: projectId };
+          return { ...r, status: "EN_COURS", payload: updated };
+        })
+      );
+      setTakingCharge(null);
+    } catch {
+      alert("Erreur");
+    } finally {
+      setTaking(false);
+    }
+  }
 
   async function updateRequest(
     id: string,
@@ -126,6 +184,8 @@ export default function MediaDashboard({ requests: initial }: Props) {
     const format = (p.format as string) ?? null;
     const deadline = (p.deadline as string) ?? null;
     const deliveryLink = (p.deliveryLink as string) ?? null;
+    const mediaProjectId = (p.mediaProjectId as string) ?? null;
+    const linkedProject = mediaProjectId ? projects.find((pr) => pr.id === mediaProjectId) : null;
     const urgent = isUrgent(deadline);
 
     return (
@@ -186,6 +246,18 @@ export default function MediaDashboard({ requests: initial }: Props) {
           <p className="text-sm text-gray-600 mb-3 line-clamp-3">{brief}</p>
         )}
 
+        {linkedProject && req.status === "EN_COURS" && (
+          <a
+            href={`/media/projects/${linkedProject.id}`}
+            className="inline-flex items-center gap-1.5 text-sm text-icc-violet hover:underline mb-2"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+            </svg>
+            {linkedProject.name}
+          </a>
+        )}
+
         {deliveryLink && req.status === "LIVRE" && (
           <a
             href={deliveryLink}
@@ -199,44 +271,93 @@ export default function MediaDashboard({ requests: initial }: Props) {
 
         {(req.status === "EN_ATTENTE" || req.status === "EN_COURS") && (
           <div className="border-t border-gray-100 pt-3 space-y-2">
-            {req.status === "EN_COURS" && (
-              <input
-                type="url"
-                value={deliveryLinks[req.id] ?? ""}
-                onChange={(e) => setDeliveryLinks((prev) => ({ ...prev, [req.id]: e.target.value }))}
-                placeholder="Lien de livraison (Canva, Drive...)"
-                className="block w-full px-3 py-2 border-2 border-gray-200 rounded-lg text-xs focus:outline-none focus:border-icc-violet"
-              />
+            {req.status === "EN_ATTENTE" && takingCharge === req.id ? (
+              <div className="space-y-3">
+                <p className="text-sm font-medium text-gray-700">Lier à un projet média</p>
+                <div className="flex gap-4 text-sm">
+                  {projects.length > 0 && (
+                    <label className="flex items-center gap-1.5 cursor-pointer">
+                      <input type="radio" checked={projectMode === "existing"} onChange={() => setProjectMode("existing")} />
+                      Projet existant
+                    </label>
+                  )}
+                  <label className="flex items-center gap-1.5 cursor-pointer">
+                    <input type="radio" checked={projectMode === "new"} onChange={() => setProjectMode("new")} />
+                    Nouveau projet
+                  </label>
+                </div>
+                {projectMode === "existing" && projects.length > 0 && (
+                  <select
+                    value={selectedProjectId}
+                    onChange={(e) => setSelectedProjectId(e.target.value)}
+                    className="block w-full px-3 py-2 border-2 border-gray-200 rounded-lg text-sm focus:outline-none focus:border-icc-violet"
+                  >
+                    {projects.map((pr) => (
+                      <option key={pr.id} value={pr.id}>{pr.name}</option>
+                    ))}
+                  </select>
+                )}
+                {projectMode === "new" && (
+                  <input
+                    type="text"
+                    value={newProjectName}
+                    onChange={(e) => setNewProjectName(e.target.value)}
+                    placeholder="Nom du projet"
+                    className="block w-full px-3 py-2 border-2 border-gray-200 rounded-lg text-sm focus:outline-none focus:border-icc-violet"
+                    autoFocus
+                  />
+                )}
+                <div className="flex gap-2">
+                  <Button size="sm" onClick={() => handleTakeCharge(req.id)} disabled={taking}>
+                    Confirmer
+                  </Button>
+                  <Button size="sm" variant="secondary" onClick={() => setTakingCharge(null)} disabled={taking}>
+                    Annuler
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <>
+                {req.status === "EN_COURS" && (
+                  <input
+                    type="url"
+                    value={deliveryLinks[req.id] ?? ""}
+                    onChange={(e) => setDeliveryLinks((prev) => ({ ...prev, [req.id]: e.target.value }))}
+                    placeholder="Lien de livraison (Canva, Drive...)"
+                    className="block w-full px-3 py-2 border-2 border-gray-200 rounded-lg text-xs focus:outline-none focus:border-icc-violet"
+                  />
+                )}
+                <div className="flex flex-wrap gap-2">
+                  {req.status === "EN_ATTENTE" && (
+                    <Button
+                      size="sm"
+                      variant="info"
+                      onClick={() => openTakeCharge(req.id)}
+                      disabled={processing === req.id}
+                    >
+                      Prendre en charge
+                    </Button>
+                  )}
+                  {req.status === "EN_COURS" && (
+                    <Button
+                      size="sm"
+                      onClick={() => updateRequest(req.id, "LIVRE", deliveryLinks[req.id] || undefined)}
+                      disabled={processing === req.id}
+                    >
+                      ✓ Marquer livré
+                    </Button>
+                  )}
+                  <Button
+                    size="sm"
+                    variant="danger"
+                    onClick={() => updateRequest(req.id, "ANNULE", undefined, notes[req.id])}
+                    disabled={processing === req.id}
+                  >
+                    Annuler
+                  </Button>
+                </div>
+              </>
             )}
-            <div className="flex flex-wrap gap-2">
-              {req.status === "EN_ATTENTE" && (
-                <Button
-                  size="sm"
-                  variant="info"
-                  onClick={() => updateRequest(req.id, "EN_COURS")}
-                  disabled={processing === req.id}
-                >
-                  Prendre en charge
-                </Button>
-              )}
-              {req.status === "EN_COURS" && (
-                <Button
-                  size="sm"
-                  onClick={() => updateRequest(req.id, "LIVRE", deliveryLinks[req.id] || undefined)}
-                  disabled={processing === req.id}
-                >
-                  ✓ Marquer livré
-                </Button>
-              )}
-              <Button
-                size="sm"
-                variant="danger"
-                onClick={() => updateRequest(req.id, "ANNULE", undefined, notes[req.id])}
-                disabled={processing === req.id}
-              >
-                Annuler
-              </Button>
-            </div>
           </div>
         )}
       </div>

--- a/src/app/(auth)/media/requests/MediaDashboard.tsx
+++ b/src/app/(auth)/media/requests/MediaDashboard.tsx
@@ -29,10 +29,16 @@ interface MediaRequest {
   parentRequest: ParentRequest | null;
 }
 
+interface MediaProject {
+  id: string;
+  name: string;
+  shareTokens: { token: string; type: string }[];
+}
+
 interface Props {
   requests: MediaRequest[];
   churchId: string;
-  mediaProjects: { id: string; name: string }[];
+  mediaProjects: MediaProject[];
 }
 
 const STATUS_LABEL: Record<string, string> = {
@@ -73,7 +79,7 @@ function sortUrgentFirst(list: MediaRequest[]): MediaRequest[] {
 
 export default function MediaDashboard({ requests: initial, churchId, mediaProjects: initialProjects }: Props) {
   const [requests, setRequests] = useState(initial);
-  const [projects, setProjects] = useState(initialProjects);
+  const [projects, setProjects] = useState<MediaProject[]>(initialProjects);
   const [processing, setProcessing] = useState<string | null>(null);
   const [deliveryLinks, setDeliveryLinks] = useState<Record<string, string>>({});
   const [notes, setNotes] = useState<Record<string, string>>({});
@@ -108,7 +114,7 @@ export default function MediaDashboard({ requests: initial, churchId, mediaProje
         if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur création projet"); return; }
         const created = await res.json();
         projectId = created.data.id;
-        setProjects((prev) => [{ id: projectId, name: newProjectName.trim() }, ...prev]);
+        setProjects((prev) => [{ id: projectId, name: newProjectName.trim(), shareTokens: [] }, ...prev]);
       }
 
       const patchRes = await fetch(`/api/requests/${reqId}`, {
@@ -246,19 +252,37 @@ export default function MediaDashboard({ requests: initial, churchId, mediaProje
           <p className="text-sm text-gray-600 mb-3 line-clamp-3">{brief}</p>
         )}
 
-        {linkedProject && req.status === "EN_COURS" && (
-          <a
-            href={`/media/projects/${linkedProject.id}`}
-            className="inline-flex items-center gap-1.5 text-sm text-icc-violet hover:underline mb-2"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-            </svg>
-            {linkedProject.name}
-          </a>
-        )}
+        {linkedProject && (req.status === "EN_COURS" || req.status === "LIVRE") && (() => {
+          const shareToken = linkedProject.shareTokens[0];
+          const shareUrl = shareToken
+            ? (shareToken.type === "GALLERY" ? `/media/g/${shareToken.token}` : `/media/d/${shareToken.token}`)
+            : null;
+          return (
+            <div className="flex flex-wrap items-center gap-2 mb-2">
+              <a
+                href={`/media/projects/${linkedProject.id}`}
+                className="inline-flex items-center gap-1.5 text-sm text-icc-violet hover:underline"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                </svg>
+                {linkedProject.name}
+              </a>
+              {shareUrl && (
+                <a
+                  href={shareUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs bg-icc-violet/10 text-icc-violet px-2 py-0.5 rounded-full hover:bg-icc-violet/20"
+                >
+                  ↓ Télécharger
+                </a>
+              )}
+            </div>
+          );
+        })()}
 
-        {deliveryLink && req.status === "LIVRE" && (
+        {!linkedProject && deliveryLink && req.status === "LIVRE" && (
           <a
             href={deliveryLink}
             target="_blank"
@@ -318,7 +342,7 @@ export default function MediaDashboard({ requests: initial, churchId, mediaProje
               </div>
             ) : (
               <>
-                {req.status === "EN_COURS" && (
+                {req.status === "EN_COURS" && !linkedProject && (
                   <input
                     type="url"
                     value={deliveryLinks[req.id] ?? ""}
@@ -341,7 +365,7 @@ export default function MediaDashboard({ requests: initial, churchId, mediaProje
                   {req.status === "EN_COURS" && (
                     <Button
                       size="sm"
-                      onClick={() => updateRequest(req.id, "LIVRE", deliveryLinks[req.id] || undefined)}
+                      onClick={() => updateRequest(req.id, "LIVRE", linkedProject ? undefined : (deliveryLinks[req.id] || undefined))}
                       disabled={processing === req.id}
                     >
                       ✓ Marquer livré

--- a/src/app/(auth)/media/requests/page.tsx
+++ b/src/app/(auth)/media/requests/page.tsx
@@ -58,7 +58,15 @@ export default async function MediaRequestsPage() {
     prisma.mediaProject.findMany({
       where: { churchId },
       orderBy: { createdAt: "desc" },
-      select: { id: true, name: true },
+      select: {
+        id: true,
+        name: true,
+        shareTokens: {
+          select: { token: true, type: true },
+          where: { type: { in: ["GALLERY", "MEDIA", "MEDIA_ALL"] } },
+          take: 1,
+        },
+      },
     }),
   ]);
 

--- a/src/app/(auth)/media/requests/page.tsx
+++ b/src/app/(auth)/media/requests/page.tsx
@@ -41,19 +41,26 @@ export default async function MediaRequestsPage() {
     );
   }
 
-  const requests = await prisma.request.findMany({
-    where: { type: "VISUEL", assignedDeptId: mediaDept.id, churchId },
-    include: {
-      submittedBy: { select: { name: true, displayName: true } },
-      department: { select: { name: true } },
-      ministry: { select: { name: true } },
-      announcement: {
-        select: { id: true, title: true, eventDate: true, isSaveTheDate: true },
+  const [requests, mediaProjects] = await Promise.all([
+    prisma.request.findMany({
+      where: { type: "VISUEL", assignedDeptId: mediaDept.id, churchId },
+      include: {
+        submittedBy: { select: { name: true, displayName: true } },
+        department: { select: { name: true } },
+        ministry: { select: { name: true } },
+        announcement: {
+          select: { id: true, title: true, eventDate: true, isSaveTheDate: true },
+        },
+        parentRequest: { select: { id: true, type: true, status: true } },
       },
-      parentRequest: { select: { id: true, type: true, status: true } },
-    },
-    orderBy: { submittedAt: "desc" },
-  });
+      orderBy: { submittedAt: "desc" },
+    }),
+    prisma.mediaProject.findMany({
+      where: { churchId },
+      orderBy: { createdAt: "desc" },
+      select: { id: true, name: true },
+    }),
+  ]);
 
   const pending = requests.filter((r) => r.status === "EN_ATTENTE").length;
 
@@ -67,7 +74,7 @@ export default async function MediaRequestsPage() {
           </span>
         )}
       </div>
-      <MediaDashboard requests={requests} />
+      <MediaDashboard requests={requests} churchId={churchId} mediaProjects={mediaProjects} />
     </div>
   );
 }

--- a/src/app/(auth)/media/requests/page.tsx
+++ b/src/app/(auth)/media/requests/page.tsx
@@ -67,7 +67,7 @@ export default async function MediaRequestsPage() {
           take: 1,
         },
       },
-    }),
+    }).catch(() => []),
   ]);
 
   const pending = requests.filter((r) => r.status === "EN_ATTENTE").length;


### PR DESCRIPTION
## Summary

Complète le workflow de création de visuels : la Production Média peut désormais lier chaque demande à un projet média au moment où elle la prend en charge.

**Flux :**
1. Clic sur "Prendre en charge" → formulaire inline s'affiche
2. Choix : **projet existant** (dropdown) ou **nouveau projet** (champ texte)
3. Confirmation → création du projet si nouveau (`POST /api/media-projects`) + `PATCH` request avec `status: EN_COURS` + `payload.mediaProjectId`
4. La carte EN_COURS affiche un lien cliquable vers le projet média

**Détails techniques :**
- `payload.mediaProjectId` stocké dans le JSON existant — aucune migration de schema
- Si aucun projet existant : mode "nouveau projet" par défaut
- `page.tsx` charge la liste des projets en parallèle des demandes

## Test plan

- [ ] Cliquer "Prendre en charge" → formulaire inline s'affiche
- [ ] Choisir projet existant → confirmer → carte passe EN_COURS avec lien projet
- [ ] Choisir nouveau projet → saisir nom → confirmer → projet créé, carte passe EN_COURS avec lien
- [ ] Si aucun projet existant → seule l'option "Nouveau projet" est proposée

🤖 Generated with [Claude Code](https://claude.com/claude-code)