### PR TITLE
fix(member-link): lien STAR multi-église sur le même enregistrement Member

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -216,7 +216,7 @@ model Member {
   plannings       Planning[]
   taskAssignments TaskAssignment[]
   createdAt       DateTime            @default(now())
-  userLink        MemberUserLink?
+  userLinks       MemberUserLink[]
   linkRequests    MemberLinkRequest[]
 
   // Discipolat (un seul enregistrement actif par église grâce au @@unique du modèle)
@@ -243,7 +243,7 @@ model MemberDepartment {
 
 model MemberUserLink {
   id            String    @id @default(cuid())
-  memberId      String    @unique
+  memberId      String
   userId        String
   churchId      String
   validatedAt   DateTime?
@@ -254,6 +254,7 @@ model MemberUserLink {
   church      Church  @relation(fields: [churchId],      references: [id])
   validatedBy User?   @relation("LinkValidator",         fields: [validatedById], references: [id])
 
+  @@unique([memberId, churchId])
   @@unique([userId, churchId])
   @@map("member_user_links")
 }

--- a/src/app/(auth)/admin/members/duplicates/page.tsx
+++ b/src/app/(auth)/admin/members/duplicates/page.tsx
@@ -18,7 +18,7 @@ export default async function DuplicatesPage() {
         },
         orderBy: { isPrimary: "desc" },
       },
-      userLink: { select: { userId: true, user: { select: { name: true, email: true } } } },
+      userLinks: { where: { churchId }, select: { userId: true, user: { select: { name: true, email: true } } } },
       _count: { select: { plannings: true, discipleships: true, disciplesMade: true } },
     },
   });
@@ -81,8 +81,8 @@ export default async function DuplicatesPage() {
         ministryName: d.department.ministry.name,
         isPrimary: d.isPrimary,
       })),
-      userLink: m.userLink
-        ? { userId: m.userLink.userId, name: m.userLink.user.name, email: m.userLink.user.email }
+      userLink: m.userLinks[0]
+        ? { userId: m.userLinks[0].userId, name: m.userLinks[0].user.name, email: m.userLinks[0].user.email }
         : null,
       counts: { plannings: m._count.plannings, disciples: m._count.discipleships, disciplesMade: m._count.disciplesMade },
     };

--- a/src/app/(auth)/admin/members/page.tsx
+++ b/src/app/(auth)/admin/members/page.tsx
@@ -75,7 +75,8 @@ export default async function MembersPage() {
         },
         orderBy: { isPrimary: "desc" },
       },
-      userLink: {
+      userLinks: {
+        where: { churchId },
         select: { userId: true, user: { select: { name: true, email: true } } },
       },
     },
@@ -158,8 +159,8 @@ export default async function MembersPage() {
               isPrimary: d.isPrimary,
               ministry: { id: d.department.ministry.id, name: d.department.ministry.name },
             })),
-            userLink: m.userLink
-              ? { userId: m.userLink.userId, userName: m.userLink.user.name, userEmail: m.userLink.user.email }
+            userLink: m.userLinks[0]
+              ? { userId: m.userLinks[0].userId, userName: m.userLinks[0].user.name, userEmail: m.userLinks[0].user.email }
               : null,
             churchId: primaryDept?.department.ministry.churchId ?? "",
           };

--- a/src/app/api/admin/members/duplicates/route.ts
+++ b/src/app/api/admin/members/duplicates/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: Request) {
           },
           orderBy: { isPrimary: "desc" },
         },
-        userLink: { select: { userId: true, user: { select: { name: true, email: true } } } },
+        userLinks: { where: { churchId }, select: { userId: true, user: { select: { name: true, email: true } } } },
         _count: { select: { plannings: true, discipleships: true, disciplesMade: true } },
       },
     });

--- a/src/app/api/admin/members/merge/route.ts
+++ b/src/app/api/admin/members/merge/route.ts
@@ -127,20 +127,19 @@ export async function POST(request: Request) {
       await tx.memberLinkRequest.updateMany({ where: { memberId: sourceId }, data: { memberId: targetId } });
 
       // ── MemberUserLink ────────────────────────────────────────────────────────
-      const srcLink = await tx.memberUserLink.findUnique({ where: { memberId: sourceId } });
-      const tgtLink = await tx.memberUserLink.findUnique({ where: { memberId: targetId } });
+      const srcLink = await tx.memberUserLink.findUnique({ where: { memberId_churchId: { memberId: sourceId, churchId: srcChurchId } } });
+      const tgtLink = await tx.memberUserLink.findUnique({ where: { memberId_churchId: { memberId: targetId, churchId: srcChurchId } } });
 
       if (srcLink && tgtLink) {
         // Les deux ont un compte lié — garder celui choisi, supprimer l'autre
-        const userIdToRemove = resolution.keepUserId === srcLink.userId ? tgtLink.userId : srcLink.userId;
-        const memberIdToRemove = userIdToRemove === srcLink.userId ? sourceId : targetId;
-        await tx.memberUserLink.delete({ where: { memberId: memberIdToRemove } });
+        const linkToRemove = resolution.keepUserId === srcLink.userId ? tgtLink : srcLink;
+        await tx.memberUserLink.delete({ where: { id: linkToRemove.id } });
         // Déplacer le lien source vers le target si c'est le lien source qu'on conserve
         if (resolution.keepUserId === srcLink.userId) {
-          await tx.memberUserLink.update({ where: { memberId: sourceId }, data: { memberId: targetId } });
+          await tx.memberUserLink.update({ where: { id: srcLink.id }, data: { memberId: targetId } });
         }
       } else if (srcLink && !tgtLink) {
-        await tx.memberUserLink.update({ where: { memberId: sourceId }, data: { memberId: targetId } });
+        await tx.memberUserLink.update({ where: { id: srcLink.id }, data: { memberId: targetId } });
       }
       // else: tgtLink && !srcLink → rien à faire (target garde son lien)
 

--- a/src/app/api/member-link-requests/route.ts
+++ b/src/app/api/member-link-requests/route.ts
@@ -80,7 +80,7 @@ export async function POST(request: Request) {
       const member = await prisma.member.findUnique({
         where: { id: data.memberId },
         include: {
-          userLink: true,
+          userLinks: { where: { churchId: data.churchId } },
           departments: {
             where: { isPrimary: true },
             include: { department: { include: { ministry: { select: { churchId: true } } } } },
@@ -88,7 +88,7 @@ export async function POST(request: Request) {
         },
       });
       if (!member) throw new ApiError(404, "STAR introuvable");
-      if (member.userLink) throw new ApiError(409, "Ce STAR est déjà lié à un compte");
+      if (member.userLinks.length > 0) throw new ApiError(409, "Ce STAR est déjà lié à un compte dans cette église");
 
       const primaryChurchId = member.departments[0]?.department.ministry.churchId;
       if (primaryChurchId !== data.churchId) {

--- a/src/app/api/member-user-links/route.ts
+++ b/src/app/api/member-user-links/route.ts
@@ -40,11 +40,11 @@ export async function POST(request: Request) {
       throw new ApiError(403, "Cet utilisateur n'a pas de lien avec cette église");
     }
 
-    // Vérifier qu'il n'y a pas déjà un lien pour ce membre ou cet utilisateur dans cette église
+    // Vérifier qu'il n'y a pas déjà un lien pour ce membre dans cette église
     const existingByMember = await prisma.memberUserLink.findUnique({
-      where: { memberId },
+      where: { memberId_churchId: { memberId, churchId } },
     });
-    if (existingByMember) throw new ApiError(409, "Ce STAR est déjà lié à un compte");
+    if (existingByMember) throw new ApiError(409, "Ce STAR est déjà lié à un compte dans cette église");
 
     const existingByUser = await prisma.memberUserLink.findFirst({
       where: { userId, churchId },
@@ -86,10 +86,9 @@ export async function DELETE(request: Request) {
     requireRateLimit(request, { prefix: `unlink:${session.user.id}`, ...RATE_LIMIT_SENSITIVE });
 
     const link = await prisma.memberUserLink.findUnique({
-      where: { memberId },
+      where: { memberId_churchId: { memberId, churchId } },
     });
-    if (!link) throw new ApiError(404, "Ce STAR n'est lié à aucun compte");
-    if (link.churchId !== churchId) throw new ApiError(403, "Ce lien n'appartient pas à cette église");
+    if (!link) throw new ApiError(404, "Ce STAR n'est lié à aucun compte dans cette église");
 
     await prisma.memberUserLink.delete({ where: { id: link.id } });
 

--- a/src/app/api/members/search/route.ts
+++ b/src/app/api/members/search/route.ts
@@ -43,16 +43,16 @@ export async function GET(request: Request) {
             },
           },
         },
-        userLink: { select: { id: true } },
+        userLinks: { where: { churchId }, select: { id: true } },
       },
       take: 20,
       orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
     });
 
     const members = matches
-      .filter((m) => !m.userLink)
+      .filter((m) => m.userLinks.length === 0)
       .slice(0, 10)
-      .map(({ userLink: _, ...m }) => m);
+      .map(({ userLinks: _, ...m }) => m);
 
     return successResponse(members);
   } catch (error) {

--- a/src/app/no-access/page.tsx
+++ b/src/app/no-access/page.tsx
@@ -14,15 +14,20 @@ export default async function NoAccessPage() {
     redirect("/dashboard");
   }
 
-  // Vérifier si une demande est déjà en attente
-  const pendingRequest = await prisma.memberLinkRequest.findFirst({
-    where: { userId: session.user.id, status: "PENDING" },
-  });
-
-  const churches = await prisma.church.findMany({
+  const allChurches = await prisma.church.findMany({
     select: { id: true, name: true },
     orderBy: { name: "asc" },
   });
+
+  // Demandes en attente par église — scoped pour ne pas bloquer les autres églises
+  const pendingRequests = await prisma.memberLinkRequest.findMany({
+    where: { userId: session.user.id, status: "PENDING" },
+    select: { churchId: true },
+  });
+  const pendingChurchIds = new Set(pendingRequests.map((r) => r.churchId));
+
+  // Églises disponibles = toutes les églises sans demande en attente
+  const churches = allChurches.filter((c) => !pendingChurchIds.has(c.id));
 
   const ministries = await prisma.ministry.findMany({
     where: { isSystem: false },
@@ -57,18 +62,20 @@ export default async function NoAccessPage() {
           {session.user.email}
         </p>
 
-        {pendingRequest ? (
-          <div className="text-center">
-            <div className="w-12 h-12 bg-yellow-100 rounded-full flex items-center justify-center mx-auto mb-3">
-              <svg className="w-6 h-6 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </div>
-            <p className="text-gray-600 text-sm">
-              Votre demande d&apos;accès est <strong>en cours de traitement</strong>. Un administrateur va l&apos;examiner prochainement.
+        {pendingRequests.length > 0 && (
+          <div className="mb-5 flex items-start gap-3 bg-yellow-50 border border-yellow-200 rounded-lg p-3">
+            <svg className="w-5 h-5 text-yellow-600 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <p className="text-sm text-yellow-800">
+              {churches.length === 0
+                ? "Votre demande d'accès est en cours de traitement. Un administrateur va l'examiner prochainement."
+                : "Une demande est déjà en attente pour certaines de vos églises."}
             </p>
           </div>
-        ) : (
+        )}
+
+        {churches.length > 0 ? (
           <NoAccessClient
             churches={churches}
             ministries={ministries.map((m) => ({
@@ -78,7 +85,9 @@ export default async function NoAccessPage() {
               departments: m.departments,
             }))}
           />
-        )}
+        ) : pendingRequests.length === 0 ? (
+          <p className="text-sm text-gray-400 text-center">Aucune église disponible.</p>
+        ) : null}
 
         <div className="mt-6 pt-4 border-t border-gray-100 text-center">
           <form action={async () => { "use server"; await signOut({ redirectTo: "/" }); }}>


### PR DESCRIPTION
## Problème

Un STAR servant dans plusieurs églises avec le même enregistrement `Member` (ayant des départements dans plusieurs églises) ne pouvait pas être lié dans une deuxième église :

- L'autocomplete de recherche le filtrait comme « déjà lié » même si son lien existant appartenait à une autre église
- En fond : la contrainte `memberId @unique` sur `MemberUserLink` limitait chaque `Member` à un seul lien au total, alors que `@@unique([userId, churchId])` avait été conçu pour le multi-église

## Solution

**Schema** (`prisma/schema.prisma`) :
- Suppression de `memberId @unique`
- Ajout de `@@unique([memberId, churchId])` — un Member ne peut être lié qu'une fois **par église**
- `Member.userLink MemberUserLink?` → `Member.userLinks MemberUserLink[]`

**Endpoints** :
- `members/search` — filtre `!m.userLink` → `userLinks(where:{churchId}).length === 0`
- `member-link-requests` POST — check « déjà lié » scopé à l'église ciblée
- `member-user-links` POST/DELETE — lookup composite `memberId_churchId` au lieu de `memberId` seul

**Pages admin** (`members/`, `duplicates/`) — query `userLinks(where:{churchId})` + `[0]` pour la sérialisation vers les composants clients (interface inchangée côté client)

**Bonus** : `no-access/page` — même pattern que PR #294 (pending request scopé par église) appliqué à la page serveur qui était restée avec un check global

## Avant migration

Après merge, exécuter :
```bash
npm run db:migrate
# Nom suggéré : allow_member_link_per_church
```

La migration est non-destructive : elle retire l'index unique sur `memberId` et crée un index composite `(memberId, churchId)`. Toutes les données existantes sont valides (chaque lien a déjà un `memberId` unique).

## Test plan

- [ ] Un STAR déjà lié en église A apparaît dans l'autocomplete de l'église B
- [ ] La soumission d'une demande de lien pour l'église B réussit
- [ ] L'approbation admin crée bien un second `MemberUserLink` avec `churchId=B`
- [ ] Le STAR lié dans les deux églises s'affiche correctement dans `/admin/members` pour chacune
- [ ] Un STAR déjà lié dans l'église courante n'apparaît toujours pas dans l'autocomplete (comportement inchangé)
- [ ] `no-access` : un utilisateur sans rôle avec une demande en attente pour l'église A peut soumettre pour l'église B

🤖 Generated with [Claude Code](https://claude.com/claude-code)