### PR TITLE
fix(events): FK violation quand on retire un département d'un événement

### DIFF
--- a/src/app/api/events/[eventId]/departments/route.ts
+++ b/src/app/api/events/[eventId]/departments/route.ts
@@ -117,10 +117,15 @@ export async function DELETE(
       return successResponse({ success: true });
     }
 
-    await prisma.eventDepartment.delete({
-      where: {
-        eventId_departmentId: { eventId, departmentId },
-      },
+    await prisma.$transaction(async (tx) => {
+      const ed = await tx.eventDepartment.findUnique({
+        where: { eventId_departmentId: { eventId, departmentId } },
+        select: { id: true },
+      });
+      if (ed) await tx.planning.deleteMany({ where: { eventDepartmentId: ed.id } });
+      await tx.eventDepartment.delete({
+        where: { eventId_departmentId: { eventId, departmentId } },
+      });
     });
 
     return successResponse({ success: true });


### PR DESCRIPTION
## Problème

Logs de production du 2026-05-13 :
```
Foreign key constraint violated on the fields: (eventDepartmentId)
Invalid prisma.eventDepartment.delete() invocation
```

Quand on retire un département d'un événement (non-série), `DELETE /api/events/[eventId]/departments` appelait `eventDepartment.delete()` directement sans supprimer les enregistrements `Planning` liés (qui ont une FK sur `eventDepartmentId`).

Le path `applyToSeries` gérait déjà ce cas correctement (ligne 109 : `planning.deleteMany` avant `eventDepartment.deleteMany`).

## Fix

Alignement du path single-event sur le même pattern : transaction qui supprime d'abord les `Planning` liés, puis supprime le `EventDepartment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)