### PR TITLE
chore: release v1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.4.7] - 2026-05-22
+
+### Corrigé
+
+- Projets médias : miniatures non affichées, suppression bloquée, liens de validation projet (#336)
+- Validation projet : refonte UX (swipe, raccourcis clavier, vue mobile/desktop, commentaires obligatoires pour la révision)
+- Validation projet : décomptes fichiers en attente incorrects dans la vue validateur
+- Validation projet : statistiques incomplètes dans la vue projet (statuts APPROVED, PREVALIDATED, PREREJECTED manquants)
+- Upload nouvelle version : miniature non régénérée (`thumbnailKey = originalKey`)
+
 ## [v1.4.6] - 2026-05-21
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

- Bump version `1.4.6` → `1.4.7`
- Mise à jour CHANGELOG

## Changements inclus (PR #336)

- Projets médias : miniatures non affichées, suppression bloquée, liens de validation projet
- Validation projet : refonte UX (swipe, raccourcis clavier, vue mobile/desktop, commentaires obligatoires pour la révision)
- Validation projet : décomptes fichiers en attente incorrects dans la vue validateur
- Validation projet : statistiques incomplètes (statuts APPROVED, PREVALIDATED, PREREJECTED manquants)
- Upload nouvelle version : miniature non régénérée

## Test plan

- [ ] CI passe
- [ ] Vérifier la version dans le footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)