### PR TITLE
chore: release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.5.2] - 2026-06-06
+
+### Corrigé
+
+- Navigation : les sections Intégration et Médias n'apparaissaient pas pour les super admins sans rôle église explicite (`isGlobalManager` ne prenait pas en compte `isSuperAdmin`)
+
 ## [v1.5.1] - 2026-06-06
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Bump version `1.5.1` → `1.5.2`.