### PR TITLE
fix(integration): fonction Intégration manquante dans Fonctions des départements

### DIFF
--- a/src/app/(auth)/admin/departments/functions/DeptFunctionsClient.tsx
+++ b/src/app/(auth)/admin/departments/functions/DeptFunctionsClient.tsx
@@ -38,18 +38,24 @@ const FUNCTIONS = [
     description: "Gère l'agenda pastoral et planifie les rendez-vous.",
     icon: "📅",
   },
+  {
+    key: "INTEGRATION" as const,
+    label: "Intégration",
+    description: "Traite les demandes d'intégration dans les familles d'impact.",
+    icon: "🤝",
+  },
 ];
 
 export default function DeptFunctionsClient({ departments }: Props) {
   const [depts, setDepts] = useState(departments);
   const [saving, setSaving] = useState<string | null>(null);
 
-  function getAssigned(fn: "SECRETARIAT" | "COMMUNICATION" | "PRODUCTION_MEDIA" | "PROTOCOLE") {
+  function getAssigned(fn: "SECRETARIAT" | "COMMUNICATION" | "PRODUCTION_MEDIA" | "PROTOCOLE" | "INTEGRATION") {
     return depts.find((d) => d.function === fn)?.id ?? "";
   }
 
   async function handleChange(
-    fn: "SECRETARIAT" | "COMMUNICATION" | "PRODUCTION_MEDIA" | "PROTOCOLE",
+    fn: "SECRETARIAT" | "COMMUNICATION" | "PRODUCTION_MEDIA" | "PROTOCOLE" | "INTEGRATION",
     newDeptId: string
   ) {
     setSaving(fn);


### PR DESCRIPTION
## Problème

La fonction système \`INTEGRATION\` était définie dans \`department-functions.ts\` et utilisée dans \`auth.ts\` pour contrôler l'accès à la section Intégration, mais elle était **absente du tableau \`FUNCTIONS\`** dans \`DeptFunctionsClient.tsx\`.

Résultat : impossible d'assigner la fonction à un département depuis Admin → Départements → Fonctions, donc aucun membre d'équipe intégration ne pouvait voir la section dans la sidebar.

## Fix

Ajout de la carte "Intégration 🤝" dans le composant admin, avec mise à jour des types TypeScript.

## Après déploiement

Aller dans **Admin → Départements → Fonctions** et assigner la fonction "Intégration" au département concerné.

🤖 Generated with [Claude Code](https://claude.com/claude-code)