### PR TITLE
fix(admin): PROTOCOLE dans Fonctions des départements + Qualificateur Agenda dans gestion des rôles

### DIFF
--- a/src/app/(auth)/admin/departments/functions/DeptFunctionsClient.tsx
+++ b/src/app/(auth)/admin/departments/functions/DeptFunctionsClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { isSystemFunction } from "@/lib/department-functions";
 
 interface Department {
   id: string;
@@ -12,7 +11,6 @@ interface Department {
 
 interface Props {
   departments: Department[];
-  initialCustomFunctions: string[];
 }
 
 const FUNCTIONS = [
@@ -34,25 +32,24 @@ const FUNCTIONS = [
     description: "Crée les visuels pour toutes les demandes.",
     icon: "🎨",
   },
+  {
+    key: "PROTOCOLE" as const,
+    label: "Protocole",
+    description: "Gère l'agenda pastoral et planifie les rendez-vous.",
+    icon: "📅",
+  },
 ];
 
-export default function DeptFunctionsClient({ departments, initialCustomFunctions }: Props) {
+export default function DeptFunctionsClient({ departments }: Props) {
   const [depts, setDepts] = useState(departments);
   const [saving, setSaving] = useState<string | null>(null);
 
-  // Custom functions state
-  const [customFunctions, setCustomFunctions] = useState<string[]>(initialCustomFunctions);
-  const [newFnName, setNewFnName] = useState("");
-  const [newFnDeptId, setNewFnDeptId] = useState("");
-  const [creating, setCreating] = useState(false);
-  const [createError, setCreateError] = useState<string | null>(null);
-
-  function getAssigned(fn: "SECRETARIAT" | "COMMUNICATION" | "PRODUCTION_MEDIA") {
+  function getAssigned(fn: "SECRETARIAT" | "COMMUNICATION" | "PRODUCTION_MEDIA" | "PROTOCOLE") {
     return depts.find((d) => d.function === fn)?.id ?? "";
   }
 
   async function handleChange(
-    fn: "SECRETARIAT" | "COMMUNICATION" | "PRODUCTION_MEDIA",
+    fn: "SECRETARIAT" | "COMMUNICATION" | "PRODUCTION_MEDIA" | "PROTOCOLE",
     newDeptId: string
   ) {
     setSaving(fn);
@@ -96,132 +93,6 @@ export default function DeptFunctionsClient({ departments, initialCustomFunction
     }
   }
 
-  async function handleCustomChange(fnKey: string, newDeptId: string) {
-    setSaving(fnKey);
-    const prevDept = depts.find((d) => d.function === fnKey);
-    const prevDeptId = prevDept?.id ?? "";
-
-    try {
-      if (prevDeptId && prevDeptId !== newDeptId) {
-        await fetch(`/api/departments/${prevDeptId}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ function: null }),
-        });
-      }
-
-      if (newDeptId) {
-        const res = await fetch(`/api/departments/${newDeptId}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ function: fnKey }),
-        });
-        if (!res.ok) {
-          const data = await res.json();
-          alert(data.error || "Erreur");
-          return;
-        }
-      }
-
-      setDepts((prev) =>
-        prev.map((d) => {
-          if (d.id === prevDeptId) return { ...d, function: null };
-          if (d.id === newDeptId) return { ...d, function: fnKey };
-          return d;
-        })
-      );
-    } catch {
-      alert("Erreur lors de la mise à jour");
-    } finally {
-      setSaving(null);
-    }
-  }
-
-  async function handleDeleteCustom(fnKey: string) {
-    const dept = depts.find((d) => d.function === fnKey);
-    setSaving(`delete:${fnKey}`);
-
-    try {
-      if (dept) {
-        const res = await fetch(`/api/departments/${dept.id}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ function: null }),
-        });
-        if (!res.ok) {
-          const data = await res.json();
-          alert(data.error || "Erreur lors de la suppression");
-          return;
-        }
-        setDepts((prev) =>
-          prev.map((d) => (d.id === dept.id ? { ...d, function: null } : d))
-        );
-      }
-      setCustomFunctions((prev) => prev.filter((f) => f !== fnKey));
-    } catch {
-      alert("Erreur lors de la suppression");
-    } finally {
-      setSaving(null);
-    }
-  }
-
-  async function handleCreate() {
-    setCreateError(null);
-    const trimmedName = newFnName.trim().toUpperCase().replace(/\s+/g, "_");
-
-    if (!trimmedName) {
-      setCreateError("Le nom est requis.");
-      return;
-    }
-
-    if (isSystemFunction(trimmedName)) {
-      setCreateError("Ce nom est réservé à une fonction système.");
-      return;
-    }
-
-    if (customFunctions.includes(trimmedName)) {
-      setCreateError("Cette fonction personnalisée existe déjà.");
-      return;
-    }
-
-    if (!newFnDeptId) {
-      setCreateError("Veuillez choisir un département.");
-      return;
-    }
-
-    setCreating(true);
-    try {
-      const res = await fetch(`/api/departments/${newFnDeptId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ function: trimmedName }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        setCreateError(data.error || "Erreur lors de la création");
-        return;
-      }
-
-      setDepts((prev) =>
-        prev.map((d) => {
-          // Clear previous holder of this function (handled server-side, but update local state)
-          if (d.function === trimmedName && d.id !== newFnDeptId) return { ...d, function: null };
-          if (d.id === newFnDeptId) return { ...d, function: trimmedName };
-          return d;
-        })
-      );
-
-      setCustomFunctions((prev) => [...prev, trimmedName].sort());
-      setNewFnName("");
-      setNewFnDeptId("");
-    } catch {
-      setCreateError("Erreur lors de la création");
-    } finally {
-      setCreating(false);
-    }
-  }
-
   const grouped = depts.reduce(
     (acc, d) => {
       if (!acc[d.ministryName]) acc[d.ministryName] = [];
@@ -233,11 +104,7 @@ export default function DeptFunctionsClient({ departments, initialCustomFunction
 
   return (
     <div className="space-y-10">
-      {/* System functions */}
       <div>
-        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-4">
-          Fonctions système
-        </h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {FUNCTIONS.map((fn) => {
             const assigned = getAssigned(fn.key);
@@ -294,151 +161,6 @@ export default function DeptFunctionsClient({ departments, initialCustomFunction
               </div>
             );
           })}
-        </div>
-      </div>
-
-      {/* Custom functions */}
-      <div>
-        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-4">
-          Fonctions personnalisées
-        </h2>
-
-        {customFunctions.length === 0 && (
-          <p className="text-sm text-gray-400 mb-6">Aucune fonction personnalisée configurée.</p>
-        )}
-
-        {customFunctions.length > 0 && (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
-            {customFunctions.map((fnKey) => {
-              const assignedDept = depts.find((d) => d.function === fnKey);
-              const assignedId = assignedDept?.id ?? "";
-              const isSaving = saving === fnKey;
-              const isDeleting = saving === `delete:${fnKey}`;
-
-              return (
-                <div
-                  key={fnKey}
-                  className="bg-white rounded-lg shadow p-5 border-2 border-transparent hover:border-icc-violet/20 transition-colors"
-                >
-                  <div className="flex items-center justify-between mb-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-xl">🔧</span>
-                      <h3 className="font-semibold text-gray-900">{fnKey}</h3>
-                    </div>
-                    <button
-                      onClick={() => handleDeleteCustom(fnKey)}
-                      disabled={isDeleting || isSaving}
-                      title="Supprimer cette fonction"
-                      className="text-gray-400 hover:text-icc-rouge disabled:opacity-40 transition-colors text-lg leading-none"
-                    >
-                      🗑️
-                    </button>
-                  </div>
-
-                  <label className="block text-xs font-medium text-gray-700 mb-1 mt-4">
-                    Département assigné
-                  </label>
-                  <select
-                    value={assignedId}
-                    onChange={(e) => handleCustomChange(fnKey, e.target.value)}
-                    disabled={isSaving || isDeleting}
-                    className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet focus:ring-1 focus:ring-icc-violet disabled:opacity-50 bg-white"
-                  >
-                    <option value="">— Non configuré —</option>
-                    {Object.entries(grouped).map(([ministry, deps]) => (
-                      <optgroup key={ministry} label={ministry}>
-                        {deps.map((d) => (
-                          <option key={d.id} value={d.id}>
-                            {d.name}
-                            {d.function && d.function !== fnKey
-                              ? ` (${d.function})`
-                              : ""}
-                          </option>
-                        ))}
-                      </optgroup>
-                    ))}
-                  </select>
-
-                  {assignedId ? (
-                    <p className="mt-2 text-xs text-icc-violet font-medium">
-                      ✓ {assignedDept?.name}
-                    </p>
-                  ) : (
-                    <p className="mt-2 text-xs text-amber-600">
-                      ⚠ Aucun département configuré
-                    </p>
-                  )}
-
-                  {(isSaving || isDeleting) && (
-                    <p className="mt-1 text-xs text-gray-400">
-                      {isDeleting ? "Suppression..." : "Enregistrement..."}
-                    </p>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        )}
-
-        {/* Add custom function form */}
-        <div className="bg-white rounded-lg shadow p-5 border-2 border-dashed border-gray-200 max-w-md">
-          <h3 className="text-sm font-semibold text-gray-700 mb-4">Ajouter une fonction</h3>
-
-          <div className="space-y-3">
-            <div>
-              <label className="block text-xs font-medium text-gray-700 mb-1">
-                Nom
-              </label>
-              <input
-                type="text"
-                value={newFnName}
-                onChange={(e) => {
-                  setNewFnName(e.target.value);
-                  setCreateError(null);
-                }}
-                placeholder="ex : TECHNIQUE"
-                className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet focus:ring-1 focus:ring-icc-violet"
-              />
-            </div>
-
-            <div>
-              <label className="block text-xs font-medium text-gray-700 mb-1">
-                Département
-              </label>
-              <select
-                value={newFnDeptId}
-                onChange={(e) => {
-                  setNewFnDeptId(e.target.value);
-                  setCreateError(null);
-                }}
-                className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet focus:ring-1 focus:ring-icc-violet bg-white"
-              >
-                <option value="">— Choisir —</option>
-                {Object.entries(grouped).map(([ministry, deps]) => (
-                  <optgroup key={ministry} label={ministry}>
-                    {deps.map((d) => (
-                      <option key={d.id} value={d.id}>
-                        {d.name}
-                        {d.function ? ` (${d.function})` : ""}
-                      </option>
-                    ))}
-                  </optgroup>
-                ))}
-              </select>
-            </div>
-
-            {createError && (
-              <p className="text-xs text-icc-rouge">{createError}</p>
-            )}
-
-            <button
-              onClick={handleCreate}
-              disabled={creating}
-              className="w-full bg-icc-violet text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-icc-violet/90 disabled:opacity-50 transition-colors"
-            >
-              {creating ? "Création..." : "Créer"}
-            </button>
-          </div>
         </div>
       </div>
     </div>

--- a/src/app/(auth)/admin/departments/functions/page.tsx
+++ b/src/app/(auth)/admin/departments/functions/page.tsx
@@ -1,7 +1,6 @@
 import { requireChurchPermission, getCurrentChurchId, requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import DeptFunctionsClient from "./DeptFunctionsClient";
-import { SYSTEM_FUNCTIONS } from "@/lib/department-functions";
 
 export default async function DeptFunctionsPage() {
   const session = await requireAuth();
@@ -15,25 +14,14 @@ export default async function DeptFunctionsPage() {
     orderBy: [{ ministry: { name: "asc" } }, { name: "asc" }],
   });
 
-  const systemFunctionKeys = SYSTEM_FUNCTIONS.map((f) => f.key);
-
-  // Collect distinct custom function names (non-system, non-null)
-  const customFunctionNames = Array.from(
-    new Set(
-      departments
-        .map((d) => d.function)
-        .filter((fn): fn is string => fn !== null && !systemFunctionKeys.includes(fn as never))
-    )
-  ).sort();
-
   return (
     <div>
       <h1 className="text-2xl font-bold text-gray-900 mb-2">
         Fonctions des départements
       </h1>
       <p className="text-sm text-gray-500 mb-6">
-        Configurez quel département est en charge de chaque fonction. Ces
-        assignations déterminent le routage automatique des demandes d&apos;annonces.
+        Configurez quel département est en charge de chaque fonction système.
+        Ces assignations déterminent le routage des demandes et les accès aux modules spécialisés.
       </p>
       <DeptFunctionsClient
         departments={departments.map((d) => ({
@@ -42,7 +30,6 @@ export default async function DeptFunctionsPage() {
           ministryName: d.ministry.name,
           function: d.function,
         }))}
-        initialCustomFunctions={customFunctionNames}
       />
     </div>
   );

--- a/src/app/(auth)/admin/users/UsersClient.tsx
+++ b/src/app/(auth)/admin/users/UsersClient.tsx
@@ -16,6 +16,7 @@ const ROLES = [
   { value: "DEPARTMENT_HEAD", label: "Responsable de département" },
   { value: "DISCIPLE_MAKER", label: "Faiseur de Disciples" },
   { value: "REPORTER", label: "Reporter (Comptes rendus)" },
+  { value: "AGENDA_QUALIFIER", label: "Qualificateur Agenda" },
 ];
 
 const ROLE_LABELS: Record<string, string> = Object.fromEntries(


### PR DESCRIPTION
## Problèmes

1. La fonction système `PROTOCOLE` était absente de la liste dans `DeptFunctionsClient` — impossible d'assigner le département Protocole depuis l'interface, bloquant l'accès à l'agenda pastoral.

2. Le rôle `AGENDA_QUALIFIER` n'était pas dans la liste des rôles assignables dans `/admin/users` — impossible de désigner un qualificateur de demandes de RDV.

3. La section « Fonctions personnalisées » permettait de créer des labels sans aucun comportement applicatif — source de confusion.

## Corrections

- `DeptFunctionsClient` : ajout de `PROTOCOLE` (icône 📅, description, typage)
- `UsersClient` : ajout de `AGENDA_QUALIFIER` → "Qualificateur Agenda" dans la liste des rôles
- Suppression de la section « Fonctions personnalisées » (UI + logique + prop `initialCustomFunctions`)
- Description de la page mise à jour

🤖 Generated with [Claude Code](https://claude.com/claude-code)