### PR TITLE
chore: release v1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.3.5] - 2026-05-13
+
+### Corrigé
+
+- Demandes : le texte complet des annonces n'était pas affiché dans "Mes demandes" — ajout du contenu avec un toggle "Voir plus / Voir moins" pour les textes longs
+- Planning : retirer un STAR d'un département supprime désormais automatiquement ses affectations futures dans ce département (plannings et tâches)
+
 ## [v1.3.4] - 2026-05-09
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v1.3.5

### Corrigé

- Demandes : le texte complet des annonces n'était pas affiché dans "Mes demandes" — ajout du contenu avec toggle "Voir plus / Voir moins" (PR #304, closes #301)
- Planning : retirer un STAR d'un département supprime automatiquement ses affectations futures dans ce département (PR #303, closes #302)

🤖 Generated with [Claude Code](https://claude.com/claude-code)