### PR TITLE
fix(planning): forcer la largeur portrait A4 à l'export sur mobile

### DIFF
--- a/src/components/MonthlyPlanningView.tsx
+++ b/src/components/MonthlyPlanningView.tsx
@@ -76,15 +76,27 @@ export default function MonthlyPlanningView({ departmentId, departmentName, chur
     return `Planning-${name}-${label}`;
   }
 
+  // Force portrait A4 width (max-w-2xl = 672px) for consistent capture on mobile.
+  async function captureForExport(): Promise<HTMLCanvasElement | null> {
+    if (!printRef.current) return null;
+    const html2canvas = (await import("html2canvas-pro")).default;
+    const el = printRef.current;
+    const savedWidth = el.style.width;
+    el.style.width = "672px";
+    await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
+    try {
+      return await html2canvas(el, { scale: 2, useCORS: true, windowWidth: 1440 });
+    } finally {
+      el.style.width = savedWidth;
+    }
+  }
+
   async function copyImage() {
     if (!printRef.current || exporting) return;
     setExporting("copy");
     try {
-      const html2canvas = (await import("html2canvas-pro")).default;
-      const canvas = await html2canvas(printRef.current, {
-        scale: 2,
-        useCORS: true,
-      });
+      const canvas = await captureForExport();
+      if (!canvas) return;
 
       try {
         const blob = await new Promise<Blob>((resolve, reject) => {
@@ -119,11 +131,8 @@ export default function MonthlyPlanningView({ departmentId, departmentName, chur
     if (!printRef.current || exporting) return;
     setExporting("image");
     try {
-      const html2canvas = (await import("html2canvas-pro")).default;
-      const canvas = await html2canvas(printRef.current, {
-        scale: 2,
-        useCORS: true,
-      });
+      const canvas = await captureForExport();
+      if (!canvas) return;
 
       const dataUrl = canvas.toDataURL("image/png");
       const link = document.createElement("a");
@@ -141,13 +150,9 @@ export default function MonthlyPlanningView({ departmentId, departmentName, chur
     if (!printRef.current || exporting) return;
     setExporting("pdf");
     try {
-      const html2canvas = (await import("html2canvas-pro")).default;
       const { jsPDF } = await import("jspdf");
-
-      const canvas = await html2canvas(printRef.current, {
-        scale: 2,
-        useCORS: true,
-      });
+      const canvas = await captureForExport();
+      if (!canvas) return;
 
       const imgData = canvas.toDataURL("image/png");
       const pdf = new jsPDF("portrait", "mm", "a4");

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -166,12 +166,27 @@ export default function WeeklyPlanningView({
     }
   }
 
+  // Force portrait A4 width (max-w-2xl = 672px) for consistent capture on mobile.
+  async function captureForExport(): Promise<HTMLCanvasElement | null> {
+    if (!printRef.current) return null;
+    const html2canvas = (await import("html2canvas-pro")).default;
+    const el = printRef.current;
+    const savedWidth = el.style.width;
+    el.style.width = "672px";
+    await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
+    try {
+      return await html2canvas(el, { scale: 2, useCORS: true, windowWidth: 1440 });
+    } finally {
+      el.style.width = savedWidth;
+    }
+  }
+
   async function copyImage() {
     if (!printRef.current || exporting) return;
     setExporting("copy");
     try {
-      const html2canvas = (await import("html2canvas-pro")).default;
-      const canvas = await html2canvas(printRef.current, { scale: 2, useCORS: true });
+      const canvas = await captureForExport();
+      if (!canvas) return;
       try {
         const blob = await new Promise<Blob>((resolve, reject) => {
           canvas.toBlob((b: Blob | null) => { if (b) resolve(b); else reject(new Error("failed")); }, "image/png");
@@ -189,8 +204,8 @@ export default function WeeklyPlanningView({
     if (!printRef.current || exporting) return;
     setExporting("image");
     try {
-      const html2canvas = (await import("html2canvas-pro")).default;
-      const canvas = await html2canvas(printRef.current, { scale: 2, useCORS: true });
+      const canvas = await captureForExport();
+      if (!canvas) return;
       const link = document.createElement("a");
       link.download = `${getExportFileName(departmentName, weekStart)}.png`;
       link.href = canvas.toDataURL("image/png");
@@ -202,9 +217,9 @@ export default function WeeklyPlanningView({
     if (!printRef.current || exporting) return;
     setExporting("pdf");
     try {
-      const html2canvas = (await import("html2canvas-pro")).default;
       const { jsPDF } = await import("jspdf");
-      const canvas = await html2canvas(printRef.current, { scale: 2, useCORS: true });
+      const canvas = await captureForExport();
+      if (!canvas) return;
       const imgData = canvas.toDataURL("image/png");
       const pdf = new jsPDF("portrait", "mm", "a4");
       const pdfWidth = pdf.internal.pageSize.getWidth();


### PR DESCRIPTION
## Résumé

- `MonthlyPlanningView` et `WeeklyPlanningView` capturaient le layout mobile (~350px) au lieu de leur largeur naturelle `max-w-2xl` (672px)
- Même pattern que la Star view (#297) : helper `captureForExport()` qui force temporairement 672px + `windowWidth: 1440` avant le rendu html2canvas
- Orientation **portrait** conservée (les deux vues sont des listes verticales par nature)
- Star view reste en paysage A4 (déjà corrigée séparément)

## Plan de test

- [ ] Sur mobile, exporter le planning mensuel en PDF → vérifier rendu portrait propre à 672px
- [ ] Sur mobile, télécharger le planning mensuel en PNG → vérifier la largeur
- [ ] Sur mobile, exporter le planning hebdomadaire en PDF/PNG → même vérification
- [ ] Sur desktop, vérifier que les exports sont inchangés

🤖 Generated with [Claude Code](https://claude.com/claude-code)