### PR TITLE
fix(members): supprimer les plannings futurs quand un STAR quitte un département

### DIFF
--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -83,6 +83,27 @@ export async function PUT(
       await tx.memberDepartment.deleteMany({
         where: { memberId, departmentId: { notIn: allDeptIds } },
       });
+
+      // Supprimer les affectations planning et tâches futures dans les départements retirés
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      await tx.planning.deleteMany({
+        where: {
+          memberId,
+          eventDepartment: {
+            departmentId: { notIn: allDeptIds },
+            event: { date: { gte: today } },
+          },
+        },
+      });
+      await tx.taskAssignment.deleteMany({
+        where: {
+          memberId,
+          event: { date: { gte: today } },
+          task: { departmentId: { notIn: allDeptIds } },
+        },
+      });
+
       // 2. Upsert chaque département avec le bon flag isPrimary
       for (const deptId of allDeptIds) {
         await tx.memberDepartment.upsert({


### PR DESCRIPTION
## Résumé

- Quand un STAR est retiré d'un département via la mise à jour de ses affiliations, ses `Planning` et `TaskAssignment` futurs dans ce département restaient en base et continuaient d'apparaître dans les plannings
- Ajout de deux `deleteMany` dans la transaction `PUT /api/members/[id]`, après le retrait des `MemberDepartment` :
  - `Planning` où `eventDepartment.departmentId ∉ allDeptIds` et `event.date >= aujourd'hui`
  - `TaskAssignment` où `task.departmentId ∉ allDeptIds` et `event.date >= aujourd'hui`
- Les plannings passés (historique) sont conservés

## Plan de test

- [ ] Retirer un STAR d'un département → vérifier que ses affectations futures dans ce département disparaissent du planning
- [ ] Vérifier que ses affectations passées sont conservées (historique intact)
- [ ] Vérifier que ses affectations dans les autres départements conservés sont inchangées

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)