### PR TITLE
fix(star-view): forcer le rendu A4 paysage à l'export sur mobile

### DIFF
--- a/src/app/(auth)/events/[eventId]/star-view/StarViewClient.tsx
+++ b/src/app/(auth)/events/[eventId]/star-view/StarViewClient.tsx
@@ -60,15 +60,28 @@ export default function StarViewClient({ eventId }: Props) {
     return `STAR-${data?.event.title || "export"}`;
   }
 
+  // Force A4 landscape layout (1122px wide, desktop breakpoints) before html2canvas capture,
+  // regardless of the current mobile viewport — restores original width in all cases.
+  async function captureForExport(): Promise<HTMLCanvasElement | null> {
+    if (!printRef.current) return null;
+    const html2canvas = (await import("html2canvas-pro")).default;
+    const el = printRef.current;
+    const savedWidth = el.style.width;
+    el.style.width = "1122px";
+    await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
+    try {
+      return await html2canvas(el, { scale: 2, useCORS: true, windowWidth: 1440 });
+    } finally {
+      el.style.width = savedWidth;
+    }
+  }
+
   async function copyImage() {
     if (!printRef.current || exporting) return;
     setExporting("copy");
     try {
-      const html2canvas = (await import("html2canvas-pro")).default;
-      const canvas = await html2canvas(printRef.current, {
-        scale: 2,
-        useCORS: true,
-      });
+      const canvas = await captureForExport();
+      if (!canvas) return;
 
       try {
         const blob = await new Promise<Blob>((resolve, reject) => {
@@ -103,11 +116,8 @@ export default function StarViewClient({ eventId }: Props) {
     if (!printRef.current || exporting) return;
     setExporting("image");
     try {
-      const html2canvas = (await import("html2canvas-pro")).default;
-      const canvas = await html2canvas(printRef.current, {
-        scale: 2,
-        useCORS: true,
-      });
+      const canvas = await captureForExport();
+      if (!canvas) return;
 
       const dataUrl = canvas.toDataURL("image/png");
       const link = document.createElement("a");
@@ -125,13 +135,10 @@ export default function StarViewClient({ eventId }: Props) {
     if (!printRef.current || exporting) return;
     setExporting("pdf");
     try {
-      const html2canvas = (await import("html2canvas-pro")).default;
       const { jsPDF } = await import("jspdf");
+      const canvas = await captureForExport();
+      if (!canvas) return;
 
-      const canvas = await html2canvas(printRef.current, {
-        scale: 2,
-        useCORS: true,
-      });
       const imgData = canvas.toDataURL("image/png");
       const pdf = new jsPDF("landscape", "mm", "a4");
       const pdfWidth = pdf.internal.pageSize.getWidth();


### PR DESCRIPTION
## Résumé

- L'export PDF/PNG de la vue STAR capturait le layout mobile (2 colonnes) au lieu du rendu A4 paysage (4 colonnes)
- Ajout d'un helper `captureForExport()` commun aux trois exports (Copier image, Télécharger PNG, Export PDF) qui force temporairement la largeur à 1122px et `windowWidth: 1440` avant le rendu html2canvas
- Les breakpoints `lg:grid-cols-4` s'activent quelle que soit la taille du viewport, puis la largeur est restaurée après capture

## Plan de test

- [ ] Sur mobile, exporter le planning STAR en PDF → vérifier 4 colonnes en paysage A4
- [ ] Sur mobile, télécharger en PNG → vérifier le rendu 4 colonnes
- [ ] Sur mobile, copier l'image → vérifier le rendu 4 colonnes
- [ ] Sur desktop, vérifier que les exports sont inchangés

🤖 Generated with [Claude Code](https://claude.com/claude-code)