### PR TITLE
chore: release v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.4.3] - 2026-05-18
+
+### Corrigé
+
+- Liaison STAR multi-église : migration BDD manquante dans v1.4.2 — la contrainte `memberId @unique` n'était pas supprimée en production, empêchant le lien d'un même STAR dans plusieurs églises (#327)
+
 ## [v1.4.2] - 2026-05-18
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Migration BDD manquante dans v1.4.2 pour le fix multi-église (#327).

🤖 Generated with [Claude Code](https://claude.com/claude-code)