### PR TITLE
test(agenda): couverture routes et helpers d'auth (T07)

### DIFF
--- a/src/__mocks__/auth.ts
+++ b/src/__mocks__/auth.ts
@@ -112,3 +112,36 @@ export function createSecretarySession(churchId = "church-1"): Session {
   });
 }
 
+export function createAgendaQualifierSession(churchId = "church-1"): Session {
+  return createSession({
+    churchRoles: [
+      {
+        id: "role-1",
+        churchId,
+        role: "AGENDA_QUALIFIER",
+        ministryId: null,
+        church: { id: churchId, name: "Test Church", slug: "test-church" },
+        departments: [],
+      },
+    ],
+  });
+}
+
+export function createProtocoleMemberSession(
+  protocoleDeptId: string,
+  churchId = "church-1"
+): Session {
+  return createSession({
+    churchRoles: [
+      {
+        id: "role-1",
+        churchId,
+        role: "STAR",
+        ministryId: null,
+        church: { id: churchId, name: "Test Church", slug: "test-church" },
+        departments: [{ department: { id: protocoleDeptId, name: "Protocole" } }],
+      },
+    ],
+  });
+}
+

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -47,6 +47,11 @@ export const prismaMock = {
   mediaPhoto: createModelMock(),
   mediaShareToken: createModelMock(),
   mediaSettings: createModelMock(),
+  mrbsUserLink: createModelMock(),
+  // Module agenda
+  pastoralProfile: createModelMock(),
+  appointmentRequest: createModelMock(),
+  agendaEntry: createModelMock(),
   $transaction: vi.fn((fn: (tx: typeof prismaMock) => Promise<unknown>) =>
     fn(prismaMock)
   ),

--- a/src/app/api/agenda/entries/__tests__/security.test.ts
+++ b/src/app/api/agenda/entries/__tests__/security.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createAdminSession } from "@/__mocks__/auth";
+
+const mockRequireAgendaView = vi.fn();
+const mockRequireAgendaManage = vi.fn();
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/audit", () => ({ logAudit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/lib/auth", () => ({
+  resolveChurchId: vi.fn().mockResolvedValue("church-1"),
+  requireChurchPermission: vi.fn(),
+}));
+vi.mock("@/modules/agenda/auth", () => ({
+  requireAgendaView: (...args: unknown[]) => mockRequireAgendaView(...args),
+  requireAgendaManage: (...args: unknown[]) => mockRequireAgendaManage(...args),
+}));
+
+const { GET, POST } = await import("../route");
+
+const validEntry = {
+  churchId: "church-1",
+  recipientId: "prof-1",
+  type: "ACTIVITY",
+  title: "Réunion",
+  startsAt: "2026-06-01T10:00:00.000Z",
+  endsAt: "2026-06-01T11:00:00.000Z",
+};
+
+describe("POST /api/agenda/entries — temporal validation (T04)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAgendaManage.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.pastoralProfile.findFirst.mockResolvedValue({ id: "prof-1" });
+    prismaMock.agendaEntry.create.mockResolvedValue({ id: "entry-1", ...validEntry });
+  });
+
+  it("returns 400 when endsAt is before startsAt", async () => {
+    const req = new Request("http://localhost/api/agenda/entries", {
+      method: "POST",
+      body: JSON.stringify({
+        ...validEntry,
+        startsAt: "2026-06-01T11:00:00.000Z",
+        endsAt: "2026-06-01T10:00:00.000Z",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    // ZodError wraps details in body.details
+    const hasFinError =
+      (body.error && body.error.includes("fin")) ||
+      (body.details && body.details.some((d: { message: string }) => d.message.includes("fin")));
+    expect(hasFinError).toBe(true);
+  });
+
+  it("returns 400 when endsAt equals startsAt", async () => {
+    const req = new Request("http://localhost/api/agenda/entries", {
+      method: "POST",
+      body: JSON.stringify({
+        ...validEntry,
+        startsAt: "2026-06-01T10:00:00.000Z",
+        endsAt: "2026-06-01T10:00:00.000Z",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("creates entry when endsAt > startsAt", async () => {
+    const req = new Request("http://localhost/api/agenda/entries", {
+      method: "POST",
+      body: JSON.stringify(validEntry),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+  });
+
+  it("creates entry without endsAt", async () => {
+    const { endsAt: _endsAt, ...withoutEnd } = validEntry;
+    const req = new Request("http://localhost/api/agenda/entries", {
+      method: "POST",
+      body: JSON.stringify(withoutEnd),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 400 when profile is not in the church (cross-tenant)", async () => {
+    prismaMock.pastoralProfile.findFirst.mockResolvedValue(null);
+
+    const req = new Request("http://localhost/api/agenda/entries", {
+      method: "POST",
+      body: JSON.stringify({ ...validEntry, recipientId: "prof-other-church" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("périmètre");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireAgendaManage.mockRejectedValue(new Error("UNAUTHORIZED"));
+    const req = new Request("http://localhost/api/agenda/entries", {
+      method: "POST",
+      body: JSON.stringify(validEntry),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when lacking agenda:manage", async () => {
+    mockRequireAgendaManage.mockRejectedValue(new Error("FORBIDDEN"));
+    const req = new Request("http://localhost/api/agenda/entries", {
+      method: "POST",
+      body: JSON.stringify(validEntry),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /api/agenda/entries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAgendaView.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.agendaEntry.findMany.mockResolvedValue([]);
+  });
+
+  it("returns entries for the church", async () => {
+    const req = new Request(
+      "http://localhost/api/agenda/entries?churchId=church-1"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when churchId is missing", async () => {
+    const req = new Request("http://localhost/api/agenda/entries");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireAgendaView.mockRejectedValue(new Error("UNAUTHORIZED"));
+    const req = new Request(
+      "http://localhost/api/agenda/entries?churchId=church-1"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/agenda/profiles/__tests__/security.test.ts
+++ b/src/app/api/agenda/profiles/__tests__/security.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createAdminSession } from "@/__mocks__/auth";
+
+const mockRequireChurchPermission = vi.fn();
+const mockRequireAgendaView = vi.fn();
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/audit", () => ({ logAudit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/lib/auth", () => ({
+  requireChurchPermission: (...args: unknown[]) => mockRequireChurchPermission(...args),
+  resolveChurchId: vi.fn().mockResolvedValue("church-1"),
+}));
+vi.mock("@/modules/agenda/auth", () => ({
+  requireAgendaView: (...args: unknown[]) => mockRequireAgendaView(...args),
+  requireAgendaManage: vi.fn(),
+}));
+
+const { GET, POST } = await import("../route");
+
+describe("POST /api/agenda/profiles — cross-tenant userId validation (T02)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.pastoralProfile.create.mockResolvedValue({ id: "prof-1", name: "Pasteur X" });
+  });
+
+  it("returns 400 when userId belongs to another church", async () => {
+    prismaMock.userChurchRole.findFirst.mockResolvedValue(null);
+
+    const req = new Request("http://localhost/api/agenda/profiles", {
+      method: "POST",
+      body: JSON.stringify({
+        churchId: "church-1",
+        name: "Pasteur X",
+        role: "PASTEUR",
+        userId: "user-other-church",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("n'appartient pas");
+  });
+
+  it("creates profile without userId (no cross-tenant check needed)", async () => {
+    const req = new Request("http://localhost/api/agenda/profiles", {
+      method: "POST",
+      body: JSON.stringify({
+        churchId: "church-1",
+        name: "Pasteur X",
+        role: "PASTEUR",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    expect(prismaMock.userChurchRole.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("creates profile with valid userId in same church", async () => {
+    prismaMock.userChurchRole.findFirst.mockResolvedValue({ id: "ucr-1" });
+
+    const req = new Request("http://localhost/api/agenda/profiles", {
+      method: "POST",
+      body: JSON.stringify({
+        churchId: "church-1",
+        name: "Pasteur X",
+        role: "PASTEUR",
+        userId: "user-church-1",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireChurchPermission.mockRejectedValue(new Error("UNAUTHORIZED"));
+
+    const req = new Request("http://localhost/api/agenda/profiles", {
+      method: "POST",
+      body: JSON.stringify({
+        churchId: "church-1",
+        name: "Pasteur X",
+        role: "PASTEUR",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when lacking church:manage", async () => {
+    mockRequireChurchPermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const req = new Request("http://localhost/api/agenda/profiles", {
+      method: "POST",
+      body: JSON.stringify({
+        churchId: "church-1",
+        name: "Pasteur X",
+        role: "PASTEUR",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when role is invalid", async () => {
+    const req = new Request("http://localhost/api/agenda/profiles", {
+      method: "POST",
+      body: JSON.stringify({
+        churchId: "church-1",
+        name: "Pasteur X",
+        role: "INVALID_ROLE",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/agenda/profiles — requires agenda:view", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAgendaView.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.pastoralProfile.findMany.mockResolvedValue([]);
+  });
+
+  it("returns profiles when authenticated with agenda:view", async () => {
+    const req = new Request("http://localhost/api/agenda/profiles?churchId=church-1");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when churchId is missing", async () => {
+    const req = new Request("http://localhost/api/agenda/profiles");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireAgendaView.mockRejectedValue(new Error("UNAUTHORIZED"));
+    const req = new Request("http://localhost/api/agenda/profiles?churchId=church-1");
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/agenda/requests/__tests__/security.test.ts
+++ b/src/app/api/agenda/requests/__tests__/security.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import {
+  createAdminSession,
+  createAgendaQualifierSession,
+  createProtocoleMemberSession,
+} from "@/__mocks__/auth";
+
+const mockAuth = vi.fn();
+const mockRequireChurchPermission = vi.fn();
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/audit", () => ({ logAudit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/lib/rate-limit", () => ({
+  requireRateLimit: vi.fn(),
+  RATE_LIMIT_MUTATION: {},
+}));
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: mockAuth,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...original,
+    auth: () => mockAuth(),
+    requireChurchPermission: (...args: unknown[]) => mockRequireChurchPermission(...args),
+  };
+});
+vi.mock("@/modules/agenda/auth", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/modules/agenda/auth")>();
+  return { ...original };
+});
+
+const { GET, POST } = await import("../route");
+
+describe("GET /api/agenda/requests — status enum validation (T01)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.appointmentRequest.findMany.mockResolvedValue([]);
+    prismaMock.department.count.mockResolvedValue(0);
+  });
+
+  it("returns 400 for invalid status SCHEDULED", async () => {
+    const req = new Request(
+      "http://localhost/api/agenda/requests?churchId=church-1&status=SCHEDULED"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Statut invalide");
+  });
+
+  it("returns 400 for invalid status REJECTED", async () => {
+    const req = new Request(
+      "http://localhost/api/agenda/requests?churchId=church-1&status=REJECTED"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for arbitrary status string", async () => {
+    const req = new Request(
+      "http://localhost/api/agenda/requests?churchId=church-1&status=ALL"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts status=PENDING for qualifier", async () => {
+    mockAuth.mockResolvedValue(createAgendaQualifierSession("church-1"));
+    prismaMock.department.count.mockResolvedValue(0);
+    const req = new Request(
+      "http://localhost/api/agenda/requests?churchId=church-1&status=PENDING"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 when qualifier requests status=VALIDATED", async () => {
+    mockAuth.mockResolvedValue(createAgendaQualifierSession("church-1"));
+    prismaMock.department.count.mockResolvedValue(0);
+    const req = new Request(
+      "http://localhost/api/agenda/requests?churchId=church-1&status=VALIDATED"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when churchId is missing", async () => {
+    const req = new Request("http://localhost/api/agenda/requests");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("allows admin to see both PENDING and VALIDATED without status filter", async () => {
+    const req = new Request(
+      "http://localhost/api/agenda/requests?churchId=church-1"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    expect(prismaMock.appointmentRequest.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: expect.arrayContaining(["PENDING", "VALIDATED"]) },
+        }),
+      })
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const req = new Request(
+      "http://localhost/api/agenda/requests?churchId=church-1"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/agenda/requests — auth and validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.appointmentRequest.create.mockResolvedValue({ id: "req-1" });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireChurchPermission.mockRejectedValue(new Error("UNAUTHORIZED"));
+    const req = new Request("http://localhost/api/agenda/requests", {
+      method: "POST",
+      body: JSON.stringify({
+        churchId: "church-1",
+        firstName: "Jean",
+        lastName: "Dupont",
+        subject: "RDV pastoral",
+        message: "Besoin d'un entretien",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const req = new Request("http://localhost/api/agenda/requests", {
+      method: "POST",
+      body: JSON.stringify({ churchId: "church-1" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("creates the request successfully", async () => {
+    const req = new Request("http://localhost/api/agenda/requests", {
+      method: "POST",
+      body: JSON.stringify({
+        churchId: "church-1",
+        firstName: "Jean",
+        lastName: "Dupont",
+        subject: "RDV pastoral",
+        message: "Besoin d'un entretien",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("GET /api/agenda/requests — PROTOCOLE member access", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("PROTOCOLE member can see VALIDATED requests", async () => {
+    const session = createProtocoleMemberSession("dept-protocole", "church-1");
+    mockAuth.mockResolvedValue(session);
+    prismaMock.department.count.mockResolvedValue(1);
+    prismaMock.appointmentRequest.findMany.mockResolvedValue([]);
+
+    const req = new Request(
+      "http://localhost/api/agenda/requests?churchId=church-1&status=VALIDATED"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("PROTOCOLE member cannot see PENDING requests (only qualifiers can)", async () => {
+    const session = createProtocoleMemberSession("dept-protocole", "church-1");
+    mockAuth.mockResolvedValue(session);
+    prismaMock.department.count.mockResolvedValue(1);
+
+    const req = new Request(
+      "http://localhost/api/agenda/requests?churchId=church-1&status=PENDING"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/modules/agenda/__tests__/auth.test.ts
+++ b/src/modules/agenda/__tests__/auth.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import {
+  createAdminSession,
+  createSuperAdminSession,
+  createSecretarySession,
+  createAgendaQualifierSession,
+  createDepartmentHeadSession,
+  createProtocoleMemberSession,
+} from "@/__mocks__/auth";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: mockAuth,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/auth")>();
+  return { ...original, auth: () => mockAuth() };
+});
+
+const { isProtocoleMember, requireAgendaView, requireAgendaManage, requireAgendaQualify } =
+  await import("@/modules/agenda/auth");
+
+describe("isProtocoleMember", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns true when user has a PROTOCOLE dept in the church", async () => {
+    const session = createProtocoleMemberSession("dept-protocole", "church-1");
+    prismaMock.department.count.mockResolvedValue(1);
+    expect(await isProtocoleMember(session, "church-1")).toBe(true);
+  });
+
+  it("returns false when user has no departments in the church", async () => {
+    const session = createAdminSession("church-1");
+    expect(await isProtocoleMember(session, "church-2")).toBe(false);
+    expect(prismaMock.department.count).not.toHaveBeenCalled();
+  });
+
+  it("returns false when department is not PROTOCOLE function", async () => {
+    const session = createDepartmentHeadSession([{ id: "dept-1", name: "Son" }], "church-1");
+    prismaMock.department.count.mockResolvedValue(0);
+    expect(await isProtocoleMember(session, "church-1")).toBe(false);
+  });
+
+  it("returns false when dept belongs to another church (cross-tenant)", async () => {
+    const session = createProtocoleMemberSession("dept-protocole", "church-2");
+    prismaMock.department.count.mockResolvedValue(0);
+    expect(await isProtocoleMember(session, "church-1")).toBe(false);
+  });
+});
+
+describe("requireAgendaView", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("allows super admin", async () => {
+    mockAuth.mockResolvedValue(createSuperAdminSession());
+    const session = await requireAgendaView("church-1");
+    expect(session.user.isSuperAdmin).toBe(true);
+  });
+
+  it("allows admin (has agenda:view)", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+    const session = await requireAgendaView("church-1");
+    expect(session.user.id).toBe("user-1");
+  });
+
+  it("allows secretary (has agenda:view)", async () => {
+    mockAuth.mockResolvedValue(createSecretarySession("church-1"));
+    const session = await requireAgendaView("church-1");
+    expect(session.user.id).toBe("user-1");
+  });
+
+  it("denies AGENDA_QUALIFIER (removed from agenda:view — T03)", async () => {
+    mockAuth.mockResolvedValue(createAgendaQualifierSession("church-1"));
+    await expect(requireAgendaView("church-1")).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("allows PROTOCOLE member via isProtocoleMember", async () => {
+    const session = createProtocoleMemberSession("dept-protocole", "church-1");
+    mockAuth.mockResolvedValue(session);
+    prismaMock.department.count.mockResolvedValue(1);
+    const result = await requireAgendaView("church-1");
+    expect(result.user.id).toBe("user-1");
+  });
+
+  it("denies user with no role in the church", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-2"));
+    await expect(requireAgendaView("church-1")).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("denies unauthenticated user", async () => {
+    mockAuth.mockResolvedValue(null);
+    await expect(requireAgendaView("church-1")).rejects.toThrow("UNAUTHORIZED");
+  });
+});
+
+describe("requireAgendaManage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("allows admin (has agenda:manage)", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+    const session = await requireAgendaManage("church-1");
+    expect(session.user.id).toBe("user-1");
+  });
+
+  it("allows PROTOCOLE member", async () => {
+    const session = createProtocoleMemberSession("dept-protocole", "church-1");
+    mockAuth.mockResolvedValue(session);
+    prismaMock.department.count.mockResolvedValue(1);
+    const result = await requireAgendaManage("church-1");
+    expect(result.user.id).toBe("user-1");
+  });
+
+  it("denies AGENDA_QUALIFIER (has no agenda:manage)", async () => {
+    mockAuth.mockResolvedValue(createAgendaQualifierSession("church-1"));
+    prismaMock.department.count.mockResolvedValue(0);
+    await expect(requireAgendaManage("church-1")).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("denies department head (has no agenda:manage)", async () => {
+    mockAuth.mockResolvedValue(
+      createDepartmentHeadSession([{ id: "dept-1", name: "Son" }], "church-1")
+    );
+    prismaMock.department.count.mockResolvedValue(0);
+    await expect(requireAgendaManage("church-1")).rejects.toThrow("FORBIDDEN");
+  });
+});
+
+describe("requireAgendaQualify", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("allows AGENDA_QUALIFIER", async () => {
+    mockAuth.mockResolvedValue(createAgendaQualifierSession("church-1"));
+    const session = await requireAgendaQualify("church-1");
+    expect(session.user.id).toBe("user-1");
+  });
+
+  it("allows admin (has agenda:qualify)", async () => {
+    mockAuth.mockResolvedValue(createAdminSession("church-1"));
+    const session = await requireAgendaQualify("church-1");
+    expect(session.user.id).toBe("user-1");
+  });
+
+  it("denies PROTOCOLE member (no agenda:qualify)", async () => {
+    const session = createProtocoleMemberSession("dept-protocole", "church-1");
+    mockAuth.mockResolvedValue(session);
+    await expect(requireAgendaQualify("church-1")).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("denies secretary (no agenda:qualify)", async () => {
+    mockAuth.mockResolvedValue(createSecretarySession("church-1"));
+    await expect(requireAgendaQualify("church-1")).rejects.toThrow("FORBIDDEN");
+  });
+});


### PR DESCRIPTION
## Résumé

Suite de l'audit de sécurité — item T07 : couverture de tests pour le module agenda pastoral.

### Nouveaux tests (51 tests)

| Fichier | Couverture |
|---|---|
| `modules/agenda/__tests__/auth.test.ts` | `isProtocoleMember`, `requireAgendaView`, `requireAgendaManage`, `requireAgendaQualify` |
| `api/agenda/requests/__tests__/security.test.ts` | T01 enum validation, matrice RBAC, accès PROTOCOLE |
| `api/agenda/profiles/__tests__/security.test.ts` | T02 cross-tenant userId, auth guards |
| `api/agenda/entries/__tests__/security.test.ts` | T04 validation temporelle, cross-tenant profil |

### Points clés vérifiés

- **T01** : `status=SCHEDULED` et `status=REJECTED` bloqués avec 400 avant toute vérification d'auth
- **T02** : userId lié au bon tenant via `userChurchRole.findFirst`
- **T03** : `AGENDA_QUALIFIER` n'a plus `agenda:view` (test échouerait si la permission était re-ajoutée)
- **T04** : `endsAt <= startsAt` renvoie 400 via refine Zod
- Matrice PROTOCOLE : accès VALIDATED ✓, accès PENDING ✗

### Mocks mis à jour

- `prismaMock` : ajout `pastoralProfile`, `appointmentRequest`, `agendaEntry`, `mrbsUserLink`
- `createAgendaQualifierSession()` et `createProtocoleMemberSession()` dans `auth.ts`

## Plan de test

- [ ] `npm run test` → 318/318 tests passent
- [ ] `npm run typecheck` → 0 erreur
- [ ] `npm run lint:boundaries` → 0 violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)