### PR TITLE
fix(member-link): migration contrainte multi-église member_user_links

### DIFF
--- a/prisma/migrations/20260518000000_member_user_link_multi_church/migration.sql
+++ b/prisma/migrations/20260518000000_member_user_link_multi_church/migration.sql
@@ -1,0 +1,5 @@
+-- Drop old single-member unique constraint
+DROP INDEX `member_user_links_memberId_key` ON `member_user_links`;
+
+-- Add composite unique constraint (memberId, churchId)
+ALTER TABLE `member_user_links` ADD CONSTRAINT `member_user_links_memberId_churchId_key` UNIQUE (`memberId`, `churchId`);


### PR DESCRIPTION
## Contexte

La PR #325 avait modifié `prisma/schema.prisma` pour remplacer `memberId @unique` par `@@unique([memberId, churchId])` sur `MemberUserLink`, mais **sans créer de fichier de migration**. Résultat : le déploiement v1.4.2 a dit « No pending migrations to apply » et la contrainte BDD n'a pas changé — le fix ne fonctionne donc pas en production.

## Changement

Ajoute la migration SQL manquante :
- Supprime `member_user_links_memberId_key` (l'ancienne contrainte `memberId @unique`)
- Crée `member_user_links_memberId_churchId_key` (la nouvelle contrainte composite)

## Test plan

- [ ] CI passe (typecheck, lint, tests)
- [ ] Après merge : `npm run db:migrate:deploy` en production → 1 migration appliquée
- [ ] Vérifier qu'un STAR peut être lié dans deux églises différentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)