### PR TITLE
feat(agenda): formulaire public de demande de RDV pastoral

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,5 +46,10 @@ MRBS_DB_URL=mysql://USER:PASSWORD@localhost:3306/mrbs  # BDD MRBS (lecture seule
 MRBS_URL=https://salles.example.com       # URL publique de l'instance MRBS (lien sidebar)
 MRBS_CHURCH_ID=                           # churchId Koinonia servi par cette instance MRBS
 
+# ─── Agenda public (formulaire de demande de RDV sans authentification) ───
+# Obtenir les clés sur https://dash.cloudflare.com/ > Turnstile
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=           # clé publique Turnstile (affichée dans le widget)
+TURNSTILE_SECRET_KEY=                     # clé secrète Turnstile (vérification serveur)
+
 # ─── Monitoring ───
 # GET /api/health — public, retourne { status, version, db, uptime }

--- a/src/app/(auth)/agenda/AgendaCalendar.tsx
+++ b/src/app/(auth)/agenda/AgendaCalendar.tsx
@@ -35,6 +35,10 @@ function fmtTime(d: Date) {
   return new Date(d).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
 }
 
+function toLocalISO(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
 export default function AgendaCalendar({ profiles, entries, weekStart }: Props) {
   const router = useRouter();
   const from = new Date(weekStart);
@@ -67,7 +71,7 @@ export default function AgendaCalendar({ profiles, entries, weekStart }: Props) 
       {/* Navigation semaine */}
       <div className="flex items-center justify-between mb-4">
         <button
-          onClick={() => router.push(`/agenda?week=${prevWeek.toISOString().split("T")[0]}`)}
+          onClick={() => router.push(`/agenda?week=${toLocalISO(prevWeek)}`)}
           className="px-3 py-1 text-sm border border-gray-200 rounded-lg hover:bg-gray-50"
         >
           ← Semaine précédente
@@ -76,7 +80,7 @@ export default function AgendaCalendar({ profiles, entries, weekStart }: Props) 
           {fmtDate(days[0])} — {fmtDate(days[6])}
         </span>
         <button
-          onClick={() => router.push(`/agenda?week=${nextWeek.toISOString().split("T")[0]}`)}
+          onClick={() => router.push(`/agenda?week=${toLocalISO(nextWeek)}`)}
           className="px-3 py-1 text-sm border border-gray-200 rounded-lg hover:bg-gray-50"
         >
           Semaine suivante →

--- a/src/app/(auth)/agenda/PublicUrlBanner.tsx
+++ b/src/app/(auth)/agenda/PublicUrlBanner.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+
+export default function PublicUrlBanner({ slug }: { slug: string }) {
+  const [copied, setCopied] = useState(false);
+  const url = `${typeof window !== "undefined" ? window.location.origin : ""}/agenda-public/${slug}`;
+
+  function copy() {
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="mb-6 flex items-center gap-3 bg-icc-violet/5 border border-icc-violet/20 rounded-xl px-4 py-3">
+      <svg className="w-4 h-4 text-icc-violet shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+      </svg>
+      <div className="flex-1 min-w-0">
+        <p className="text-xs font-medium text-icc-violet mb-0.5">Lien public — formulaire de demande de RDV</p>
+        <p className="text-xs text-gray-500 truncate">{url}</p>
+      </div>
+      <button
+        onClick={copy}
+        className="shrink-0 flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg border border-icc-violet/30 text-icc-violet hover:bg-icc-violet/10 transition-colors font-medium"
+      >
+        {copied ? (
+          <>
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+            </svg>
+            Copié !
+          </>
+        ) : (
+          <>
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+            Copier
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/app/(auth)/agenda/[profileId]/ProfileAgenda.tsx
+++ b/src/app/(auth)/agenda/[profileId]/ProfileAgenda.tsx
@@ -20,6 +20,10 @@ interface Profile { id: string; name: string; role: string }
 interface Props { profile: Profile; entries: Entry[]; weekStart: string }
 
 
+function toLocalISO(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
 function fmtTime(d: Date) {
   return new Date(d).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
 }
@@ -59,14 +63,14 @@ export default function ProfileAgenda({ profile, entries, weekStart }: Props) {
       {/* Navigation */}
       <div className="flex items-center justify-between mb-6">
         <button
-          onClick={() => router.push(`/agenda/${profile.id}?week=${prevWeek.toISOString().split("T")[0]}`)}
+          onClick={() => router.push(`/agenda/${profile.id}?week=${toLocalISO(prevWeek)}`)}
           className="px-3 py-1 text-sm border border-gray-200 rounded-lg hover:bg-gray-50"
         >
           ← Semaine précédente
         </button>
         <span className="text-sm font-medium text-gray-700">{fromLabel} — {toLabel}</span>
         <button
-          onClick={() => router.push(`/agenda/${profile.id}?week=${nextWeek.toISOString().split("T")[0]}`)}
+          onClick={() => router.push(`/agenda/${profile.id}?week=${toLocalISO(nextWeek)}`)}
           className="px-3 py-1 text-sm border border-gray-200 rounded-lg hover:bg-gray-50"
         >
           Semaine suivante →

--- a/src/app/(auth)/agenda/[profileId]/page.tsx
+++ b/src/app/(auth)/agenda/[profileId]/page.tsx
@@ -5,6 +5,10 @@ import { notFound } from "next/navigation";
 
 import ProfileAgenda from "./ProfileAgenda";
 
+function toLocalISO(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
 function getWeekBounds(date: Date): { from: Date; to: Date } {
   const from = new Date(date);
   from.setHours(0, 0, 0, 0);
@@ -63,7 +67,7 @@ export default async function ProfileAgendaPage({
         Agenda — {profile.name}
       </h1>
       <p className="text-sm text-gray-500 mb-6">{ROLE_LABELS[profile.role]}</p>
-      <ProfileAgenda profile={profile} entries={entries} weekStart={from.toISOString()} />
+      <ProfileAgenda profile={profile} entries={entries} weekStart={toLocalISO(from)} />
     </div>
   );
 }

--- a/src/app/(auth)/agenda/page.tsx
+++ b/src/app/(auth)/agenda/page.tsx
@@ -5,6 +5,10 @@ import AgendaCalendar from "./AgendaCalendar";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
 
+function toLocalISO(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
 function getWeekBounds(date: Date): { from: Date; to: Date } {
   const from = new Date(date);
   from.setHours(0, 0, 0, 0);
@@ -63,7 +67,7 @@ export default async function AgendaPage({
           <a href="/admin/pastoral-profiles" className="underline">Configurer maintenant →</a>
         </div>
       ) : (
-        <AgendaCalendar profiles={profiles} entries={entries} weekStart={from.toISOString()} />
+        <AgendaCalendar profiles={profiles} entries={entries} weekStart={toLocalISO(from)} />
       )}
     </div>
   );

--- a/src/app/(auth)/agenda/page.tsx
+++ b/src/app/(auth)/agenda/page.tsx
@@ -2,6 +2,7 @@ import { requireAuth, getCurrentChurchId } from "@/lib/auth";
 import { requireAgendaManage } from "@/modules/agenda/auth";
 import { prisma } from "@/lib/prisma";
 import AgendaCalendar from "./AgendaCalendar";
+import PublicUrlBanner from "./PublicUrlBanner";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
 
@@ -32,7 +33,8 @@ export default async function AgendaPage({
   const refDate = week ? new Date(week) : new Date();
   const { from, to } = getWeekBounds(refDate);
 
-  const [profiles, entries] = await Promise.all([
+  const [church, profiles, entries] = await Promise.all([
+    prisma.church.findUnique({ where: { id: churchId }, select: { slug: true } }),
     prisma.pastoralProfile.findMany({
       where: { churchId },
       select: { id: true, name: true, role: true },
@@ -61,6 +63,7 @@ export default async function AgendaPage({
           </Link>
         </div>
       </div>
+      {church?.slug && <PublicUrlBanner slug={church.slug} />}
       {profiles.length === 0 ? (
         <div className="p-6 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800">
           Aucun profil pastoral configuré.{" "}

--- a/src/app/(auth)/agenda/request/RequestForm.tsx
+++ b/src/app/(auth)/agenda/request/RequestForm.tsx
@@ -5,51 +5,99 @@ import Button from "@/components/ui/Button";
 
 interface Props {
   churchId: string;
+  churchName: string;
   defaultFirstName: string;
   defaultLastName: string;
   defaultEmail: string;
+  defaultIsStar?: string;
+  defaultDepartment?: string;
 }
 
-const DAYS_OPTIONS = [
-  { value: "LUNDI", label: "Lundi" },
-  { value: "MARDI", label: "Mardi" },
-  { value: "MERCREDI", label: "Mercredi" },
-  { value: "JEUDI", label: "Jeudi" },
-  { value: "VENDREDI", label: "Vendredi" },
-  { value: "SAMEDI", label: "Samedi" },
-  { value: "DIMANCHE", label: "Dimanche" },
-];
+type FieldErrors = Partial<Record<string, string>>;
 
-export default function RequestForm({ churchId, defaultFirstName, defaultLastName, defaultEmail }: Props) {
-  const [submitted, setSubmitted] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
+const AGE_RANGES = ["18-20 ans", "21-30 ans", "31-40 ans", "41-50 ans", "+50 ans"];
+const DURATIONS = ["Moins de 1 an", "1 à 2 ans", "2 à 3 ans", "3 à 5 ans", "+ 5 ans"];
+const MOTIFS = ["Renseignements", "Démarches administratives", "Vie familiale", "Croissance spirituelle", "Oppressions", "Maladie", "Service", "Études"];
+const DAYS = ["Mardi", "Dimanche"];
+
+const inputCls = "w-full border-2 border-gray-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-icc-violet";
+
+function RadioGroup({ name, options, value, onChange }: {
+  name: string; options: string[]; value: string; onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((opt) => (
+        <label key={opt} className={`flex items-center gap-2 px-3 py-2.5 md:py-1.5 min-h-[44px] md:min-h-0 rounded-full border text-sm cursor-pointer transition-colors ${
+          value === opt ? "bg-icc-violet text-white border-icc-violet" : "border-gray-200 text-gray-700 hover:border-icc-violet"
+        }`}>
+          <input type="radio" name={name} value={opt} checked={value === opt}
+            onChange={() => onChange(opt)} className="sr-only" />
+          {opt}
+        </label>
+      ))}
+    </div>
+  );
+}
+
+export default function RequestForm({ churchId, churchName, defaultFirstName, defaultLastName, defaultEmail, defaultIsStar = "", defaultDepartment = "" }: Props) {
   const [form, setForm] = useState({
     firstName: defaultFirstName,
     lastName: defaultLastName,
     email: defaultEmail,
     phone: "",
-    subject: "",
-    message: "",
-    preferredDays: [] as string[],
+    gender: "",
+    ageRange: "",
+    membershipDuration: "",
+    isStar: defaultIsStar,
+    department: defaultDepartment,
+    motifs: [] as string[],
+    preferredDay: "",
   });
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   function set(field: string, value: string) {
-    setForm((prev) => ({ ...prev, [field]: value }));
+    setForm((f) => ({ ...f, [field]: value }));
+    if (fieldErrors[field]) setFieldErrors((e) => ({ ...e, [field]: undefined }));
   }
 
-  function toggleDay(day: string) {
-    setForm((prev) => ({
-      ...prev,
-      preferredDays: prev.preferredDays.includes(day)
-        ? prev.preferredDays.filter((d) => d !== day)
-        : [...prev.preferredDays, day],
+  function toggleMotif(motif: string) {
+    setForm((f) => ({
+      ...f,
+      motifs: f.motifs.includes(motif) ? f.motifs.filter((m) => m !== motif) : [...f.motifs, motif],
     }));
+    if (fieldErrors["motifs"]) setFieldErrors((e) => ({ ...e, motifs: undefined }));
   }
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
-    if (!form.subject || !form.message) { alert("L'objet et le message sont requis."); return; }
+    const errs: FieldErrors = {};
+    if (!form.gender) errs.gender = "Veuillez sélectionner votre sexe";
+    if (!form.ageRange) errs.ageRange = "Veuillez sélectionner votre tranche d'âge";
+    if (!form.membershipDuration) errs.membershipDuration = "Veuillez sélectionner votre ancienneté";
+    if (!form.isStar) errs.isStar = "Veuillez répondre à cette question";
+    if (form.motifs.length === 0) errs.motifs = "Veuillez sélectionner au moins un motif";
+    if (!form.preferredDay) errs.preferredDay = "Veuillez sélectionner un jour";
+    if (Object.keys(errs).length > 0) {
+      setFieldErrors(errs);
+      setGlobalError("Veuillez corriger les erreurs ci-dessous.");
+      return;
+    }
+
     setSubmitting(true);
+    setGlobalError(null);
+
+    const subject = form.motifs.join(", ");
+    const message = [
+      `Sexe : ${form.gender}`,
+      `Tranche d'âge : ${form.ageRange}`,
+      `À l'église depuis : ${form.membershipDuration}`,
+      `STAR : ${form.isStar}${form.isStar === "Oui" && form.department ? ` — Département : ${form.department}` : ""}`,
+    ].join("\n");
+
     try {
       const res = await fetch("/api/agenda/requests", {
         method: "POST",
@@ -60,22 +108,30 @@ export default function RequestForm({ churchId, defaultFirstName, defaultLastNam
           lastName: form.lastName,
           email: form.email || null,
           phone: form.phone || null,
-          subject: form.subject,
-          message: form.message,
-          preferredDays: form.preferredDays.length > 0 ? form.preferredDays.join(",") : null,
+          subject,
+          message,
+          preferredDays: form.preferredDay,
         }),
       });
-      if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur"); return; }
+      if (!res.ok) {
+        const d = await res.json();
+        setGlobalError(d.error || "Une erreur est survenue. Veuillez réessayer.");
+        return;
+      }
       setSubmitted(true);
-    } catch { alert("Erreur réseau"); }
-    finally { setSubmitting(false); }
+    } catch {
+      setGlobalError("Erreur réseau. Veuillez réessayer.");
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   if (submitted) {
     return (
-      <div className="bg-green-50 border border-green-200 rounded-lg p-6 text-center">
-        <p className="text-green-800 font-semibold text-lg mb-2">Demande envoyée !</p>
-        <p className="text-green-700 text-sm">
+      <div className="bg-white rounded-xl border border-green-200 p-6 sm:p-8 text-center space-y-3">
+        <div className="w-12 h-12 rounded-full bg-green-100 flex items-center justify-center mx-auto text-2xl">✓</div>
+        <h2 className="text-lg font-semibold text-gray-900">Demande envoyée !</h2>
+        <p className="text-sm text-gray-600">
           Votre demande a bien été reçue. Un qualificateur la traitera prochainement et vous sera assigné un créneau.
         </p>
       </div>
@@ -83,104 +139,112 @@ export default function RequestForm({ churchId, defaultFirstName, defaultLastNam
   }
 
   return (
-    <form onSubmit={submit} className="space-y-5 bg-white rounded-lg shadow border border-gray-100 p-6">
-      <div className="grid grid-cols-2 gap-4">
+    <form onSubmit={submit} className="space-y-5">
+
+      {/* Coordonnées */}
+      <div className="bg-white rounded-xl border border-gray-200 p-4 sm:p-6 space-y-4">
+        <h2 className="text-base font-semibold text-gray-900">Vos coordonnées</h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Nom *</label>
+            <input type="text" required value={form.lastName} onChange={(e) => set("lastName", e.target.value)} className={inputCls} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Prénom *</label>
+            <input type="text" required value={form.firstName} onChange={(e) => set("firstName", e.target.value)} className={inputCls} />
+          </div>
+        </div>
+
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Prénom</label>
-          <input
-            type="text"
-            value={form.firstName}
-            onChange={(e) => set("firstName", e.target.value)}
-            required
-            className="w-full px-3 py-2 border-2 border-gray-200 rounded-lg text-sm focus:outline-none focus:border-icc-violet"
-          />
+          <label className="block text-sm font-medium text-gray-700 mb-2">Sexe *</label>
+          <RadioGroup name="gender" options={["Homme", "Femme"]} value={form.gender} onChange={(v) => set("gender", v)} />
+          {fieldErrors.gender && <p className="text-xs text-red-600 mt-1">{fieldErrors.gender}</p>}
         </div>
+
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Nom</label>
-          <input
-            type="text"
-            value={form.lastName}
-            onChange={(e) => set("lastName", e.target.value)}
-            required
-            className="w-full px-3 py-2 border-2 border-gray-200 rounded-lg text-sm focus:outline-none focus:border-icc-violet"
-          />
+          <label className="block text-sm font-medium text-gray-700 mb-1">Téléphone *</label>
+          <input type="tel" required value={form.phone} onChange={(e) => set("phone", e.target.value)} className={inputCls} />
         </div>
-      </div>
 
-      <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-          <input
-            type="email"
-            value={form.email}
-            onChange={(e) => set("email", e.target.value)}
-            className="w-full px-3 py-2 border-2 border-gray-200 rounded-lg text-sm focus:outline-none focus:border-icc-violet"
-          />
+          <label className="block text-sm font-medium text-gray-700 mb-1">Adresse mail</label>
+          <input type="email" value={form.email} onChange={(e) => set("email", e.target.value)} className={inputCls} />
         </div>
+      </div>
+
+      {/* Profil */}
+      <div className="bg-white rounded-xl border border-gray-200 p-4 sm:p-6 space-y-4">
+        <h2 className="text-base font-semibold text-gray-900">Votre profil</h2>
+
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Téléphone</label>
-          <input
-            type="tel"
-            value={form.phone}
-            onChange={(e) => set("phone", e.target.value)}
-            className="w-full px-3 py-2 border-2 border-gray-200 rounded-lg text-sm focus:outline-none focus:border-icc-violet"
-          />
+          <label className="block text-sm font-medium text-gray-700 mb-2">Tranche d&apos;âge *</label>
+          <RadioGroup name="ageRange" options={AGE_RANGES} value={form.ageRange} onChange={(v) => set("ageRange", v)} />
+          {fieldErrors.ageRange && <p className="text-xs text-red-600 mt-1">{fieldErrors.ageRange}</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Depuis quand êtes-vous à {churchName} ? *
+          </label>
+          <RadioGroup name="membershipDuration" options={DURATIONS} value={form.membershipDuration} onChange={(v) => set("membershipDuration", v)} />
+          {fieldErrors.membershipDuration && <p className="text-xs text-red-600 mt-1">{fieldErrors.membershipDuration}</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Êtes-vous STAR ? *</label>
+          <RadioGroup name="isStar" options={["Oui", "Non"]} value={form.isStar} onChange={(v) => set("isStar", v)} />
+          {fieldErrors.isStar && <p className="text-xs text-red-600 mt-1">{fieldErrors.isStar}</p>}
+        </div>
+
+        {form.isStar === "Oui" && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Dans quel département servez-vous ?</label>
+            <input type="text" value={form.department} onChange={(e) => set("department", e.target.value)}
+              placeholder="Ex : Choristes, Accueil, Son…" className={inputCls} />
+          </div>
+        )}
+      </div>
+
+      {/* Demande */}
+      <div className="bg-white rounded-xl border border-gray-200 p-4 sm:p-6 space-y-4">
+        <h2 className="text-base font-semibold text-gray-900">Votre demande</h2>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Pour quel motif sollicitez-vous un entretien ? *{" "}
+            <span className="font-normal text-gray-400">(plusieurs choix possibles)</span>
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {MOTIFS.map((motif) => (
+              <label key={motif} className={`flex items-center gap-2 px-3 py-2.5 md:py-1.5 min-h-[44px] md:min-h-0 rounded-full border text-sm cursor-pointer transition-colors ${
+                form.motifs.includes(motif) ? "bg-icc-violet text-white border-icc-violet" : "border-gray-200 text-gray-700 hover:border-icc-violet"
+              }`}>
+                <input type="checkbox" checked={form.motifs.includes(motif)}
+                  onChange={() => toggleMotif(motif)} className="sr-only" />
+                {motif}
+              </label>
+            ))}
+          </div>
+          {fieldErrors.motifs && <p className="text-xs text-red-600 mt-1">{fieldErrors.motifs}</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Choix du jour *</label>
+          <RadioGroup name="preferredDay" options={DAYS} value={form.preferredDay} onChange={(v) => set("preferredDay", v)} />
+          {fieldErrors.preferredDay && <p className="text-xs text-red-600 mt-1">{fieldErrors.preferredDay}</p>}
         </div>
       </div>
 
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          Objet de la demande <span className="text-red-500">*</span>
-        </label>
-        <input
-          type="text"
-          value={form.subject}
-          onChange={(e) => set("subject", e.target.value)}
-          required
-          placeholder="Croissance spirituelle, conseil, prière..."
-          className="w-full px-3 py-2 border-2 border-gray-200 rounded-lg text-sm focus:outline-none focus:border-icc-violet"
-        />
-      </div>
+      {globalError && (
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">{globalError}</p>
+      )}
 
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          Message <span className="text-red-500">*</span>
-        </label>
-        <textarea
-          value={form.message}
-          onChange={(e) => set("message", e.target.value)}
-          required
-          rows={4}
-          placeholder="Décrivez votre demande..."
-          className="w-full px-3 py-2 border-2 border-gray-200 rounded-lg text-sm focus:outline-none focus:border-icc-violet resize-none"
-        />
-      </div>
-
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
-          Disponibilités souhaitées
-        </label>
-        <div className="flex flex-wrap gap-2">
-          {DAYS_OPTIONS.map((d) => (
-            <button
-              key={d.value}
-              type="button"
-              onClick={() => toggleDay(d.value)}
-              className={`px-3 py-1 rounded-full text-sm border-2 transition-colors ${
-                form.preferredDays.includes(d.value)
-                  ? "bg-icc-violet text-white border-icc-violet"
-                  : "border-gray-200 text-gray-700 hover:border-icc-violet"
-              }`}
-            >
-              {d.label}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <Button type="submit" disabled={submitting}>
-        {submitting ? "Envoi en cours..." : "Envoyer ma demande"}
+      <Button type="submit" disabled={submitting} className="w-full py-3">
+        {submitting ? "Envoi en cours…" : "Envoyer ma demande"}
       </Button>
+
+      <p className="text-xs text-gray-400 text-center">* Champs obligatoires.</p>
     </form>
   );
 }

--- a/src/app/(auth)/agenda/request/page.tsx
+++ b/src/app/(auth)/agenda/request/page.tsx
@@ -1,5 +1,6 @@
 import { requireChurchPermission, getCurrentChurchId } from "@/lib/auth";
 import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 import RequestForm from "./RequestForm";
 
 export default async function AgendaRequestPage() {
@@ -7,6 +8,26 @@ export default async function AgendaRequestPage() {
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
   await requireChurchPermission("planning:view", churchId);
+
+  const [church, memberLink] = await Promise.all([
+    prisma.church.findUnique({ where: { id: churchId }, select: { name: true } }),
+    prisma.memberUserLink.findUnique({
+      where: { userId_churchId: { userId: session.user.id, churchId } },
+      select: {
+        validatedAt: true,
+        member: {
+          select: {
+            departments: { include: { department: { select: { name: true } } } },
+          },
+        },
+      },
+    }),
+  ]);
+
+  const isStar = memberLink?.validatedAt ? "Oui" : "";
+  const department = isStar
+    ? memberLink!.member.departments.map((d) => d.department.name).join(", ")
+    : "";
 
   return (
     <div className="max-w-xl mx-auto">
@@ -16,9 +37,12 @@ export default async function AgendaRequestPage() {
       </p>
       <RequestForm
         churchId={churchId}
+        churchName={church?.name ?? "votre église"}
         defaultFirstName={session.user.name?.split(" ")[0] ?? ""}
         defaultLastName={session.user.name?.split(" ").slice(1).join(" ") ?? ""}
         defaultEmail={session.user.email ?? ""}
+        defaultIsStar={isStar}
+        defaultDepartment={department}
       />
     </div>
   );

--- a/src/app/(auth)/agenda/requests/QualificationDashboard.tsx
+++ b/src/app/(auth)/agenda/requests/QualificationDashboard.tsx
@@ -91,7 +91,7 @@ export default function QualificationDashboard({ requests: initial, profiles }: 
                   {req.preferredDays && ` · Disponibilités : ${req.preferredDays}`}
                 </p>
                 <p className="text-sm font-medium text-gray-700 mt-1">{req.subject}</p>
-                <p className="text-sm text-gray-600 mt-1 line-clamp-2">{req.message}</p>
+                <p className="text-sm text-gray-600 mt-1 whitespace-pre-line">{req.message}</p>
               </div>
               <span className="text-xs text-gray-400 shrink-0">
                 {new Date(req.createdAt).toLocaleDateString("fr-FR")}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -139,6 +139,15 @@ export default async function AuthLayout({
   const hasAgendaManage = userPermissions.has("agenda:manage") || isProtocoleMember;
   const hasAgendaQualify = userPermissions.has("agenda:qualify");
 
+  // Profil pastoral lié au compte → lien "Mon agenda" en tête de section
+  if (currentChurchId) {
+    const ownProfile = await prisma.pastoralProfile.findFirst({
+      where: { userId: session.user.id, churchId: currentChurchId },
+      select: { id: true },
+    });
+    if (ownProfile) agendaLinks.push({ href: `/agenda/${ownProfile.id}`, label: "Mon agenda" });
+  }
+
   if (hasAgendaView) agendaLinks.push({ href: "/agenda", label: "Vue agenda" });
   if (hasAgendaQualify) agendaLinks.push({ href: "/agenda/requests", label: "Qualification" });
   if (hasAgendaManage) agendaLinks.push({ href: "/agenda/schedule", label: "Planification" });

--- a/src/app/agenda-public/[churchSlug]/PublicRequestForm.tsx
+++ b/src/app/agenda-public/[churchSlug]/PublicRequestForm.tsx
@@ -21,8 +21,8 @@ function FieldError({ errors, field }: { errors: FieldErrors; field: string }) {
 }
 
 function inputClass(errors: FieldErrors, field: string, extra = "") {
-  return `w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet ${
-    errors[field] ? "border-red-400 bg-red-50" : "border-gray-200"
+  return `w-full border-2 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet focus:border-icc-violet ${
+    errors[field] ? "border-red-500 bg-red-50" : "border-gray-300"
   } ${extra}`;
 }
 
@@ -33,7 +33,7 @@ function RadioGroup({ name, options, value, onChange, errors }: {
   return (
     <div className={`flex flex-wrap gap-2 ${errors[name] ? "p-2 rounded-lg border border-red-300 bg-red-50" : ""}`}>
       {options.map((opt) => (
-        <label key={opt} className={`flex items-center gap-2 px-3 py-1.5 rounded-full border text-sm cursor-pointer transition-colors ${
+        <label key={opt} className={`flex items-center gap-2 px-3 py-2.5 md:py-1.5 min-h-[44px] md:min-h-0 rounded-full border text-sm cursor-pointer transition-colors ${
           value === opt ? "bg-icc-violet text-white border-icc-violet" : "border-gray-200 text-gray-700 hover:border-icc-violet"
         }`}>
           <input type="radio" name={name} value={opt} checked={value === opt}
@@ -143,11 +143,11 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
 
   if (success) {
     return (
-      <div className="bg-white rounded-xl border border-green-200 p-8 text-center space-y-3">
+      <div className="bg-white rounded-xl border border-green-200 p-6 sm:p-8 text-center space-y-3">
         <div className="w-12 h-12 rounded-full bg-green-100 flex items-center justify-center mx-auto text-2xl">✓</div>
         <h2 className="text-lg font-semibold text-gray-900">Demande envoyée !</h2>
         <p className="text-sm text-gray-600">
-          Votre demande de rendez-vous auprès de <strong>{churchName}</strong> a bien été reçue.
+          Votre demande de rendez-vous auprès de <strong>{churchName}</strong>{" "}a bien été reçue.
           Un email de confirmation vous a été envoyé. L&apos;équipe pastorale vous contactera prochainement.
         </p>
       </div>
@@ -158,10 +158,10 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
     <form onSubmit={handleSubmit} className="space-y-5">
 
       {/* Coordonnées */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
+      <div className="bg-white rounded-xl border border-gray-200 p-4 sm:p-6 space-y-4">
         <h2 className="text-base font-semibold text-gray-900">Vos coordonnées</h2>
 
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Nom *</label>
             <input type="text" required value={form.lastName} onChange={(e) => set("lastName", e.target.value)}
@@ -199,7 +199,7 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
       </div>
 
       {/* Profil */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
+      <div className="bg-white rounded-xl border border-gray-200 p-4 sm:p-6 space-y-4">
         <h2 className="text-base font-semibold text-gray-900">Votre profil</h2>
 
         <div>
@@ -235,7 +235,7 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
       </div>
 
       {/* Motif */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
+      <div className="bg-white rounded-xl border border-gray-200 p-4 sm:p-6 space-y-4">
         <h2 className="text-base font-semibold text-gray-900">Votre demande</h2>
 
         <div>
@@ -244,7 +244,7 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
           </label>
           <div className={`flex flex-wrap gap-2 ${fieldErrors["motifs"] ? "p-2 rounded-lg border border-red-300 bg-red-50" : ""}`}>
             {MOTIFS.map((motif) => (
-              <label key={motif} className={`flex items-center gap-2 px-3 py-1.5 rounded-full border text-sm cursor-pointer transition-colors ${
+              <label key={motif} className={`flex items-center gap-2 px-3 py-2.5 md:py-1.5 min-h-[44px] md:min-h-0 rounded-full border text-sm cursor-pointer transition-colors ${
                 form.motifs.includes(motif) ? "bg-icc-violet text-white border-icc-violet" : "border-gray-200 text-gray-700 hover:border-icc-violet"
               }`}>
                 <input type="checkbox" checked={form.motifs.includes(motif)}
@@ -278,7 +278,7 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
 
       <button type="submit"
         disabled={submitting || (!!turnstileSiteKey && !turnstileToken)}
-        className="w-full bg-icc-violet text-white py-3 rounded-xl font-medium text-sm hover:bg-icc-violet/90 disabled:opacity-50 transition-colors"
+        className="w-full bg-icc-violet text-white py-3 rounded-lg font-medium text-sm hover:bg-icc-jaune hover:text-icc-violet focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-icc-violet disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
       >
         {submitting ? "Envoi en cours…" : "Envoyer ma demande"}
       </button>

--- a/src/app/agenda-public/[churchSlug]/PublicRequestForm.tsx
+++ b/src/app/agenda-public/[churchSlug]/PublicRequestForm.tsx
@@ -8,6 +8,8 @@ interface Props {
   turnstileSiteKey: string;
 }
 
+type FieldErrors = Partial<Record<string, string>>;
+
 const DAYS = [
   { value: "lundi", label: "Lundi" },
   { value: "mardi", label: "Mardi" },
@@ -17,6 +19,17 @@ const DAYS = [
   { value: "samedi", label: "Samedi" },
   { value: "dimanche", label: "Dimanche" },
 ];
+
+function FieldError({ errors, field }: { errors: FieldErrors; field: string }) {
+  if (!errors[field]) return null;
+  return <p className="text-xs text-red-600 mt-1">{errors[field]}</p>;
+}
+
+function inputClass(errors: FieldErrors, field: string) {
+  return `w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet ${
+    errors[field] ? "border-red-400 bg-red-50" : "border-gray-200"
+  }`;
+}
 
 export default function PublicRequestForm({ churchSlug, churchName, turnstileSiteKey }: Props) {
   const [form, setForm] = useState({
@@ -30,7 +43,8 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
   });
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const widgetRef = useRef<HTMLDivElement>(null);
   const widgetId = useRef<string | null>(null);
@@ -64,6 +78,7 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
 
   function set(field: string, value: string) {
     setForm((f) => ({ ...f, [field]: value }));
+    if (fieldErrors[field]) setFieldErrors((e) => ({ ...e, [field]: undefined }));
   }
 
   function toggleDay(day: string) {
@@ -78,11 +93,12 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!turnstileToken) {
-      setError("Veuillez compléter la vérification CAPTCHA.");
+      setGlobalError("Veuillez compléter la vérification CAPTCHA.");
       return;
     }
     setSubmitting(true);
-    setError(null);
+    setGlobalError(null);
+    setFieldErrors({});
 
     try {
       const res = await fetch("/api/agenda/requests/public", {
@@ -99,7 +115,17 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
 
       const json = await res.json().catch(() => ({}));
       if (!res.ok) {
-        setError(json.error ?? "Une erreur est survenue. Veuillez réessayer.");
+        // Erreurs de validation Zod → afficher par champ
+        if (json.details?.length) {
+          const errs: FieldErrors = {};
+          for (const d of json.details as { field: string; message: string }[]) {
+            errs[d.field] = d.message;
+          }
+          setFieldErrors(errs);
+          setGlobalError("Veuillez corriger les erreurs ci-dessous.");
+        } else {
+          setGlobalError(json.error ?? "Une erreur est survenue. Veuillez réessayer.");
+        }
         // Reset Turnstile
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if (widgetId.current) (window as any).turnstile?.reset(widgetId.current);
@@ -108,7 +134,7 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
         setSuccess(true);
       }
     } catch {
-      setError("Une erreur réseau est survenue. Veuillez réessayer.");
+      setGlobalError("Une erreur réseau est survenue. Veuillez réessayer.");
     } finally {
       setSubmitting(false);
     }
@@ -140,8 +166,9 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
               required
               value={form.firstName}
               onChange={(e) => set("firstName", e.target.value)}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+              className={inputClass(fieldErrors, "firstName")}
             />
+            <FieldError errors={fieldErrors} field="firstName" />
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Nom *</label>
@@ -150,8 +177,9 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
               required
               value={form.lastName}
               onChange={(e) => set("lastName", e.target.value)}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+              className={inputClass(fieldErrors, "lastName")}
             />
+            <FieldError errors={fieldErrors} field="lastName" />
           </div>
         </div>
 
@@ -162,8 +190,9 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
             required
             value={form.email}
             onChange={(e) => set("email", e.target.value)}
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+            className={inputClass(fieldErrors, "email")}
           />
+          <FieldError errors={fieldErrors} field="email" />
         </div>
 
         <div>
@@ -172,8 +201,9 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
             type="tel"
             value={form.phone}
             onChange={(e) => set("phone", e.target.value)}
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+            className={inputClass(fieldErrors, "phone")}
           />
+          <FieldError errors={fieldErrors} field="phone" />
         </div>
       </div>
 
@@ -188,20 +218,24 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
             placeholder="Ex : Counseling, accompagnement spirituel…"
             value={form.subject}
             onChange={(e) => set("subject", e.target.value)}
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+            className={inputClass(fieldErrors, "subject")}
           />
+          <FieldError errors={fieldErrors} field="subject" />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Message *</label>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Message * <span className="text-gray-400 font-normal">(10 caractères minimum)</span>
+          </label>
           <textarea
             required
             rows={4}
             placeholder="Décrivez brièvement l'objet de votre demande…"
             value={form.message}
             onChange={(e) => set("message", e.target.value)}
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet resize-none"
+            className={`${inputClass(fieldErrors, "message")} resize-none`}
           />
+          <FieldError errors={fieldErrors} field="message" />
         </div>
 
         <div>
@@ -235,8 +269,8 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
         </div>
       )}
 
-      {error && (
-        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">{error}</p>
+      {globalError && (
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">{globalError}</p>
       )}
 
       <button

--- a/src/app/agenda-public/[churchSlug]/PublicRequestForm.tsx
+++ b/src/app/agenda-public/[churchSlug]/PublicRequestForm.tsx
@@ -10,36 +10,54 @@ interface Props {
 
 type FieldErrors = Partial<Record<string, string>>;
 
-const DAYS = [
-  { value: "lundi", label: "Lundi" },
-  { value: "mardi", label: "Mardi" },
-  { value: "mercredi", label: "Mercredi" },
-  { value: "jeudi", label: "Jeudi" },
-  { value: "vendredi", label: "Vendredi" },
-  { value: "samedi", label: "Samedi" },
-  { value: "dimanche", label: "Dimanche" },
-];
+const AGE_RANGES = ["18-20 ans", "21-30 ans", "31-40 ans", "41-50 ans", "+50 ans"];
+const DURATIONS = ["Moins de 1 an", "1 à 2 ans", "2 à 3 ans", "3 à 5 ans", "+ 5 ans"];
+const MOTIFS = ["Renseignements", "Démarches administratives", "Vie familiale", "Croissance spirituelle", "Oppressions", "Maladie", "Service", "Études"];
+const DAYS = ["Mardi", "Dimanche"];
 
 function FieldError({ errors, field }: { errors: FieldErrors; field: string }) {
   if (!errors[field]) return null;
   return <p className="text-xs text-red-600 mt-1">{errors[field]}</p>;
 }
 
-function inputClass(errors: FieldErrors, field: string) {
+function inputClass(errors: FieldErrors, field: string, extra = "") {
   return `w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet ${
     errors[field] ? "border-red-400 bg-red-50" : "border-gray-200"
-  }`;
+  } ${extra}`;
+}
+
+function RadioGroup({ name, options, value, onChange, errors }: {
+  name: string; options: string[]; value: string;
+  onChange: (v: string) => void; errors: FieldErrors;
+}) {
+  return (
+    <div className={`flex flex-wrap gap-2 ${errors[name] ? "p-2 rounded-lg border border-red-300 bg-red-50" : ""}`}>
+      {options.map((opt) => (
+        <label key={opt} className={`flex items-center gap-2 px-3 py-1.5 rounded-full border text-sm cursor-pointer transition-colors ${
+          value === opt ? "bg-icc-violet text-white border-icc-violet" : "border-gray-200 text-gray-700 hover:border-icc-violet"
+        }`}>
+          <input type="radio" name={name} value={opt} checked={value === opt}
+            onChange={() => onChange(opt)} className="sr-only" />
+          {opt}
+        </label>
+      ))}
+    </div>
+  );
 }
 
 export default function PublicRequestForm({ churchSlug, churchName, turnstileSiteKey }: Props) {
   const [form, setForm] = useState({
-    firstName: "",
     lastName: "",
-    email: "",
+    firstName: "",
+    gender: "",
     phone: "",
-    subject: "",
-    message: "",
-    preferredDays: [] as string[],
+    email: "",
+    ageRange: "",
+    membershipDuration: "",
+    isStar: "",
+    department: "",
+    motifs: [] as string[],
+    preferredDay: "",
   });
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -51,7 +69,6 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
 
   useEffect(() => {
     if (!turnstileSiteKey) return;
-
     function init() {
       if (!widgetRef.current || widgetId.current) return;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -62,16 +79,11 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
         "error-callback": () => setTurnstileToken(null),
       });
     }
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((window as any).turnstile) {
-      init();
-    } else {
+    if ((window as any).turnstile) { init(); } else {
       const script = document.createElement("script");
       script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
-      script.async = true;
-      script.defer = true;
-      script.onload = init;
+      script.async = true; script.defer = true; script.onload = init;
       document.head.appendChild(script);
     }
   }, [turnstileSiteKey]);
@@ -81,41 +93,31 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
     if (fieldErrors[field]) setFieldErrors((e) => ({ ...e, [field]: undefined }));
   }
 
-  function toggleDay(day: string) {
+  function toggleMotif(motif: string) {
     setForm((f) => ({
       ...f,
-      preferredDays: f.preferredDays.includes(day)
-        ? f.preferredDays.filter((d) => d !== day)
-        : [...f.preferredDays, day],
+      motifs: f.motifs.includes(motif) ? f.motifs.filter((m) => m !== motif) : [...f.motifs, motif],
     }));
+    if (fieldErrors["motifs"]) setFieldErrors((e) => ({ ...e, motifs: undefined }));
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!turnstileToken) {
-      setGlobalError("Veuillez compléter la vérification CAPTCHA.");
-      return;
-    }
-    setSubmitting(true);
-    setGlobalError(null);
-    setFieldErrors({});
+    if (!turnstileToken) { setGlobalError("Veuillez compléter la vérification CAPTCHA."); return; }
+    setSubmitting(true); setGlobalError(null); setFieldErrors({});
 
     try {
       const res = await fetch("/api/agenda/requests/public", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          churchSlug,
-          ...form,
-          preferredDays: form.preferredDays.join(", ") || null,
-          phone: form.phone || null,
+          churchSlug, ...form,
+          department: form.department || null,
           turnstileToken,
         }),
       });
-
       const json = await res.json().catch(() => ({}));
       if (!res.ok) {
-        // Erreurs de validation Zod → afficher par champ
         if (json.details?.length) {
           const errs: FieldErrors = {};
           for (const d of json.details as { field: string; message: string }[]) {
@@ -126,7 +128,6 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
         } else {
           setGlobalError(json.error ?? "Une erreur est survenue. Veuillez réessayer.");
         }
-        // Reset Turnstile
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if (widgetId.current) (window as any).turnstile?.reset(widgetId.current);
         setTurnstileToken(null);
@@ -155,107 +156,111 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
+
+      {/* Coordonnées */}
       <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
         <h2 className="text-base font-semibold text-gray-900">Vos coordonnées</h2>
 
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Prénom *</label>
-            <input
-              type="text"
-              required
-              value={form.firstName}
-              onChange={(e) => set("firstName", e.target.value)}
-              className={inputClass(fieldErrors, "firstName")}
-            />
-            <FieldError errors={fieldErrors} field="firstName" />
-          </div>
-          <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Nom *</label>
-            <input
-              type="text"
-              required
-              value={form.lastName}
-              onChange={(e) => set("lastName", e.target.value)}
-              className={inputClass(fieldErrors, "lastName")}
-            />
+            <input type="text" required value={form.lastName} onChange={(e) => set("lastName", e.target.value)}
+              className={inputClass(fieldErrors, "lastName")} />
             <FieldError errors={fieldErrors} field="lastName" />
           </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Prénom *</label>
+            <input type="text" required value={form.firstName} onChange={(e) => set("firstName", e.target.value)}
+              className={inputClass(fieldErrors, "firstName")} />
+            <FieldError errors={fieldErrors} field="firstName" />
+          </div>
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Email *</label>
-          <input
-            type="email"
-            required
-            value={form.email}
-            onChange={(e) => set("email", e.target.value)}
-            className={inputClass(fieldErrors, "email")}
-          />
-          <FieldError errors={fieldErrors} field="email" />
+          <label className="block text-sm font-medium text-gray-700 mb-2">Sexe *</label>
+          <RadioGroup name="gender" options={["Homme", "Femme"]} value={form.gender}
+            onChange={(v) => set("gender", v)} errors={fieldErrors} />
+          <FieldError errors={fieldErrors} field="gender" />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Téléphone</label>
-          <input
-            type="tel"
-            value={form.phone}
-            onChange={(e) => set("phone", e.target.value)}
-            className={inputClass(fieldErrors, "phone")}
-          />
+          <label className="block text-sm font-medium text-gray-700 mb-1">Téléphone *</label>
+          <input type="tel" required value={form.phone} onChange={(e) => set("phone", e.target.value)}
+            className={inputClass(fieldErrors, "phone")} />
           <FieldError errors={fieldErrors} field="phone" />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Adresse mail *</label>
+          <input type="email" required value={form.email} onChange={(e) => set("email", e.target.value)}
+            className={inputClass(fieldErrors, "email")} />
+          <FieldError errors={fieldErrors} field="email" />
         </div>
       </div>
 
+      {/* Profil */}
+      <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
+        <h2 className="text-base font-semibold text-gray-900">Votre profil</h2>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Tranche d&apos;âge *</label>
+          <RadioGroup name="ageRange" options={AGE_RANGES} value={form.ageRange}
+            onChange={(v) => set("ageRange", v)} errors={fieldErrors} />
+          <FieldError errors={fieldErrors} field="ageRange" />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Depuis quand êtes-vous à {churchName} ? *</label>
+          <RadioGroup name="membershipDuration" options={DURATIONS} value={form.membershipDuration}
+            onChange={(v) => set("membershipDuration", v)} errors={fieldErrors} />
+          <FieldError errors={fieldErrors} field="membershipDuration" />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Êtes-vous STAR ? *</label>
+          <RadioGroup name="isStar" options={["Oui", "Non"]} value={form.isStar}
+            onChange={(v) => set("isStar", v)} errors={fieldErrors} />
+          <FieldError errors={fieldErrors} field="isStar" />
+        </div>
+
+        {form.isStar === "Oui" && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Dans quel département servez-vous ?</label>
+            <input type="text" value={form.department} onChange={(e) => set("department", e.target.value)}
+              placeholder="Ex : Choristes, Accueil, Son…"
+              className={inputClass(fieldErrors, "department")} />
+            <FieldError errors={fieldErrors} field="department" />
+          </div>
+        )}
+      </div>
+
+      {/* Motif */}
       <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
         <h2 className="text-base font-semibold text-gray-900">Votre demande</h2>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Objet *</label>
-          <input
-            type="text"
-            required
-            placeholder="Ex : Counseling, accompagnement spirituel…"
-            value={form.subject}
-            onChange={(e) => set("subject", e.target.value)}
-            className={inputClass(fieldErrors, "subject")}
-          />
-          <FieldError errors={fieldErrors} field="subject" />
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Message * <span className="text-gray-400 font-normal">(10 caractères minimum)</span>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Pour quel motif sollicitez-vous un entretien ? * <span className="font-normal text-gray-400">(plusieurs choix possibles)</span>
           </label>
-          <textarea
-            required
-            rows={4}
-            placeholder="Décrivez brièvement l'objet de votre demande…"
-            value={form.message}
-            onChange={(e) => set("message", e.target.value)}
-            className={`${inputClass(fieldErrors, "message")} resize-none`}
-          />
-          <FieldError errors={fieldErrors} field="message" />
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">Jours préférés</label>
-          <div className="flex flex-wrap gap-2">
-            {DAYS.map((d) => (
-              <button
-                key={d.value}
-                type="button"
-                onClick={() => toggleDay(d.value)}
-                className={`px-3 py-1 text-sm rounded-full border transition-colors ${
-                  form.preferredDays.includes(d.value)
-                    ? "bg-icc-violet text-white border-icc-violet"
-                    : "border-gray-200 text-gray-600 hover:border-icc-violet"
-                }`}
-              >
-                {d.label}
-              </button>
+          <div className={`flex flex-wrap gap-2 ${fieldErrors["motifs"] ? "p-2 rounded-lg border border-red-300 bg-red-50" : ""}`}>
+            {MOTIFS.map((motif) => (
+              <label key={motif} className={`flex items-center gap-2 px-3 py-1.5 rounded-full border text-sm cursor-pointer transition-colors ${
+                form.motifs.includes(motif) ? "bg-icc-violet text-white border-icc-violet" : "border-gray-200 text-gray-700 hover:border-icc-violet"
+              }`}>
+                <input type="checkbox" checked={form.motifs.includes(motif)}
+                  onChange={() => toggleMotif(motif)} className="sr-only" />
+                {motif}
+              </label>
             ))}
           </div>
+          <FieldError errors={fieldErrors} field="motifs" />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Choix du jour *</label>
+          <RadioGroup name="preferredDay" options={DAYS} value={form.preferredDay}
+            onChange={(v) => set("preferredDay", v)} errors={fieldErrors} />
+          <FieldError errors={fieldErrors} field="preferredDay" />
         </div>
       </div>
 
@@ -263,9 +268,7 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
       {turnstileSiteKey && (
         <div>
           <div ref={widgetRef} />
-          {!turnstileToken && (
-            <p className="text-xs text-gray-400 mt-1">Vérification anti-spam requise.</p>
-          )}
+          {!turnstileToken && <p className="text-xs text-gray-400 mt-1">Vérification anti-spam requise.</p>}
         </div>
       )}
 
@@ -273,17 +276,14 @@ export default function PublicRequestForm({ churchSlug, churchName, turnstileSit
         <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">{globalError}</p>
       )}
 
-      <button
-        type="submit"
+      <button type="submit"
         disabled={submitting || (!!turnstileSiteKey && !turnstileToken)}
         className="w-full bg-icc-violet text-white py-3 rounded-xl font-medium text-sm hover:bg-icc-violet/90 disabled:opacity-50 transition-colors"
       >
         {submitting ? "Envoi en cours…" : "Envoyer ma demande"}
       </button>
 
-      <p className="text-xs text-gray-400 text-center">
-        * Champs obligatoires. Un email de confirmation vous sera envoyé.
-      </p>
+      <p className="text-xs text-gray-400 text-center">* Champs obligatoires. Un email de confirmation vous sera envoyé.</p>
     </form>
   );
 }

--- a/src/app/agenda-public/[churchSlug]/PublicRequestForm.tsx
+++ b/src/app/agenda-public/[churchSlug]/PublicRequestForm.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+
+interface Props {
+  churchSlug: string;
+  churchName: string;
+  turnstileSiteKey: string;
+}
+
+const DAYS = [
+  { value: "lundi", label: "Lundi" },
+  { value: "mardi", label: "Mardi" },
+  { value: "mercredi", label: "Mercredi" },
+  { value: "jeudi", label: "Jeudi" },
+  { value: "vendredi", label: "Vendredi" },
+  { value: "samedi", label: "Samedi" },
+  { value: "dimanche", label: "Dimanche" },
+];
+
+export default function PublicRequestForm({ churchSlug, churchName, turnstileSiteKey }: Props) {
+  const [form, setForm] = useState({
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    subject: "",
+    message: "",
+    preferredDays: [] as string[],
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  const widgetRef = useRef<HTMLDivElement>(null);
+  const widgetId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!turnstileSiteKey) return;
+
+    function init() {
+      if (!widgetRef.current || widgetId.current) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      widgetId.current = (window as any).turnstile?.render(widgetRef.current, {
+        sitekey: turnstileSiteKey,
+        callback: (token: string) => setTurnstileToken(token),
+        "expired-callback": () => setTurnstileToken(null),
+        "error-callback": () => setTurnstileToken(null),
+      });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((window as any).turnstile) {
+      init();
+    } else {
+      const script = document.createElement("script");
+      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+      script.async = true;
+      script.defer = true;
+      script.onload = init;
+      document.head.appendChild(script);
+    }
+  }, [turnstileSiteKey]);
+
+  function set(field: string, value: string) {
+    setForm((f) => ({ ...f, [field]: value }));
+  }
+
+  function toggleDay(day: string) {
+    setForm((f) => ({
+      ...f,
+      preferredDays: f.preferredDays.includes(day)
+        ? f.preferredDays.filter((d) => d !== day)
+        : [...f.preferredDays, day],
+    }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!turnstileToken) {
+      setError("Veuillez compléter la vérification CAPTCHA.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/agenda/requests/public", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          churchSlug,
+          ...form,
+          preferredDays: form.preferredDays.join(", ") || null,
+          phone: form.phone || null,
+          turnstileToken,
+        }),
+      });
+
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(json.error ?? "Une erreur est survenue. Veuillez réessayer.");
+        // Reset Turnstile
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if (widgetId.current) (window as any).turnstile?.reset(widgetId.current);
+        setTurnstileToken(null);
+      } else {
+        setSuccess(true);
+      }
+    } catch {
+      setError("Une erreur réseau est survenue. Veuillez réessayer.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="bg-white rounded-xl border border-green-200 p-8 text-center space-y-3">
+        <div className="w-12 h-12 rounded-full bg-green-100 flex items-center justify-center mx-auto text-2xl">✓</div>
+        <h2 className="text-lg font-semibold text-gray-900">Demande envoyée !</h2>
+        <p className="text-sm text-gray-600">
+          Votre demande de rendez-vous auprès de <strong>{churchName}</strong> a bien été reçue.
+          Un email de confirmation vous a été envoyé. L&apos;équipe pastorale vous contactera prochainement.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
+        <h2 className="text-base font-semibold text-gray-900">Vos coordonnées</h2>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Prénom *</label>
+            <input
+              type="text"
+              required
+              value={form.firstName}
+              onChange={(e) => set("firstName", e.target.value)}
+              className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Nom *</label>
+            <input
+              type="text"
+              required
+              value={form.lastName}
+              onChange={(e) => set("lastName", e.target.value)}
+              className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Email *</label>
+          <input
+            type="email"
+            required
+            value={form.email}
+            onChange={(e) => set("email", e.target.value)}
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Téléphone</label>
+          <input
+            type="tel"
+            value={form.phone}
+            onChange={(e) => set("phone", e.target.value)}
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+          />
+        </div>
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
+        <h2 className="text-base font-semibold text-gray-900">Votre demande</h2>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Objet *</label>
+          <input
+            type="text"
+            required
+            placeholder="Ex : Counseling, accompagnement spirituel…"
+            value={form.subject}
+            onChange={(e) => set("subject", e.target.value)}
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Message *</label>
+          <textarea
+            required
+            rows={4}
+            placeholder="Décrivez brièvement l'objet de votre demande…"
+            value={form.message}
+            onChange={(e) => set("message", e.target.value)}
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet resize-none"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Jours préférés</label>
+          <div className="flex flex-wrap gap-2">
+            {DAYS.map((d) => (
+              <button
+                key={d.value}
+                type="button"
+                onClick={() => toggleDay(d.value)}
+                className={`px-3 py-1 text-sm rounded-full border transition-colors ${
+                  form.preferredDays.includes(d.value)
+                    ? "bg-icc-violet text-white border-icc-violet"
+                    : "border-gray-200 text-gray-600 hover:border-icc-violet"
+                }`}
+              >
+                {d.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Turnstile */}
+      {turnstileSiteKey && (
+        <div>
+          <div ref={widgetRef} />
+          {!turnstileToken && (
+            <p className="text-xs text-gray-400 mt-1">Vérification anti-spam requise.</p>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">{error}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitting || (!!turnstileSiteKey && !turnstileToken)}
+        className="w-full bg-icc-violet text-white py-3 rounded-xl font-medium text-sm hover:bg-icc-violet/90 disabled:opacity-50 transition-colors"
+      >
+        {submitting ? "Envoi en cours…" : "Envoyer ma demande"}
+      </button>
+
+      <p className="text-xs text-gray-400 text-center">
+        * Champs obligatoires. Un email de confirmation vous sera envoyé.
+      </p>
+    </form>
+  );
+}

--- a/src/app/agenda-public/[churchSlug]/page.tsx
+++ b/src/app/agenda-public/[churchSlug]/page.tsx
@@ -20,17 +20,18 @@ export default async function PublicAgendaRequestPage({
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
-      <header className="bg-white border-b border-gray-200 px-4 py-5">
+      <header className="bg-icc-violet px-4 py-5">
         <div className="max-w-xl mx-auto">
-          <h1 className="text-xl font-bold text-gray-900">{church.name}</h1>
-          <p className="text-sm text-gray-500 mt-0.5">Demande de rendez-vous pastoral</p>
+          <p className="text-xs font-semibold text-white/60 uppercase tracking-widest mb-1">Koinonia</p>
+          <h1 className="text-xl font-bold text-white">{church.name}</h1>
+          <p className="text-sm text-white/70 mt-0.5">Demande de rendez-vous pastoral</p>
         </div>
       </header>
       <main className="flex-1 max-w-xl mx-auto w-full px-4 py-8">
         <PublicRequestForm churchSlug={church.slug} churchName={church.name} turnstileSiteKey={siteKey} />
       </main>
       <footer className="text-center text-xs text-gray-400 py-4">
-        Propulsé par Koinonia
+        Propulsé par <span className="font-medium text-gray-500">Koinonia</span>
       </footer>
     </div>
   );

--- a/src/app/agenda-public/[churchSlug]/page.tsx
+++ b/src/app/agenda-public/[churchSlug]/page.tsx
@@ -1,0 +1,37 @@
+import { prisma } from "@/lib/prisma";
+import { notFound } from "next/navigation";
+import PublicRequestForm from "./PublicRequestForm";
+
+export default async function PublicAgendaRequestPage({
+  params,
+}: {
+  params: Promise<{ churchSlug: string }>;
+}) {
+  const { churchSlug } = await params;
+
+  const church = await prisma.church.findUnique({
+    where: { slug: churchSlug },
+    select: { id: true, name: true, slug: true },
+  });
+
+  if (!church) return notFound();
+
+  const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "";
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <header className="bg-white border-b border-gray-200 px-4 py-5">
+        <div className="max-w-xl mx-auto">
+          <h1 className="text-xl font-bold text-gray-900">{church.name}</h1>
+          <p className="text-sm text-gray-500 mt-0.5">Demande de rendez-vous pastoral</p>
+        </div>
+      </header>
+      <main className="flex-1 max-w-xl mx-auto w-full px-4 py-8">
+        <PublicRequestForm churchSlug={church.slug} churchName={church.name} turnstileSiteKey={siteKey} />
+      </main>
+      <footer className="text-center text-xs text-gray-400 py-4">
+        Propulsé par Koinonia
+      </footer>
+    </div>
+  );
+}

--- a/src/app/api/agenda/requests/public/route.ts
+++ b/src/app/api/agenda/requests/public/route.ts
@@ -4,15 +4,24 @@ import { sendEmail, buildAppointmentConfirmationEmail } from "@/lib/email";
 import { requireRateLimit } from "@/lib/rate-limit";
 import { z } from "zod";
 
+const AGE_RANGES = ["18-20 ans", "21-30 ans", "31-40 ans", "41-50 ans", "+50 ans"] as const;
+const DURATIONS = ["Moins de 1 an", "1 à 2 ans", "2 à 3 ans", "3 à 5 ans", "+ 5 ans"] as const;
+const MOTIFS = ["Renseignements", "Démarches administratives", "Vie familiale", "Croissance spirituelle", "Oppressions", "Maladie", "Service", "Études"] as const;
+const DAYS = ["Mardi", "Dimanche"] as const;
+
 const submitSchema = z.object({
   churchSlug: z.string().min(1),
-  firstName: z.string().min(1, "Le prénom est requis"),
   lastName: z.string().min(1, "Le nom est requis"),
+  firstName: z.string().min(1, "Le prénom est requis"),
+  gender: z.enum(["Homme", "Femme"], { errorMap: () => ({ message: "Veuillez sélectionner votre sexe" }) }),
+  phone: z.string().min(1, "Le téléphone est requis"),
   email: z.string().email("Email invalide"),
-  phone: z.string().nullable().optional(),
-  subject: z.string().min(1, "L'objet est requis"),
-  message: z.string().min(10, "Le message est trop court"),
-  preferredDays: z.string().nullable().optional(),
+  ageRange: z.enum(AGE_RANGES, { errorMap: () => ({ message: "Veuillez sélectionner votre tranche d'âge" }) }),
+  membershipDuration: z.enum(DURATIONS, { errorMap: () => ({ message: "Veuillez sélectionner votre ancienneté à l'église" }) }),
+  isStar: z.enum(["Oui", "Non"], { errorMap: () => ({ message: "Veuillez répondre à cette question" }) }),
+  department: z.string().nullable().optional(),
+  motifs: z.array(z.enum(MOTIFS)).min(1, "Veuillez sélectionner au moins un motif"),
+  preferredDay: z.enum(DAYS, { errorMap: () => ({ message: "Veuillez sélectionner un jour" }) }),
   turnstileToken: z.string().min(1, "Vérification CAPTCHA manquante"),
 });
 
@@ -45,6 +54,15 @@ export async function POST(request: Request) {
     });
     if (!church) throw new ApiError(404, "Église introuvable");
 
+    // Motifs → subject ; contexte démographique → message structuré
+    const subject = data.motifs.join(", ");
+    const message = [
+      `Sexe : ${data.gender}`,
+      `Tranche d'âge : ${data.ageRange}`,
+      `À l'église depuis : ${data.membershipDuration}`,
+      `STAR : ${data.isStar}${data.isStar === "Oui" && data.department ? ` — Département : ${data.department}` : ""}`,
+    ].join("\n");
+
     const req = await prisma.appointmentRequest.create({
       data: {
         churchId: church.id,
@@ -52,21 +70,21 @@ export async function POST(request: Request) {
         firstName: data.firstName,
         lastName: data.lastName,
         email: data.email,
-        phone: data.phone ?? null,
-        subject: data.subject,
-        message: data.message,
-        preferredDays: data.preferredDays ?? null,
+        phone: data.phone,
+        subject,
+        message,
+        preferredDays: data.preferredDay,
       },
     });
 
-    const { subject, html } = buildAppointmentConfirmationEmail({
+    const { subject: emailSubject, html } = buildAppointmentConfirmationEmail({
       firstName: data.firstName,
       lastName: data.lastName,
-      subject: data.subject,
+      subject,
       churchName: church.name,
     });
-    await sendEmail({ to: data.email, subject, html }).catch(() => {
-      // Email non bloquant — la demande est enregistrée même si l'envoi échoue
+    await sendEmail({ to: data.email, subject: emailSubject, html }).catch((err) => {
+      console.error("[agenda/requests/public] sendEmail failed:", err?.message ?? err);
     });
 
     return successResponse({ id: req.id }, 201);

--- a/src/app/api/agenda/requests/public/route.ts
+++ b/src/app/api/agenda/requests/public/route.ts
@@ -1,0 +1,76 @@
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { sendEmail, buildAppointmentConfirmationEmail } from "@/lib/email";
+import { requireRateLimit } from "@/lib/rate-limit";
+import { z } from "zod";
+
+const submitSchema = z.object({
+  churchSlug: z.string().min(1),
+  firstName: z.string().min(1, "Le prénom est requis"),
+  lastName: z.string().min(1, "Le nom est requis"),
+  email: z.string().email("Email invalide"),
+  phone: z.string().nullable().optional(),
+  subject: z.string().min(1, "L'objet est requis"),
+  message: z.string().min(10, "Le message est trop court"),
+  preferredDays: z.string().nullable().optional(),
+  turnstileToken: z.string().min(1, "Vérification CAPTCHA manquante"),
+});
+
+async function verifyTurnstile(token: string, ip: string): Promise<boolean> {
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+  if (!secret) return false;
+  const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ secret, response: token, remoteip: ip }),
+  });
+  const data = await res.json() as { success: boolean };
+  return data.success === true;
+}
+
+export async function POST(request: Request) {
+  try {
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    requireRateLimit(request, { prefix: `public-rdv:${ip}`, windowMs: 60_000, max: 3 });
+
+    const body = await request.json();
+    const data = submitSchema.parse(body);
+
+    const valid = await verifyTurnstile(data.turnstileToken, ip);
+    if (!valid) throw new ApiError(400, "Vérification CAPTCHA échouée. Veuillez réessayer.");
+
+    const church = await prisma.church.findUnique({
+      where: { slug: data.churchSlug },
+      select: { id: true, name: true },
+    });
+    if (!church) throw new ApiError(404, "Église introuvable");
+
+    const req = await prisma.appointmentRequest.create({
+      data: {
+        churchId: church.id,
+        userId: null,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        email: data.email,
+        phone: data.phone ?? null,
+        subject: data.subject,
+        message: data.message,
+        preferredDays: data.preferredDays ?? null,
+      },
+    });
+
+    const { subject, html } = buildAppointmentConfirmationEmail({
+      firstName: data.firstName,
+      lastName: data.lastName,
+      subject: data.subject,
+      churchName: church.name,
+    });
+    await sendEmail({ to: data.email, subject, html }).catch(() => {
+      // Email non bloquant — la demande est enregistrée même si l'envoi échoue
+    });
+
+    return successResponse({ id: req.id }, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/agenda/requests/route.ts
+++ b/src/app/api/agenda/requests/route.ts
@@ -5,6 +5,7 @@ import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { rolePermissions } from "@/lib/registry";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
+import { sendEmail, buildAppointmentConfirmationEmail } from "@/lib/email";
 import { z } from "zod";
 
 const submitSchema = z.object({
@@ -83,19 +84,22 @@ export async function POST(request: Request) {
     const session = await requireChurchPermission("planning:view", data.churchId);
     requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
-    const req = await prisma.appointmentRequest.create({
-      data: {
-        churchId: data.churchId,
-        userId: session.user.id,
-        firstName: data.firstName,
-        lastName: data.lastName,
-        email: data.email ?? null,
-        phone: data.phone ?? null,
-        subject: data.subject,
-        message: data.message,
-        preferredDays: data.preferredDays ?? null,
-      },
-    });
+    const [req, church] = await Promise.all([
+      prisma.appointmentRequest.create({
+        data: {
+          churchId: data.churchId,
+          userId: session.user.id,
+          firstName: data.firstName,
+          lastName: data.lastName,
+          email: data.email ?? null,
+          phone: data.phone ?? null,
+          subject: data.subject,
+          message: data.message,
+          preferredDays: data.preferredDays ?? null,
+        },
+      }),
+      prisma.church.findUnique({ where: { id: data.churchId }, select: { name: true } }),
+    ]);
 
     await logAudit({
       userId: session.user.id,
@@ -105,6 +109,18 @@ export async function POST(request: Request) {
       entityId: req.id,
       details: { subject: data.subject },
     });
+
+    if (data.email && church) {
+      const { subject: emailSubject, html } = buildAppointmentConfirmationEmail({
+        firstName: data.firstName,
+        lastName: data.lastName,
+        subject: data.subject,
+        churchName: church.name,
+      });
+      sendEmail({ to: data.email, subject: emailSubject, html }).catch((err) => {
+        console.error("[agenda/requests] sendEmail failed:", err?.message ?? err);
+      });
+    }
 
     return successResponse(req, 201);
   } catch (error) {

--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -267,10 +267,14 @@ export default function MobileNavSheet({
     pathname.startsWith("/admin/events") ||
     pathname.startsWith("/admin/reports");
   const isRequestsActive =
-    pathname.startsWith("/requests") || pathname.startsWith("/secretariat");
+    pathname.startsWith("/requests") ||
+    pathname.startsWith("/secretariat") ||
+    pathname === "/agenda/request";
   const isMediaActive =
     pathname.startsWith("/media") || pathname.startsWith("/communication");
-  const isAgendaActive = pathname.startsWith("/agenda") || pathname.startsWith("/admin/pastoral-profiles");
+  const isAgendaActive =
+    (pathname.startsWith("/agenda") || pathname.startsWith("/admin/pastoral-profiles")) &&
+    pathname !== "/agenda/request";
   const isConfigActive =
     pathname.startsWith("/admin") &&
     !pathname.startsWith("/admin/events") &&
@@ -302,6 +306,33 @@ export default function MobileNavSheet({
             onClick={() => setView("planning")}
           />
         )}
+        {hasMembersAccess && (
+          <RootRow
+            label="STAR"
+            icon={<IconMembers className="w-5 h-5" />}
+            href="/admin/members"
+            isActive={pathname.startsWith("/admin/members")}
+            onClose={onClose}
+          />
+        )}
+        {hasDiscipleship && (
+          <RootRow
+            label="Discipolat"
+            icon={<IconDiscipleship className="w-5 h-5" />}
+            href="/admin/discipleship"
+            isActive={pathname.startsWith("/admin/discipleship")}
+            onClose={onClose}
+          />
+        )}
+        {agendaLinks.length > 0 && (
+          <RootRow
+            label="Agenda pastoral"
+            icon={<IconDiscipleship className="w-5 h-5" />}
+            hasChildren
+            isActive={isAgendaActive}
+            onClick={() => setView("agenda")}
+          />
+        )}
         {hasEventsAccess && (
           <RootRow
             label="Événements"
@@ -309,15 +340,6 @@ export default function MobileNavSheet({
             hasChildren
             isActive={isEventsActive}
             onClick={() => setView("events")}
-          />
-        )}
-        {hasMembersAccess && (
-          <RootRow
-            label="Membres"
-            icon={<IconMembers className="w-5 h-5" />}
-            href="/admin/members"
-            isActive={pathname.startsWith("/admin/members")}
-            onClose={onClose}
           />
         )}
         {requestLinks.length > 0 && (
@@ -336,24 +358,6 @@ export default function MobileNavSheet({
             hasChildren
             isActive={isMediaActive}
             onClick={() => setView("media")}
-          />
-        )}
-        {agendaLinks.length > 0 && (
-          <RootRow
-            label="Agenda pastoral"
-            icon={<IconDiscipleship className="w-5 h-5" />}
-            hasChildren
-            isActive={isAgendaActive}
-            onClick={() => setView("agenda")}
-          />
-        )}
-        {hasDiscipleship && (
-          <RootRow
-            label="Discipolat"
-            icon={<IconDiscipleship className="w-5 h-5" />}
-            href="/admin/discipleship"
-            isActive={pathname.startsWith("/admin/discipleship")}
-            onClose={onClose}
           />
         )}
         {mrbsUrl && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -322,11 +322,14 @@ export default function Sidebar({
   const isMembersActive = pathname.startsWith("/admin/members");
   const isRequestsActive =
     pathname.startsWith("/requests") ||
-    pathname.startsWith("/secretariat");
+    pathname.startsWith("/secretariat") ||
+    pathname === "/agenda/request";
   const isMediaActive =
     pathname.startsWith("/media") ||
     pathname.startsWith("/communication");
-  const isAgendaActive = pathname.startsWith("/agenda") || pathname.startsWith("/admin/pastoral-profiles");
+  const isAgendaActive =
+    (pathname.startsWith("/agenda") || pathname.startsWith("/admin/pastoral-profiles")) &&
+    pathname !== "/agenda/request";
   const isDiscipleshipActive = pathname.startsWith("/admin/discipleship");
   const isConfigActive =
     pathname.startsWith("/admin") &&
@@ -417,7 +420,52 @@ export default function Sidebar({
         </AccordionSection>
       )}
 
-      {/* 2. Événements */}
+      {/* 2. STAR */}
+      {hasMembersAccess && (
+        <Link
+          href="/admin/members"
+          onClick={onClose}
+          data-tour="sidebar-members"
+          className={`${sectionHeaderBase} ${isMembersActive ? sectionHeaderActive : sectionHeaderIdle} rounded-md`}
+        >
+          <IconMembers className="w-4 h-4 shrink-0" />
+          <span className="flex-1">STAR</span>
+        </Link>
+      )}
+
+      {/* 3. Discipolat */}
+      {hasDiscipleship && (
+        <Link
+          href="/admin/discipleship"
+          onClick={onClose}
+          data-tour="sidebar-discipleship"
+          className={`${sectionHeaderBase} ${isDiscipleshipActive ? sectionHeaderActive : sectionHeaderIdle} rounded-md`}
+        >
+          <IconDiscipleship className="w-4 h-4 shrink-0" />
+          <span className="flex-1">Discipolat</span>
+        </Link>
+      )}
+
+      {/* 4. Agenda pastoral */}
+      {agendaLinks.length > 0 && (
+        <AccordionSection
+          title="Agenda pastoral"
+          icon={<IconAgenda className="w-4 h-4" />}
+          open={openSection === "agenda"}
+          onToggle={() => toggle("agenda")}
+          isActive={isAgendaActive}
+        >
+          <nav className="space-y-0.5 pl-6">
+            {agendaLinks.map((link) => (
+              <NavLink key={link.href} href={link.href} active={pathname.startsWith(link.href)} onClose={onClose}>
+                {link.label}
+              </NavLink>
+            ))}
+          </nav>
+        </AccordionSection>
+      )}
+
+      {/* 5. Événements */}
       {hasEventsAccess && (
         <AccordionSection
           title="Événements"
@@ -450,20 +498,7 @@ export default function Sidebar({
         </AccordionSection>
       )}
 
-      {/* 3. Membres */}
-      {hasMembersAccess && (
-        <Link
-          href="/admin/members"
-          onClick={onClose}
-          data-tour="sidebar-members"
-          className={`${sectionHeaderBase} ${isMembersActive ? sectionHeaderActive : sectionHeaderIdle} rounded-md`}
-        >
-          <IconMembers className="w-4 h-4 shrink-0" />
-          <span className="flex-1">Membres</span>
-        </Link>
-      )}
-
-      {/* 4. Demandes */}
+      {/* 6. Demandes */}
       {requestLinks.length > 0 && (
         <AccordionSection
           title="Demandes"
@@ -483,7 +518,7 @@ export default function Sidebar({
         </AccordionSection>
       )}
 
-      {/* 5. Médias */}
+      {/* 7. Médias */}
       {mediaLinks.length > 0 && (
         <AccordionSection
           title="Médias"
@@ -503,7 +538,7 @@ export default function Sidebar({
         </AccordionSection>
       )}
 
-      {/* 6. Réservation de salles (module MRBS optionnel) */}
+      {/* 8. Réservation de salles (module MRBS optionnel) */}
       {(mrbsUrl || mrbsAdminLink) && (
         <AccordionSection
           title="Salles"
@@ -533,39 +568,7 @@ export default function Sidebar({
         </AccordionSection>
       )}
 
-      {/* 7. Agenda pastoral */}
-      {agendaLinks.length > 0 && (
-        <AccordionSection
-          title="Agenda pastoral"
-          icon={<IconAgenda className="w-4 h-4" />}
-          open={openSection === "agenda"}
-          onToggle={() => toggle("agenda")}
-          isActive={isAgendaActive}
-        >
-          <nav className="space-y-0.5 pl-6">
-            {agendaLinks.map((link) => (
-              <NavLink key={link.href} href={link.href} active={pathname.startsWith(link.href)} onClose={onClose}>
-                {link.label}
-              </NavLink>
-            ))}
-          </nav>
-        </AccordionSection>
-      )}
-
-      {/* 8. Discipolat — lien direct (une seule sous-page) */}
-      {hasDiscipleship && (
-        <Link
-          href="/admin/discipleship"
-          onClick={onClose}
-          data-tour="sidebar-discipleship"
-          className={`${sectionHeaderBase} ${isDiscipleshipActive ? sectionHeaderActive : sectionHeaderIdle} rounded-md`}
-        >
-          <IconDiscipleship className="w-4 h-4 shrink-0" />
-          <span className="flex-1">Discipolat</span>
-        </Link>
-      )}
-
-      {/* 7. Configuration */}
+      {/* 9. Configuration */}
       {configLinks.length > 0 && (
         <AccordionSection
           title="Configuration"

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -125,6 +125,36 @@ export function buildPlanningDigestEmail(params: {
   };
 }
 
+export function buildAppointmentConfirmationEmail(params: {
+  firstName: string;
+  lastName: string;
+  subject: string;
+  churchName: string;
+}) {
+  const name = escapeHtml(`${params.firstName} ${params.lastName}`);
+  const subject = escapeHtml(params.subject);
+  const church = escapeHtml(params.churchName);
+  return {
+    subject: `Votre demande de RDV pastoral a bien été reçue — ${church}`,
+    html: `
+      <div style="font-family: Montserrat, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background: #5E17EB; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
+          <h1 style="margin: 0; font-size: 20px;">Koinonia</h1>
+          <p style="margin: 4px 0 0; font-size: 13px; opacity: 0.85;">${church}</p>
+        </div>
+        <div style="padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+          <p>Bonjour <strong>${name}</strong>,</p>
+          <p>Votre demande de rendez-vous pastoral concernant <strong>« ${subject} »</strong> a bien été reçue.</p>
+          <p>Un membre de l'équipe pastorale prendra contact avec vous prochainement pour convenir d'un créneau.</p>
+          <p style="color: #6b7280; font-size: 13px; margin-top: 24px;">
+            Vous recevez cet email car vous avez soumis une demande de RDV sur le formulaire de ${church}.
+          </p>
+        </div>
+      </div>
+    `,
+  };
+}
+
 export function buildReminderEmail(params: {
   memberName: string;
   eventTitle: string;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,6 +21,10 @@ export function proxy(request: NextRequest) {
     if (request.nextUrl.pathname.startsWith("/api/auth/mrbs/")) {
       return NextResponse.next();
     }
+    // Allow public agenda request form (Turnstile-protected, no session required)
+    if (request.nextUrl.pathname === "/api/agenda/requests/public") {
+      return NextResponse.next();
+    }
     if (request.nextUrl.pathname.startsWith("/api/")) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }


### PR DESCRIPTION
## Résumé

- Formulaire public accessible à `/agenda-public/[churchSlug]` sans authentification
- Protection anti-spam par **Cloudflare Turnstile** (vérification serveur, reset côté client en cas d'erreur)
- **Rate limit IP** : 3 soumissions/minute
- **Email de confirmation** automatique à l'adresse fournie
- Demande enregistrée dans `AppointmentRequest` (`userId: null`) — visible dans le dashboard de qualification existant

## Configuration requise (variables d'env)

```env
NEXT_PUBLIC_TURNSTILE_SITE_KEY=   # clé publique (widget)
TURNSTILE_SECRET_KEY=             # clé secrète (vérification serveur)
```

Créer les clés sur [Cloudflare Turnstile](https://dash.cloudflare.com/) — gratuit, sans quota.

## URL du formulaire

`https://[domaine]/agenda-public/[slug-de-l-eglise]`

Exemple : `https://koinonia.iccrennes.fr/agenda-public/icc-rennes`

## Plan de test

- [ ] Accès sans session → formulaire affiché
- [ ] Soumission sans CAPTCHA → bouton désactivé
- [ ] Soumission avec CAPTCHA invalide → message d'erreur
- [ ] Soumission valide → demande en base + email de confirmation reçu
- [ ] Demande visible dans `/agenda/requests` (dashboard qualification)
- [ ] Rate limit : 4e soumission en 1 minute → rejetée

🤖 Generated with [Claude Code](https://claude.com/claude-code)