### PR TITLE
fix(users): scope enforcement sur PATCH /users/[userId]/roles (T10)

### DIFF
--- a/src/app/api/users/[userId]/roles/__tests__/scope.test.ts
+++ b/src/app/api/users/[userId]/roles/__tests__/scope.test.ts
@@ -207,3 +207,90 @@ describe("BLOCKER-1 : POST /api/users/[userId]/roles — RBAC events:manage", ()
     expect(res.status).toBe(201);
   });
 });
+
+const { PATCH } = await import("../route");
+
+describe("PATCH /api/users/[userId]/roles — scope validation (T10)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequireRateLimit.mockReturnValue(undefined);
+  });
+
+  it("returns 400 when setting ministryId on a non-MINISTER role", async () => {
+    prismaMock.userChurchRole.findFirst.mockResolvedValue({
+      id: "role-1",
+      userId: "user-1",
+      churchId: "church-1",
+      role: "DEPARTMENT_HEAD",
+    } as never);
+
+    const request = new Request("http://localhost/api/users/user-1/roles", {
+      method: "PATCH",
+      body: JSON.stringify({ roleId: "role-1", ministryId: "min-1" }),
+    });
+    const res = await PATCH(request, { params: Promise.resolve({ userId: "user-1" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Ministre");
+  });
+
+  it("returns 400 when setting departments on a non-DEPARTMENT_HEAD role", async () => {
+    prismaMock.userChurchRole.findFirst.mockResolvedValue({
+      id: "role-1",
+      userId: "user-1",
+      churchId: "church-1",
+      role: "MINISTER",
+    } as never);
+
+    const request = new Request("http://localhost/api/users/user-1/roles", {
+      method: "PATCH",
+      body: JSON.stringify({ roleId: "role-1", departments: [{ id: "dept-1" }] }),
+    });
+    const res = await PATCH(request, { params: Promise.resolve({ userId: "user-1" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Responsable");
+  });
+
+  it("allows updating ministryId for MINISTER role", async () => {
+    prismaMock.userChurchRole.findFirst.mockResolvedValue({
+      id: "role-1",
+      userId: "user-1",
+      churchId: "church-1",
+      role: "MINISTER",
+    } as never);
+    prismaMock.ministry.findUnique.mockResolvedValue({ churchId: "church-1" } as never);
+    prismaMock.userChurchRole.update.mockResolvedValue({} as never);
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({ id: "role-1" } as never);
+
+    const request = new Request("http://localhost/api/users/user-1/roles", {
+      method: "PATCH",
+      body: JSON.stringify({ roleId: "role-1", ministryId: "min-1" }),
+    });
+    const res = await PATCH(request, { params: Promise.resolve({ userId: "user-1" }) });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows updating departments for DEPARTMENT_HEAD role", async () => {
+    prismaMock.userChurchRole.findFirst.mockResolvedValue({
+      id: "role-1",
+      userId: "user-1",
+      churchId: "church-1",
+      role: "DEPARTMENT_HEAD",
+    } as never);
+    prismaMock.department.findMany.mockResolvedValue([
+      { id: "dept-1", name: "Son", ministry: { churchId: "church-1" } },
+    ] as never);
+    prismaMock.userDepartment.deleteMany.mockResolvedValue({} as never);
+    prismaMock.userDepartment.createMany.mockResolvedValue({} as never);
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({ id: "role-1" } as never);
+
+    const request = new Request("http://localhost/api/users/user-1/roles", {
+      method: "PATCH",
+      body: JSON.stringify({ roleId: "role-1", departments: [{ id: "dept-1" }] }),
+    });
+    const res = await PATCH(request, { params: Promise.resolve({ userId: "user-1" }) });
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/users/[userId]/roles/route.ts
+++ b/src/app/api/users/[userId]/roles/route.ts
@@ -164,6 +164,14 @@ export async function PATCH(
     const patchSession = await requireChurchPermission("events:manage", existing.churchId);
     requireRateLimit(request, { prefix: `roles:${patchSession.user.id}`, ...RATE_LIMIT_SENSITIVE });
 
+    // Scope enforcement : ministryId uniquement pour MINISTER, departments pour DEPARTMENT_HEAD
+    if (ministryId !== undefined && existing.role !== "MINISTER") {
+      throw new ApiError(400, "ministryId n'est applicable qu'au rôle Ministre");
+    }
+    if ((departments?.length || departmentIds?.length) && existing.role !== "DEPARTMENT_HEAD") {
+      throw new ApiError(400, "departments n'est applicable qu'au rôle Responsable de département");
+    }
+
     // Vérifier que le ministryId appartient à cette église
     if (ministryId) {
       const ministry = await prisma.ministry.findUnique({


### PR DESCRIPTION
## Résumé

Suite de l'audit de sécurité — item T10 : prévention d'escalade de rôle via `PATCH /api/users/[userId]/roles`.

### Problème

Le handler `PATCH` n'avait pas de contrôle de scope sur les champs envoyés, contrairement au `POST`. Il était possible de :
- Passer un `ministryId` sur un rôle `DEPARTMENT_HEAD` (champ ignoré mais non bloqué)
- Passer des `departments` sur un rôle `MINISTER` (idem)

### Fix

```typescript
if (ministryId !== undefined && existing.role !== "MINISTER") {
  throw new ApiError(400, "ministryId n'est applicable qu'au rôle Ministre");
}
if ((departments?.length || departmentIds?.length) && existing.role !== "DEPARTMENT_HEAD") {
  throw new ApiError(400, "departments n'est applicable qu'au rôle Responsable de département");
}
```

### Tests ajoutés (4)

- `returns 400 when setting ministryId on a non-MINISTER role`
- `returns 400 when setting departments on a non-DEPARTMENT_HEAD role`
- `allows updating ministryId for MINISTER role`
- `allows updating departments for DEPARTMENT_HEAD role`

## Plan de test

- [ ] `npm run typecheck` → 0 erreur
- [ ] `npm run test` → 322/322 tests passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)