### PR TITLE
feat(media): collections multi-sources — sélection croisée événements/projets

### DIFF
--- a/prisma/migrations/20260607000000_add_collection_token_type/migration.sql
+++ b/prisma/migrations/20260607000000_add_collection_token_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum: Add COLLECTION to MediaTokenType
+ALTER TABLE `media_share_tokens` MODIFY COLUMN `type` ENUM('VALIDATOR', 'MEDIA', 'MEDIA_ALL', 'PREVALIDATOR', 'GALLERY', 'COLLECTION') NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -679,6 +679,7 @@ enum MediaTokenType {
   MEDIA_ALL    // Accès téléchargement (toutes photos, validées ou non)
   PREVALIDATOR // Accès prévalidation (filtrage avant validation finale)
   GALLERY      // Accès galerie (téléchargement photo par photo)
+  COLLECTION   // Collection multi-sources (plusieurs événements/projets)
 }
 
 enum MediaJobStatus {

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -133,6 +133,9 @@ export default async function AuthLayout({
       mediaLinks.push({ href: "/media/events", label: "Événements" });
       mediaLinks.push({ href: "/media/projects", label: "Projets" });
     }
+    if (userPermissions.has("media:manage") || isMemberOf("PRODUCTION_MEDIA")) {
+      mediaLinks.push({ href: "/media/collections", label: "Collections" });
+    }
 
     // Protocole check for agenda access (don't inherit from isGlobalManager — role permissions handle that)
     isProtocoleMember = serviceDepts.some((d) => d.function === "PROTOCOLE" && userDeptIds.has(d.id));

--- a/src/app/(auth)/media/collections/CollectionBuilder.tsx
+++ b/src/app/(auth)/media/collections/CollectionBuilder.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { useState, useMemo } from "react";
+
+type EventItem = {
+  id: string;
+  name: string;
+  date: string;
+  approvedPhotoCount: number;
+};
+
+type ProjectItem = {
+  id: string;
+  name: string;
+  createdAt: string;
+  approvedFileCount: number;
+};
+
+type Scope = "photos" | "files" | "both";
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString("fr-FR", { day: "numeric", month: "short", year: "numeric" });
+}
+
+export default function CollectionBuilder({
+  churchId,
+  events,
+  projects,
+}: {
+  churchId: string;
+  events: EventItem[];
+  projects: ProjectItem[];
+}) {
+  const [scope, setScope]           = useState<Scope>("both");
+  const [selectedEvents, setSelectedEvents] = useState<Set<string>>(new Set());
+  const [selectedProjects, setSelectedProjects] = useState<Set<string>>(new Set());
+  const [label, setLabel]           = useState("");
+  const [expiresInDays, setExpiresInDays] = useState<number | "">(30);
+  const [dateFrom, setDateFrom]     = useState("");
+  const [dateTo, setDateTo]         = useState("");
+  const [creating, setCreating]     = useState(false);
+  const [result, setResult]         = useState<{ url: string; label: string | null } | null>(null);
+  const [error, setError]           = useState<string | null>(null);
+  const [copied, setCopied]         = useState(false);
+
+  // Filter events by date range
+  const filteredEvents = useMemo(() => {
+    return events.filter((e) => {
+      if (dateFrom && e.date < dateFrom) return false;
+      if (dateTo   && e.date > dateTo + "T23:59:59") return false;
+      return true;
+    });
+  }, [events, dateFrom, dateTo]);
+
+  function toggleEvent(id: string) {
+    setSelectedEvents((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleProject(id: string) {
+    setSelectedProjects((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  function selectAllEvents() {
+    if (selectedEvents.size === filteredEvents.length) {
+      setSelectedEvents(new Set());
+    } else {
+      setSelectedEvents(new Set(filteredEvents.map((e) => e.id)));
+    }
+  }
+
+  function selectAllProjects() {
+    if (selectedProjects.size === projects.length) {
+      setSelectedProjects(new Set());
+    } else {
+      setSelectedProjects(new Set(projects.map((p) => p.id)));
+    }
+  }
+
+  const showEvents   = scope === "photos" || scope === "both";
+  const showProjects = scope === "files"  || scope === "both";
+
+  const totalPhotos = filteredEvents
+    .filter((e) => selectedEvents.has(e.id))
+    .reduce((n, e) => n + e.approvedPhotoCount, 0);
+  const totalFiles = projects
+    .filter((p) => selectedProjects.has(p.id))
+    .reduce((n, p) => n + p.approvedFileCount, 0);
+
+  const canCreate =
+    !creating &&
+    ((showEvents   && selectedEvents.size > 0)   ||
+     (showProjects && selectedProjects.size > 0));
+
+  async function createCollection() {
+    setCreating(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const res = await fetch("/api/admin/media/collections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          churchId,
+          label: label.trim() || undefined,
+          scope,
+          eventIds:   showEvents   ? Array.from(selectedEvents)   : [],
+          projectIds: showProjects ? Array.from(selectedProjects) : [],
+          expiresInDays: expiresInDays !== "" ? expiresInDays : undefined,
+        }),
+      });
+
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(json.error ?? "Erreur lors de la création");
+      } else {
+        setResult({ url: json.url, label: json.label ?? null });
+      }
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function copyLink() {
+    if (!result) return;
+    await navigator.clipboard.writeText(result.url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="space-y-5 max-w-3xl">
+      {/* ── Scope ─────────────────────────────────────────────────────────── */}
+      <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 space-y-3">
+        <h2 className="text-sm font-semibold text-gray-900">Contenu à inclure</h2>
+        <div className="flex gap-2 flex-wrap">
+          {(["both", "photos", "files"] as Scope[]).map((s) => (
+            <button
+              key={s}
+              onClick={() => setScope(s)}
+              className={`px-4 py-2 rounded-xl text-sm font-medium border transition-colors ${
+                scope === s
+                  ? "bg-icc-violet text-white border-icc-violet"
+                  : "bg-white text-gray-600 border-gray-200 hover:border-icc-violet/40 hover:bg-icc-violet/5"
+              }`}
+            >
+              {s === "both" ? "Photos + Visuels" : s === "photos" ? "Photos uniquement" : "Visuels uniquement"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Events filter + selection ──────────────────────────────────────── */}
+      {showEvents && (
+        <div className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+          <div className="px-5 py-4 border-b border-gray-100">
+            <h2 className="text-sm font-semibold text-gray-900 mb-3">Événements — photos validées</h2>
+            <div className="flex gap-2">
+              <input
+                type="date"
+                value={dateFrom}
+                onChange={(e) => setDateFrom(e.target.value)}
+                className="text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-icc-violet"
+                placeholder="Du"
+              />
+              <input
+                type="date"
+                value={dateTo}
+                onChange={(e) => setDateTo(e.target.value)}
+                className="text-xs border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-icc-violet"
+                placeholder="Au"
+              />
+              {(dateFrom || dateTo) && (
+                <button
+                  onClick={() => { setDateFrom(""); setDateTo(""); }}
+                  className="text-xs text-gray-400 hover:text-gray-600 px-2"
+                >
+                  Effacer
+                </button>
+              )}
+            </div>
+          </div>
+
+          {filteredEvents.length === 0 ? (
+            <p className="p-5 text-sm text-gray-400">Aucun événement{dateFrom || dateTo ? " sur cette période" : ""}.</p>
+          ) : (
+            <>
+              <div className="px-5 py-2 border-b border-gray-50 flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={selectedEvents.size === filteredEvents.length && filteredEvents.length > 0}
+                  onChange={selectAllEvents}
+                  className="w-4 h-4 rounded border-gray-300 accent-icc-violet"
+                />
+                <span className="text-xs text-gray-500">
+                  {selectedEvents.size > 0
+                    ? `${selectedEvents.size} sélectionné${selectedEvents.size > 1 ? "s" : ""} · ${totalPhotos} photo${totalPhotos !== 1 ? "s" : ""}`
+                    : "Tout sélectionner"}
+                </span>
+              </div>
+              <ul className="max-h-64 overflow-y-auto divide-y divide-gray-50">
+                {filteredEvents.map((e) => (
+                  <li
+                    key={e.id}
+                    onClick={() => toggleEvent(e.id)}
+                    className={`flex items-center gap-3 px-5 py-3 cursor-pointer hover:bg-gray-50 transition-colors ${selectedEvents.has(e.id) ? "bg-icc-violet/5" : ""}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedEvents.has(e.id)}
+                      onChange={() => toggleEvent(e.id)}
+                      onClick={(ev) => ev.stopPropagation()}
+                      className="w-4 h-4 rounded border-gray-300 accent-icc-violet shrink-0"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-gray-800 truncate">{e.name}</p>
+                      <p className="text-xs text-gray-400">{formatDate(e.date)}</p>
+                    </div>
+                    <span className={`text-xs rounded-full px-2 py-0.5 shrink-0 ${e.approvedPhotoCount > 0 ? "bg-green-50 text-green-700" : "bg-gray-100 text-gray-400"}`}>
+                      {e.approvedPhotoCount} validée{e.approvedPhotoCount !== 1 ? "s" : ""}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* ── Projects selection ─────────────────────────────────────────────── */}
+      {showProjects && (
+        <div className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+          <div className="px-5 py-4 border-b border-gray-100">
+            <h2 className="text-sm font-semibold text-gray-900">Projets — visuels approuvés</h2>
+          </div>
+          {projects.length === 0 ? (
+            <p className="p-5 text-sm text-gray-400">Aucun projet disponible.</p>
+          ) : (
+            <>
+              <div className="px-5 py-2 border-b border-gray-50 flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={selectedProjects.size === projects.length && projects.length > 0}
+                  onChange={selectAllProjects}
+                  className="w-4 h-4 rounded border-gray-300 accent-icc-violet"
+                />
+                <span className="text-xs text-gray-500">
+                  {selectedProjects.size > 0
+                    ? `${selectedProjects.size} sélectionné${selectedProjects.size > 1 ? "s" : ""} · ${totalFiles} visuel${totalFiles !== 1 ? "s" : ""}`
+                    : "Tout sélectionner"}
+                </span>
+              </div>
+              <ul className="max-h-64 overflow-y-auto divide-y divide-gray-50">
+                {projects.map((p) => (
+                  <li
+                    key={p.id}
+                    onClick={() => toggleProject(p.id)}
+                    className={`flex items-center gap-3 px-5 py-3 cursor-pointer hover:bg-gray-50 transition-colors ${selectedProjects.has(p.id) ? "bg-icc-violet/5" : ""}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedProjects.has(p.id)}
+                      onChange={() => toggleProject(p.id)}
+                      onClick={(ev) => ev.stopPropagation()}
+                      className="w-4 h-4 rounded border-gray-300 accent-icc-violet shrink-0"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-gray-800 truncate">{p.name}</p>
+                      <p className="text-xs text-gray-400">{formatDate(p.createdAt)}</p>
+                    </div>
+                    <span className={`text-xs rounded-full px-2 py-0.5 shrink-0 ${p.approvedFileCount > 0 ? "bg-green-50 text-green-700" : "bg-gray-100 text-gray-400"}`}>
+                      {p.approvedFileCount} approuvé{p.approvedFileCount !== 1 ? "s" : ""}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* ── Options ────────────────────────────────────────────────────────── */}
+      <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 space-y-4">
+        <h2 className="text-sm font-semibold text-gray-900">Options du lien</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Nom du lien (optionnel)</label>
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Ex : Mariage Dupont - Jan 2026"
+              className="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/30 focus:border-icc-violet"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Expiration</label>
+            <select
+              value={expiresInDays}
+              onChange={(e) => setExpiresInDays(e.target.value === "" ? "" : Number(e.target.value))}
+              className="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/30 focus:border-icc-violet"
+            >
+              <option value={7}>7 jours</option>
+              <option value={30}>30 jours</option>
+              <option value={90}>90 jours</option>
+              <option value={365}>1 an</option>
+              <option value="">Pas d&apos;expiration</option>
+            </select>
+          </div>
+        </div>
+
+        <button
+          onClick={createCollection}
+          disabled={!canCreate}
+          className="w-full py-2.5 rounded-xl bg-icc-violet text-white text-sm font-medium hover:bg-icc-violet/90 disabled:opacity-40 transition-colors"
+        >
+          {creating ? "Génération…" : "Générer le lien de collection"}
+        </button>
+
+        {error && (
+          <p className="text-xs text-red-600 bg-red-50 px-3 py-2 rounded-lg">{error}</p>
+        )}
+      </div>
+
+      {/* ── Result ─────────────────────────────────────────────────────────── */}
+      {result && (
+        <div className="bg-green-50 border border-green-200 rounded-2xl p-5 space-y-3">
+          <p className="text-sm font-semibold text-green-800">
+            Lien créé {result.label ? `"${result.label}"` : ""}
+          </p>
+          <div className="flex items-center gap-2">
+            <input
+              readOnly
+              value={result.url}
+              className="flex-1 text-xs bg-white border border-green-200 rounded-lg px-3 py-2 text-gray-700 truncate focus:outline-none"
+              onClick={(e) => (e.target as HTMLInputElement).select()}
+            />
+            <button
+              onClick={copyLink}
+              className="shrink-0 text-xs bg-green-700 text-white rounded-lg px-3 py-2 hover:bg-green-800 transition-colors font-medium"
+            >
+              {copied ? "Copié !" : "Copier"}
+            </button>
+          </div>
+          <a
+            href={result.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-xs text-green-700 underline hover:text-green-900"
+          >
+            Ouvrir la collection →
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(auth)/media/collections/page.tsx
+++ b/src/app/(auth)/media/collections/page.tsx
@@ -1,0 +1,62 @@
+import { requireMediaManageAccess, getCurrentChurchId, requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import CollectionBuilder from "./CollectionBuilder";
+
+export default async function CollectionsPage() {
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p>Aucune église sélectionnée.</p>;
+
+  await requireMediaManageAccess(churchId);
+
+  const [events, projects] = await Promise.all([
+    prisma.mediaEvent.findMany({
+      where: { churchId },
+      orderBy: { date: "desc" },
+      select: {
+        id: true,
+        name: true,
+        date: true,
+        _count: { select: { photos: { where: { status: "APPROVED" } } } },
+      },
+    }),
+    prisma.mediaProject.findMany({
+      where: { churchId },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        createdAt: true,
+        _count: { select: { files: { where: { status: { in: ["APPROVED", "FINAL_APPROVED"] } } } } },
+      },
+    }),
+  ]);
+
+  const serializedEvents = events.map((e) => ({
+    id: e.id,
+    name: e.name,
+    date: e.date.toISOString(),
+    approvedPhotoCount: e._count.photos,
+  }));
+
+  const serializedProjects = projects.map((p) => ({
+    id: p.id,
+    name: p.name,
+    createdAt: p.createdAt.toISOString(),
+    approvedFileCount: p._count.files,
+  }));
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-1">Collections</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Créez un lien de partage regroupant des photos validées et/ou des visuels approuvés provenant de plusieurs événements ou projets.
+      </p>
+      <CollectionBuilder
+        churchId={churchId}
+        events={serializedEvents}
+        projects={serializedProjects}
+      />
+    </div>
+  );
+}

--- a/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
+++ b/src/app/(auth)/media/events/[id]/MediaEventDetail.tsx
@@ -73,6 +73,7 @@ const TOKEN_TYPE_LABELS: Record<MediaTokenType, string> = {
   MEDIA:        "Téléchargement (validées)",
   MEDIA_ALL:    "Téléchargement (toutes)",
   GALLERY:      "Galerie",
+  COLLECTION:   "Collection",
 };
 
 const TOKEN_TYPE_ICONS: Record<MediaTokenType, string> = {
@@ -81,6 +82,7 @@ const TOKEN_TYPE_ICONS: Record<MediaTokenType, string> = {
   MEDIA:        "⬇️",
   MEDIA_ALL:    "📦",
   GALLERY:      "🖼️",
+  COLLECTION:   "📂",
 };
 
 const EVENT_STATUS_LABELS: Record<MediaEventStatus, string> = {
@@ -273,7 +275,7 @@ function ShareTokenSection({ eventId, tokens, onRefresh }: {
   }
 
   function getTokenUrl(token: ShareToken) {
-    const paths: Record<MediaTokenType, string> = { VALIDATOR: "v", PREVALIDATOR: "v", MEDIA: "d", MEDIA_ALL: "d", GALLERY: "g" };
+    const paths: Record<MediaTokenType, string> = { VALIDATOR: "v", PREVALIDATOR: "v", MEDIA: "d", MEDIA_ALL: "d", GALLERY: "g", COLLECTION: "c" };
     return `${origin}/media/${paths[token.type]}/${token.token}`;
   }
 

--- a/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
+++ b/src/app/(auth)/media/projects/[id]/MediaProjectDetail.tsx
@@ -119,6 +119,7 @@ const TOKEN_TYPE_LABELS: Record<MediaTokenType, string> = {
   MEDIA:        "Téléchargement (validées)",
   MEDIA_ALL:    "Téléchargement (toutes)",
   GALLERY:      "Galerie",
+  COLLECTION:   "Collection",
 };
 
 const TOKEN_TYPE_ICONS: Record<MediaTokenType, string> = {
@@ -127,6 +128,7 @@ const TOKEN_TYPE_ICONS: Record<MediaTokenType, string> = {
   MEDIA:        "⬇️",
   MEDIA_ALL:    "📦",
   GALLERY:      "🖼️",
+  COLLECTION:   "📂",
 };
 
 const ALLOWED_TYPES: Record<string, MediaFileType> = {
@@ -268,7 +270,7 @@ function ShareTokenSection({ projectId, tokens, onRefresh }: {
   }
 
   function getTokenUrl(token: ShareToken) {
-    const paths: Record<MediaTokenType, string> = { VALIDATOR: "v", PREVALIDATOR: "v", MEDIA: "d", MEDIA_ALL: "d", GALLERY: "g" };
+    const paths: Record<MediaTokenType, string> = { VALIDATOR: "v", PREVALIDATOR: "v", MEDIA: "d", MEDIA_ALL: "d", GALLERY: "g", COLLECTION: "c" };
     return `${origin}/media/${paths[token.type]}/${token.token}`;
   }
 

--- a/src/app/api/admin/media/collections/route.ts
+++ b/src/app/api/admin/media/collections/route.ts
@@ -1,0 +1,74 @@
+import { prisma } from "@/lib/prisma";
+import { requireMediaManageAccess } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { createMediaShareToken } from "@/modules/media";
+import { logAudit } from "@/lib/audit";
+import { z } from "zod";
+
+const createSchema = z.object({
+  churchId: z.string().min(1),
+  label: z.string().optional(),
+  scope: z.enum(["photos", "files", "both"]),
+  eventIds: z.array(z.string()).default([]),
+  projectIds: z.array(z.string()).default([]),
+  expiresInDays: z.number().int().positive().optional(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const data = createSchema.parse(body);
+
+    const session = await requireMediaManageAccess(data.churchId);
+
+    if (data.eventIds.length === 0 && data.projectIds.length === 0) {
+      throw new ApiError(400, "Sélectionnez au moins un événement ou projet");
+    }
+
+    // Verify all eventIds belong to the church
+    if (data.eventIds.length > 0) {
+      const events = await prisma.mediaEvent.findMany({
+        where: { id: { in: data.eventIds }, churchId: data.churchId },
+        select: { id: true },
+      });
+      if (events.length !== data.eventIds.length) {
+        throw new ApiError(400, "Certains événements sont invalides ou hors périmètre");
+      }
+    }
+
+    // Verify all projectIds belong to the church
+    if (data.projectIds.length > 0) {
+      const projects = await prisma.mediaProject.findMany({
+        where: { id: { in: data.projectIds }, churchId: data.churchId },
+        select: { id: true },
+      });
+      if (projects.length !== data.projectIds.length) {
+        throw new ApiError(400, "Certains projets sont invalides ou hors périmètre");
+      }
+    }
+
+    const token = await createMediaShareToken({
+      type: "COLLECTION",
+      label: data.label,
+      expiresInDays: data.expiresInDays,
+      collectionConfig: {
+        scope: data.scope,
+        eventIds: data.eventIds,
+        projectIds: data.projectIds,
+      },
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId: data.churchId,
+      action: "CREATE",
+      entityType: "MediaShareToken",
+      entityId: token.id,
+      details: { type: "COLLECTION", scope: data.scope, eventIds: data.eventIds, projectIds: data.projectIds },
+    });
+
+    return successResponse(token, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/collection/[token]/file/[fileId]/route.ts
+++ b/src/app/api/media/collection/[token]/file/[fileId]/route.ts
@@ -1,0 +1,51 @@
+/**
+ * GET /api/media/collection/[token]/file/[fileId]
+ * Retourne une URL signée pour télécharger un visuel de la collection.
+ */
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { validateMediaShareToken, getSignedDownloadUrl } from "@/modules/media";
+import type { CollectionConfig } from "@/modules/media";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string; fileId: string }> }
+) {
+  try {
+    const { token, fileId } = await params;
+    const shareToken = await validateMediaShareToken(token, "COLLECTION");
+    const config = shareToken.config as CollectionConfig | null;
+    if (!config) throw new ApiError(400, "Configuration manquante");
+
+    const file = await prisma.mediaFile.findUnique({
+      where: { id: fileId },
+      select: {
+        id: true,
+        filename: true,
+        mediaProjectId: true,
+        status: true,
+        versions: {
+          orderBy: { versionNumber: "desc" },
+          take: 1,
+          select: { originalKey: true },
+        },
+      },
+    });
+
+    if (!file) throw new ApiError(404, "Fichier introuvable");
+    if (!file.mediaProjectId || !config.projectIds.includes(file.mediaProjectId)) {
+      throw new ApiError(403, "Fichier hors périmètre");
+    }
+    if (!["APPROVED", "FINAL_APPROVED"].includes(file.status)) {
+      throw new ApiError(403, "Fichier non approuvé");
+    }
+
+    const originalKey = file.versions[0]?.originalKey;
+    if (!originalKey) throw new ApiError(404, "Fichier S3 introuvable");
+
+    const downloadUrl = await getSignedDownloadUrl(originalKey, file.filename);
+    return successResponse({ id: file.id, filename: file.filename, downloadUrl });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/collection/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/collection/[token]/photo/[photoId]/route.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /api/media/collection/[token]/photo/[photoId]
+ * Retourne une URL signée pour télécharger une photo de la collection.
+ */
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { validateMediaShareToken, getSignedDownloadUrl } from "@/modules/media";
+import type { CollectionConfig } from "@/modules/media";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string; photoId: string }> }
+) {
+  try {
+    const { token, photoId } = await params;
+    const shareToken = await validateMediaShareToken(token, "COLLECTION");
+    const config = shareToken.config as CollectionConfig | null;
+    if (!config) throw new ApiError(400, "Configuration manquante");
+
+    const photo = await prisma.mediaPhoto.findUnique({
+      where: { id: photoId },
+      select: { id: true, filename: true, mediaEventId: true, originalKey: true, status: true },
+    });
+
+    if (!photo) throw new ApiError(404, "Photo introuvable");
+    if (!config.eventIds.includes(photo.mediaEventId)) throw new ApiError(403, "Photo hors périmètre");
+    if (photo.status !== "APPROVED") throw new ApiError(403, "Photo non approuvée");
+
+    const downloadUrl = await getSignedDownloadUrl(photo.originalKey, photo.filename);
+    return successResponse({ id: photo.id, filename: photo.filename, downloadUrl });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/collection/[token]/route.ts
+++ b/src/app/api/media/collection/[token]/route.ts
@@ -1,0 +1,124 @@
+/**
+ * GET /api/media/collection/[token]
+ * Retourne les contenus d'une collection multi-sources (token COLLECTION).
+ */
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
+import type { CollectionConfig } from "@/modules/media";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  try {
+    const { token } = await params;
+    const shareToken = await validateMediaShareToken(token, "COLLECTION");
+    const config = shareToken.config as CollectionConfig | null;
+
+    if (!config) throw new ApiError(400, "Configuration de collection manquante");
+
+    const { scope, eventIds, projectIds } = config;
+
+    // ── Photos (scope: photos | both) ──────────────────────────────────────────
+    type PhotoGroup = {
+      eventId: string;
+      eventName: string;
+      eventDate: string;
+      photos: { id: string; filename: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }[];
+    };
+    const photoGroups: PhotoGroup[] = [];
+
+    if ((scope === "photos" || scope === "both") && eventIds.length > 0) {
+      const events = await prisma.mediaEvent.findMany({
+        where: { id: { in: eventIds } },
+        orderBy: { date: "desc" },
+        include: {
+          photos: {
+            where: { status: "APPROVED" },
+            orderBy: { uploadedAt: "asc" },
+            select: { id: true, filename: true, size: true, width: true, height: true, thumbnailKey: true },
+          },
+        },
+      });
+
+      for (const event of events) {
+        const photos = await Promise.all(
+          event.photos.map(async (p) => ({
+            id: p.id,
+            filename: p.filename,
+            size: p.size,
+            width: p.width,
+            height: p.height,
+            thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
+          }))
+        );
+        photoGroups.push({ eventId: event.id, eventName: event.name, eventDate: event.date.toISOString(), photos });
+      }
+    }
+
+    // ── Fichiers/Visuels (scope: files | both) ─────────────────────────────────
+    type FileGroup = {
+      projectId: string;
+      projectName: string;
+      files: { id: string; filename: string; type: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }[];
+    };
+    const fileGroups: FileGroup[] = [];
+
+    if ((scope === "files" || scope === "both") && projectIds.length > 0) {
+      const projects = await prisma.mediaProject.findMany({
+        where: { id: { in: projectIds } },
+        orderBy: { createdAt: "desc" },
+        include: {
+          files: {
+            where: { status: { in: ["APPROVED", "FINAL_APPROVED"] } },
+            orderBy: { createdAt: "asc" },
+            select: {
+              id: true,
+              filename: true,
+              type: true,
+              size: true,
+              width: true,
+              height: true,
+              versions: {
+                orderBy: { versionNumber: "desc" },
+                take: 1,
+                select: { thumbnailKey: true },
+              },
+            },
+          },
+        },
+      });
+
+      for (const project of projects) {
+        const files = await Promise.all(
+          project.files.map(async (f) => ({
+            id: f.id,
+            filename: f.filename,
+            type: f.type,
+            size: f.size,
+            width: f.width,
+            height: f.height,
+            thumbnailUrl: f.versions[0]?.thumbnailKey
+              ? await getSignedThumbnailUrl(f.versions[0].thumbnailKey)
+              : "",
+          }))
+        );
+        fileGroups.push({ projectId: project.id, projectName: project.name, files });
+      }
+    }
+
+    const totalPhotos = photoGroups.reduce((n, g) => n + g.photos.length, 0);
+    const totalFiles  = fileGroups.reduce((n, g) => n + g.files.length, 0);
+
+    return successResponse({
+      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label, config },
+      photoGroups,
+      fileGroups,
+      totalPhotos,
+      totalFiles,
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/media/collection/[token]/zip/route.ts
+++ b/src/app/api/media/collection/[token]/zip/route.ts
@@ -1,0 +1,140 @@
+/**
+ * POST /api/media/collection/[token]/zip
+ * Streame un ZIP de la collection (photos approuvées + visuels approuvés).
+ * Body: { photoIds?: string[]; fileIds?: string[] } — si absent, tout est inclus.
+ */
+import { prisma } from "@/lib/prisma";
+import { errorResponse, ApiError } from "@/lib/api-utils";
+import { validateMediaShareToken, getS3ObjectStream } from "@/modules/media";
+import type { CollectionConfig } from "@/modules/media";
+import archiver from "archiver";
+import { PassThrough } from "node:stream";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+
+const bodySchema = z.object({
+  photoIds: z.array(z.string()).optional(),
+  fileIds:  z.array(z.string()).optional(),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  try {
+    const { token } = await params;
+    const shareToken = await validateMediaShareToken(token, "COLLECTION");
+    const config = shareToken.config as CollectionConfig | null;
+    if (!config) throw new ApiError(400, "Configuration manquante");
+
+    const body = bodySchema.parse(await request.json().catch(() => ({})));
+    const { scope, eventIds, projectIds } = config;
+
+    type PhotoEntry = { filename: string; originalKey: string; folder: string };
+    type FileEntry  = { filename: string; originalKey: string; folder: string };
+
+    const photoEntries: PhotoEntry[] = [];
+    const fileEntries:  FileEntry[]  = [];
+
+    // ── Photos ─────────────────────────────────────────────────────────────────
+    if ((scope === "photos" || scope === "both") && eventIds.length > 0) {
+      const events = await prisma.mediaEvent.findMany({
+        where: { id: { in: eventIds } },
+        select: {
+          id: true,
+          name: true,
+          photos: {
+            where: {
+              status: "APPROVED",
+              ...(body.photoIds?.length ? { id: { in: body.photoIds } } : {}),
+            },
+            select: { filename: true, originalKey: true },
+          },
+        },
+      });
+
+      for (const event of events) {
+        const safeFolder = event.name.replace(/[^a-z0-9\-_]/gi, "_").slice(0, 50);
+        for (const p of event.photos) {
+          photoEntries.push({ filename: p.filename, originalKey: p.originalKey, folder: safeFolder });
+        }
+      }
+    }
+
+    // ── Fichiers visuels ───────────────────────────────────────────────────────
+    if ((scope === "files" || scope === "both") && projectIds.length > 0) {
+      const projects = await prisma.mediaProject.findMany({
+        where: { id: { in: projectIds } },
+        select: {
+          id: true,
+          name: true,
+          files: {
+            where: {
+              status: { in: ["APPROVED", "FINAL_APPROVED"] },
+              ...(body.fileIds?.length ? { id: { in: body.fileIds } } : {}),
+            },
+            select: {
+              filename: true,
+              versions: {
+                orderBy: { versionNumber: "desc" },
+                take: 1,
+                select: { originalKey: true },
+              },
+            },
+          },
+        },
+      });
+
+      for (const project of projects) {
+        const safeFolder = project.name.replace(/[^a-z0-9\-_]/gi, "_").slice(0, 50);
+        for (const f of project.files) {
+          if (f.versions[0]?.originalKey) {
+            fileEntries.push({ filename: f.filename, originalKey: f.versions[0].originalKey, folder: safeFolder });
+          }
+        }
+      }
+    }
+
+    const totalEntries = photoEntries.length + fileEntries.length;
+    if (totalEntries === 0) throw new ApiError(404, "Aucun fichier disponible");
+
+    const label = shareToken.label ?? "collection";
+    const safeLabel = label.replace(/[^a-z0-9\-_]/gi, "_").slice(0, 60);
+
+    const archive = archiver("zip", { zlib: { level: 1 } });
+    const passthrough = new PassThrough();
+    archive.pipe(passthrough);
+
+    (async () => {
+      const allEntries = [...photoEntries, ...fileEntries];
+      for (const entry of allEntries) {
+        try {
+          const stream = await getS3ObjectStream(entry.originalKey);
+          archive.append(stream, { name: `${entry.folder}/${entry.filename}` });
+        } catch {
+          // Fichier manquant en S3 — skip sans planter le ZIP
+        }
+      }
+      await archive.finalize();
+    })();
+
+    const readable = new ReadableStream({
+      start(controller) {
+        passthrough.on("data", (chunk) => controller.enqueue(chunk));
+        passthrough.on("end", () => controller.close());
+        passthrough.on("error", (err) => controller.error(err));
+      },
+    });
+
+    return new Response(readable, {
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": `attachment; filename="${safeLabel}.zip"`,
+        "Transfer-Encoding": "chunked",
+      },
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/media/c/[token]/CollectionView.tsx
+++ b/src/app/media/c/[token]/CollectionView.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import type { CollectionConfig } from "@/modules/media";
+
+type Photo = {
+  id: string;
+  filename: string;
+  size: number;
+  width: number | null;
+  height: number | null;
+  thumbnailUrl: string;
+};
+
+type MediaFile = {
+  id: string;
+  filename: string;
+  type: string;
+  size: number;
+  width: number | null;
+  height: number | null;
+  thumbnailUrl: string;
+};
+
+type PhotoGroup = {
+  eventId: string;
+  eventName: string;
+  eventDate: string;
+  photos: Photo[];
+};
+
+type FileGroup = {
+  projectId: string;
+  projectName: string;
+  files: MediaFile[];
+};
+
+type CollectionData = {
+  token: { id: string; label: string | null; config: CollectionConfig };
+  photoGroups: PhotoGroup[];
+  fileGroups: FileGroup[];
+};
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" });
+}
+
+function formatSize(bytes: number) {
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} Ko`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} Mo`;
+}
+
+// ── Lightbox ──────────────────────────────────────────────────────────────────
+
+type LightboxItem = { kind: "photo"; item: Photo } | { kind: "file"; item: MediaFile };
+
+function Lightbox({
+  items,
+  index,
+  token,
+  onClose,
+  onPrev,
+  onNext,
+}: {
+  items: LightboxItem[];
+  index: number;
+  token: string;
+  onClose: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  const current = items[index];
+  const [downloading, setDownloading] = useState(false);
+
+  async function download() {
+    setDownloading(true);
+    try {
+      const path =
+        current.kind === "photo"
+          ? `/api/media/collection/${token}/photo/${current.item.id}`
+          : `/api/media/collection/${token}/file/${current.item.id}`;
+      const res = await fetch(path);
+      const json = await res.json();
+      if (!res.ok || !json.downloadUrl) return;
+      const a = document.createElement("a");
+      a.href = json.downloadUrl;
+      a.download = current.item.filename;
+      a.click();
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/95 flex flex-col" onClick={onClose}>
+      {/* Top bar */}
+      <div className="flex items-center justify-between px-4 py-3 shrink-0" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center gap-3 min-w-0">
+          <button onClick={onClose} className="text-white/70 hover:text-white transition-colors shrink-0">
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <span className="text-white/80 text-sm truncate">{current.item.filename}</span>
+          {current.kind === "file" && (
+            <span className="text-xs text-icc-violet bg-icc-violet/20 rounded-full px-2 py-0.5 shrink-0">
+              {current.item.type}
+            </span>
+          )}
+        </div>
+        <span className="text-white/50 text-sm tabular-nums shrink-0">{index + 1}/{items.length}</span>
+      </div>
+
+      {/* Image */}
+      <div className="flex-1 flex items-center justify-center relative px-14 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+        <button onClick={onPrev} disabled={index === 0} className="absolute left-3 top-1/2 -translate-y-1/2 text-white/60 hover:text-white bg-black/40 hover:bg-black/60 rounded-full p-2.5 transition-all disabled:opacity-20 z-10">
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <button onClick={onNext} disabled={index === items.length - 1} className="absolute right-3 top-1/2 -translate-y-1/2 text-white/60 hover:text-white bg-black/40 hover:bg-black/60 rounded-full p-2.5 transition-all disabled:opacity-20 z-10">
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={current.item.thumbnailUrl}
+          alt={current.item.filename}
+          className="max-w-full max-h-[75vh] object-contain rounded shadow-2xl"
+        />
+      </div>
+
+      {/* Bottom bar */}
+      <div className="flex items-center justify-end px-4 py-3 gap-3 shrink-0" onClick={(e) => e.stopPropagation()}>
+        <button
+          onClick={download}
+          disabled={downloading}
+          className="flex items-center gap-1.5 text-sm bg-icc-violet text-white px-3 py-1.5 rounded-lg hover:bg-icc-violet/90 disabled:opacity-50 transition-colors font-medium"
+        >
+          {downloading ? (
+            <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+          ) : (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+            </svg>
+          )}
+          Télécharger
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+export default function CollectionView({ token, data }: { token: string; data: CollectionData }) {
+  const { photoGroups, fileGroups } = data;
+
+  // Flat list for lightbox navigation
+  const allItems: LightboxItem[] = [
+    ...photoGroups.flatMap((g) => g.photos.map((p): LightboxItem => ({ kind: "photo", item: p }))),
+    ...fileGroups.flatMap((g) => g.files.map((f): LightboxItem => ({ kind: "file", item: f }))),
+  ];
+
+  // Maps item.id → flat index
+  const idxMap = new Map<string, number>();
+  allItems.forEach((it, i) => idxMap.set(it.item.id, i));
+
+  const [lightboxIdx, setLightboxIdx] = useState<number | null>(null);
+  const [zipping, setZipping]         = useState(false);
+
+  const closeLightbox = useCallback(() => setLightboxIdx(null), []);
+  const prevItem = useCallback(() => setLightboxIdx((i) => i !== null ? Math.max(0, i - 1) : null), []);
+  const nextItem = useCallback(() => setLightboxIdx((i) => i !== null ? Math.min(allItems.length - 1, i + 1) : null), [allItems.length]);
+
+  const totalPhotos = photoGroups.reduce((n, g) => n + g.photos.length, 0);
+  const totalFiles  = fileGroups.reduce((n, g) => n + g.files.length, 0);
+
+  async function downloadZip() {
+    setZipping(true);
+    try {
+      const res = await fetch(`/api/media/collection/${token}/zip`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) return;
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = res.headers.get("Content-Disposition")?.match(/filename="(.+)"/)?.[1] ?? "collection.zip";
+      a.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setZipping(false);
+    }
+  }
+
+  return (
+    <>
+      {lightboxIdx !== null && (
+        <Lightbox
+          items={allItems}
+          index={lightboxIdx}
+          token={token}
+          onClose={closeLightbox}
+          onPrev={prevItem}
+          onNext={nextItem}
+        />
+      )}
+
+      <div className="min-h-screen bg-gray-50">
+        {/* Header */}
+        <header className="bg-white border-b border-gray-200 px-4 py-5">
+          <div className="max-w-5xl mx-auto">
+            <h1 className="text-xl font-bold text-gray-900">
+              {data.token.label ?? "Collection"}
+            </h1>
+            <div className="flex items-center justify-between mt-2 flex-wrap gap-2">
+              <p className="text-sm text-gray-500">
+                {totalPhotos > 0 && `${totalPhotos} photo${totalPhotos !== 1 ? "s" : ""}`}
+                {totalPhotos > 0 && totalFiles > 0 && " · "}
+                {totalFiles > 0 && `${totalFiles} visuel${totalFiles !== 1 ? "s" : ""}`}
+              </p>
+              {allItems.length > 0 && (
+                <button
+                  onClick={downloadZip}
+                  disabled={zipping}
+                  className="flex items-center gap-1.5 text-sm bg-icc-violet text-white px-4 py-2 rounded-lg hover:bg-icc-violet/90 disabled:opacity-50 transition-colors font-medium"
+                >
+                  {zipping ? (
+                    <>
+                      <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                      Préparation…
+                    </>
+                  ) : (
+                    <>
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                      </svg>
+                      Tout télécharger (.zip)
+                    </>
+                  )}
+                </button>
+              )}
+            </div>
+          </div>
+        </header>
+
+        <main className="max-w-5xl mx-auto p-4 space-y-8">
+          {allItems.length === 0 && (
+            <p className="text-center text-gray-400 py-16">Aucun contenu disponible.</p>
+          )}
+
+          {/* Photos grouped by event */}
+          {photoGroups.map((group) => (
+            group.photos.length > 0 && (
+              <section key={group.eventId}>
+                <div className="flex items-baseline gap-2 mb-3">
+                  <h2 className="text-base font-semibold text-gray-800">{group.eventName}</h2>
+                  <span className="text-xs text-gray-400">{formatDate(group.eventDate)}</span>
+                  <span className="text-xs text-gray-400">· {group.photos.length} photo{group.photos.length !== 1 ? "s" : ""}</span>
+                </div>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
+                  {group.photos.map((photo) => (
+                    <button
+                      key={photo.id}
+                      onClick={() => setLightboxIdx(idxMap.get(photo.id) ?? null)}
+                      className="group aspect-square rounded-lg overflow-hidden bg-gray-100 hover:opacity-90 transition-opacity relative"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={photo.thumbnailUrl} alt={photo.filename} className="w-full h-full object-cover transition-transform group-hover:scale-105" />
+                      <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors" />
+                    </button>
+                  ))}
+                </div>
+              </section>
+            )
+          ))}
+
+          {/* Files grouped by project */}
+          {fileGroups.map((group) => (
+            group.files.length > 0 && (
+              <section key={group.projectId}>
+                <div className="flex items-baseline gap-2 mb-3">
+                  <h2 className="text-base font-semibold text-gray-800">{group.projectName}</h2>
+                  <span className="text-xs text-gray-400">· {group.files.length} visuel{group.files.length !== 1 ? "s" : ""}</span>
+                </div>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
+                  {group.files.map((file) => {
+                    const flatIdx = idxMap.get(file.id) ?? null;
+                    return (
+                      <div key={file.id} className="group rounded-lg overflow-hidden border border-gray-200 bg-white">
+                        <button
+                          onClick={() => setLightboxIdx(flatIdx)}
+                          className="w-full aspect-square bg-gray-100 relative overflow-hidden block"
+                        >
+                          {file.thumbnailUrl ? (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img src={file.thumbnailUrl} alt={file.filename} className="w-full h-full object-cover transition-transform group-hover:scale-105" />
+                          ) : (
+                            <div className="w-full h-full flex items-center justify-center text-gray-300">
+                              <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                              </svg>
+                            </div>
+                          )}
+                          <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors" />
+                        </button>
+                        <div className="p-2">
+                          <p className="text-xs text-gray-600 truncate font-medium">{file.filename}</p>
+                          <p className="text-xs text-gray-400">{formatSize(file.size)}</p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            )
+          ))}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/src/app/media/c/[token]/page.tsx
+++ b/src/app/media/c/[token]/page.tsx
@@ -1,0 +1,125 @@
+/**
+ * Page publique collection multi-sources.
+ * Accessible via un lien COLLECTION sans authentification.
+ */
+import { notFound } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
+import type { CollectionConfig } from "@/modules/media";
+import CollectionView from "./CollectionView";
+
+async function fetchCollectionData(token: string) {
+  try {
+    const shareToken = await validateMediaShareToken(token, "COLLECTION");
+    const config = shareToken.config as CollectionConfig | null;
+    if (!config) return null;
+
+    const { scope, eventIds, projectIds } = config;
+
+    type PhotoGroup = {
+      eventId: string;
+      eventName: string;
+      eventDate: string;
+      photos: { id: string; filename: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }[];
+    };
+    const photoGroups: PhotoGroup[] = [];
+
+    if ((scope === "photos" || scope === "both") && eventIds.length > 0) {
+      const events = await prisma.mediaEvent.findMany({
+        where: { id: { in: eventIds } },
+        orderBy: { date: "desc" },
+        include: {
+          photos: {
+            where: { status: "APPROVED" },
+            orderBy: { uploadedAt: "asc" },
+            select: { id: true, filename: true, size: true, width: true, height: true, thumbnailKey: true },
+          },
+        },
+      });
+
+      for (const event of events) {
+        const photos = await Promise.all(
+          event.photos.map(async (p) => ({
+            id: p.id,
+            filename: p.filename,
+            size: p.size,
+            width: p.width,
+            height: p.height,
+            thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
+          }))
+        );
+        photoGroups.push({
+          eventId: event.id,
+          eventName: event.name,
+          eventDate: event.date.toISOString(),
+          photos,
+        });
+      }
+    }
+
+    type FileGroup = {
+      projectId: string;
+      projectName: string;
+      files: { id: string; filename: string; type: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }[];
+    };
+    const fileGroups: FileGroup[] = [];
+
+    if ((scope === "files" || scope === "both") && projectIds.length > 0) {
+      const projects = await prisma.mediaProject.findMany({
+        where: { id: { in: projectIds } },
+        orderBy: { createdAt: "desc" },
+        include: {
+          files: {
+            where: { status: { in: ["APPROVED", "FINAL_APPROVED"] } },
+            orderBy: { createdAt: "asc" },
+            select: {
+              id: true,
+              filename: true,
+              type: true,
+              size: true,
+              width: true,
+              height: true,
+              versions: {
+                orderBy: { versionNumber: "desc" },
+                take: 1,
+                select: { thumbnailKey: true },
+              },
+            },
+          },
+        },
+      });
+
+      for (const project of projects) {
+        const files = await Promise.all(
+          project.files.map(async (f) => ({
+            id: f.id,
+            filename: f.filename,
+            type: f.type,
+            size: f.size,
+            width: f.width,
+            height: f.height,
+            thumbnailUrl: f.versions[0]?.thumbnailKey
+              ? await getSignedThumbnailUrl(f.versions[0].thumbnailKey)
+              : "",
+          }))
+        );
+        fileGroups.push({ projectId: project.id, projectName: project.name, files });
+      }
+    }
+
+    return {
+      token: { id: shareToken.id, label: shareToken.label, config },
+      photoGroups,
+      fileGroups,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export default async function CollectionPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  const data = await fetchCollectionData(token);
+  if (!data) notFound();
+  return <CollectionView token={token} data={data} />;
+}

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -1,6 +1,7 @@
 import { defineModule } from "@/core/module-registry";
 
 export { createMediaShareToken, validateMediaShareToken, getTokenUrlPath, isTokenExpired, generateToken } from "./services/tokens";
+export type { CollectionConfig } from "./services/tokens";
 export { processImage, validatePhotoFile, getExtensionFromMimeType, ALLOWED_PHOTO_MIME_TYPES, MAX_PHOTO_SIZE } from "./services/image";
 export {
   uploadFile as uploadMediaFile,

--- a/src/modules/media/services/tokens.ts
+++ b/src/modules/media/services/tokens.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "crypto";
 import { prisma } from "@/lib/prisma";
 import { ApiError } from "@/lib/api-utils";
-import type { MediaTokenType } from "@/generated/prisma/client";
+import type { MediaTokenType, Prisma } from "@/generated/prisma/client";
 
 export function generateToken(): string {
   return randomBytes(32).toString("hex"); // 64 chars
@@ -16,7 +16,14 @@ export function isTokenExpired(expiresAt: Date | null): boolean {
 export function getTokenUrlPath(type: MediaTokenType): string {
   if (type === "MEDIA" || type === "MEDIA_ALL") return "d";
   if (type === "GALLERY") return "g";
+  if (type === "COLLECTION") return "c";
   return "v";
+}
+
+export interface CollectionConfig {
+  scope: "photos" | "files" | "both";
+  eventIds: string[];
+  projectIds: string[];
 }
 
 interface CreateTokenOptions {
@@ -24,10 +31,15 @@ interface CreateTokenOptions {
   label?: string;
   expiresInDays?: number;
   onlyApproved?: boolean;
+  collectionConfig?: CollectionConfig;
 }
 
 type CreateTokenWithTarget = CreateTokenOptions &
-  ({ mediaEventId: string; mediaProjectId?: never } | { mediaProjectId: string; mediaEventId?: never });
+  (
+    | { mediaEventId: string; mediaProjectId?: never }
+    | { mediaProjectId: string; mediaEventId?: never }
+    | { mediaEventId?: never; mediaProjectId?: never }
+  );
 
 /** Valide un token de partage et retourne ses données + l'événement ou projet lié. */
 export async function validateMediaShareToken(
@@ -89,24 +101,29 @@ export async function validateMediaShareToken(
 }
 
 export async function createMediaShareToken(options: CreateTokenWithTarget) {
-  const { type, label, expiresInDays, onlyApproved, mediaEventId, mediaProjectId } = options;
+  const { type, label, expiresInDays, onlyApproved, collectionConfig, mediaEventId, mediaProjectId } = options;
 
   const token = generateToken();
   const expiresAt = expiresInDays
     ? new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
     : null;
-  const config = type === "GALLERY" ? { onlyApproved: onlyApproved ?? false } : null;
+  const config =
+    type === "GALLERY"
+      ? { onlyApproved: onlyApproved ?? false }
+      : type === "COLLECTION" && collectionConfig
+        ? collectionConfig
+        : null;
 
+  // Prisma requires exactly one of mediaEventId / mediaProjectId / neither (for COLLECTION)
+  // We must build the data object with a concrete shape to satisfy the union type.
+  const configValue = config as unknown as Prisma.InputJsonValue;
+  const baseData = { token, type, label, expiresAt, ...(config ? { config: configValue } : {}) };
   const shareToken = await prisma.mediaShareToken.create({
-    data: {
-      token,
-      type,
-      label,
-      expiresAt,
-      ...(config && { config }),
-      ...(mediaEventId && { mediaEventId }),
-      ...(mediaProjectId && { mediaProjectId }),
-    },
+    data: mediaEventId
+      ? { ...baseData, mediaEventId }
+      : mediaProjectId
+        ? { ...baseData, mediaProjectId }
+        : baseData,
   });
 
   const baseUrl = process.env.APP_URL ?? process.env.NEXTAUTH_URL ?? "http://localhost:3000";


### PR DESCRIPTION
## Summary
- Nouveau type de token `COLLECTION` (migration Prisma) permettant d'agréger plusieurs événements et/ou projets dans un seul lien partageable
- Interface admin `/media/collections` : sélection de la portée (photos / visuels / les deux), filtre par période, cases à cocher événements et projets, options label + expiration
- Page publique `/media/c/[token]` : galerie unifiée groupée par source (événement ou projet), lightbox avec navigation, téléchargement individuel et ZIP groupé
- Les photos incluses sont uniquement les `APPROVED`, les fichiers visuels uniquement les `APPROVED` / `FINAL_APPROVED`
- ZIP organisé en sous-dossiers par événement/projet

## Routes ajoutées
- `POST /api/admin/media/collections` — création du token collection (requiert `media:manage`)
- `GET /api/media/collection/[token]` — données publiques de la collection
- `GET /api/media/collection/[token]/photo/[photoId]` — URL présignée photo individuelle
- `GET /api/media/collection/[token]/file/[fileId]` — URL présignée visuel individuel
- `POST /api/media/collection/[token]/zip` — stream ZIP de la collection

## Test plan
- [ ] Se connecter en tant que admin/production media
- [ ] Aller sur `/media/collections` → liste des événements et projets
- [ ] Sélectionner plusieurs éléments, générer un lien
- [ ] Ouvrir le lien `/media/c/<token>` sans être connecté → galerie groupée visible
- [ ] Télécharger un fichier individuel via lightbox
- [ ] Télécharger tout en ZIP → sous-dossiers par source

🤖 Generated with [Claude Code](https://claude.com/claude-code)