### PR TITLE
chore: release v1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.3.6] - 2026-05-13
+
+### Corrigé
+
+- Événements : retirer un département d'un événement causait une erreur FK en production — les plannings associés sont maintenant supprimés avant la suppression du lien événement-département
+- Annonces : soumettre une annonce avec diffusion externe/interne quand le département cible n'était pas configuré créait une demande orpheline invisible — une erreur explicite est maintenant retournée
+
 ## [v1.3.5] - 2026-05-13
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v1.3.6

### Corrigé

- Événements : FK violation en production lors du retrait d'un département d'un événement — les Planning liés sont maintenant supprimés en transaction avant le delete (PR #307)
- Annonces : demande orpheline silencieuse quand le département cible n'est pas configuré — erreur 400 explicite retournée (PR #306)

🤖 Generated with [Claude Code](https://claude.com/claude-code)