### PR TITLE
fix(announcements): erreur explicite si département cible non configuré

### DIFF
--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -144,6 +144,13 @@ export async function POST(request: Request) {
         findDeptByFunction(data.churchId, DEPT_FN.PRODUCTION_MEDIA),
       ]);
 
+    if (data.channelInterne && !secretariatDept) {
+      throw new ApiError(400, "Le département Secrétariat n'est pas configuré. Contactez un administrateur.");
+    }
+    if (data.channelExterne && !communicationDept) {
+      throw new ApiError(400, "Le département Communication n'est pas configuré. Contactez un administrateur.");
+    }
+
     const announcement = await prisma.$transaction(async (tx) => {
       const ann = await tx.announcement.create({
         data: {


### PR DESCRIPTION
## Problème

Rapporté par Raissa Prudence : une annonce soumise avec "diffusion réseaux sociaux" (channelExterne) n'apparaissait pas dans `/communication/requests`.

**Cause** : si aucun département n'a la fonction `COMMUNICATION` configurée, `findDeptByFunction` retourne `null`. La `Request` de type `RESEAUX_SOCIAUX` était quand même créée avec `assignedDeptId: null`. Or, le dashboard Communication filtre sur `assignedDeptId: commDept.id` → la requête était **invisible dans tous les dashboards**, silencieusement.

Même bug pour `channelInterne` / département `SECRETARIAT`.

## Fix

Ajout de deux vérifications après la résolution des départements :
- `channelInterne && !secretariatDept` → erreur 400 explicite
- `channelExterne && !communicationDept` → erreur 400 explicite

L'utilisateur reçoit un message clair ("Le département Communication n'est pas configuré. Contactez un administrateur.") au lieu de croire que sa demande a été envoyée.

## Note

Les demandes orphelines déjà créées (assignedDeptId: null) ne sont pas migrées — à traiter manuellement si nécessaire via l'admin DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)