### PR TITLE
fix(lint): react-hooks/set-state-in-effect dans BackupsClient et DownloadView (T14)

### DIFF
--- a/src/app/(auth)/admin/backups/BackupsClient.tsx
+++ b/src/app/(auth)/admin/backups/BackupsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 
 type BackupEntry = {
   key: string;
@@ -133,21 +133,32 @@ export default function BackupsClient() {
   const [restoreTarget, setRestoreTarget] = useState<BackupEntry | null>(null);
   const [restoreLoading, setRestoreLoading] = useState(false);
   const [restoreResult, setRestoreResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [currentRefreshKey, setCurrentRefreshKey] = useState(0);
 
-  const fetchBackups = useCallback(async () => {
+  // Reset loading/error during render when a refresh is requested (avoids synchronous setState in effect)
+  if (currentRefreshKey !== refreshKey) {
+    setCurrentRefreshKey(refreshKey);
     setLoading(true);
     setError(null);
-    const res = await fetch("/api/admin/backups");
-    if (!res.ok) {
-      const json = await res.json().catch(() => ({}));
-      setError(json.error ?? "Impossible de charger les sauvegardes");
-    } else {
-      setBackups(await res.json());
-    }
-    setLoading(false);
-  }, []);
+  }
 
-  useEffect(() => { fetchBackups(); }, [fetchBackups]);
+  useEffect(() => {
+    let mounted = true;
+    fetch("/api/admin/backups")
+      .then(async (res) => {
+        if (!mounted) return;
+        if (!res.ok) {
+          const json = await res.json().catch(() => ({}));
+          if (mounted) setError(json.error ?? "Impossible de charger les sauvegardes");
+        } else {
+          const data = await res.json();
+          if (mounted) setBackups(data);
+        }
+      })
+      .finally(() => { if (mounted) setLoading(false); });
+    return () => { mounted = false; };
+  }, [refreshKey]);
 
   async function triggerBackup() {
     setTriggering(true);
@@ -158,7 +169,7 @@ export default function BackupsClient() {
       setTriggerResult(`Erreur : ${json.error ?? "échec de la sauvegarde"}`);
     } else {
       setTriggerResult(`Sauvegarde créée : ${keyToLabel(json.key)} (${formatBytes(json.sizeBytes)})`);
-      fetchBackups();
+      setRefreshKey((k) => k + 1);
     }
     setTriggering(false);
   }
@@ -221,7 +232,7 @@ export default function BackupsClient() {
             )}
           </h2>
           <button
-            onClick={fetchBackups}
+            onClick={() => setRefreshKey((k) => k + 1)}
             disabled={loading}
             className="text-xs text-gray-400 hover:text-icc-violet transition-colors disabled:opacity-50"
           >

--- a/src/app/media/d/[token]/DownloadView.tsx
+++ b/src/app/media/d/[token]/DownloadView.tsx
@@ -56,17 +56,25 @@ function Lightbox({
   downloading: boolean;
   isMediaAll: boolean;
 }) {
+  const [currentPhotoId, setCurrentPhotoId] = useState(photo.id);
   const [hdUrl, setHdUrl] = useState<string | null>(null);
   const [hdLoading, setHdLoading] = useState(true);
 
-  useEffect(() => {
+  // Reset state synchronously during render when photo changes (recommended pattern over useEffect reset)
+  if (currentPhotoId !== photo.id) {
+    setCurrentPhotoId(photo.id);
     setHdUrl(null);
     setHdLoading(true);
+  }
+
+  useEffect(() => {
+    let mounted = true;
     fetch(`/api/media/download/${token}/photo/${photo.id}`)
       .then((r) => r.json())
-      .then((j) => { if (j.downloadUrl) setHdUrl(j.downloadUrl); })
+      .then((j) => { if (mounted && j.downloadUrl) setHdUrl(j.downloadUrl); })
       .catch(() => {})
-      .finally(() => setHdLoading(false));
+      .finally(() => { if (mounted) setHdLoading(false); });
+    return () => { mounted = false; };
   }, [photo.id, token]);
 
   useEffect(() => {


### PR DESCRIPTION
## Résumé

Corrige les 2 avertissements ESLint `react-hooks/set-state-in-effect` identifiés en T14.

- **BackupsClient.tsx** : supprime le `useCallback` + `useEffect` en cascade. La liste de sauvegardes est maintenant rechargée via un `refreshKey` state — le reset `loading/error` se fait pendant le rendu (guard `currentRefreshKey !== refreshKey`), l'effet async ne contient que le `fetch` avec un flag `mounted`.
- **DownloadView.tsx / Lightbox** : le reset `hdUrl/hdLoading` lors du changement de photo se fait pendant le rendu via un guard `currentPhotoId !== photo.id`, conformément au [pattern officiel React](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes). L'effet async ajoute un flag `mounted` pour éviter les mises à jour après démontage.

## Plan de test

- [ ] `npm run lint` → 0 warnings
- [ ] `npm run test` → 42 fichiers, 322 tests passent
- [ ] Vérifier manuellement la page `/admin/backups` : chargement, actualisation, sauvegarde déclenchée
- [ ] Vérifier la lightbox dans `/media/d/[token]` : changement de photo reset correctement l'image HD

🤖 Generated with [Claude Code](https://claude.com/claude-code)