### PR TITLE
fix(media): miniatures et liens de validation sur les projets

### DIFF
--- a/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
+++ b/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
@@ -491,12 +491,12 @@ function FileUploadZone({ projectId, onUploaded, onActivityChange }: {
         });
         const signJson = await signRes.json();
         if (!signRes.ok) throw new Error(signJson.error || "Erreur serveur");
-        const { fileId, uploadUrl, key } = signJson.data;
+        const { fileId, uploadUrl } = signJson.data;
         await uploadToS3(uploadUrl, file, (pct) => setProgress({ file: file.name, pct }));
         await fetch(`/api/media/files/${fileId}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ originalKey: key }),
+          body: JSON.stringify({ confirmUpload: true }),
         });
       } catch (err) {
         errors.push(`${file.name}: ${err instanceof Error ? err.message : "Erreur"}`);
@@ -970,7 +970,7 @@ export default function MediaProjectDetail({
   const [statusFilter, setStatusFilter] = useState<MediaFileStatus | "">("");
   const [typeFilter, setTypeFilter] = useState<MediaFileType | "">("");
   const [selectedFile, setSelectedFile] = useState<MediaFile | null>(null);
-  const [showUpload, setShowUpload] = useState(false);
+  const [showUpload, setShowUpload] = useState(canUpload && initialProject.files.length === 0);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [activity, setActivity] = useState<{ label: string } | null>(null);
 

--- a/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
+++ b/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
@@ -136,7 +136,7 @@ const ALLOWED_TYPES: Record<string, MediaFileType> = {
 };
 
 // Statuts qui comptent comme "traités" pour la barre de progression
-const DONE_STATUSES: MediaFileStatus[] = ["FINAL_APPROVED", "REJECTED"];
+const DONE_STATUSES: MediaFileStatus[] = ["FINAL_APPROVED", "APPROVED", "REJECTED", "PREREJECTED"];
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -176,7 +176,7 @@ function ConfirmModal({ title, message, confirmLabel = "Confirmer", danger = fal
   onCancel: () => void;
 }) {
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-[80] flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onCancel} />
       <div className="relative bg-white rounded-2xl shadow-2xl max-w-sm w-full p-6 space-y-4">
         <div className="flex items-center gap-3">
@@ -449,8 +449,11 @@ async function uploadToS3(uploadUrl: string, file: File, onProgress?: (p: number
         if (e.lengthComputable) onProgress(Math.round((e.loaded / e.total) * 100));
       };
     }
-    xhr.onload  = () => (xhr.status >= 200 && xhr.status < 300 ? resolve() : reject(new Error(`S3 ${xhr.status}`)));
-    xhr.onerror = () => reject(new Error("Erreur réseau"));
+    xhr.onload  = () => {
+      xhr.status >= 200 && xhr.status < 300 ? resolve() : reject(new Error(`S3 ${xhr.status}: ${xhr.responseText.slice(0, 200)}`));
+    };
+    xhr.onerror = () => reject(new Error("Erreur réseau (vérifiez CORS)"));
+    xhr.onabort = () => reject(new Error("Upload annulé"));
     xhr.send(file);
   });
 }
@@ -469,7 +472,10 @@ function FileUploadZone({ projectId, onUploaded, onActivityChange }: {
 
   async function handleFiles(files: File[]) {
     const valid = files.filter((f) => ALLOWED_TYPES[f.type]);
-    if (valid.length === 0) { setError("Format non supporté (MP4, MOV, WebM, JPEG, PNG, PDF)"); return; }
+    if (valid.length === 0) {
+      setError("Format non supporté (MP4, MOV, WebM, JPEG, PNG, PDF)");
+      return;
+    }
     setUploading(true);
     setError(null);
     const errors: string[] = [];
@@ -478,6 +484,8 @@ function FileUploadZone({ projectId, onUploaded, onActivityChange }: {
       try {
         setProgress({ file: file.name, pct: 0 });
         onActivityChange?.(true, file.name);
+
+        // 1. Sign
         const signRes = await fetch("/api/media/files/upload/sign", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -491,13 +499,19 @@ function FileUploadZone({ projectId, onUploaded, onActivityChange }: {
         });
         const signJson = await signRes.json();
         if (!signRes.ok) throw new Error(signJson.error || "Erreur serveur");
-        const { fileId, uploadUrl } = signJson.data;
+        const { fileId, uploadUrl } = signJson;
+
+        // 2. Upload S3
         await uploadToS3(uploadUrl, file, (pct) => setProgress({ file: file.name, pct }));
-        await fetch(`/api/media/files/${fileId}`, {
+
+        // 3. Confirm
+        const confirmRes = await fetch(`/api/media/files/${fileId}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ confirmUpload: true }),
         });
+        const confirmJson = await confirmRes.json();
+        if (!confirmRes.ok) throw new Error(confirmJson.error || "Erreur confirm");
       } catch (err) {
         errors.push(`${file.name}: ${err instanceof Error ? err.message : "Erreur"}`);
       }
@@ -980,7 +994,6 @@ export default function MediaProjectDetail({
     if (res.ok) {
       const updated = json.data ?? json;
       setProject(updated);
-      // Keep the selected file in sync with the refreshed data
       setSelectedFile((prev) => prev ? (updated.files?.find((f: MediaFile) => f.id === prev.id) ?? prev) : null);
     }
     router.refresh();
@@ -1014,20 +1027,26 @@ export default function MediaProjectDetail({
 
   // ── Stats ──────────────────────────────────────────────────────────────────
   const allFiles = project.files ?? [];
-  const doneCount    = allFiles.filter((f) => DONE_STATUSES.includes(f.status)).length;
-  const approvedCount = allFiles.filter((f) => f.status === "FINAL_APPROVED").length;
-  const rejectedCount = allFiles.filter((f) => f.status === "REJECTED").length;
-  const inReviewCount = allFiles.filter((f) => f.status === "IN_REVIEW").length;
-  const revisionCount = allFiles.filter((f) => f.status === "REVISION_REQUESTED").length;
-  const progressPct   = allFiles.length > 0 ? Math.round((doneCount / allFiles.length) * 100) : 0;
+  const doneCount        = allFiles.filter((f) => DONE_STATUSES.includes(f.status)).length;
+  const finalApprovedCount = allFiles.filter((f) => f.status === "FINAL_APPROVED").length;
+  const approvedCount    = allFiles.filter((f) => f.status === "APPROVED").length;
+  const prevalidatedCount = allFiles.filter((f) => f.status === "PREVALIDATED").length;
+  const rejectedCount    = allFiles.filter((f) => f.status === "REJECTED").length;
+  const prerejectedCount = allFiles.filter((f) => f.status === "PREREJECTED").length;
+  const inReviewCount    = allFiles.filter((f) => f.status === "IN_REVIEW").length;
+  const revisionCount    = allFiles.filter((f) => f.status === "REVISION_REQUESTED").length;
+  const progressPct      = allFiles.length > 0 ? Math.round((doneCount / allFiles.length) * 100) : 0;
 
   // ── Onglets statut ─────────────────────────────────────────────────────────
   const statusTabs: { label: string; value: MediaFileStatus | ""; count: number }[] = [
     { label: "Tous", value: "", count: allFiles.length },
-    ...(inReviewCount > 0  ? [{ label: "En révision", value: "IN_REVIEW" as MediaFileStatus, count: inReviewCount }] : []),
-    ...(revisionCount > 0  ? [{ label: "Révision demandée", value: "REVISION_REQUESTED" as MediaFileStatus, count: revisionCount }] : []),
-    ...(approvedCount > 0  ? [{ label: "Validé final", value: "FINAL_APPROVED" as MediaFileStatus, count: approvedCount }] : []),
-    ...(rejectedCount > 0  ? [{ label: "Rejeté", value: "REJECTED" as MediaFileStatus, count: rejectedCount }] : []),
+    ...(inReviewCount > 0      ? [{ label: "En révision",       value: "IN_REVIEW"           as MediaFileStatus, count: inReviewCount }]      : []),
+    ...(revisionCount > 0      ? [{ label: "Révision demandée", value: "REVISION_REQUESTED"  as MediaFileStatus, count: revisionCount }]      : []),
+    ...(prevalidatedCount > 0  ? [{ label: "Pré-validé",        value: "PREVALIDATED"         as MediaFileStatus, count: prevalidatedCount }]  : []),
+    ...(prerejectedCount > 0   ? [{ label: "Pré-rejeté",        value: "PREREJECTED"          as MediaFileStatus, count: prerejectedCount }]   : []),
+    ...(approvedCount > 0      ? [{ label: "Approuvé",          value: "APPROVED"             as MediaFileStatus, count: approvedCount }]      : []),
+    ...(finalApprovedCount > 0 ? [{ label: "Validé final",      value: "FINAL_APPROVED"       as MediaFileStatus, count: finalApprovedCount }] : []),
+    ...(rejectedCount > 0      ? [{ label: "Rejeté",            value: "REJECTED"             as MediaFileStatus, count: rejectedCount }]      : []),
   ];
 
   const filteredFiles = allFiles.filter((f) => {
@@ -1121,11 +1140,32 @@ export default function MediaProjectDetail({
                   <span className="text-xs text-amber-700">révision demandée</span>
                 </div>
               )}
+              {prevalidatedCount > 0 && (
+                <div className="flex items-center gap-1.5 bg-blue-50 border border-blue-200 rounded-lg px-3 py-1.5">
+                  <span className="w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
+                  <span className="text-xs font-semibold text-blue-800">{prevalidatedCount}</span>
+                  <span className="text-xs text-blue-700">pré-validé{prevalidatedCount > 1 ? "s" : ""}</span>
+                </div>
+              )}
+              {prerejectedCount > 0 && (
+                <div className="flex items-center gap-1.5 bg-orange-50 border border-orange-200 rounded-lg px-3 py-1.5">
+                  <span className="w-1.5 h-1.5 rounded-full bg-orange-500 shrink-0" />
+                  <span className="text-xs font-semibold text-orange-800">{prerejectedCount}</span>
+                  <span className="text-xs text-orange-700">pré-rejeté{prerejectedCount > 1 ? "s" : ""}</span>
+                </div>
+              )}
               {approvedCount > 0 && (
+                <div className="flex items-center gap-1.5 bg-green-50 border border-green-200 rounded-lg px-3 py-1.5">
+                  <span className="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
+                  <span className="text-xs font-semibold text-green-800">{approvedCount}</span>
+                  <span className="text-xs text-green-700">approuvé{approvedCount > 1 ? "s" : ""}</span>
+                </div>
+              )}
+              {finalApprovedCount > 0 && (
                 <div className="flex items-center gap-1.5 bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-1.5">
                   <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 shrink-0" />
-                  <span className="text-xs font-semibold text-emerald-800">{approvedCount}</span>
-                  <span className="text-xs text-emerald-700">validé{approvedCount > 1 ? "s" : ""} final</span>
+                  <span className="text-xs font-semibold text-emerald-800">{finalApprovedCount}</span>
+                  <span className="text-xs text-emerald-700">validé{finalApprovedCount > 1 ? "s" : ""} final</span>
                 </div>
               )}
               {rejectedCount > 0 && (
@@ -1148,11 +1188,11 @@ export default function MediaProjectDetail({
               <div className="h-2 bg-gray-100 rounded-full overflow-hidden flex">
                 <div
                   className="h-full bg-emerald-500 transition-all duration-500"
-                  style={{ width: `${allFiles.length > 0 ? (approvedCount / allFiles.length) * 100 : 0}%` }}
+                  style={{ width: `${allFiles.length > 0 ? ((finalApprovedCount + approvedCount) / allFiles.length) * 100 : 0}%` }}
                 />
                 <div
                   className="h-full bg-red-400 transition-all duration-500"
-                  style={{ width: `${allFiles.length > 0 ? (rejectedCount / allFiles.length) * 100 : 0}%` }}
+                  style={{ width: `${allFiles.length > 0 ? ((rejectedCount + prerejectedCount) / allFiles.length) * 100 : 0}%` }}
                 />
               </div>
             </div>

--- a/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
+++ b/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
@@ -805,7 +805,7 @@ function FileDetailPanel({ file, allFiles, fileIndex, onNavigate, canUpload, can
                 <p className="text-sm text-gray-500 text-center">Vidéo non disponible<br/><span className="text-xs text-gray-400">Vérifiez la configuration S3</span></p>
               </div>
             )
-          ) : file.thumbnailUrl ? (
+          ) : file.thumbnailUrl && file.mimeType.startsWith("image/") ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img src={file.thumbnailUrl} alt={file.filename} className="w-full h-full object-contain" />
           ) : (
@@ -1278,6 +1278,7 @@ export default function MediaProjectDetail({
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
                 {filteredFiles.map((file) => {
                   const thumb = file.thumbnailUrl;
+                  const isImage = file.mimeType.startsWith("image/");
                   const latestV = file.versions[0];
                   return (
                     <div
@@ -1287,25 +1288,18 @@ export default function MediaProjectDetail({
                     >
                       {/* Preview */}
                       <div className="aspect-video bg-gray-100 relative overflow-hidden">
-                        {thumb ? (
-                          <>
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src={thumb} alt={file.filename} className="w-full h-full object-cover transition-transform group-hover:scale-105" />
-                            {file.type === "VIDEO" && (
-                              <div className="absolute inset-0 flex items-center justify-center">
-                                <div className="bg-black/50 rounded-full p-3 group-hover:bg-black/70 transition-colors">
-                                  <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
-                                    <path d="M8 5v14l11-7z" />
-                                  </svg>
-                                </div>
-                              </div>
-                            )}
-                          </>
+                        {thumb && isImage ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={thumb} alt={file.filename} className="w-full h-full object-cover transition-transform group-hover:scale-105" />
                         ) : (
                           <div className="w-full h-full flex flex-col items-center justify-center gap-2 text-gray-300">
                             {file.type === "VIDEO" ? (
                               <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M15 10l4.553-2.069A1 1 0 0121 8.882v6.236a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                              </svg>
+                            ) : file.mimeType === "application/pdf" ? (
+                              <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                               </svg>
                             ) : (
                               <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/app/(auth)/media/projects/[id]/page.tsx
+++ b/src/app/(auth)/media/projects/[id]/page.tsx
@@ -1,6 +1,6 @@
-import { requireMediaAccess, isProductionMediaMember, isCommunicationMember, resolveChurchId, requireAuth } from "@/lib/auth";
+import { requireMediaAccess, isProductionMediaMember, isCommunicationMember, resolveChurchId, auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { rolePermissions } from "@/lib/registry";
 import { getSignedThumbnailUrl } from "@/modules/media";
 import MediaProjectDetail from "./MediaProjectDetail";
@@ -11,7 +11,8 @@ export default async function MediaProjectDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const session = await requireAuth();
+  const session = await auth();
+  if (!session?.user) redirect("/");
 
   let churchId: string;
   try {

--- a/src/app/api/media-projects/[id]/route.ts
+++ b/src/app/api/media-projects/[id]/route.ts
@@ -1,8 +1,8 @@
 import { prisma } from "@/lib/prisma";
-import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission, resolveChurchId } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess, requireMediaManageAccess, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
-import { deleteFiles } from "@/lib/s3";
+import { deleteMediaFiles } from "@/lib/s3";
 import { getSignedThumbnailUrl } from "@/modules/media";
 import { z } from "zod";
 
@@ -105,7 +105,7 @@ export async function DELETE(
   try {
     const { id } = await params;
     const churchId = await resolveChurchId("mediaProject", id);
-    const session = await requireChurchPermission("media:manage", churchId);
+    const session = await requireMediaManageAccess(churchId);
 
     const project = await prisma.mediaProject.findUnique({
       where: { id },
@@ -121,7 +121,7 @@ export async function DELETE(
     const s3Keys = project.files.flatMap((f) =>
       f.versions.flatMap((v) => [v.originalKey, v.thumbnailKey])
     );
-    if (s3Keys.length > 0) await deleteFiles(s3Keys);
+    if (s3Keys.length > 0) await deleteMediaFiles(s3Keys);
 
     await prisma.mediaProject.delete({ where: { id } });
 

--- a/src/app/api/media/files/[id]/route.ts
+++ b/src/app/api/media/files/[id]/route.ts
@@ -3,7 +3,7 @@
  * CRUD sur un fichier média (visual/vidéo).
  */
 import { prisma } from "@/lib/prisma";
-import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission } from "@/lib/auth";
+import { requireMediaAccess, requireMediaUploadAccess, requireChurchPermission, requireMediaManageAccess } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { deleteMediaFiles } from "@/lib/s3";
 import { getFileOriginalKey } from "@/modules/media";
@@ -120,7 +120,6 @@ export async function PATCH(
             createdById: session.user.id,
           },
         });
-        // Update status from DRAFT to IN_REVIEW
         await prisma.mediaFile.update({ where: { id }, data: { status: "IN_REVIEW" } });
       }
     }
@@ -159,7 +158,7 @@ export async function DELETE(
   try {
     const { id } = await params;
     const { churchId } = await resolveMediaFileChurchId(id);
-    await requireChurchPermission("media:manage", churchId);
+    await requireMediaManageAccess(churchId);
 
     const file = await prisma.mediaFile.findUnique({
       where: { id },

--- a/src/app/api/media/files/[id]/versions/route.ts
+++ b/src/app/api/media/files/[id]/versions/route.ts
@@ -11,7 +11,7 @@
 import { prisma } from "@/lib/prisma";
 import { requireMediaAccess, requireMediaUploadAccess } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
-import { getVersionOriginalKey, getVersionThumbnailKey, getSignedOriginalUrl } from "@/modules/media";
+import { getVersionOriginalKey, getSignedOriginalUrl } from "@/modules/media";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { s3Media, MEDIA_BUCKET } from "@/lib/s3";
@@ -98,14 +98,13 @@ export async function POST(
 
     const ext = data.filename.split(".").pop()?.toLowerCase() ?? "bin";
     const originalKey = getVersionOriginalKey(id, nextVersion, ext);
-    const thumbnailKey = getVersionThumbnailKey(id, nextVersion);
 
     const version = await prisma.mediaFileVersion.create({
       data: {
         mediaFileId: id,
         versionNumber: nextVersion,
         originalKey,
-        thumbnailKey,
+        thumbnailKey: originalKey,
         notes: data.notes,
         createdById: session.user.id,
       },

--- a/src/app/api/media/validate/[token]/file/[fileId]/route.ts
+++ b/src/app/api/media/validate/[token]/file/[fileId]/route.ts
@@ -1,0 +1,76 @@
+/**
+ * GET    /api/media/validate/[token]/file/[fileId]  — URL signée de la version courante
+ * PATCH  /api/media/validate/[token]/file/[fileId]  — validation/rejet via token public
+ */
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { validateMediaShareToken, getSignedOriginalUrl } from "@/modules/media";
+import { z } from "zod";
+
+const patchSchema = z.object({
+  status: z.enum(["APPROVED", "REJECTED", "PREVALIDATED", "PREREJECTED"]),
+});
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string; fileId: string }> }
+) {
+  try {
+    const { token, fileId } = await params;
+    const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
+
+    if (!shareToken.mediaProjectId) throw new ApiError(403, "Token non associé à un projet");
+
+    const version = await prisma.mediaFileVersion.findFirst({
+      where: { mediaFile: { id: fileId, mediaProjectId: shareToken.mediaProjectId } },
+      orderBy: { versionNumber: "desc" },
+      select: { originalKey: true, mediaFile: { select: { filename: true } } },
+    });
+
+    if (!version) throw new ApiError(404, "Fichier introuvable");
+
+    const originalUrl = await getSignedOriginalUrl(version.originalKey);
+    return successResponse({ id: fileId, originalUrl, filename: version.mediaFile.filename });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ token: string; fileId: string }> }
+) {
+  try {
+    const { token, fileId } = await params;
+    const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
+
+    if (!shareToken.mediaProjectId) throw new ApiError(403, "Token non associé à un projet");
+
+    const body = await request.json();
+    const { status } = patchSchema.parse(body);
+
+    if (shareToken.type === "PREVALIDATOR" && !["PREVALIDATED", "PREREJECTED"].includes(status)) {
+      throw new ApiError(403, "Le prévalidateur ne peut que prévalider ou écarter");
+    }
+    if (shareToken.type === "VALIDATOR" && !["APPROVED", "REJECTED"].includes(status)) {
+      throw new ApiError(403, "Le validateur ne peut qu'approuver ou rejeter");
+    }
+
+    const file = await prisma.mediaFile.findUnique({
+      where: { id: fileId },
+      select: { id: true, mediaProjectId: true },
+    });
+
+    if (!file) throw new ApiError(404, "Fichier introuvable");
+    if (file.mediaProjectId !== shareToken.mediaProjectId) throw new ApiError(403, "Fichier hors périmètre");
+
+    const updated = await prisma.mediaFile.update({
+      where: { id: fileId },
+      data: { status },
+    });
+
+    return successResponse(updated);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/validate/[token]/file/[fileId]/route.ts
+++ b/src/app/api/media/validate/[token]/file/[fileId]/route.ts
@@ -1,6 +1,6 @@
 /**
  * GET    /api/media/validate/[token]/file/[fileId]  — URL signée de la version courante
- * PATCH  /api/media/validate/[token]/file/[fileId]  — validation/rejet via token public
+ * PATCH  /api/media/validate/[token]/file/[fileId]  — validation/rejet/révision via token public
  */
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
@@ -8,7 +8,8 @@ import { validateMediaShareToken, getSignedOriginalUrl } from "@/modules/media";
 import { z } from "zod";
 
 const patchSchema = z.object({
-  status: z.enum(["APPROVED", "REJECTED", "PREVALIDATED", "PREREJECTED"]),
+  status: z.enum(["APPROVED", "REJECTED", "PREVALIDATED", "PREREJECTED", "REVISION_REQUESTED"]),
+  comment: z.string().max(2000).optional(),
 });
 
 export async function GET(
@@ -47,13 +48,16 @@ export async function PATCH(
     if (!shareToken.mediaProjectId) throw new ApiError(403, "Token non associé à un projet");
 
     const body = await request.json();
-    const { status } = patchSchema.parse(body);
+    const { status, comment } = patchSchema.parse(body);
 
-    if (shareToken.type === "PREVALIDATOR" && !["PREVALIDATED", "PREREJECTED"].includes(status)) {
-      throw new ApiError(403, "Le prévalidateur ne peut que prévalider ou écarter");
+    const prevalidatorStatuses = ["PREVALIDATED", "PREREJECTED", "REVISION_REQUESTED"];
+    const validatorStatuses    = ["APPROVED", "REJECTED", "REVISION_REQUESTED"];
+
+    if (shareToken.type === "PREVALIDATOR" && !prevalidatorStatuses.includes(status)) {
+      throw new ApiError(403, "Action non autorisée pour un prévalidateur");
     }
-    if (shareToken.type === "VALIDATOR" && !["APPROVED", "REJECTED"].includes(status)) {
-      throw new ApiError(403, "Le validateur ne peut qu'approuver ou rejeter");
+    if (shareToken.type === "VALIDATOR" && !validatorStatuses.includes(status)) {
+      throw new ApiError(403, "Action non autorisée pour un validateur");
     }
 
     const file = await prisma.mediaFile.findUnique({
@@ -68,6 +72,17 @@ export async function PATCH(
       where: { id: fileId },
       data: { status },
     });
+
+    if (comment?.trim()) {
+      await prisma.mediaComment.create({
+        data: {
+          mediaFileId: fileId,
+          content: comment.trim(),
+          authorName: shareToken.label ?? (shareToken.type === "PREVALIDATOR" ? "Prévalidateur" : "Validateur"),
+          type: "GENERAL",
+        },
+      });
+    }
 
     return successResponse(updated);
   } catch (error) {

--- a/src/app/media/v/[token]/ProjectValidatorView.tsx
+++ b/src/app/media/v/[token]/ProjectValidatorView.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+type ProjectFile = {
+  id: string;
+  filename: string;
+  type: string;
+  mimeType: string;
+  size: number;
+  status: string;
+  thumbnailUrl: string | null;
+};
+
+type ProjectValidationData = {
+  type: "project";
+  token: { id: string; type: string; label: string | null };
+  project: {
+    id: string;
+    name: string;
+    isPrevalidator: boolean;
+    totalFiles: number;
+    approvedCount: number;
+    pendingCount: number;
+    rejectedCount: number;
+  };
+  files: ProjectFile[];
+};
+
+const STATUS_BADGE: Record<string, string> = {
+  DRAFT:           "bg-gray-700 text-gray-200",
+  IN_REVIEW:       "bg-yellow-600 text-white",
+  PREVALIDATED:    "bg-blue-600 text-white",
+  PREREJECTED:     "bg-orange-600 text-white",
+  APPROVED:        "bg-green-600 text-white",
+  FINAL_APPROVED:  "bg-emerald-700 text-white",
+  REJECTED:        "bg-red-600 text-white",
+  REVISION_REQUESTED: "bg-purple-600 text-white",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  DRAFT:           "Brouillon",
+  IN_REVIEW:       "En révision",
+  PREVALIDATED:    "Pré-validé",
+  PREREJECTED:     "Pré-rejeté",
+  APPROVED:        "Approuvé",
+  FINAL_APPROVED:  "Validé définitivement",
+  REJECTED:        "Rejeté",
+  REVISION_REQUESTED: "Révision demandée",
+};
+
+function formatSize(bytes: number) {
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} Ko`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} Mo`;
+}
+
+function FileTypeIcon({ mimeType }: { mimeType: string }) {
+  if (mimeType.startsWith("video/")) return (
+    <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 10l4.553-2.069A1 1 0 0121 8.87v6.26a1 1 0 01-1.447.894L15 14M3 8a2 2 0 012-2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z" />
+    </svg>
+  );
+  if (mimeType === "application/pdf") return (
+    <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+    </svg>
+  );
+  return (
+    <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+    </svg>
+  );
+}
+
+export default function ProjectValidatorView({ token, data }: { token: string; data: ProjectValidationData }) {
+  const { project } = data;
+  const isPrevalidator = data.token.type === "PREVALIDATOR";
+  const approveStatus = isPrevalidator ? "PREVALIDATED" : "APPROVED";
+  const rejectStatus = isPrevalidator ? "PREREJECTED" : "REJECTED";
+  const labels = isPrevalidator
+    ? { approve: "Pré-valider", reject: "Écarter" }
+    : { approve: "Approuver", reject: "Rejeter" };
+
+  const [files, setFiles] = useState<ProjectFile[]>(data.files);
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
+
+  const isPending = (f: ProjectFile) =>
+    f.status === "IN_REVIEW" || f.status === "PREVALIDATED" || f.status === "DRAFT";
+  const pendingCount = files.filter(isPending).length;
+  const approvedCount = files.filter((f) => f.status === "APPROVED" || f.status === "PREVALIDATED" || f.status === "FINAL_APPROVED").length;
+  const rejectedCount = files.filter((f) => f.status === "REJECTED" || f.status === "PREREJECTED").length;
+
+  const setStatus = useCallback(async (fileId: string, status: string) => {
+    setSaving((prev) => ({ ...prev, [fileId]: true }));
+    try {
+      const res = await fetch(`/api/media/validate/${token}/file/${fileId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      if (res.ok) {
+        setFiles((prev) => prev.map((f) => f.id === fileId ? { ...f, status } : f));
+      }
+    } finally {
+      setSaving((prev) => ({ ...prev, [fileId]: false }));
+    }
+  }, [token]);
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      {/* Header */}
+      <header className="sticky top-0 z-10 bg-gray-900/95 border-b border-white/10 px-4 py-4">
+        <div className="max-w-3xl mx-auto">
+          <p className="text-xs text-gray-400 mb-0.5">{data.token.label ?? (isPrevalidator ? "Pré-validation" : "Validation")}</p>
+          <h1 className="text-lg font-semibold truncate">{project.name}</h1>
+          <div className="flex gap-4 mt-2 text-xs">
+            <span className="text-green-400">{approvedCount} {isPrevalidator ? "pré-validés" : "approuvés"}</span>
+            <span className="text-gray-500">{pendingCount} en attente</span>
+            <span className="text-red-400">{rejectedCount} rejetés</span>
+          </div>
+        </div>
+      </header>
+
+      {/* Files list */}
+      <main className="max-w-3xl mx-auto px-4 py-4 space-y-3">
+        {files.length === 0 && (
+          <p className="text-center text-gray-500 py-12">Aucun fichier à valider.</p>
+        )}
+
+        {files.map((file) => {
+          const canDecide = isPending(file);
+          const isSaving = saving[file.id];
+
+          return (
+            <div key={file.id} className="bg-gray-900 rounded-xl border border-white/10 overflow-hidden">
+              <div className="flex items-center gap-3 p-3">
+                {/* Preview */}
+                <div className="w-14 h-14 rounded-lg overflow-hidden bg-gray-800 shrink-0 flex items-center justify-center">
+                  {file.thumbnailUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={file.thumbnailUrl} alt={file.filename} className="w-full h-full object-cover" />
+                  ) : (
+                    <FileTypeIcon mimeType={file.mimeType} />
+                  )}
+                </div>
+
+                {/* Info */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">{file.filename}</p>
+                  <p className="text-xs text-gray-400 mt-0.5">{formatSize(file.size)}</p>
+                  <span className={`inline-block mt-1 px-2 py-0.5 text-[10px] font-semibold rounded-full ${STATUS_BADGE[file.status] ?? "bg-gray-700 text-gray-300"}`}>
+                    {STATUS_LABELS[file.status] ?? file.status}
+                  </span>
+                </div>
+              </div>
+
+              {/* Actions */}
+              {canDecide && (
+                <div className="flex border-t border-white/10">
+                  <button
+                    onClick={() => void setStatus(file.id, rejectStatus)}
+                    disabled={isSaving}
+                    className="flex-1 py-2.5 text-sm text-red-400 hover:bg-red-900/30 disabled:opacity-50 transition-colors font-medium"
+                  >
+                    ✗ {labels.reject}
+                  </button>
+                  <div className="w-px bg-white/10" />
+                  <button
+                    onClick={() => void setStatus(file.id, approveStatus)}
+                    disabled={isSaving}
+                    className="flex-1 py-2.5 text-sm text-green-400 hover:bg-green-900/30 disabled:opacity-50 transition-colors font-medium"
+                  >
+                    ✓ {labels.approve}
+                  </button>
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {files.length > 0 && pendingCount === 0 && (
+          <div className="text-center py-8 text-green-400">
+            <p className="text-lg font-semibold">Tout est traité ✓</p>
+            <p className="text-sm text-gray-400 mt-1">{approvedCount} approuvés · {rejectedCount} rejetés</p>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/media/v/[token]/ProjectValidatorView.tsx
+++ b/src/app/media/v/[token]/ProjectValidatorView.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
 
 type ProjectFile = {
   id: string;
@@ -19,132 +21,335 @@ type ProjectValidationData = {
     id: string;
     name: string;
     isPrevalidator: boolean;
+    hasPrevalidator: boolean;
     totalFiles: number;
-    approvedCount: number;
-    pendingCount: number;
-    rejectedCount: number;
   };
   files: ProjectFile[];
 };
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
 const STATUS_BADGE: Record<string, string> = {
-  DRAFT:           "bg-gray-700 text-gray-200",
-  IN_REVIEW:       "bg-yellow-600 text-white",
-  PREVALIDATED:    "bg-blue-600 text-white",
-  PREREJECTED:     "bg-orange-600 text-white",
-  APPROVED:        "bg-green-600 text-white",
-  FINAL_APPROVED:  "bg-emerald-700 text-white",
-  REJECTED:        "bg-red-600 text-white",
+  IN_REVIEW:          "bg-yellow-600 text-white",
+  PREVALIDATED:       "bg-blue-600 text-white",
+  PREREJECTED:        "bg-orange-600 text-white",
+  APPROVED:           "bg-green-600 text-white",
+  FINAL_APPROVED:     "bg-emerald-700 text-white",
+  REJECTED:           "bg-red-600 text-white",
   REVISION_REQUESTED: "bg-purple-600 text-white",
 };
 
 const STATUS_LABELS: Record<string, string> = {
-  DRAFT:           "Brouillon",
-  IN_REVIEW:       "En révision",
-  PREVALIDATED:    "Pré-validé",
-  PREREJECTED:     "Pré-rejeté",
-  APPROVED:        "Approuvé",
-  FINAL_APPROVED:  "Validé définitivement",
-  REJECTED:        "Rejeté",
+  IN_REVIEW:          "En révision",
+  PREVALIDATED:       "Pré-validé",
+  PREREJECTED:        "Pré-rejeté",
+  APPROVED:           "Approuvé",
+  FINAL_APPROVED:     "Validé définitivement",
+  REJECTED:           "Rejeté",
   REVISION_REQUESTED: "Révision demandée",
 };
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 function formatSize(bytes: number) {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} Ko`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} Mo`;
 }
 
-function FileTypeIcon({ mimeType }: { mimeType: string }) {
+// A file is actionable (shows action buttons, counted as "en attente") when it has no decision yet.
+// REVISION_REQUESTED / APPROVED / REJECTED are already decided — not pending from the validator's view.
+function isActionable(status: string, isPrevalidator: boolean, hasPrevalidator: boolean): boolean {
+  if (isPrevalidator) return status === "IN_REVIEW";
+  if (hasPrevalidator) return status === "PREVALIDATED";
+  return status === "IN_REVIEW";
+}
+
+// ── Progress bar ──────────────────────────────────────────────────────────────
+
+function ProgressBar({ total, approved, rejected }: { total: number; approved: number; rejected: number }) {
+  if (total === 0) return null;
+  const approvedPct = (approved / total) * 100;
+  const rejectedPct = (rejected / total) * 100;
+  const pendingPct  = 100 - approvedPct - rejectedPct;
+  return (
+    <div className="h-1 w-full flex shrink-0 overflow-hidden">
+      <div className="bg-green-500 transition-all duration-300" style={{ width: `${approvedPct}%` }} />
+      <div className="bg-red-500 transition-all duration-300"   style={{ width: `${rejectedPct}%` }} />
+      <div className="bg-white/10"                              style={{ width: `${pendingPct}%` }} />
+    </div>
+  );
+}
+
+// ── File type icon ────────────────────────────────────────────────────────────
+
+function FileTypeIcon({ mimeType, className = "w-16 h-16" }: { mimeType: string; className?: string }) {
   if (mimeType.startsWith("video/")) return (
-    <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg className={`${className} text-gray-400`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 10l4.553-2.069A1 1 0 0121 8.87v6.26a1 1 0 01-1.447.894L15 14M3 8a2 2 0 012-2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z" />
     </svg>
   );
   if (mimeType === "application/pdf") return (
-    <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg className={`${className} text-gray-400`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
     </svg>
   );
   return (
-    <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg className={`${className} text-gray-400`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
     </svg>
   );
 }
 
-export default function ProjectValidatorView({ token, data }: { token: string; data: ProjectValidationData }) {
-  const { project } = data;
-  const isPrevalidator = data.token.type === "PREVALIDATOR";
-  const approveStatus = isPrevalidator ? "PREVALIDATED" : "APPROVED";
-  const rejectStatus = isPrevalidator ? "PREREJECTED" : "REJECTED";
-  const labels = isPrevalidator
-    ? { approve: "Pré-valider", reject: "Écarter" }
-    : { approve: "Approuver", reject: "Rejeter" };
+// ── Image lightbox ────────────────────────────────────────────────────────────
 
-  const [files, setFiles] = useState<ProjectFile[]>(data.files);
-  const [saving, setSaving] = useState<Record<string, boolean>>({});
+function ImageLightbox({ file, token, onClose }: { file: ProjectFile; token: string; onClose: () => void }) {
+  const [hdUrl, setHdUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
-  const isPending = (f: ProjectFile) =>
-    f.status === "IN_REVIEW" || f.status === "PREVALIDATED" || f.status === "DRAFT";
-  const pendingCount = files.filter(isPending).length;
-  const approvedCount = files.filter((f) => f.status === "APPROVED" || f.status === "PREVALIDATED" || f.status === "FINAL_APPROVED").length;
-  const rejectedCount = files.filter((f) => f.status === "REJECTED" || f.status === "PREREJECTED").length;
+  useEffect(() => {
+    fetch(`/api/media/validate/${token}/file/${file.id}`)
+      .then((r) => r.json())
+      .then((j) => { if (j.originalUrl) setHdUrl(j.originalUrl); })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [file.id, token]);
 
-  const setStatus = useCallback(async (fileId: string, status: string) => {
-    setSaving((prev) => ({ ...prev, [fileId]: true }));
-    try {
-      const res = await fetch(`/api/media/validate/${token}/file/${fileId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status }),
-      });
-      if (res.ok) {
-        setFiles((prev) => prev.map((f) => f.id === fileId ? { ...f, status } : f));
-      }
-    } finally {
-      setSaving((prev) => ({ ...prev, [fileId]: false }));
-    }
-  }, [token]);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white">
-      {/* Header */}
-      <header className="sticky top-0 z-10 bg-gray-900/95 border-b border-white/10 px-4 py-4">
-        <div className="max-w-3xl mx-auto">
-          <p className="text-xs text-gray-400 mb-0.5">{data.token.label ?? (isPrevalidator ? "Pré-validation" : "Validation")}</p>
-          <h1 className="text-lg font-semibold truncate">{project.name}</h1>
-          <div className="flex gap-4 mt-2 text-xs">
-            <span className="text-green-400">{approvedCount} {isPrevalidator ? "pré-validés" : "approuvés"}</span>
-            <span className="text-gray-500">{pendingCount} en attente</span>
-            <span className="text-red-400">{rejectedCount} rejetés</span>
+    <div className="fixed inset-0 z-50 bg-black/95 flex flex-col" onClick={onClose}>
+      <div className="flex items-center justify-between px-4 py-3 shrink-0" onClick={(e) => e.stopPropagation()}>
+        <button onClick={onClose} className="text-white/70 hover:text-white transition-colors">
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+        <span className="text-white/60 text-xs truncate max-w-[60%]">{file.filename}</span>
+        {hdUrl ? (
+          <a href={hdUrl} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}
+            className="text-xs text-white/50 hover:text-white underline shrink-0 transition-colors">
+            Ouvrir ↗
+          </a>
+        ) : <span />}
+      </div>
+      <div className="flex-1 flex items-center justify-center px-4" onClick={(e) => e.stopPropagation()}>
+        <div className="relative">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={hdUrl ?? file.thumbnailUrl ?? ""}
+            alt={file.filename}
+            className="max-w-full max-h-[80vh] object-contain rounded shadow-2xl"
+            style={{ filter: loading && !hdUrl ? "blur(3px)" : "none", transition: "filter 300ms" }}
+          />
+          {loading && !hdUrl && (
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+            </div>
+          )}
+          {hdUrl && <div className="absolute top-2 right-2 text-[10px] text-white/40 bg-black/40 rounded px-1.5 py-0.5">HD</div>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Action drawer (reject / revision) ────────────────────────────────────────
+
+function ActionDrawer({
+  type,
+  comment,
+  onCommentChange,
+  onConfirm,
+  onCancel,
+  saving,
+  isPrevalidator,
+}: {
+  type: "reject" | "revision";
+  comment: string;
+  onCommentChange: (v: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  saving: boolean;
+  isPrevalidator: boolean;
+}) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isRevision = type === "revision";
+  const canConfirm = !saving && (!isRevision || comment.trim().length > 0);
+
+  useEffect(() => {
+    const t = setTimeout(() => textareaRef.current?.focus(), 50);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-40 flex flex-col justify-end sm:items-center sm:justify-center">
+      <div className="absolute inset-0 bg-black/60" onClick={onCancel} />
+      <div
+        className="relative bg-gray-900 border-t border-white/10 sm:border sm:rounded-2xl w-full sm:max-w-md p-4 sm:p-6 space-y-4 shadow-2xl rounded-t-2xl"
+        style={{ paddingBottom: "max(1rem, env(safe-area-inset-bottom))" }}
+      >
+        <p className="font-semibold text-white text-base">
+          {isRevision
+            ? "Demande de révision"
+            : isPrevalidator ? "Écarter ce fichier" : "Rejeter ce fichier"}
+        </p>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1.5">
+            {isRevision ? "Modifications demandées *" : "Raison (optionnel)"}
+          </label>
+          <textarea
+            ref={textareaRef}
+            value={comment}
+            onChange={(e) => onCommentChange(e.target.value)}
+            rows={3}
+            placeholder={
+              isRevision
+                ? "Décrivez les modifications à apporter…"
+                : "Expliquez pourquoi ce fichier est rejeté…"
+            }
+            className="w-full bg-gray-800 text-white rounded-xl px-3 py-2.5 text-sm resize-none border border-white/10 focus:border-white/30 focus:outline-none placeholder-gray-600"
+          />
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={onCancel}
+            className="flex-1 py-2.5 text-sm text-gray-400 border border-white/10 rounded-xl hover:bg-white/5 transition-colors"
+          >
+            Annuler
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={!canConfirm}
+            className={`flex-1 py-2.5 text-sm font-semibold rounded-xl transition-colors disabled:opacity-40 ${
+              isRevision
+                ? "bg-purple-600 hover:bg-purple-700 text-white"
+                : "bg-red-600 hover:bg-red-700 text-white"
+            }`}
+          >
+            {saving
+              ? "…"
+              : isRevision
+                ? "Demander révision"
+                : isPrevalidator ? "Écarter" : "Rejeter"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Summary view ──────────────────────────────────────────────────────────────
+
+type SummaryFilter = "ALL" | "PENDING" | "APPROVED" | "REJECTED";
+
+function SummaryView({
+  files,
+  isPrevalidator,
+  hasPrevalidator,
+  projectName,
+  onBack,
+  onGoTo,
+}: {
+  files: ProjectFile[];
+  isPrevalidator: boolean;
+  hasPrevalidator: boolean;
+  projectName: string;
+  onBack: () => void;
+  onGoTo: (index: number) => void;
+}) {
+  const [filter, setFilter] = useState<SummaryFilter>("ALL");
+
+  const total        = files.length;
+  const approvedCount = files.filter((f) =>
+    f.status === "APPROVED" || f.status === "PREVALIDATED" || f.status === "FINAL_APPROVED"
+  ).length;
+  const rejectedCount = files.filter((f) =>
+    f.status === "REJECTED" || f.status === "PREREJECTED"
+  ).length;
+  const pendingCount = files.filter((f) => isActionable(f.status, isPrevalidator, hasPrevalidator)).length;
+
+  const filtered = files.filter((f) => {
+    if (filter === "ALL")      return true;
+    if (filter === "PENDING")  return isActionable(f.status, isPrevalidator, hasPrevalidator);
+    if (filter === "APPROVED") return f.status === "APPROVED" || f.status === "PREVALIDATED" || f.status === "FINAL_APPROVED";
+    return f.status === "REJECTED" || f.status === "PREREJECTED";
+  });
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white flex flex-col">
+      <header className="sticky top-0 z-10 bg-gray-950/95 border-b border-white/10 px-4 pt-4 pb-3">
+        <div className="flex items-center justify-between mb-3">
+          <button onClick={onBack} className="text-sm text-white/60 hover:text-white transition-colors">
+            ← {pendingCount > 0 ? `${pendingCount} en attente` : "Retour"}
+          </button>
+          <span className="text-sm font-medium truncate max-w-[40%]">{projectName}</span>
+          <span className="text-xs text-white/40 tabular-nums shrink-0">{total} fichier{total > 1 ? "s" : ""}</span>
+        </div>
+
+        <div className="grid grid-cols-3 gap-2 mb-3">
+          <div className="rounded-xl px-3 py-2 text-center bg-green-500/15 border border-green-500/30">
+            <p className="text-xl font-bold text-green-400 tabular-nums">{approvedCount}</p>
+            <p className="text-xs text-green-400/70">{isPrevalidator ? "pré-validés" : "approuvés"}</p>
           </div>
+          <div className="rounded-xl px-3 py-2 text-center bg-white/5 border border-white/10">
+            <p className="text-xl font-bold text-white/50 tabular-nums">{pendingCount}</p>
+            <p className="text-xs text-white/30">en attente</p>
+          </div>
+          <div className="rounded-xl px-3 py-2 text-center bg-red-500/15 border border-red-500/30">
+            <p className="text-xl font-bold text-red-400 tabular-nums">{rejectedCount}</p>
+            <p className="text-xs text-red-400/70">{isPrevalidator ? "écartés" : "rejetés"}</p>
+          </div>
+        </div>
+
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {([
+            { key: "ALL" as const,      label: "Tous",                                             count: total },
+            { key: "PENDING" as const,  label: "En attente",                                       count: pendingCount },
+            { key: "APPROVED" as const, label: isPrevalidator ? "Pré-validés" : "Approuvés",       count: approvedCount },
+            { key: "REJECTED" as const, label: isPrevalidator ? "Écartés" : "Rejetés",             count: rejectedCount },
+          ] as const)
+            .filter(({ key, count }) => key === "ALL" || count > 0)
+            .map(({ key, label, count }) => (
+              <button
+                key={key}
+                onClick={() => setFilter(key)}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium whitespace-nowrap shrink-0 border transition-colors ${
+                  filter === key
+                    ? "bg-white/20 text-white border-transparent"
+                    : "bg-transparent text-white/40 border-white/10 hover:text-white/60"
+                }`}
+              >
+                {label} <span className="tabular-nums opacity-70">({count})</span>
+              </button>
+            ))}
         </div>
       </header>
 
-      {/* Files list */}
-      <main className="max-w-3xl mx-auto px-4 py-4 space-y-3">
-        {files.length === 0 && (
-          <p className="text-center text-gray-500 py-12">Aucun fichier à valider.</p>
-        )}
-
-        {files.map((file) => {
-          const canDecide = isPending(file);
-          const isSaving = saving[file.id];
-
+      <div className="flex-1 p-3 space-y-2">
+        {filtered.map((file) => {
+          const originalIndex = files.findIndex((f) => f.id === file.id);
+          const actionable = isActionable(file.status, isPrevalidator, hasPrevalidator);
           return (
-            <div key={file.id} className="bg-gray-900 rounded-xl border border-white/10 overflow-hidden">
+            <button
+              key={file.id}
+              onClick={() => onGoTo(originalIndex)}
+              className={`w-full text-left bg-gray-900 rounded-xl border overflow-hidden transition-colors hover:bg-gray-800 ${
+                actionable ? "border-white/10" : "border-white/5"
+              }`}
+            >
               <div className="flex items-center gap-3 p-3">
-                {/* Preview */}
                 <div className="w-14 h-14 rounded-lg overflow-hidden bg-gray-800 shrink-0 flex items-center justify-center">
-                  {file.thumbnailUrl ? (
+                  {file.mimeType.startsWith("image/") && file.thumbnailUrl ? (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img src={file.thumbnailUrl} alt={file.filename} className="w-full h-full object-cover" />
                   ) : (
-                    <FileTypeIcon mimeType={file.mimeType} />
+                    <FileTypeIcon mimeType={file.mimeType} className="w-7 h-7" />
                   )}
                 </div>
-
-                {/* Info */}
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium truncate">{file.filename}</p>
                   <p className="text-xs text-gray-400 mt-0.5">{formatSize(file.size)}</p>
@@ -152,39 +357,468 @@ export default function ProjectValidatorView({ token, data }: { token: string; d
                     {STATUS_LABELS[file.status] ?? file.status}
                   </span>
                 </div>
+                {actionable && (
+                  <svg className="w-4 h-4 text-white/30 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                )}
               </div>
-
-              {/* Actions */}
-              {canDecide && (
-                <div className="flex border-t border-white/10">
-                  <button
-                    onClick={() => void setStatus(file.id, rejectStatus)}
-                    disabled={isSaving}
-                    className="flex-1 py-2.5 text-sm text-red-400 hover:bg-red-900/30 disabled:opacity-50 transition-colors font-medium"
-                  >
-                    ✗ {labels.reject}
-                  </button>
-                  <div className="w-px bg-white/10" />
-                  <button
-                    onClick={() => void setStatus(file.id, approveStatus)}
-                    disabled={isSaving}
-                    className="flex-1 py-2.5 text-sm text-green-400 hover:bg-green-900/30 disabled:opacity-50 transition-colors font-medium"
-                  >
-                    ✓ {labels.approve}
-                  </button>
-                </div>
-              )}
-            </div>
+            </button>
           );
         })}
+        {filtered.length === 0 && (
+          <p className="text-center text-gray-500 py-12 text-sm">Aucun fichier dans cette catégorie.</p>
+        )}
+      </div>
+    </div>
+  );
+}
 
-        {files.length > 0 && pendingCount === 0 && (
-          <div className="text-center py-8 text-green-400">
-            <p className="text-lg font-semibold">Tout est traité ✓</p>
-            <p className="text-sm text-gray-400 mt-1">{approvedCount} approuvés · {rejectedCount} rejetés</p>
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+export default function ProjectValidatorView({ token, data }: { token: string; data: ProjectValidationData }) {
+  const { project } = data;
+  const isPrevalidator = data.token.type === "PREVALIDATOR";
+  const hasPrevalidator = project.hasPrevalidator;
+  const approveStatus = isPrevalidator ? "PREVALIDATED" : "APPROVED";
+  const rejectStatus  = isPrevalidator ? "PREREJECTED"  : "REJECTED";
+
+  const [files, setFiles] = useState<ProjectFile[]>(data.files);
+  const [currentIndex, setCurrentIndex] = useState(() => {
+    const first = data.files.findIndex((f) => isActionable(f.status, isPrevalidator, hasPrevalidator));
+    return first >= 0 ? first : 0;
+  });
+  const [showSummary, setShowSummary] = useState(false);
+  const [drawer, setDrawer] = useState<"reject" | "revision" | null>(null);
+  const [comment, setComment] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [showLightbox, setShowLightbox] = useState(false);
+  const [undoAction, setUndoAction] = useState<{ fileId: string; prevStatus: string } | null>(null);
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Signed URL for video/PDF (loaded on demand per card)
+  const [fileUrl, setFileUrl] = useState<string | null>(null);
+  const [fileUrlLoading, setFileUrlLoading] = useState(false);
+
+  // Swipe
+  const [dragX, setDragX] = useState(0);
+  const [dragging, setDragging] = useState(false);
+  const pointerIdRef = useRef<number | null>(null);
+  const startXRef    = useRef(0);
+
+  const currentFile  = files[currentIndex];
+  const totalFiles   = files.length;
+  const approvedCount = files.filter((f) => f.status === "APPROVED" || f.status === "PREVALIDATED" || f.status === "FINAL_APPROVED").length;
+  const rejectedCount = files.filter((f) => f.status === "REJECTED"  || f.status === "PREREJECTED").length;
+  const actionableCount = files.filter((f) => isActionable(f.status, isPrevalidator, hasPrevalidator)).length;
+  const canAct = !!currentFile && isActionable(currentFile.status, isPrevalidator, hasPrevalidator);
+
+  // Load signed URL when switching to a video or PDF card
+  // (images use thumbnailUrl directly — fileUrl is only read for video/PDF in JSX)
+  useEffect(() => {
+    if (!currentFile || currentFile.mimeType.startsWith("image/")) return;
+    setFileUrl(null);
+    setFileUrlLoading(true);
+    fetch(`/api/media/validate/${token}/file/${currentFile.id}`)
+      .then((r) => r.json())
+      .then((j) => { if (j.originalUrl) setFileUrl(j.originalUrl); })
+      .catch(() => {})
+      .finally(() => setFileUrlLoading(false));
+  }, [currentFile?.id, token]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const navigate = useCallback((direction: 1 | -1) => {
+    setCurrentIndex((i) => Math.max(0, Math.min(totalFiles - 1, i + direction)));
+  }, [totalFiles]);
+
+  const doAction = useCallback(async (status: string, commentText: string) => {
+    if (!currentFile || saving) return;
+    setSaving(true);
+    const prevStatus = currentFile.status;
+    const fileId = currentFile.id;
+
+    // Compute updated files synchronously to find next actionable
+    const newFiles = files.map((f) => f.id === fileId ? { ...f, status } : f);
+    setFiles(newFiles);
+
+    // Undo
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    setUndoAction({ fileId, prevStatus });
+    undoTimerRef.current = setTimeout(() => setUndoAction(null), 3000);
+
+    // Navigate to next actionable file (search forward, then backward)
+    const nextIdx = newFiles.findIndex((f, i) => i > currentIndex && isActionable(f.status, isPrevalidator, hasPrevalidator));
+    if (nextIdx >= 0) {
+      setCurrentIndex(nextIdx);
+    } else {
+      const remaining = newFiles.some((f, i) => i !== currentIndex && isActionable(f.status, isPrevalidator, hasPrevalidator));
+      if (!remaining) {
+        setShowSummary(true);
+      } else {
+        // Some remain before current index, go back to first actionable
+        const prevIdx = newFiles.findIndex((f) => isActionable(f.status, isPrevalidator, hasPrevalidator));
+        if (prevIdx >= 0) setCurrentIndex(prevIdx);
+        else setShowSummary(true);
+      }
+    }
+
+    try {
+      await fetch(`/api/media/validate/${token}/file/${fileId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status, ...(commentText.trim() && { comment: commentText.trim() }) }),
+      });
+    } catch { /* silent — optimistic already applied */ }
+
+    setSaving(false);
+  }, [currentFile, currentIndex, files, saving, token, isPrevalidator, hasPrevalidator]);
+
+  const handleApprove = useCallback(() => void doAction(approveStatus, ""), [doAction, approveStatus]);
+
+  const handleRejectConfirm = useCallback(() => {
+    setDrawer(null);
+    const c = comment;
+    setComment("");
+    void doAction(rejectStatus, c);
+  }, [doAction, rejectStatus, comment]);
+
+  const handleRevisionConfirm = useCallback(() => {
+    if (!comment.trim()) return;
+    setDrawer(null);
+    const c = comment;
+    setComment("");
+    void doAction("REVISION_REQUESTED", c);
+  }, [doAction, comment]);
+
+  const undo = useCallback(() => {
+    if (!undoAction) return;
+    if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    const { fileId, prevStatus } = undoAction;
+    setFiles((prev) => prev.map((f) => f.id === fileId ? { ...f, status: prevStatus } : f));
+    const idx = files.findIndex((f) => f.id === fileId);
+    if (idx >= 0) { setCurrentIndex(idx); setShowSummary(false); }
+    fetch(`/api/media/validate/${token}/file/${fileId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: prevStatus }),
+    }).catch(() => {});
+    setUndoAction(null);
+  }, [undoAction, files, token]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (drawer || showLightbox || showSummary) return;
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return;
+      if (e.key === "ArrowRight" && canAct)  handleApprove();
+      else if (e.key === "ArrowLeft" && canAct)  setDrawer("reject");
+      else if ((e.key === "r" || e.key === "R") && canAct) setDrawer("revision");
+      else if ((e.key === "h" || e.key === "H" || e.key === "Enter") && currentFile?.mimeType.startsWith("image/")) setShowLightbox(true);
+      else if (e.key === "ArrowUp")   { e.preventDefault(); navigate(-1); }
+      else if (e.key === "ArrowDown") { e.preventDefault(); navigate(1); }
+      else if (e.key === " ")         { e.preventDefault(); navigate(1); }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [drawer, showLightbox, showSummary, canAct, handleApprove, navigate, currentFile]);
+
+  // Swipe handlers
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (drawer || showLightbox || !canAct) return;
+    pointerIdRef.current = e.pointerId;
+    startXRef.current    = e.clientX;
+    setDragging(true);
+    setDragX(0);
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }, [drawer, showLightbox, canAct]);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragging || pointerIdRef.current !== e.pointerId) return;
+    setDragX(e.clientX - startXRef.current);
+  }, [dragging]);
+
+  const handlePointerEnd = useCallback(() => {
+    if (!dragging) return;
+    const delta = dragX;
+    setDragging(false);
+    setDragX(0);
+    pointerIdRef.current = null;
+    if (Math.abs(delta) >= 80) void doAction(delta > 0 ? approveStatus : rejectStatus, "");
+  }, [dragging, dragX, doAction, approveStatus, rejectStatus]);
+
+  if (totalFiles === 0) {
+    return (
+      <div className="min-h-screen bg-gray-950 flex items-center justify-center p-4">
+        <p className="text-gray-500">Aucun fichier à valider.</p>
+      </div>
+    );
+  }
+
+  if (showSummary) {
+    return (
+      <SummaryView
+        files={files}
+        isPrevalidator={isPrevalidator}
+        hasPrevalidator={hasPrevalidator}
+        projectName={project.name}
+        onBack={() => {
+          const first = files.findIndex((f) => isActionable(f.status, isPrevalidator, hasPrevalidator));
+          setCurrentIndex(first >= 0 ? first : 0);
+          setShowSummary(false);
+        }}
+        onGoTo={(idx) => { setCurrentIndex(idx); setShowSummary(false); }}
+      />
+    );
+  }
+
+  const labels = isPrevalidator
+    ? { approve: "Pré-valider", reject: "Écarter", revision: "Révision" }
+    : { approve: "Approuver",   reject: "Rejeter",  revision: "Révision" };
+
+  return (
+    <>
+      {showLightbox && currentFile && (
+        <ImageLightbox file={currentFile} token={token} onClose={() => setShowLightbox(false)} />
+      )}
+
+      {drawer && (
+        <ActionDrawer
+          type={drawer}
+          comment={comment}
+          onCommentChange={setComment}
+          onConfirm={drawer === "reject" ? handleRejectConfirm : handleRevisionConfirm}
+          onCancel={() => { setDrawer(null); setComment(""); }}
+          saving={saving}
+          isPrevalidator={isPrevalidator}
+        />
+      )}
+
+      <div className="min-h-screen bg-gray-950 text-white flex flex-col select-none overflow-hidden">
+        {/* Progress bar */}
+        <ProgressBar total={totalFiles} approved={approvedCount} rejected={rejectedCount} />
+
+        {/* Header */}
+        <header className="px-4 py-3 flex items-center justify-between shrink-0">
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              onClick={() => navigate(-1)}
+              disabled={currentIndex === 0}
+              className="text-white/60 disabled:opacity-25 text-2xl w-8 flex items-center justify-center hover:text-white transition-colors"
+              aria-label="Précédent"
+            >‹</button>
+            <span className="text-sm tabular-nums text-white/60 min-w-[3rem] text-center">{currentIndex + 1}/{totalFiles}</span>
+            <button
+              onClick={() => navigate(1)}
+              disabled={currentIndex === totalFiles - 1}
+              className="text-white/60 disabled:opacity-25 text-2xl w-8 flex items-center justify-center hover:text-white transition-colors"
+              aria-label="Suivant"
+            >›</button>
+          </div>
+
+          <p className="text-sm font-medium truncate max-w-[40%] text-center">{project.name}</p>
+
+          <button onClick={() => setShowSummary(true)} className="text-sm text-white/60 hover:text-white transition-colors shrink-0">
+            Récap
+          </button>
+        </header>
+
+        {/* Preview area */}
+        <div
+          className="flex-1 flex flex-col items-center justify-center overflow-hidden relative px-4"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerEnd}
+          onPointerCancel={handlePointerEnd}
+          style={{ touchAction: "pan-y" }}
+        >
+          {currentFile && (
+            <div
+              className="flex flex-col items-center w-full max-w-2xl"
+              style={{
+                transform: canAct ? `translateX(${dragX}px) rotate(${dragX / 25}deg)` : "none",
+                transition: dragging ? "none" : "transform 150ms ease-out",
+              }}
+            >
+              {/* File preview */}
+              <div className="w-full flex items-center justify-center mb-3">
+                {currentFile.mimeType.startsWith("image/") ? (
+                  <div className="relative">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={currentFile.thumbnailUrl ?? ""}
+                      alt={currentFile.filename}
+                      className="max-w-[90vw] max-h-[48vh] sm:max-h-[58vh] object-contain rounded-lg shadow-2xl"
+                      draggable={false}
+                    />
+                    <button
+                      onClick={(e) => { e.stopPropagation(); setShowLightbox(true); }}
+                      onPointerDown={(e) => e.stopPropagation()}
+                      className="absolute bottom-2 right-2 text-xs text-white/60 hover:text-white bg-black/50 hover:bg-black/70 rounded-lg px-2 py-1 flex items-center gap-1 transition-colors"
+                    >
+                      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                      </svg>
+                      HD
+                    </button>
+                  </div>
+                ) : currentFile.mimeType.startsWith("video/") ? (
+                  <div className="w-full max-w-[90vw] sm:max-w-[70vw]">
+                    {fileUrlLoading ? (
+                      <div className="h-48 sm:h-56 flex items-center justify-center">
+                        <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+                      </div>
+                    ) : fileUrl ? (
+                      <video
+                        controls
+                        src={fileUrl}
+                        className="w-full max-h-[48vh] sm:max-h-[58vh] rounded-lg shadow-2xl bg-black"
+                        onClick={(e) => e.stopPropagation()}
+                        onPointerDown={(e) => e.stopPropagation()}
+                      />
+                    ) : (
+                      <div className="h-40 flex flex-col items-center justify-center gap-2">
+                        <FileTypeIcon mimeType={currentFile.mimeType} />
+                        <p className="text-gray-500 text-sm">Impossible de charger la vidéo</p>
+                      </div>
+                    )}
+                  </div>
+                ) : currentFile.mimeType === "application/pdf" ? (
+                  <div className="flex flex-col items-center gap-4 py-6">
+                    <FileTypeIcon mimeType={currentFile.mimeType} className="w-20 h-20" />
+                    {fileUrlLoading ? (
+                      <div className="w-5 h-5 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+                    ) : fileUrl ? (
+                      <a
+                        href={fileUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        onPointerDown={(e) => e.stopPropagation()}
+                        className="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-xl text-sm text-white/80 transition-colors"
+                      >
+                        Ouvrir le PDF ↗
+                      </a>
+                    ) : null}
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center gap-2 py-8">
+                    <FileTypeIcon mimeType={currentFile.mimeType} />
+                  </div>
+                )}
+              </div>
+
+              {/* File info */}
+              <p className="text-sm font-medium text-white/90 truncate max-w-[80vw] text-center">
+                {currentFile.filename}
+              </p>
+              <p className="text-xs text-gray-500 mt-0.5">{formatSize(currentFile.size)}</p>
+              {currentFile.status !== "IN_REVIEW" && (
+                <span className={`mt-1.5 inline-block px-2.5 py-0.5 text-[11px] font-semibold rounded-full ${STATUS_BADGE[currentFile.status] ?? "bg-gray-700 text-gray-300"}`}>
+                  {STATUS_LABELS[currentFile.status] ?? currentFile.status}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Swipe feedback overlay */}
+          {canAct && dragX !== 0 && (
+            <div
+              className={`absolute inset-0 flex items-start ${dragX > 0 ? "justify-start" : "justify-end"} pointer-events-none`}
+              style={{ opacity: Math.min(Math.abs(dragX) / 100, 1) }}
+            >
+              <div className={`m-4 mt-20 w-14 h-14 rounded-full flex items-center justify-center text-2xl text-white ${dragX > 0 ? "bg-green-500" : "bg-red-500"}`}>
+                {dragX > 0 ? "✓" : "✗"}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Stats bar */}
+        <div className="px-4 py-1.5 flex items-center justify-center gap-3 shrink-0 text-xs">
+          <span className="text-green-400 tabular-nums">{approvedCount} {isPrevalidator ? "pré-validés" : "approuvés"}</span>
+          <span className="text-white/20">·</span>
+          <span className="text-white/40 tabular-nums">{actionableCount} en attente</span>
+          <span className="text-white/20">·</span>
+          <span className="text-red-400 tabular-nums">{rejectedCount} {isPrevalidator ? "écartés" : "rejetés"}</span>
+        </div>
+
+        {/* All decided banner */}
+        {actionableCount === 0 && totalFiles > 0 && (
+          <div className="bg-green-700/80 text-white text-sm px-4 py-2 text-center shrink-0">
+            Tout est traité.{" "}
+            <button onClick={() => setShowSummary(true)} className="font-bold underline">Voir le récap</button>
           </div>
         )}
-      </main>
-    </div>
+
+        {/* Action buttons */}
+        {canAct ? (
+          <div
+            className="px-6 pt-3 flex items-center justify-center gap-4 shrink-0"
+            style={{ paddingBottom: "max(1.25rem, env(safe-area-inset-bottom))" }}
+          >
+            <button
+              onClick={() => setDrawer("reject")}
+              disabled={saving}
+              className="w-16 h-16 sm:w-14 sm:h-14 rounded-full bg-red-500 hover:bg-red-600 active:scale-95 text-white text-2xl flex items-center justify-center disabled:opacity-50 transition-all shadow-lg"
+              aria-label={labels.reject}
+              title={labels.reject}
+            >✗</button>
+            <button
+              onClick={() => setDrawer("revision")}
+              disabled={saving}
+              className="w-12 h-12 sm:w-11 sm:h-11 rounded-full bg-purple-600 hover:bg-purple-700 active:scale-95 text-white flex items-center justify-center disabled:opacity-50 transition-all shadow-lg"
+              aria-label={labels.revision}
+              title={labels.revision}
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+            <button
+              onClick={handleApprove}
+              disabled={saving}
+              className="w-16 h-16 sm:w-14 sm:h-14 rounded-full bg-green-500 hover:bg-green-600 active:scale-95 text-white text-2xl flex items-center justify-center disabled:opacity-50 transition-all shadow-lg"
+              aria-label={labels.approve}
+              title={labels.approve}
+            >✓</button>
+          </div>
+        ) : (
+          <div
+            className="px-4 pt-2 flex items-center justify-center gap-2 shrink-0"
+            style={{ paddingBottom: "max(1rem, env(safe-area-inset-bottom))" }}
+          >
+            <span className={`px-3 py-1.5 rounded-full text-xs font-semibold ${STATUS_BADGE[currentFile?.status ?? ""] ?? "bg-gray-700 text-gray-300"}`}>
+              {STATUS_LABELS[currentFile?.status ?? ""] ?? "—"}
+            </span>
+            <span className="text-xs text-gray-600">Aucune action disponible</span>
+          </div>
+        )}
+
+        {/* Keyboard hints — desktop only */}
+        {canAct && (
+          <div className="hidden sm:flex px-4 py-1 justify-center gap-4 shrink-0">
+            <span className="text-[10px] text-white/25">← : {labels.reject}</span>
+            <span className="text-[10px] text-white/25">R : révision</span>
+            <span className="text-[10px] text-white/25">→ : {labels.approve}</span>
+            {currentFile?.mimeType.startsWith("image/") && (
+              <span className="text-[10px] text-white/25">H : HD</span>
+            )}
+          </div>
+        )}
+
+        {/* Undo toast */}
+        {undoAction && (
+          <div
+            className="fixed left-4 right-4 bg-gray-800 text-white rounded-xl px-4 py-3 flex items-center justify-between z-30 shadow-xl"
+            style={{ bottom: "calc(5.5rem + env(safe-area-inset-bottom))" }}
+          >
+            <span className="text-sm">
+              {STATUS_LABELS[files.find((f) => f.id === undoAction.fileId)?.status ?? ""] ?? "Décision enregistrée"}
+            </span>
+            <button onClick={undo} className="text-icc-violet font-bold text-sm ml-4">ANNULER</button>
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/src/app/media/v/[token]/page.tsx
+++ b/src/app/media/v/[token]/page.tsx
@@ -1,20 +1,20 @@
 /**
- * Page publique de validation/pré-validation de photos.
+ * Page publique de validation/pré-validation — photos (event) ou fichiers (projet).
  * Accessible via un lien VALIDATOR ou PREVALIDATOR sans authentification.
  */
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
 import ValidatorView from "./ValidatorView";
+import ProjectValidatorView from "./ProjectValidatorView";
 
-async function fetchValidationData(token: string) {
+async function fetchEventValidationData(token: string) {
   try {
     const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
+    if (!shareToken.mediaEvent) return null;
+
     const isPrevalidator = shareToken.type === "PREVALIDATOR";
     const event = shareToken.mediaEvent;
-
-    if (!event) return { token: shareToken, event: null, photos: [] };
-
     const hasPrevalidator = event.shareTokens.some((t) => t.type === "PREVALIDATOR");
 
     let statusFilter: string[];
@@ -39,6 +39,7 @@ async function fetchValidationData(token: string) {
     );
 
     return {
+      type: "event" as const,
       token: { id: shareToken.id, type: shareToken.type, label: shareToken.label },
       event: {
         id: event.id,
@@ -61,9 +62,69 @@ async function fetchValidationData(token: string) {
   }
 }
 
+async function fetchProjectValidationData(token: string) {
+  try {
+    const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
+    if (!shareToken.mediaProject) return null;
+
+    const isPrevalidator = shareToken.type === "PREVALIDATOR";
+    const project = shareToken.mediaProject;
+
+    const filesWithUrls = await Promise.all(
+      project.files.map(async (f) => {
+        const thumbKey = f.versions[0]?.thumbnailKey;
+        let thumbnailUrl: string | null = null;
+        if (thumbKey) {
+          try { thumbnailUrl = await getSignedThumbnailUrl(thumbKey); } catch { /* pas de preview */ }
+        }
+        return {
+          id: f.id,
+          filename: f.filename,
+          type: f.type,
+          mimeType: f.mimeType,
+          size: f.size,
+          status: f.status,
+          thumbnailUrl,
+        };
+      })
+    );
+
+    return {
+      type: "project" as const,
+      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label },
+      project: {
+        id: project.id,
+        name: project.name,
+        isPrevalidator,
+        totalFiles: filesWithUrls.length,
+        approvedCount: filesWithUrls.filter((f) => f.status === "APPROVED" || f.status === "FINAL_APPROVED").length,
+        pendingCount: filesWithUrls.filter((f) => f.status === "IN_REVIEW" || f.status === "DRAFT").length,
+        rejectedCount: filesWithUrls.filter((f) => f.status === "REJECTED").length,
+      },
+      files: filesWithUrls,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export default async function ValidatorPage({ params }: { params: Promise<{ token: string }> }) {
   const { token } = await params;
-  const data = await fetchValidationData(token);
+
+  // Detect project vs event by trying each
+  const shareToken = await (async () => {
+    try { return await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]); } catch { return null; }
+  })();
+
+  if (!shareToken) notFound();
+
+  if (shareToken!.mediaProjectId) {
+    const data = await fetchProjectValidationData(token);
+    if (!data) notFound();
+    return <ProjectValidatorView token={token} data={data} />;
+  }
+
+  const data = await fetchEventValidationData(token);
   if (!data) notFound();
-  return <ValidatorView token={token} data={data} />;
+  return <ValidatorView token={token} data={{ token: data.token, event: data.event, photos: data.photos }} />;
 }

--- a/src/app/media/v/[token]/page.tsx
+++ b/src/app/media/v/[token]/page.tsx
@@ -69,12 +69,13 @@ async function fetchProjectValidationData(token: string) {
 
     const isPrevalidator = shareToken.type === "PREVALIDATOR";
     const project = shareToken.mediaProject;
+    const hasPrevalidator = project.shareTokens.some((t) => t.type === "PREVALIDATOR");
 
     const filesWithUrls = await Promise.all(
       project.files.map(async (f) => {
         const thumbKey = f.versions[0]?.thumbnailKey;
         let thumbnailUrl: string | null = null;
-        if (thumbKey) {
+        if (thumbKey && f.mimeType.startsWith("image/")) {
           try { thumbnailUrl = await getSignedThumbnailUrl(thumbKey); } catch { /* pas de preview */ }
         }
         return {
@@ -96,10 +97,8 @@ async function fetchProjectValidationData(token: string) {
         id: project.id,
         name: project.name,
         isPrevalidator,
+        hasPrevalidator,
         totalFiles: filesWithUrls.length,
-        approvedCount: filesWithUrls.filter((f) => f.status === "APPROVED" || f.status === "FINAL_APPROVED").length,
-        pendingCount: filesWithUrls.filter((f) => f.status === "IN_REVIEW" || f.status === "DRAFT").length,
-        rejectedCount: filesWithUrls.filter((f) => f.status === "REJECTED").length,
       },
       files: filesWithUrls,
     };

--- a/src/modules/media/services/tokens.ts
+++ b/src/modules/media/services/tokens.ts
@@ -48,8 +48,10 @@ export async function validateMediaShareToken(
           id: true,
           name: true,
           churchId: true,
+          shareTokens: { select: { type: true } },
           files: {
             orderBy: { createdAt: "asc" as const },
+            where: { status: { not: "DRAFT" } },
             select: {
               id: true,
               filename: true,

--- a/src/modules/media/services/tokens.ts
+++ b/src/modules/media/services/tokens.ts
@@ -43,7 +43,29 @@ export async function validateMediaShareToken(
           shareTokens: { select: { type: true } },
         },
       },
-      mediaProject: { select: { id: true, name: true, churchId: true } },
+      mediaProject: {
+        select: {
+          id: true,
+          name: true,
+          churchId: true,
+          files: {
+            orderBy: { createdAt: "asc" as const },
+            select: {
+              id: true,
+              filename: true,
+              type: true,
+              mimeType: true,
+              size: true,
+              status: true,
+              versions: {
+                orderBy: { versionNumber: "desc" as const },
+                take: 1,
+                select: { thumbnailKey: true, originalKey: true },
+              },
+            },
+          },
+        },
+      },
     },
   });
 


### PR DESCRIPTION
## Résumé

- **Upload silencieux corrigé** : `uploadToS3` envoyait le fichier sans header `Content-Type` et n'inspectait pas le code HTTP de retour (un 403 S3 appelait quand même `resolve()`). Fix : `xhr.setRequestHeader("Content-Type", file.type)` + vérification du status.
- **Version non créée corrigée** : le PATCH post-upload envoyait `{ originalKey: key }` (ignoré par Zod). Fix : `{ confirmUpload: true }`, qui déclenche la création de `MediaFileVersion` côté serveur.
- **Zone d'upload visible par défaut** : affichée sans clic si le projet est vide et que l'utilisateur a le droit d'uploader.
- **`<img>` cassé pour PDF/vidéo** : `thumbnailKey = originalKey` pour les fichiers non-image, le navigateur ne peut pas les afficher en `<img>`. Fix : afficher l'icône de type à la place.
- **Liens de validation pour les projets** : la page `/media/v/[token]` ne gérait que les événements. Ajout de `ProjectValidatorView`, de l'endpoint public `PATCH/GET /api/media/validate/[token]/file/[fileId]`, et du select étendu dans `validateMediaShareToken`.
- **Auth** : remplacé `requireAuth()` (throw non géré) par `auth() + redirect` dans la page projet.

## Plan de test

- [ ] Uploader un JPEG dans un projet → la miniature s'affiche dans la grille après l'upload
- [ ] Uploader un PDF → icône de document visible (pas d'image cassée)
- [ ] Uploader une vidéo → icône vidéo visible (pas d'image cassée)
- [ ] Créer un lien VALIDATOR/PREVALIDATOR sur un projet → le lien `/media/v/[token]` s'ouvre et liste les fichiers
- [ ] Valider/rejeter un fichier via le lien de validation → le statut se met à jour
- [ ] Ouvrir la page d'un projet sans session → redirection vers `/` (pas d'erreur 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)