### PR TITLE
feat(access): demandes refusées + override département dans l'approbation

### DIFF
--- a/src/app/(auth)/admin/access/AccessClient.tsx
+++ b/src/app/(auth)/admin/access/AccessClient.tsx
@@ -43,12 +43,24 @@ interface PendingRequest {
   createdAt: string;
 }
 
+interface RejectedRequest {
+  id: string;
+  user: { name: string; email: string };
+  member: { firstName: string; lastName: string } | null;
+  firstName: string | null;
+  lastName: string | null;
+  requestedRole: string | null;
+  rejectReason: string | null;
+  reviewedAt: string | null;
+}
+
 interface Props {
   users: UserItem[];
   ministries: Ministry[];
   churchId: string;
   isSuperAdmin: boolean;
   pendingRequests: PendingRequest[];
+  rejectedRequests?: RejectedRequest[];
 }
 
 type Tab = "requests" | "roles" | "transverse" | "reporters" | "stars";
@@ -96,12 +108,17 @@ const ROLE_LABELS: Record<string, string> = {
   REPORTER: "Reporter",
 };
 
-export default function AccessClient({ users, ministries, churchId, isSuperAdmin, pendingRequests }: Props) {
+export default function AccessClient({ users, ministries, churchId, isSuperAdmin, pendingRequests, rejectedRequests = [] }: Props) {
   const [tab, setTab] = useState<Tab>(pendingRequests.length > 0 ? "requests" : "roles");
   const [localRequests, setLocalRequests] = useState<PendingRequest[]>(pendingRequests);
+  const [rejected, setRejected] = useState<RejectedRequest[]>(rejectedRequests);
+  const [showRejected, setShowRejected] = useState(false);
   const [rejectingId, setRejectingId] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState("");
   const [approvingId, setApprovingId] = useState<string | null>(null);
+  const [reconsidering, setReconsidering] = useState<string | null>(null);
+  const [approveModal, setApproveModal] = useState<PendingRequest | null>(null);
+  const [approveModalDeptId, setApproveModalDeptId] = useState("");
   const [localUsers, setLocalUsers] = useState(users);
 
   // ── Modal states ───────────────────────────────────────────────────────────
@@ -477,22 +494,69 @@ export default function AccessClient({ users, ministries, churchId, isSuperAdmin
 
   // ── Approve / Reject link requests ────────────────────────────────────────
 
-  async function approveRequest(req: PendingRequest) {
-    setApprovingId(req.id);
+  function openApproveModal(req: PendingRequest) {
+    const allDepts = ministries.flatMap((m) => m.departments);
+    const defaultDeptId = req.department?.id ?? allDepts[0]?.id ?? "";
+    setApproveModalDeptId(defaultDeptId);
+    setApproveModal(req);
+  }
+
+  async function confirmApprove() {
+    if (!approveModal) return;
+    setApprovingId(approveModal.id);
     try {
-      const res = await fetch(`/api/member-link-requests/${req.id}`, {
+      const role = approveModal.requestedRole;
+      const needsDept = role === "DEPARTMENT_HEAD" || role === "DEPUTY";
+      const res = await fetch(`/api/member-link-requests/${approveModal.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "approve" }),
+        body: JSON.stringify({
+          action: "approve",
+          ...(needsDept && approveModalDeptId ? { departmentId: approveModalDeptId } : {}),
+        }),
       });
       if (!res.ok) {
         const json = await res.json();
         alert(json.error ?? "Erreur lors de l'approbation");
         return;
       }
-      setLocalRequests((prev) => prev.filter((r) => r.id !== req.id));
+      setLocalRequests((prev) => prev.filter((r) => r.id !== approveModal.id));
+      setApproveModal(null);
     } finally {
       setApprovingId(null);
+    }
+  }
+
+  async function reconsider(req: RejectedRequest) {
+    setReconsidering(req.id);
+    try {
+      const res = await fetch(`/api/member-link-requests/${req.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "reconsider" }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Erreur");
+      setRejected((prev) => prev.filter((r) => r.id !== req.id));
+      setLocalRequests((prev) => [
+        ...prev,
+        {
+          id: req.id,
+          user: { name: req.user.name, email: req.user.email, image: null },
+          member: req.member ? { id: "", firstName: req.member.firstName, lastName: req.member.lastName, deptName: null, ministryName: null } : null,
+          firstName: req.firstName,
+          lastName: req.lastName,
+          department: null,
+          ministry: null,
+          requestedRole: req.requestedRole,
+          notes: null,
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Une erreur est survenue");
+    } finally {
+      setReconsidering(null);
     }
   }
 
@@ -586,9 +650,10 @@ export default function AccessClient({ users, ministries, churchId, isSuperAdmin
       {/* ── Onglet Demandes ───────────────────────────────────────────────── */}
       {tab === "requests" && (
         <div className="space-y-4">
-          {localRequests.length === 0 && (
+          {localRequests.length === 0 && rejected.length === 0 && (
             <p className="text-sm text-gray-400 italic text-center py-8">Aucune demande en attente.</p>
           )}
+
           {localRequests.map((req) => {
             const displayName = req.member
               ? `${req.member.firstName} ${req.member.lastName}`
@@ -683,7 +748,7 @@ export default function AccessClient({ users, ministries, churchId, isSuperAdmin
                       Refuser
                     </button>
                     <button
-                      onClick={() => approveRequest(req)}
+                      onClick={() => openApproveModal(req)}
                       disabled={approvingId === req.id}
                       className="flex-1 px-3 py-2 text-sm font-medium bg-icc-violet text-white rounded-lg hover:bg-icc-violet/90 disabled:opacity-50 transition-colors"
                     >
@@ -694,6 +759,66 @@ export default function AccessClient({ users, ministries, churchId, isSuperAdmin
               </div>
             );
           })}
+
+          {/* Demandes refusées */}
+          {rejected.length > 0 && (
+            <div className="mt-2">
+              <button
+                onClick={() => setShowRejected((v) => !v)}
+                className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+              >
+                <svg
+                  className={`w-4 h-4 transition-transform ${showRejected ? "rotate-90" : ""}`}
+                  fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+                Demandes refusées ({rejected.length})
+              </button>
+
+              {showRejected && (
+                <div className="mt-3 space-y-2">
+                  {rejected.map((r) => {
+                    const name = r.member
+                      ? `${r.member.firstName} ${r.member.lastName}`
+                      : `${r.firstName ?? ""} ${r.lastName ?? ""}`.trim();
+                    return (
+                      <div key={r.id} className="border border-gray-200 rounded-lg p-3 bg-gray-50">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-gray-700 truncate">{r.user.name}</p>
+                            {name && (
+                              <p className="text-xs text-gray-500 truncate">{r.member ? "STAR : " : "Nouveau : "}{name}</p>
+                            )}
+                            {r.requestedRole && (
+                              <span className="inline-block mt-1 text-xs bg-gray-200 text-gray-600 px-1.5 py-0.5 rounded">
+                                {ROLE_LABELS[r.requestedRole] ?? r.requestedRole}
+                              </span>
+                            )}
+                          </div>
+                          <span className="text-xs text-gray-400 shrink-0">
+                            {r.reviewedAt ? new Date(r.reviewedAt).toLocaleDateString("fr-FR") : "—"}
+                          </span>
+                        </div>
+                        {r.rejectReason && (
+                          <p className="mt-1.5 text-xs text-gray-500 italic">&ldquo;{r.rejectReason}&rdquo;</p>
+                        )}
+                        <div className="mt-2">
+                          <button
+                            onClick={() => reconsider(r)}
+                            disabled={reconsidering === r.id}
+                            className="text-xs text-icc-violet border border-icc-violet/30 rounded-lg px-2.5 py-1 hover:bg-icc-violet/5 disabled:opacity-50 transition-colors"
+                          >
+                            {reconsidering === r.id ? "En cours…" : "↩ Reconsidérer"}
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -1068,6 +1193,62 @@ export default function AccessClient({ users, ministries, churchId, isSuperAdmin
           </div>
         </div>
       )}
+
+      {/* ── Modale Approuver une demande ──────────────────────────────────── */}
+      {approveModal && (() => {
+        const role = approveModal.requestedRole;
+        const needsDept = role === "DEPARTMENT_HEAD" || role === "DEPUTY";
+        const allDepts = ministries.flatMap((m) =>
+          m.departments.map((d) => ({ id: d.id, name: d.name, ministryName: m.name }))
+        );
+        const displayName = approveModal.member
+          ? `${approveModal.member.firstName} ${approveModal.member.lastName}`
+          : `${approveModal.firstName ?? ""} ${approveModal.lastName ?? ""}`.trim();
+        return (
+          <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4 bg-black/50">
+            <div className="bg-white rounded-t-xl sm:rounded-xl shadow-xl w-full sm:max-w-md p-6 space-y-4">
+              <h2 className="text-base font-semibold text-gray-900">Approuver la demande</h2>
+              <p className="text-sm text-gray-600">
+                Lier le compte de <strong>{approveModal.user.name}</strong>{" "}
+                {displayName && <>à <strong>{displayName}</strong></>}.
+              </p>
+
+              {needsDept && allDepts.length > 0 && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Département
+                  </label>
+                  <select
+                    value={approveModalDeptId}
+                    onChange={(e) => setApproveModalDeptId(e.target.value)}
+                    className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+                  >
+                    {allDepts.map((d) => (
+                      <option key={d.id} value={d.id}>{d.ministryName} / {d.name}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={() => setApproveModal(null)}
+                  className="px-4 py-2 text-sm rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50"
+                >
+                  Annuler
+                </button>
+                <button
+                  onClick={confirmApprove}
+                  disabled={approvingId === approveModal.id}
+                  className="px-4 py-2 text-sm rounded-lg bg-icc-violet text-white hover:bg-icc-violet/90 disabled:opacity-50"
+                >
+                  {approvingId === approveModal.id ? "…" : "Confirmer"}
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/src/app/(auth)/admin/access/page.tsx
+++ b/src/app/(auth)/admin/access/page.tsx
@@ -67,6 +67,23 @@ export default async function AccessPage() {
     orderBy: { createdAt: "asc" },
   });
 
+  // Demandes refusées (30 dernières)
+  const rejectedRequests = await prisma.memberLinkRequest.findMany({
+    where: { churchId, status: "REJECTED" },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      requestedRole: true,
+      rejectReason: true,
+      reviewedAt: true,
+      user: { select: { name: true, displayName: true, email: true } },
+      member: { select: { firstName: true, lastName: true } },
+    },
+    orderBy: { reviewedAt: "desc" },
+    take: 30,
+  });
+
   // Ministries with departments for structure view
   const ministries = await prisma.ministry.findMany({
     where: { churchId, isSystem: false },
@@ -148,6 +165,16 @@ export default async function AccessPage() {
         }))}
         churchId={churchId}
         isSuperAdmin={session.user.isSuperAdmin ?? false}
+        rejectedRequests={rejectedRequests.map((r) => ({
+          id: r.id,
+          user: { name: r.user.displayName || r.user.name || r.user.email, email: r.user.email },
+          member: r.member ? { firstName: r.member.firstName, lastName: r.member.lastName } : null,
+          firstName: r.firstName,
+          lastName: r.lastName,
+          requestedRole: r.requestedRole,
+          rejectReason: r.rejectReason,
+          reviewedAt: r.reviewedAt?.toISOString() ?? null,
+        }))}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- Affiche les 30 dernières demandes refusées dans l'onglet **Demandes** de `/admin/access` (section repliable)
- Bouton **↩ Reconsidérer** remet une demande refusée en attente
- **Modal d'approbation** avec sélecteur de département pour les rôles `DEPARTMENT_HEAD` / `DEPUTY`

Ces changements appliquent à `/admin/access/AccessClient` la même logique déjà implémentée dans `/admin/members/LinkRequestsClient` (PR #290).

## Test plan

- [ ] Ouvrir `/admin/access` → onglet Demandes → vérifier les demandes en attente
- [ ] Approuver une demande avec rôle `DEPARTMENT_HEAD` → la modale propose un sélecteur de département
- [ ] Approuver une demande sans rôle spécifique → la modale confirme sans sélecteur
- [ ] Rejeter une demande, puis dérouler "Demandes refusées" → la demande apparaît
- [ ] Cliquer "↩ Reconsidérer" → la demande repasse en attente dans la liste

🤖 Generated with [Claude Code](https://claude.com/claude-code)