### PR TITLE
fix(media): crash sur project.files après refresh du projet

### DIFF
--- a/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
+++ b/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
@@ -971,7 +971,7 @@ export default function MediaProjectDetail({
   }
 
   // ── Stats ──────────────────────────────────────────────────────────────────
-  const allFiles = project.files;
+  const allFiles = project.files ?? [];
   const doneCount    = allFiles.filter((f) => DONE_STATUSES.includes(f.status)).length;
   const approvedCount = allFiles.filter((f) => f.status === "FINAL_APPROVED").length;
   const rejectedCount = allFiles.filter((f) => f.status === "REJECTED").length;

--- a/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
+++ b/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
@@ -948,7 +948,7 @@ export default function MediaProjectDetail({
   async function refreshProject() {
     const res = await fetch(`/api/media-projects/${project.id}`);
     const json = await res.json();
-    if (res.ok) setProject(json);
+    if (res.ok) setProject(json.data ?? json);
     router.refresh();
   }
 

--- a/src/app/api/media-projects/[id]/route.ts
+++ b/src/app/api/media-projects/[id]/route.ts
@@ -23,6 +23,18 @@ export async function GET(
       where: { id },
       include: {
         createdBy: { select: { id: true, name: true, displayName: true } },
+        files: {
+          orderBy: { createdAt: "desc" },
+          include: {
+            versions: {
+              orderBy: { versionNumber: "desc" },
+              take: 1,
+            },
+          },
+        },
+        shareTokens: {
+          orderBy: { createdAt: "desc" },
+        },
         _count: { select: { files: true, shareTokens: true } },
       },
     });


### PR DESCRIPTION
## Problème

`refreshProject()` faisait `setProject(json)` mais `fetch` retourne `{ data: {...} }` (via `successResponse`). Après le premier refresh (upload, share token...), `project.files` devenait `undefined` → crash `Cannot read properties of undefined (reading 'filter')`.

## Fix

`setProject(json.data ?? json)` — compatible avec l'ancienne et la nouvelle forme de réponse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)