### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.5.1] - 2026-06-06
+
+### Corrigé
+
+- Formulaire rejoindre une famille : refonte UX section adresse — guidage visuel explicite, icône loupe dans le champ, message d'aide adaptatif, suggestions avec icône pin, résultat famille plus proéminent, dropdown plafonné pour le mobile
+
 ## [v1.5.0] - 2026-06-06
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Bump version `1.5.0` → `1.5.1` et mise à jour du CHANGELOG.

## Contenu

- Fix UX formulaire rejoindre une famille : guidage visuel section adresse, résultat famille proéminent, ergonomie mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)