### PR TITLE
fix(requests): toggle Voir plus pour le contenu des annonces

### DIFF
--- a/src/app/(auth)/communication/requests/CommunicationDashboard.tsx
+++ b/src/app/(auth)/communication/requests/CommunicationDashboard.tsx
@@ -52,6 +52,7 @@ export default function CommunicationDashboard({ requests: initial }: Props) {
   const [requests, setRequests] = useState(initial);
   const [processing, setProcessing] = useState<string | null>(null);
   const [deliveryLinks, setDeliveryLinks] = useState<Record<string, string>>({});
+  const [expandedContent, setExpandedContent] = useState<Set<string>>(new Set());
 
   async function updateRequest(id: string, status: string, deliveryLink?: string) {
     setProcessing(id);
@@ -123,9 +124,31 @@ export default function CommunicationDashboard({ requests: initial }: Props) {
           </span>
         </div>
 
-        {req.announcement && (
-          <p className="text-sm text-gray-600 mb-3 line-clamp-3">{req.announcement.content}</p>
-        )}
+        {req.announcement && (() => {
+          const content = req.announcement.content;
+          const PREVIEW = 150;
+          const isLong = content.length > PREVIEW;
+          const isExpanded = expandedContent.has(req.id);
+          return (
+            <div className="mb-3">
+              <p className="text-sm text-gray-600 whitespace-pre-wrap">
+                {isLong && !isExpanded ? `${content.slice(0, PREVIEW).trimEnd()}…` : content}
+              </p>
+              {isLong && (
+                <button
+                  onClick={() => setExpandedContent((prev) => {
+                    const next = new Set(prev);
+                    isExpanded ? next.delete(req.id) : next.add(req.id);
+                    return next;
+                  })}
+                  className="mt-1 text-xs text-icc-violet hover:underline"
+                >
+                  {isExpanded ? "Voir moins" : "Voir plus"}
+                </button>
+              )}
+            </div>
+          );
+        })()}
 
         {visuelInfo && (
           <div className={`flex items-center gap-2 text-xs mb-3 ${visuelInfo.color}`}>

--- a/src/app/(auth)/media/requests/MediaDashboard.tsx
+++ b/src/app/(auth)/media/requests/MediaDashboard.tsx
@@ -83,6 +83,7 @@ export default function MediaDashboard({ requests: initial, churchId, mediaProje
   const [processing, setProcessing] = useState<string | null>(null);
   const [deliveryLinks, setDeliveryLinks] = useState<Record<string, string>>({});
   const [notes, setNotes] = useState<Record<string, string>>({});
+  const [expandedContent, setExpandedContent] = useState<Set<string>>(new Set());
 
   // "Prendre en charge" inline form state
   const [takingCharge, setTakingCharge] = useState<string | null>(null);
@@ -248,9 +249,30 @@ export default function MediaDashboard({ requests: initial, churchId, mediaProje
           </p>
         )}
 
-        {brief && (
-          <p className="text-sm text-gray-600 mb-3 line-clamp-3">{brief}</p>
-        )}
+        {brief && (() => {
+          const PREVIEW = 150;
+          const isLong = brief.length > PREVIEW;
+          const isExpanded = expandedContent.has(req.id);
+          return (
+            <div className="mb-3">
+              <p className="text-sm text-gray-600 whitespace-pre-wrap">
+                {isLong && !isExpanded ? `${brief.slice(0, PREVIEW).trimEnd()}…` : brief}
+              </p>
+              {isLong && (
+                <button
+                  onClick={() => setExpandedContent((prev) => {
+                    const next = new Set(prev);
+                    isExpanded ? next.delete(req.id) : next.add(req.id);
+                    return next;
+                  })}
+                  className="mt-1 text-xs text-icc-violet hover:underline"
+                >
+                  {isExpanded ? "Voir moins" : "Voir plus"}
+                </button>
+              )}
+            </div>
+          );
+        })()}
 
         {linkedProject && (req.status === "EN_COURS" || req.status === "LIVRE") && (() => {
           const shareToken = linkedProject.shareTokens[0];

--- a/src/app/(auth)/secretariat/requests/RequestsDashboard.tsx
+++ b/src/app/(auth)/secretariat/requests/RequestsDashboard.tsx
@@ -98,6 +98,7 @@ export default function RequestsDashboard({ requests: initial, canManage = false
   const [notes, setNotes] = useState<Record<string, string>>({});
   const [category, setCategory] = useState<FilterCategory>("all");
   const [showProcessed, setShowProcessed] = useState(false);
+  const [expandedContent, setExpandedContent] = useState<Set<string>>(new Set());
 
   const filtered = requests.filter((r) => {
     if (category === "announcements" && !ANNOUNCEMENT_TYPES.includes(r.type)) return false;
@@ -248,11 +249,31 @@ export default function RequestsDashboard({ requests: initial, canManage = false
         </div>
 
         {/* Announcement content */}
-        {req.announcement?.content && (
-          <p className="text-sm text-gray-700 mb-3 whitespace-pre-wrap line-clamp-3">
-            {req.announcement.content}
-          </p>
-        )}
+        {req.announcement?.content && (() => {
+          const content = req.announcement.content;
+          const PREVIEW = 150;
+          const isLong = content.length > PREVIEW;
+          const isExpanded = expandedContent.has(req.id);
+          return (
+            <div className="mb-3">
+              <p className="text-sm text-gray-700 whitespace-pre-wrap">
+                {isLong && !isExpanded ? `${content.slice(0, PREVIEW).trimEnd()}…` : content}
+              </p>
+              {isLong && (
+                <button
+                  onClick={() => setExpandedContent((prev) => {
+                    const next = new Set(prev);
+                    isExpanded ? next.delete(req.id) : next.add(req.id);
+                    return next;
+                  })}
+                  className="mt-1 text-xs text-icc-violet hover:underline"
+                >
+                  {isExpanded ? "Voir moins" : "Voir plus"}
+                </button>
+              )}
+            </div>
+          );
+        })()}
 
         {/* Demand payload summary */}
         {isDemand && payloadSummary && (


### PR DESCRIPTION
## Problème

Les dashboards **Secrétariat**, **Communication** et **Production Média** affichaient le contenu des annonces avec `line-clamp-3` mais sans bouton pour lire la suite — impossible d'ouvrir une annonce longue entièrement.

## Fix

Remplace `line-clamp-3` par un toggle **Voir plus / Voir moins** (seuil 150 caractères) dans les 3 dashboards, cohérent avec le comportement déjà en place dans "Mes demandes" (`RequestsList.tsx`).

## Fichiers modifiés

- `src/app/(auth)/secretariat/requests/RequestsDashboard.tsx`
- `src/app/(auth)/communication/requests/CommunicationDashboard.tsx`
- `src/app/(auth)/media/requests/MediaDashboard.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)