### PR TITLE
fix(ci): coverage gate avec seuils minimaux (T09)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run lint:boundaries
-      - run: npm run test
+      - run: npm run test:coverage
 
   build:
     needs: lint-test

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,13 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     coverage: {
       provider: "v8",
-      include: ["src/lib/**", "src/app/api/**"],
+      include: ["src/lib/**", "src/app/api/**", "src/modules/**"],
+      thresholds: {
+        statements: 20,
+        branches: 18,
+        functions: 20,
+        lines: 20,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## Résumé

Suite de l'audit de sécurité — item T09 : gate de couverture en CI.

### Changements

**`vitest.config.ts`**
- Ajout de `src/modules/**` au périmètre de couverture (était limité à `src/lib/**` + `src/app/api/**`)
- Seuils bloquants :

| Métrique | Seuil | Actuel |
|---|---|---|
| Statements | 20 % | 25.66 % |
| Branches | 18 % | 23.48 % |
| Functions | 20 % | 25.16 % |
| Lines | 20 % | 26.78 % |

Les seuils sont intentionnellement conservateurs (en dessous de l'actuel) pour ne pas bloquer immédiatement et laisser de la marge de progression.

**`.github/workflows/ci.yml`**
- `npm run test` → `npm run test:coverage` dans le job `lint-test`
- Le rapport de couverture est désormais visible dans les logs CI

### Effet en CI

- Build fail si une PR fait chuter la couverture en dessous des seuils
- Rapport texte visible dans les logs pour chaque PR

## Plan de test

- [ ] `npm run test:coverage` → 318/318 tests, seuils atteints, exit 0
- [ ] Vérifier que le rapport apparaît dans les logs CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)