### PR TITLE
fix(migration): ordre ADD/DROP pour member_user_links

### DIFF
--- a/prisma/migrations/20260518000000_member_user_link_multi_church/migration.sql
+++ b/prisma/migrations/20260518000000_member_user_link_multi_church/migration.sql
@@ -1,5 +1,5 @@
--- Drop old single-member unique constraint
-DROP INDEX `member_user_links_memberId_key` ON `member_user_links`;
-
--- Add composite unique constraint (memberId, churchId)
+-- Add composite unique constraint first (so the FK on memberId can use it as prefix index)
 ALTER TABLE `member_user_links` ADD CONSTRAINT `member_user_links_memberId_churchId_key` UNIQUE (`memberId`, `churchId`);
+
+-- Now drop old single-column unique index (FK will use the composite index above)
+DROP INDEX `member_user_links_memberId_key` ON `member_user_links`;


### PR DESCRIPTION
## Problème

La migration `20260518000000_member_user_link_multi_church` échouait en production avec code 1553 :
> Cannot drop index 'member_user_links_memberId_key': needed in a foreign key constraint

MySQL refuse de supprimer un index unique si une FK l'utilise — même si l'index sert juste à satisfaire la FK, pas à l'enforcer.

## Fix

Inverser l'ordre des opérations :
1. **ADD** `UNIQUE (memberId, churchId)` — MariaDB peut maintenant utiliser ce composite index comme préfixe pour la FK sur `memberId`
2. **DROP** `member_user_links_memberId_key` — l'ancien index n'est plus nécessaire

## Après merge

Sur le serveur, résoudre l'état d'échec puis redéployer :
\`\`\`bash
npx prisma migrate resolve --rolled-back 20260518000000_member_user_link_multi_church
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)