### PR TITLE
fix(requests): afficher le texte complet de l'annonce dans la liste

### DIFF
--- a/src/app/(auth)/requests/RequestsList.tsx
+++ b/src/app/(auth)/requests/RequestsList.tsx
@@ -67,6 +67,7 @@ interface RequestItem {
   announcement: {
     id: string;
     title: string;
+    content: string;
     status: string;
     eventDate: Date | null;
     isSaveTheDate: boolean;
@@ -88,6 +89,11 @@ interface Props {
 function RequestCard({ req, onUpdated }: { req: RequestItem; onUpdated: (updated: Partial<RequestItem>) => void }) {
   const [cancelling, setCancelling] = useState(false);
   const [cancelError, setCancelError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const announcementContent = req.announcement?.content ?? null;
+  const PREVIEW_LENGTH = 150;
+  const isLong = announcementContent !== null && announcementContent.length > PREVIEW_LENGTH;
 
   const source = req.department?.name ?? req.ministry?.name ?? null;
   const isPending = req.status === "EN_ATTENTE";
@@ -144,6 +150,25 @@ function RequestCard({ req, onUpdated }: { req: RequestItem; onUpdated: (updated
           {STATUS_LABEL[req.status] ?? req.status}
         </span>
       </div>
+
+      {/* Announcement content */}
+      {announcementContent && (
+        <div className="mt-2">
+          <p className="text-sm text-gray-600 whitespace-pre-wrap leading-relaxed">
+            {isLong && !expanded
+              ? `${announcementContent.slice(0, PREVIEW_LENGTH).trimEnd()}…`
+              : announcementContent}
+          </p>
+          {isLong && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="mt-1 text-xs text-icc-violet hover:underline"
+            >
+              {expanded ? "Voir moins" : "Voir plus"}
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Child requests (visuals under announcements) */}
       {req.childRequests.length > 0 && (

--- a/src/app/(auth)/requests/page.tsx
+++ b/src/app/(auth)/requests/page.tsx
@@ -25,6 +25,7 @@ export default async function MyRequestsPage() {
         select: {
           id: true,
           title: true,
+          content: true,
           status: true,
           eventDate: true,
           isSaveTheDate: true,


### PR DESCRIPTION
## Résumé

- Le champ `content` des annonces n'était pas inclus dans le `select` Prisma de la page "Mes demandes" et n'apparaissait donc pas dans les cartes
- Ajout de `content: true` dans le select, de `content: string` dans l'interface `RequestItem`
- Affichage du contenu dans `RequestCard` avec un aperçu de 150 caractères et un toggle **"Voir plus / Voir moins"** pour les textes plus longs

## Plan de test

- [ ] Ouvrir "Mes demandes" avec une annonce ayant un texte court (< 150 cars) → texte affiché entièrement, pas de bouton
- [ ] Avec une annonce ayant un texte long → aperçu tronqué + bouton "Voir plus" → clic → texte complet + bouton "Voir moins"

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)