### PR TITLE
feat(backups): téléchargement d'une sauvegarde via URL présignée S3

### DIFF
--- a/src/app/(auth)/admin/backups/BackupsClient.tsx
+++ b/src/app/(auth)/admin/backups/BackupsClient.tsx
@@ -133,6 +133,7 @@ export default function BackupsClient() {
   const [restoreTarget, setRestoreTarget] = useState<BackupEntry | null>(null);
   const [restoreLoading, setRestoreLoading] = useState(false);
   const [restoreResult, setRestoreResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [downloadingKey, setDownloadingKey] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const [currentRefreshKey, setCurrentRefreshKey] = useState(0);
 
@@ -172,6 +173,23 @@ export default function BackupsClient() {
       setRefreshKey((k) => k + 1);
     }
     setTriggering(false);
+  }
+
+  async function downloadBackup(b: BackupEntry) {
+    setDownloadingKey(b.key);
+    const res = await fetch(`/api/admin/backups/download?key=${encodeURIComponent(b.key)}`);
+    const json = await res.json().catch(() => ({}));
+    setDownloadingKey(null);
+    if (!res.ok) {
+      setRestoreResult({ success: false, message: json.error ?? "Impossible de générer le lien de téléchargement" });
+      return;
+    }
+    const a = document.createElement("a");
+    a.href = json.url;
+    a.download = "";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
   }
 
   async function confirmRestore() {
@@ -256,12 +274,21 @@ export default function BackupsClient() {
                     {formatDate(b.lastModified)} · {formatBytes(b.sizeBytes)}
                   </p>
                 </div>
-                <button
-                  onClick={() => { setRestoreResult(null); setRestoreTarget(b); }}
-                  className="text-xs text-red-500 hover:text-red-700 border border-red-100 hover:border-red-200 rounded-lg px-3 py-1.5 hover:bg-red-50 transition-colors shrink-0"
-                >
-                  Restaurer
-                </button>
+                <div className="flex items-center gap-2 shrink-0">
+                  <button
+                    onClick={() => downloadBackup(b)}
+                    disabled={downloadingKey === b.key}
+                    className="text-xs text-icc-violet hover:text-icc-violet/80 border border-icc-violet/20 hover:border-icc-violet/40 rounded-lg px-3 py-1.5 hover:bg-icc-violet/5 disabled:opacity-50 transition-colors"
+                  >
+                    {downloadingKey === b.key ? "…" : "Télécharger"}
+                  </button>
+                  <button
+                    onClick={() => { setRestoreResult(null); setRestoreTarget(b); }}
+                    className="text-xs text-red-500 hover:text-red-700 border border-red-100 hover:border-red-200 rounded-lg px-3 py-1.5 hover:bg-red-50 transition-colors"
+                  >
+                    Restaurer
+                  </button>
+                </div>
               </li>
             ))}
           </ul>

--- a/src/app/api/admin/backups/download/route.ts
+++ b/src/app/api/admin/backups/download/route.ts
@@ -1,0 +1,46 @@
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireAuth } from "@/lib/auth";
+import { s3, isS3Configured } from "@/lib/s3";
+
+async function requireSuperAdmin() {
+  const session = await requireAuth();
+  if (!session.user.isSuperAdmin) {
+    throw new ApiError(403, "Réservé aux super-administrateurs");
+  }
+  return session;
+}
+
+export async function GET(request: Request) {
+  try {
+    await requireSuperAdmin();
+
+    if (!isS3Configured()) {
+      throw new ApiError(400, "S3 backup is not configured");
+    }
+
+    const key = new URL(request.url).searchParams.get("key");
+    if (!key) throw new ApiError(400, "Paramètre key requis");
+
+    // Validate key to prevent path traversal
+    if (!key.startsWith("backups/") || !key.endsWith(".sql.gz") || key.includes("..")) {
+      throw new ApiError(400, "Clé de sauvegarde invalide");
+    }
+
+    const bucket = process.env.BACKUP_S3_BUCKET!;
+    const url = await getSignedUrl(
+      s3,
+      new GetObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        ResponseContentDisposition: `attachment; filename="${key.split("/").at(-2)}-db.sql.gz"`,
+      }),
+      { expiresIn: 300 } // 5 minutes
+    );
+
+    return successResponse({ url });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}


### PR DESCRIPTION
## Summary
- Nouvelle route `GET /api/admin/backups/download?key=<clé>` (super admin uniquement) qui génère une URL présignée S3 valide 5 minutes
- Bouton **Télécharger** ajouté sur chaque ligne de la liste des sauvegardes
- Validation de la clé côté serveur (doit commencer par `backups/`, finir par `.sql.gz`, sans `..`) pour prévenir toute traversée de chemin

## Test plan
- [ ] Se connecter en tant que super admin
- [ ] Aller sur `/admin/backups`
- [ ] Cliquer sur "Télécharger" sur une sauvegarde existante → le fichier `.sql.gz` se télécharge
- [ ] Vérifier qu'un utilisateur non super admin reçoit une 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)