### PR TITLE
chore: release v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.4.2] - 2026-05-18
+
+### Corrigé
+
+- Liaison STAR multi-église : un STAR ayant déjà un lien compte dans une église n'apparaissait pas dans l'autocomplete de recherche des autres églises — la contrainte `memberId @unique` sur `MemberUserLink` a été remplacée par `@@unique([memberId, churchId])` pour permettre un lien par église (#325)
+- Page d'accès en attente (`/no-access`) : la détection de demande en attente n'était pas scopée par église, bloquant les nouveaux utilisateurs souhaitant rejoindre plusieurs églises simultanément (#325)
+
 ## [v1.4.1] - 2026-05-17
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Release v1.4.2

Bump de version suite au merge de #325.

### Changements inclus

**Corrigé**
- Liaison STAR multi-église : autocomplete scopé par église + contrainte `@@unique([memberId, churchId])` (#325)
- Page `/no-access` : détection demande en attente scopée par église (#325)

### Séquence de release après merge

```bash
git checkout main && git pull
git tag v1.4.2 && git push origin v1.4.2
gh release create v1.4.2 --title "v1.4.2" --notes "Voir CHANGELOG.md"
```

N'oublie pas de lancer la migration BDD sur le serveur :
```bash
npm run db:migrate:deploy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)