### PR TITLE
chore: release v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.3.2] - 2026-05-02
+
+### Corrigé
+
+- Demandes d'accès : la section "Demandes refusées" et la modale d'approbation avec sélecteur de département (DEPARTMENT_HEAD/DEPUTY) sont maintenant disponibles dans `/admin/access` (elles n'étaient présentes que dans `/admin/members`)
+- Multi-église : un STAR servant dans plusieurs églises ne pouvait pas soumettre une demande de lien pour une seconde église si une demande était déjà en attente pour la première — la vérification de doublon est maintenant scoped par église
+
 ## [v1.3.1] - 2026-05-02
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v1.3.2

### Corrigé

- Demandes d'accès : section "Demandes refusées" + modale d'approbation avec sélecteur de département disponibles dans `/admin/access` (#293)
- Multi-église : un STAR servant dans plusieurs églises pouvait être bloqué lors de la soumission d'une seconde demande de lien (#294)

🤖 Generated with [Claude Code](https://claude.com/claude-code)