### PR TITLE
chore: release v1.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.4.8] - 2026-05-23
+
+### Corrigé
+
+- Permissions médias : l'équipe production peut désormais créer/supprimer les liens VALIDATOR et PREVALIDATOR (#339)
+- Permissions médias : l'équipe production peut supprimer les événements médias (#339)
+- Permissions médias : l'équipe production peut valider les photos et fichiers (APPROVED/REJECTED/FINAL_APPROVED) (#339)
+- Suppression d'événements médias : utilisation du bon bucket S3 (media au lieu de backup) (#339)
+- Sidebar : lien "Sauvegardes" visible uniquement pour les super admins (#339)
+
 ## [v1.4.7] - 2026-05-22
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

- Bump version `1.4.7` → `1.4.8`
- Mise à jour CHANGELOG

## Changements inclus (PR #339)

- Permissions médias : équipe production peut créer/supprimer les liens VALIDATOR et PREVALIDATOR
- Permissions médias : équipe production peut supprimer les événements médias
- Permissions médias : équipe production peut valider les photos et fichiers (APPROVED/REJECTED/FINAL_APPROVED)
- Suppression d'événements médias : bon bucket S3 (media au lieu de backup)
- Sidebar : lien "Sauvegardes" visible uniquement pour les super admins

## Test plan

- [ ] CI passe
- [ ] Vérifier la version dans le footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)