### PR TITLE
fix(media): débloquer /api/media/collection/ pour les visiteurs non authentifiés

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,10 +11,11 @@ export function proxy(request: NextRequest) {
     if (request.nextUrl.pathname.startsWith("/api/cron")) {
       return NextResponse.next();
     }
-    // Allow public media token routes (validate, gallery, download — token-based auth)
+    // Allow public media token routes (validate, gallery, download, collection — token-based auth)
     if (request.nextUrl.pathname.startsWith("/api/media/validate/") ||
         request.nextUrl.pathname.startsWith("/api/media/gallery/") ||
-        request.nextUrl.pathname.startsWith("/api/media/download/")) {
+        request.nextUrl.pathname.startsWith("/api/media/download/") ||
+        request.nextUrl.pathname.startsWith("/api/media/collection/")) {
       return NextResponse.next();
     }
     // Allow MRBS SSO endpoints (authenticated by Bearer secret, not session cookie)


### PR DESCRIPTION
## Problème

Les routes \`/api/media/collection/[token]/*\` étaient bloquées par le middleware pour les utilisateurs sans session (401 "Not authenticated"). Impossible de charger ou télécharger une collection sans être connecté.

## Cause

\`proxy.ts\` liste explicitement les routes publiques media (\`/api/media/validate/\`, \`/api/media/gallery/\`, \`/api/media/download/\`) mais omettait \`/api/media/collection/\`. La sécurité est gérée par le token de partage dans chaque route handler.

## Fix

Ajout de \`/api/media/collection/\` dans les exceptions du middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)