### PR TITLE
fix(agenda): audit trail + updatedById + index de performance (T06/T08)

### DIFF
--- a/prisma/migrations/20260516000000_agenda_audit_indexes/migration.sql
+++ b/prisma/migrations/20260516000000_agenda_audit_indexes/migration.sql
@@ -1,0 +1,22 @@
+-- T06: champs updatedById pour la traçabilité des modifications
+ALTER TABLE `appointment_requests` ADD COLUMN `updatedById` VARCHAR(191) NULL;
+ALTER TABLE `agenda_entries` ADD COLUMN `updatedById` VARCHAR(191) NULL;
+
+-- T06: contraintes de clé étrangère
+ALTER TABLE `appointment_requests` ADD CONSTRAINT `appointment_requests_updatedById_fkey`
+  FOREIGN KEY (`updatedById`) REFERENCES `users`(`id`)
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE `agenda_entries` ADD CONSTRAINT `agenda_entries_updatedById_fkey`
+  FOREIGN KEY (`updatedById`) REFERENCES `users`(`id`)
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- T08: index de performance
+CREATE INDEX `appointment_requests_churchId_status_createdAt_idx`
+  ON `appointment_requests`(`churchId`, `status`, `createdAt`);
+
+CREATE INDEX `agenda_entries_churchId_recipientId_startsAt_idx`
+  ON `agenda_entries`(`churchId`, `recipientId`, `startsAt`);
+
+CREATE INDEX `agenda_entries_churchId_startsAt_idx`
+  ON `agenda_entries`(`churchId`, `startsAt`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,7 +134,9 @@ model User {
   appointmentsMade        AppointmentRequest[] @relation("AppointmentRequester")
   qualifiedRequests       AppointmentRequest[] @relation("AppointmentQualifier")
   scheduledRequests       AppointmentRequest[] @relation("AppointmentScheduler")
+  updatedRequests         AppointmentRequest[] @relation("AppointmentUpdater")
   agendaEntriesCreated    AgendaEntry[]        @relation("AgendaEntryCreator")
+  agendaEntriesUpdated    AgendaEntry[]        @relation("AgendaEntryUpdater")
 
   @@map("users")
 }
@@ -973,6 +975,7 @@ model AppointmentRequest {
   rejectReason      String?
   scheduledById     String?
   scheduledAt       DateTime?
+  updatedById       String?
   createdAt         DateTime                 @default(now())
   updatedAt         DateTime                 @updatedAt
 
@@ -981,8 +984,10 @@ model AppointmentRequest {
   assignedTo  PastoralProfile? @relation(fields: [assignedToId], references: [id])
   qualifiedBy User?            @relation("AppointmentQualifier", fields: [qualifiedById], references: [id])
   scheduledBy User?            @relation("AppointmentScheduler", fields: [scheduledById], references: [id])
+  updatedBy   User?            @relation("AppointmentUpdater", fields: [updatedById], references: [id])
   agendaEntry AgendaEntry?
 
+  @@index([churchId, status, createdAt])
   @@map("appointment_requests")
 }
 
@@ -998,6 +1003,7 @@ model AgendaEntry {
   location    String?
   requestId   String?         @unique
   createdById String
+  updatedById String?
   createdAt   DateTime        @default(now())
   updatedAt   DateTime        @updatedAt
 
@@ -1005,6 +1011,9 @@ model AgendaEntry {
   recipient PastoralProfile     @relation(fields: [recipientId], references: [id])
   request   AppointmentRequest? @relation(fields: [requestId], references: [id])
   createdBy User                @relation("AgendaEntryCreator", fields: [createdById], references: [id])
+  updatedBy User?               @relation("AgendaEntryUpdater", fields: [updatedById], references: [id])
 
+  @@index([churchId, recipientId, startsAt])
+  @@index([churchId, startsAt])
   @@map("agenda_entries")
 }

--- a/src/app/api/agenda/entries/[id]/route.ts
+++ b/src/app/api/agenda/entries/[id]/route.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { resolveChurchId } from "@/lib/auth";
 import { requireAgendaManage } from "@/modules/agenda/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const updateSchema = z.object({
@@ -22,7 +23,7 @@ export async function PATCH(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("agendaEntry", id);
-    await requireAgendaManage(churchId);
+    const session = await requireAgendaManage(churchId);
 
     const body = await request.json();
     const data = updateSchema.parse(body);
@@ -35,10 +36,20 @@ export async function PATCH(
         ...(data.startsAt !== undefined && { startsAt: new Date(data.startsAt) }),
         ...(data.endsAt !== undefined && { endsAt: data.endsAt ? new Date(data.endsAt) : null }),
         ...(data.location !== undefined && { location: data.location }),
+        updatedById: session.user.id,
       },
       include: {
         recipient: { select: { id: true, name: true, role: true } },
       },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "UPDATE",
+      entityType: "AgendaEntry",
+      entityId: id,
+      details: data,
     });
 
     return successResponse(entry);
@@ -54,11 +65,11 @@ export async function DELETE(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("agendaEntry", id);
-    await requireAgendaManage(churchId);
+    const session = await requireAgendaManage(churchId);
 
     const entry = await prisma.agendaEntry.findUnique({
       where: { id },
-      select: { requestId: true },
+      select: { requestId: true, title: true },
     });
     if (!entry) throw new ApiError(404, "Entrée agenda introuvable");
 
@@ -71,6 +82,15 @@ export async function DELETE(
         });
       }
       await tx.agendaEntry.delete({ where: { id } });
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "DELETE",
+      entityType: "AgendaEntry",
+      entityId: id,
+      details: { title: entry.title },
     });
 
     return successResponse({ success: true });

--- a/src/app/api/agenda/entries/route.ts
+++ b/src/app/api/agenda/entries/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireAgendaView, requireAgendaManage } from "@/modules/agenda/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const createSchema = z.object({
@@ -85,6 +86,15 @@ export async function POST(request: Request) {
       include: {
         recipient: { select: { id: true, name: true, role: true } },
       },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId: data.churchId,
+      action: "CREATE",
+      entityType: "AgendaEntry",
+      entityId: entry.id,
+      details: { type: data.type, title: data.title, recipientId: data.recipientId },
     });
 
     return successResponse(entry, 201);

--- a/src/app/api/agenda/profiles/[id]/route.ts
+++ b/src/app/api/agenda/profiles/[id]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { resolveChurchId, requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const updateSchema = z.object({
@@ -17,7 +18,7 @@ export async function PATCH(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("pastoralProfile", id);
-    await requireChurchPermission("church:manage", churchId);
+    const session = await requireChurchPermission("church:manage", churchId);
 
     const body = await request.json();
     const data = updateSchema.parse(body);
@@ -40,6 +41,15 @@ export async function PATCH(
       },
     });
 
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "UPDATE",
+      entityType: "PastoralProfile",
+      entityId: id,
+      details: data,
+    });
+
     return successResponse(profile);
   } catch (error) {
     return errorResponse(error);
@@ -53,7 +63,12 @@ export async function DELETE(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("pastoralProfile", id);
-    await requireChurchPermission("church:manage", churchId);
+    const session = await requireChurchPermission("church:manage", churchId);
+
+    const profile = await prisma.pastoralProfile.findUnique({
+      where: { id },
+      select: { name: true },
+    });
 
     const hasEntries = await prisma.agendaEntry.count({ where: { recipientId: id } });
     if (hasEntries > 0) {
@@ -61,6 +76,15 @@ export async function DELETE(
     }
 
     await prisma.pastoralProfile.delete({ where: { id } });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "DELETE",
+      entityType: "PastoralProfile",
+      entityId: id,
+      details: { name: profile?.name },
+    });
 
     return successResponse({ success: true });
   } catch (error) {

--- a/src/app/api/agenda/profiles/route.ts
+++ b/src/app/api/agenda/profiles/route.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { requireAgendaView } from "@/modules/agenda/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const createSchema = z.object({
@@ -39,7 +40,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const data = createSchema.parse(body);
 
-    await requireChurchPermission("church:manage", data.churchId);
+    const session = await requireChurchPermission("church:manage", data.churchId);
 
     if (data.userId) {
       const role = await prisma.userChurchRole.findFirst({
@@ -57,6 +58,15 @@ export async function POST(request: Request) {
         role: data.role,
         userId: data.userId ?? null,
       },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId: data.churchId,
+      action: "CREATE",
+      entityType: "PastoralProfile",
+      entityId: profile.id,
+      details: { name: data.name, role: data.role },
     });
 
     return successResponse(profile, 201);

--- a/src/app/api/agenda/requests/[id]/qualify/route.ts
+++ b/src/app/api/agenda/requests/[id]/qualify/route.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { resolveChurchId } from "@/lib/auth";
 import { requireAgendaQualify } from "@/modules/agenda/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const qualifySchema = z.discriminatedUnion("action", [
@@ -52,11 +53,22 @@ export async function PATCH(
           qualifiedById: session.user.id,
           qualifiedAt: new Date(),
           qualificationNote: data.qualificationNote ?? null,
+          updatedById: session.user.id,
         },
         include: {
           assignedTo: { select: { id: true, name: true, role: true } },
         },
       });
+
+      await logAudit({
+        userId: session.user.id,
+        churchId,
+        action: "UPDATE",
+        entityType: "AppointmentRequest",
+        entityId: id,
+        details: { transition: "PENDING→VALIDATED", assignedToId: data.assignedToId },
+      });
+
       return successResponse(updated);
     }
 
@@ -68,8 +80,19 @@ export async function PATCH(
         qualifiedById: session.user.id,
         qualifiedAt: new Date(),
         rejectReason: data.rejectReason ?? null,
+        updatedById: session.user.id,
       },
     });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "UPDATE",
+      entityType: "AppointmentRequest",
+      entityId: id,
+      details: { transition: "PENDING→REJECTED", rejectReason: data.rejectReason ?? null },
+    });
+
     return successResponse(updated);
   } catch (error) {
     return errorResponse(error);

--- a/src/app/api/agenda/requests/[id]/schedule/route.ts
+++ b/src/app/api/agenda/requests/[id]/schedule/route.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { resolveChurchId } from "@/lib/auth";
 import { requireAgendaManage } from "@/modules/agenda/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
 const scheduleSchema = z.object({
@@ -46,6 +47,7 @@ export async function PATCH(
           status: "SCHEDULED",
           scheduledById: session.user.id,
           scheduledAt: new Date(),
+          updatedById: session.user.id,
         },
       }),
       prisma.agendaEntry.create({
@@ -67,6 +69,15 @@ export async function PATCH(
         },
       }),
     ]);
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "UPDATE",
+      entityType: "AppointmentRequest",
+      entityId: id,
+      details: { transition: "VALIDATED→SCHEDULED", entryId: entry.id, startsAt: data.startsAt },
+    });
 
     return successResponse(entry, 201);
   } catch (error) {

--- a/src/app/api/agenda/requests/route.ts
+++ b/src/app/api/agenda/requests/route.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth, requireChurchPermission } from "@/lib/auth";
 import { isProtocoleMember } from "@/modules/agenda/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
 import { rolePermissions } from "@/lib/registry";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { z } from "zod";
@@ -94,6 +95,15 @@ export async function POST(request: Request) {
         message: data.message,
         preferredDays: data.preferredDays ?? null,
       },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId: data.churchId,
+      action: "CREATE",
+      entityType: "AppointmentRequest",
+      entityId: req.id,
+      details: { subject: data.subject },
     });
 
     return successResponse(req, 201);


### PR DESCRIPTION
## Résumé

Suite de l'audit de sécurité — items T06 et T08.

### T06 — Audit trail Agenda

`logAudit()` ajouté sur toutes les mutations du module Agenda :

| Route | Action tracée |
|---|---|
| `POST /api/agenda/profiles` | CREATE PastoralProfile |
| `PATCH /api/agenda/profiles/[id]` | UPDATE PastoralProfile |
| `DELETE /api/agenda/profiles/[id]` | DELETE PastoralProfile |
| `POST /api/agenda/entries` | CREATE AgendaEntry |
| `PATCH /api/agenda/entries/[id]` | UPDATE AgendaEntry |
| `DELETE /api/agenda/entries/[id]` | DELETE AgendaEntry |
| `POST /api/agenda/requests` | CREATE AppointmentRequest |
| `PATCH /api/agenda/requests/[id]/qualify` | PENDING→VALIDATED / PENDING→REJECTED |
| `PATCH /api/agenda/requests/[id]/schedule` | VALIDATED→SCHEDULED |

Nouveaux champs `updatedById` (nullable) sur `AppointmentRequest` et `AgendaEntry` pour tracer le dernier modificateur — remplis à chaque mutation.

### T08 — Index de performance

- `appointment_requests (churchId, status, createdAt)`
- `agenda_entries (churchId, recipientId, startsAt)`
- `agenda_entries (churchId, startsAt)`

## Plan de test

- [ ] `npm run typecheck` → 0 erreur
- [ ] `npm run lint` → 0 erreur
- [ ] `npm run lint:boundaries` → 0 violation
- [ ] `npm run test` → 267/267 tests passent
- [ ] Vérifier les entrées audit_logs après chaque opération en dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)