### PR TITLE
feat(notifications): système de notifications complet — in-app + email

### DIFF
--- a/src/app/api/agenda/requests/[id]/qualify/route.ts
+++ b/src/app/api/agenda/requests/[id]/qualify/route.ts
@@ -3,6 +3,9 @@ import { resolveChurchId } from "@/lib/auth";
 import { requireAgendaQualify } from "@/modules/agenda/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
+import { createNotification, notifyDeptMembers } from "@/lib/notifications";
+import { sendEmail, buildAppointmentRejectedEmail } from "@/lib/email";
+import { DEPT_FN } from "@/lib/department-functions";
 import { z } from "zod";
 
 const qualifySchema = z.discriminatedUnion("action", [
@@ -28,7 +31,7 @@ export async function PATCH(
 
     const existing = await prisma.appointmentRequest.findUnique({
       where: { id },
-      select: { status: true },
+      select: { status: true, userId: true, email: true, firstName: true, lastName: true, subject: true, churchId: true },
     });
     if (!existing) throw new ApiError(404, "Demande introuvable");
     if (existing.status !== "PENDING") {
@@ -69,6 +72,14 @@ export async function PATCH(
         details: { transition: "PENDING→VALIDATED", assignedToId: data.assignedToId },
       });
 
+      // Notify Protocole dept members that a request is ready to schedule
+      notifyDeptMembers(churchId, DEPT_FN.PROTOCOLE, {
+        type: "AGENDA_REQUEST_VALIDATED",
+        title: "Demande RDV à planifier",
+        message: `La demande de ${existing.firstName} ${existing.lastName} (« ${existing.subject} ») est prête à être planifiée.`,
+        link: "/agenda/schedule",
+      }).catch(() => {});
+
       return successResponse(updated);
     }
 
@@ -92,6 +103,32 @@ export async function PATCH(
       entityId: id,
       details: { transition: "PENDING→REJECTED", rejectReason: data.rejectReason ?? null },
     });
+
+    // Notify demandeur
+    if (existing.userId) {
+      createNotification({
+        userId: existing.userId,
+        type: "AGENDA_REQUEST_REJECTED",
+        title: "Demande de RDV non retenue",
+        message: `Votre demande « ${existing.subject} » n'a pas pu être retenue.${data.rejectReason ? ` Motif : ${data.rejectReason}` : ""}`,
+        link: "/requests",
+      }).catch(() => {});
+    }
+    if (existing.email) {
+      const church = await prisma.church.findUnique({ where: { id: churchId }, select: { name: true } });
+      if (church) {
+        const { subject: emailSubject, html } = buildAppointmentRejectedEmail({
+          firstName: existing.firstName,
+          lastName: existing.lastName,
+          subject: existing.subject,
+          churchName: church.name,
+          rejectReason: data.rejectReason ?? null,
+        });
+        sendEmail({ to: existing.email, subject: emailSubject, html }).catch((err) => {
+          console.error("[qualify] sendEmail rejected failed:", err?.message ?? err);
+        });
+      }
+    }
 
     return successResponse(updated);
   } catch (error) {

--- a/src/app/api/agenda/requests/[id]/schedule/route.ts
+++ b/src/app/api/agenda/requests/[id]/schedule/route.ts
@@ -3,6 +3,8 @@ import { resolveChurchId } from "@/lib/auth";
 import { requireAgendaManage } from "@/modules/agenda/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
+import { createNotification } from "@/lib/notifications";
+import { sendEmail, buildAppointmentScheduledEmail } from "@/lib/email";
 import { z } from "zod";
 
 const scheduleSchema = z.object({
@@ -27,7 +29,7 @@ export async function PATCH(
 
     const existing = await prisma.appointmentRequest.findUnique({
       where: { id },
-      select: { status: true, subject: true, assignedToId: true },
+      select: { status: true, subject: true, assignedToId: true, userId: true, email: true, firstName: true, lastName: true },
     });
     if (!existing) throw new ApiError(404, "Demande introuvable");
     if (existing.status !== "VALIDATED") {
@@ -78,6 +80,36 @@ export async function PATCH(
       entityId: id,
       details: { transition: "VALIDATED→SCHEDULED", entryId: entry.id, startsAt: data.startsAt },
     });
+
+    // Notify demandeur
+    const startsAt = new Date(data.startsAt);
+    const dateStr = startsAt.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" });
+    const timeStr = startsAt.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+    if (existing.userId) {
+      createNotification({
+        userId: existing.userId,
+        type: "AGENDA_REQUEST_SCHEDULED",
+        title: "Rendez-vous pastoral confirmé",
+        message: `Votre demande « ${existing.subject} » a été planifiée le ${dateStr} à ${timeStr}.`,
+        link: "/requests",
+      }).catch(() => {});
+    }
+    if (existing.email) {
+      const church = await prisma.church.findUnique({ where: { id: churchId }, select: { name: true } });
+      if (church) {
+        const { subject: emailSubject, html } = buildAppointmentScheduledEmail({
+          firstName: existing.firstName,
+          lastName: existing.lastName,
+          subject: existing.subject,
+          churchName: church.name,
+          startsAt,
+          location: data.location ?? null,
+        });
+        sendEmail({ to: existing.email, subject: emailSubject, html }).catch((err) => {
+          console.error("[schedule] sendEmail failed:", err?.message ?? err);
+        });
+      }
+    }
 
     return successResponse(entry, 201);
   } catch (error) {

--- a/src/app/api/agenda/requests/public/route.ts
+++ b/src/app/api/agenda/requests/public/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { sendEmail, buildAppointmentConfirmationEmail } from "@/lib/email";
+import { notifyUsersWithRole } from "@/lib/notifications";
 import { requireRateLimit } from "@/lib/rate-limit";
 import { z } from "zod";
 
@@ -76,6 +77,13 @@ export async function POST(request: Request) {
         preferredDays: data.preferredDay,
       },
     });
+
+    notifyUsersWithRole(church.id, "AGENDA_QUALIFIER", {
+      type: "AGENDA_REQUEST_PENDING",
+      title: "Nouvelle demande de RDV",
+      message: `${data.firstName} ${data.lastName} a soumis une demande : « ${subject} ».`,
+      link: "/agenda/requests",
+    }).catch(() => {});
 
     const { subject: emailSubject, html } = buildAppointmentConfirmationEmail({
       firstName: data.firstName,

--- a/src/app/api/agenda/requests/route.ts
+++ b/src/app/api/agenda/requests/route.ts
@@ -6,6 +6,7 @@ import { logAudit } from "@/lib/audit";
 import { rolePermissions } from "@/lib/registry";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { sendEmail, buildAppointmentConfirmationEmail } from "@/lib/email";
+import { notifyUsersWithRole } from "@/lib/notifications";
 import { z } from "zod";
 
 const submitSchema = z.object({
@@ -109,6 +110,13 @@ export async function POST(request: Request) {
       entityId: req.id,
       details: { subject: data.subject },
     });
+
+    notifyUsersWithRole(data.churchId, "AGENDA_QUALIFIER", {
+      type: "AGENDA_REQUEST_PENDING",
+      title: "Nouvelle demande de RDV",
+      message: `${data.firstName} ${data.lastName} a soumis une demande : « ${data.subject} ».`,
+      link: "/agenda/requests",
+    }).catch(() => {});
 
     if (data.email && church) {
       const { subject: emailSubject, html } = buildAppointmentConfirmationEmail({

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -46,12 +46,25 @@ export async function POST(request: Request) {
         },
       });
 
+      // Batch-lookup des comptes utilisateurs liés aux membres concernés
+      const allMemberIds = events.flatMap((e) =>
+        e.eventDepts.flatMap((ed) => ed.plannings.map((p) => p.memberId))
+      );
+      const memberLinks = allMemberIds.length > 0
+        ? await prisma.memberUserLink.findMany({
+            where: { memberId: { in: allMemberIds }, validatedAt: { not: null } },
+            select: { memberId: true, userId: true, user: { select: { email: true } } },
+          })
+        : [];
+      const userByMember = new Map(memberLinks.map((l) => [l.memberId, { userId: l.userId, email: l.user.email }]));
+
       for (const event of events) {
         for (const eventDept of event.eventDepts) {
           for (const planning of eventDept.plannings) {
             const member = planning.member;
-
             const memberName = `${member.firstName} ${member.lastName}`;
+            const linkedUser = userByMember.get(member.id);
+
             const { subject, html } = buildReminderEmail({
               memberName,
               eventTitle: event.title,
@@ -60,17 +73,32 @@ export async function POST(request: Request) {
               daysUntil: daysAhead,
             });
 
-            // Send email if SMTP is configured
-            if (process.env.SMTP_HOST && member.email) {
+            // Email vers le compte utilisateur lié (priorité) ou member.email en fallback
+            const recipientEmail = linkedUser?.email ?? member.email;
+            if (process.env.SMTP_HOST && recipientEmail) {
               try {
-                await sendEmail({ to: member.email, subject, html });
+                await sendEmail({ to: recipientEmail, subject, html });
                 emailsSent++;
               } catch {
                 console.error("Failed to send reminder email (recipient redacted)");
               }
             }
 
-            // Create in-app notification for department heads
+            // Notification in-app pour le STAR lui-même
+            if (linkedUser) {
+              await prisma.notification.create({
+                data: {
+                  userId: linkedUser.userId,
+                  type: "PLANNING_REMINDER",
+                  title: `Rappel : ${event.title}`,
+                  message: `Vous êtes en service pour ${eventDept.department.name} ${daysAhead === 1 ? "demain" : `dans ${daysAhead} jours`}.`,
+                  link: `/dashboard`,
+                },
+              });
+              notificationsCreated++;
+            }
+
+            // Notification in-app pour les responsables de département
             const deptHeads = await prisma.userDepartment.findMany({
               where: { departmentId: eventDept.departmentId },
               include: { userChurchRole: { select: { userId: true } } },
@@ -82,7 +110,7 @@ export async function POST(request: Request) {
                   userId: deptHead.userChurchRole.userId,
                   type: "PLANNING_REMINDER",
                   title: `Rappel : ${event.title}`,
-                  message: `${memberName} est en service pour ${eventDept.department.name} ${daysAhead === 1 ? "demain" : `dans ${daysAhead} jours`}`,
+                  message: `${memberName} est en service pour ${eventDept.department.name} ${daysAhead === 1 ? "demain" : `dans ${daysAhead} jours`}.`,
                   link: `/dashboard?dept=${eventDept.departmentId}&event=${event.id}`,
                 },
               });

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
@@ -8,6 +8,13 @@ import {
 import { logAudit } from "@/lib/audit";
 import { z } from "zod";
 
+const STATUS_LABELS: Record<string, string> = {
+  EN_SERVICE: "En service",
+  EN_SERVICE_DEBRIEF: "En service (débrief)",
+  INDISPONIBLE: "Indisponible",
+  REMPLACANT: "Remplaçant",
+};
+
 export async function GET(
   _request: Request,
   {
@@ -158,7 +165,7 @@ export async function PUT(
     // Check planning deadline
     const event = await prisma.event.findUnique({
       where: { id: eventId },
-      select: { planningDeadline: true },
+      select: { planningDeadline: true, title: true },
     });
 
     if (event?.planningDeadline && new Date() > new Date(event.planningDeadline)) {
@@ -226,6 +233,15 @@ export async function PUT(
       );
     }
 
+    // Snapshot état précédent pour détecter les changements à notifier
+    const prevPlannings = memberIds.length > 0
+      ? await prisma.planning.findMany({
+          where: { eventDepartmentId: eventDept!.id, memberId: { in: memberIds } },
+          select: { memberId: true, status: true },
+        })
+      : [];
+    const prevStatusMap = new Map(prevPlannings.map((p) => [p.memberId, p.status]));
+
     const results = await Promise.all(
       plannings.map((p) =>
         prisma.planning.upsert({
@@ -253,6 +269,56 @@ export async function PUT(
       entityId: eventDept!.id,
       details: { eventId, departmentId, count: plannings.length },
     });
+
+    // Notifier les STARs dont le statut a changé
+    if (memberIds.length > 0) {
+      const links = await prisma.memberUserLink.findMany({
+        where: { memberId: { in: memberIds }, churchId: eventChurchId, validatedAt: { not: null } },
+        select: { memberId: true, userId: true },
+      });
+      const userIdByMember = new Map(links.map((l) => [l.memberId, l.userId]));
+      const eventTitle = event?.title ?? "l'événement";
+
+      const notifs: { userId: string; type: string; title: string; message: string; link: string }[] = [];
+      for (const p of plannings) {
+        const userId = userIdByMember.get(p.memberId);
+        if (!userId || userId === session.user.id) continue;
+
+        const prev = prevStatusMap.get(p.memberId) ?? null;
+        const next = p.status;
+        if (prev === next) continue;
+
+        if (prev === null && next !== null) {
+          notifs.push({
+            userId,
+            type: "PLANNING_ASSIGNED",
+            title: "Affectation au planning",
+            message: `Vous êtes affecté(e) à « ${eventTitle} » — statut : ${STATUS_LABELS[next] ?? next}.`,
+            link: "/dashboard",
+          });
+        } else if (prev !== null && next === null) {
+          notifs.push({
+            userId,
+            type: "PLANNING_REMOVED",
+            title: "Retrait du planning",
+            message: `Vous avez été retiré(e) du planning de « ${eventTitle} ».`,
+            link: "/dashboard",
+          });
+        } else if (prev !== null && next !== null) {
+          notifs.push({
+            userId,
+            type: "PLANNING_STATUS_CHANGED",
+            title: "Statut planning modifié",
+            message: `Votre statut pour « ${eventTitle} » : ${STATUS_LABELS[prev] ?? prev} → ${STATUS_LABELS[next] ?? next}.`,
+            link: "/dashboard",
+          });
+        }
+      }
+
+      if (notifs.length > 0) {
+        prisma.notification.createMany({ data: notifs, skipDuplicates: true }).catch(() => {});
+      }
+    }
 
     return successResponse(results);
   } catch (error) {

--- a/src/app/api/media/files/[id]/route.ts
+++ b/src/app/api/media/files/[id]/route.ts
@@ -7,6 +7,7 @@ import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission }
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { deleteMediaFiles } from "@/lib/s3";
 import { getFileOriginalKey } from "@/modules/media";
+import { createNotification } from "@/lib/notifications";
 import { z } from "zod";
 
 const patchSchema = z.object({
@@ -28,7 +29,7 @@ type MediaFileWithContainers = {
   mediaEventId: string | null;
   mediaProjectId: string | null;
   mediaEvent: { churchId: string } | null;
-  mediaProject: { churchId: string } | null;
+  mediaProject: { churchId: string; createdById: string } | null;
 };
 
 async function resolveMediaFileChurchId(fileId: string): Promise<{ churchId: string; file: MediaFileWithContainers }> {
@@ -41,7 +42,7 @@ async function resolveMediaFileChurchId(fileId: string): Promise<{ churchId: str
       mediaEventId: true,
       mediaProjectId: true,
       mediaEvent: { select: { churchId: true } },
-      mediaProject: { select: { churchId: true } },
+      mediaProject: { select: { churchId: true, createdById: true } },
     },
   });
   if (!file) throw new ApiError(404, "Fichier média introuvable");
@@ -121,6 +122,27 @@ export async function PATCH(
         });
         // Update status from DRAFT to IN_REVIEW
         await prisma.mediaFile.update({ where: { id }, data: { status: "IN_REVIEW" } });
+      }
+    }
+
+    // Notify project creator on status change (not for self-reviews)
+    const creatorId = mediaFile.mediaProject?.createdById ?? null;
+    if (creatorId && creatorId !== session.user.id && data.status) {
+      const statusMessages: Partial<Record<string, { title: string; message: string }>> = {
+        APPROVED: { title: "Fichier approuvé", message: "Un fichier de votre projet média a été approuvé." },
+        FINAL_APPROVED: { title: "Fichier validé définitivement", message: "Un fichier de votre projet média a reçu la validation finale." },
+        REJECTED: { title: "Fichier refusé", message: "Un fichier de votre projet média a été refusé." },
+        REVISION_REQUESTED: { title: "Révision demandée", message: "Une révision a été demandée sur un fichier de votre projet média." },
+      };
+      const notif = statusMessages[data.status];
+      if (notif) {
+        createNotification({
+          userId: creatorId,
+          type: `MEDIA_FILE_${data.status}`,
+          title: notif.title,
+          message: notif.message,
+          link: "/media/projects",
+        }).catch(() => {});
       }
     }
 

--- a/src/app/api/requests/[id]/route.ts
+++ b/src/app/api/requests/[id]/route.ts
@@ -4,6 +4,7 @@ import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { rolePermissions } from "@/lib/registry";
 import { executeRequest, planningBus } from "@/modules/planning";
+import { createNotification } from "@/lib/notifications";
 import { z } from "zod";
 import type { Prisma } from "@/generated/prisma/client";
 
@@ -307,6 +308,27 @@ export async function PATCH(
     });
 
     await logAudit({ userId: session.user.id, churchId: existing.churchId, action: "UPDATE", entityType: "Request", entityId: id, details: { status: data.status, type: existing.type } });
+
+    // Notify demandeur on approval / refusal
+    if (existing.submittedById && existing.submittedById !== session.user.id) {
+      if (data.status === "APPROUVEE" || updated.status === "EXECUTEE") {
+        createNotification({
+          userId: existing.submittedById,
+          type: "REQUEST_APPROVED",
+          title: "Demande approuvée",
+          message: `Votre demande « ${existing.title} » a été approuvée.`,
+          link: `/requests`,
+        }).catch(() => {});
+      } else if (data.status === "REFUSEE") {
+        createNotification({
+          userId: existing.submittedById,
+          type: "REQUEST_REJECTED",
+          title: "Demande refusée",
+          message: `Votre demande « ${existing.title} » a été refusée.${data.reviewNotes ? ` Motif : ${data.reviewNotes}` : ""}`,
+          link: `/requests`,
+        }).catch(() => {});
+      }
+    }
 
     return successResponse(updated);
   } catch (error) {

--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -4,6 +4,7 @@ import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { rolePermissions } from "@/lib/registry";
 import { DEPT_FN } from "@/lib/department-functions";
+import { notifyDeptMembers } from "@/lib/notifications";
 import { z } from "zod";
 
 const DEMAND_TYPES = [
@@ -167,6 +168,13 @@ async function createVisuel(_request: Request, body: unknown) {
 
   await logAudit({ userId: session.user.id, churchId: data.churchId, action: "CREATE", entityType: "Request", entityId: created.id, details: { title: data.title, type: "VISUEL" } });
 
+  notifyDeptMembers(data.churchId, DEPT_FN.PRODUCTION_MEDIA, {
+    type: "REQUEST_SUBMITTED",
+    title: "Nouvelle demande de visuel",
+    message: `« ${data.title} » a été soumis par ${session.user.displayName ?? session.user.name ?? "un utilisateur"}.`,
+    link: "/media/requests",
+  }).catch(() => {});
+
   return successResponse(created, 201);
 }
 
@@ -218,6 +226,13 @@ async function createDemand(_request: Request, body: unknown) {
   });
 
   await logAudit({ userId: session.user.id, churchId: data.churchId, action: "CREATE", entityType: "Request", entityId: created.id, details: { title: data.title, type: data.type } });
+
+  notifyDeptMembers(data.churchId, DEPT_FN.SECRETARIAT, {
+    type: "REQUEST_SUBMITTED",
+    title: "Nouvelle demande",
+    message: `« ${data.title} » a été soumis par ${session.user.displayName ?? session.user.name ?? "un utilisateur"}.`,
+    link: "/secretariat/requests",
+  }).catch(() => {});
 
   return successResponse(created, 201);
 }

--- a/src/app/api/users/[userId]/roles/route.ts
+++ b/src/app/api/users/[userId]/roles/route.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
+import { createNotification } from "@/lib/notifications";
 import { requireRateLimit, RATE_LIMIT_SENSITIVE } from "@/lib/rate-limit";
 import { z } from "zod";
 
@@ -135,6 +136,17 @@ export async function POST(
     });
 
     await logAudit({ userId: session.user.id, churchId, action: "CREATE", entityType: "UserRole", entityId: userRole.id, details: { targetUserId: userId, role } });
+
+    // Only notify when assigning to someone else
+    if (userId !== session.user.id) {
+      createNotification({
+        userId,
+        type: "ROLE_ASSIGNED",
+        title: "Nouveau rôle attribué",
+        message: `Le rôle ${role} vous a été attribué dans cette église.`,
+        link: "/profile",
+      }).catch(() => {});
+    }
 
     return successResponse(userRole, 201);
   } catch (error) {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -155,6 +155,77 @@ export function buildAppointmentConfirmationEmail(params: {
   };
 }
 
+export function buildAppointmentRejectedEmail(params: {
+  firstName: string;
+  lastName: string;
+  subject: string;
+  churchName: string;
+  rejectReason?: string | null;
+}) {
+  const name = escapeHtml(`${params.firstName} ${params.lastName}`);
+  const subject = escapeHtml(params.subject);
+  const church = escapeHtml(params.churchName);
+  const reason = params.rejectReason ? `<p>Motif : <em>${escapeHtml(params.rejectReason)}</em></p>` : "";
+  return {
+    subject: `Votre demande de RDV pastoral n'a pas pu être traitée — ${church}`,
+    html: `
+      <div style="font-family: Montserrat, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background: #5E17EB; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
+          <h1 style="margin: 0; font-size: 20px;">Koinonia</h1>
+          <p style="margin: 4px 0 0; font-size: 13px; opacity: 0.85;">${church}</p>
+        </div>
+        <div style="padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+          <p>Bonjour <strong>${name}</strong>,</p>
+          <p>Votre demande de rendez-vous pastoral concernant <strong>« ${subject} »</strong> n'a malheureusement pas pu être retenue.</p>
+          ${reason}
+          <p>N'hésitez pas à soumettre une nouvelle demande si votre besoin persiste.</p>
+          <p style="color: #6b7280; font-size: 13px; margin-top: 24px;">
+            Vous recevez cet email car vous avez soumis une demande de RDV sur le formulaire de ${church}.
+          </p>
+        </div>
+      </div>
+    `,
+  };
+}
+
+export function buildAppointmentScheduledEmail(params: {
+  firstName: string;
+  lastName: string;
+  subject: string;
+  churchName: string;
+  startsAt: Date;
+  location?: string | null;
+}) {
+  const name = escapeHtml(`${params.firstName} ${params.lastName}`);
+  const subject = escapeHtml(params.subject);
+  const church = escapeHtml(params.churchName);
+  const dateStr = params.startsAt.toLocaleDateString("fr-FR", {
+    weekday: "long", day: "numeric", month: "long", year: "numeric",
+  });
+  const timeStr = params.startsAt.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+  const location = params.location ? `<p>Lieu : <strong>${escapeHtml(params.location)}</strong></p>` : "";
+  return {
+    subject: `Votre rendez-vous pastoral est confirmé — ${church}`,
+    html: `
+      <div style="font-family: Montserrat, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background: #5E17EB; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
+          <h1 style="margin: 0; font-size: 20px;">Koinonia</h1>
+          <p style="margin: 4px 0 0; font-size: 13px; opacity: 0.85;">${church}</p>
+        </div>
+        <div style="padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+          <p>Bonjour <strong>${name}</strong>,</p>
+          <p>Votre rendez-vous pastoral concernant <strong>« ${subject} »</strong> a été planifié.</p>
+          <p>Date : <strong>${dateStr} à ${timeStr}</strong></p>
+          ${location}
+          <p style="color: #6b7280; font-size: 13px; margin-top: 24px;">
+            Vous recevez cet email car vous avez soumis une demande de RDV sur le formulaire de ${church}.
+          </p>
+        </div>
+      </div>
+    `,
+  };
+}
+
 export function buildReminderEmail(params: {
   memberName: string;
   eventTitle: string;

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,54 @@
+import { prisma } from "@/lib/prisma";
+
+export async function createNotification(params: {
+  userId: string;
+  type: string;
+  title: string;
+  message: string;
+  link?: string;
+}): Promise<void> {
+  await prisma.notification.create({ data: params });
+}
+
+/** Notifie tous les utilisateurs ayant un rôle donné dans une église. */
+export async function notifyUsersWithRole(
+  churchId: string,
+  role: string,
+  notification: { type: string; title: string; message: string; link?: string }
+): Promise<void> {
+  const roles = await prisma.userChurchRole.findMany({
+    where: { churchId, role: role as never },
+    select: { userId: true },
+  });
+  if (roles.length === 0) return;
+  await prisma.notification.createMany({
+    data: roles.map((r) => ({ userId: r.userId, ...notification })),
+    skipDuplicates: true,
+  });
+}
+
+/** Notifie tous les membres d'un département ayant une fonction système donnée. */
+export async function notifyDeptMembers(
+  churchId: string,
+  deptFunction: string,
+  notification: { type: string; title: string; message: string; link?: string }
+): Promise<void> {
+  const members = await prisma.userChurchRole.findMany({
+    where: {
+      churchId,
+      departments: { some: { department: { function: deptFunction, ministry: { churchId } } } },
+    },
+    select: { userId: true },
+  });
+  // Also include users with events:manage (global managers see everything)
+  const managers = await prisma.userChurchRole.findMany({
+    where: { churchId, role: { in: ["SUPER_ADMIN", "ADMIN", "SECRETARY"] as never[] } },
+    select: { userId: true },
+  });
+  const userIds = Array.from(new Set([...members, ...managers].map((r) => r.userId)));
+  if (userIds.length === 0) return;
+  await prisma.notification.createMany({
+    data: userIds.map((userId) => ({ userId, ...notification })),
+    skipDuplicates: true,
+  });
+}


### PR DESCRIPTION
## Résumé

Câblage complet des notifications sur tous les flux métier de l'application. L'infrastructure existait (modèle `Notification`, API `GET/PATCH /notifications`, `NotificationBell`) — seuls les déclencheurs manquaient.

## Nouveaux helpers (`src/lib/notifications.ts`)

| Helper | Usage |
|---|---|
| `createNotification(params)` | Notification unitaire pour un utilisateur |
| `notifyUsersWithRole(churchId, role, notif)` | Tous les utilisateurs ayant un rôle donné |
| `notifyDeptMembers(churchId, deptFn, notif)` | Membres d'un département système + ADMIN/SECRETARY |

Tous les appels sont non-bloquants (`.catch(() => {})`) — une erreur de notification ne casse jamais la réponse API.

## Matrice complète

| Événement | Destinataire | In-app | Email |
|---|---|---|---|
| Nouvelle demande RDV (interne + public) | Qualificateurs (`AGENDA_QUALIFIER`) | ✅ | — |
| Demande RDV qualifiée (VALIDATED) | Membres Protocole | ✅ | — |
| Demande RDV **rejetée** | Demandeur | ✅ | ✅ |
| Demande RDV **planifiée** | Demandeur | ✅ | ✅ |
| Nouvelle demande **visuel** | Membres Production Média | ✅ | — |
| Nouvelle demande **annonce/diffusion** | Membres Secrétariat | ✅ | — |
| Demande **approuvée/refusée** | Demandeur | ✅ | — |
| **Rôle assigné** | Utilisateur concerné | ✅ | — |
| Fichier média APPROVED/REJECTED/REVISION | Créateur du projet | ✅ | — |
| Liaison STAR approuvée/refusée | Demandeur | ✅ (déjà existant) | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)