### PR TITLE
fix(media): URL des collections via APP_URL au lieu de request.url

### DIFF
--- a/src/app/api/admin/media/collections/route.ts
+++ b/src/app/api/admin/media/collections/route.ts
@@ -56,7 +56,6 @@ export async function POST(request: Request) {
         eventIds: data.eventIds,
         projectIds: data.projectIds,
       },
-      baseUrl: new URL(request.url).origin,
     });
 
     await logAudit({


### PR DESCRIPTION
## Problème

La route \`/api/admin/media/collections\` (POST) est sous \`/api/admin/\` — Traefik ne forward pas le header \`Host\` de la même façon que pour \`/api/media-*\`. Résultat : \`new URL(request.url).origin\` renvoie l'URL interne au lieu de l'URL publique.

## Fix

Retrait du paramètre \`baseUrl\` dans l'appel à \`createMediaShareToken\` : la fonction utilise alors \`process.env.APP_URL\` (correctement configuré) comme base de l'URL de collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)