### PR TITLE
feat(integration): refonte UX vue demandes et fiche de suivi

### DIFF
--- a/src/app/(auth)/integration/requests/IntegrationDashboard.tsx
+++ b/src/app/(auth)/integration/requests/IntegrationDashboard.tsx
@@ -7,7 +7,7 @@ const STATUS_LABELS: Record<string, string> = {
   SUBMITTED:      "En attente",
   ASSIGNED:       "Assigné",
   CONTACTED:      "Contacté",
-  WHATSAPP_ADDED: "Ajouté dans le groupe WhatsApp famille",
+  WHATSAPP_ADDED: "WhatsApp ajouté",
   INTEGRATED:     "Intégré",
   ABANDONED:      "Abandonné",
 };
@@ -19,19 +19,6 @@ const STATUS_COLORS: Record<string, string> = {
   WHATSAPP_ADDED: "bg-green-100 text-green-700",
   INTEGRATED:     "bg-emerald-100 text-emerald-800",
   ABANDONED:      "bg-gray-100 text-gray-500",
-};
-
-const AGE_LABELS: Record<string, string> = {
-  YOUTH:        "Jeune",
-  YOUNG_ADULT:  "Jeune adulte",
-  ADULT:        "Adulte",
-  SENIOR:       "Senior",
-};
-
-const CHURCH_STATUS_LABELS: Record<string, string> = {
-  VISITOR:  "Visiteur",
-  REGULAR:  "Régulier",
-  ENGAGED:  "Engagé",
 };
 
 const STATUS_FILTERS = [
@@ -63,18 +50,46 @@ interface Request {
 interface Props {
   requests: Request[];
   isScoped: boolean;
+  currentUserId: string;
 }
 
-export default function IntegrationDashboard({ requests, isScoped }: Props) {
+function daysSince(d: Date | string): number {
+  return Math.floor((Date.now() - new Date(d).getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function getNextAction(
+  req: Request,
+  isIntegration: boolean,
+  currentUserId: string
+): string | null {
+  if (req.status === "INTEGRATED" || req.status === "ABANDONED") return null;
+  if (isIntegration && req.status === "SUBMITTED") return "Assigner";
+  const isBerger = req.assignedBerger?.id === currentUserId;
+  if (isBerger) {
+    if (req.status === "ASSIGNED") return "Marquer contacté";
+    if (req.status === "CONTACTED") return "Ajouter au groupe";
+    if (req.status === "WHATSAPP_ADDED") return "Marquer intégré";
+  }
+  return null;
+}
+
+export default function IntegrationDashboard({ requests, isScoped, currentUserId }: Props) {
   const [statusFilter, setStatusFilter] = useState("");
   const [search, setSearch] = useState("");
+  const isIntegration = !isScoped;
+
+  const actionable = useMemo(
+    () => requests.filter((r) => getNextAction(r, isIntegration, currentUserId) !== null),
+    [requests, isIntegration, currentUserId]
+  );
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
     return requests.filter((r) => {
       if (statusFilter && r.status !== statusFilter) return false;
       if (q) {
-        const haystack = `${r.firstName} ${r.lastName} ${r.phone ?? ""} ${r.email ?? ""} ${r.assignedFamilyName ?? ""}`.toLowerCase();
+        const haystack =
+          `${r.firstName} ${r.lastName} ${r.phone ?? ""} ${r.email ?? ""} ${r.assignedFamilyName ?? ""}`.toLowerCase();
         if (!haystack.includes(q)) return false;
       }
       return true;
@@ -88,7 +103,53 @@ export default function IntegrationDashboard({ requests, isScoped }: Props) {
   }, [requests]);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
+      {/* Bandeau "À traiter" */}
+      {actionable.length > 0 && (
+        <div className="bg-icc-violet/5 border border-icc-violet/20 rounded-xl p-4 space-y-3">
+          <h2 className="text-sm font-semibold text-icc-violet flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-icc-violet animate-pulse" />
+            À traiter
+            <span className="text-icc-violet/60 font-normal">({actionable.length})</span>
+          </h2>
+          <div className="space-y-1.5">
+            {actionable.slice(0, 6).map((r) => {
+              const action = getNextAction(r, isIntegration, currentUserId)!;
+              const days = daysSince(r.submittedAt);
+              return (
+                <Link
+                  key={r.id}
+                  href={`/integration/requests/${r.id}`}
+                  className="flex items-center justify-between gap-3 bg-white rounded-lg px-3 py-2.5 border border-gray-100 hover:border-icc-violet/40 hover:shadow-sm transition-all group"
+                >
+                  <div className="min-w-0">
+                    <p className="font-medium text-gray-900 text-sm">
+                      {r.firstName} {r.lastName}
+                    </p>
+                    <p className="text-xs text-gray-400 mt-0.5">
+                      {STATUS_LABELS[r.status]}
+                      {r.assignedFamilyName ? ` · ${r.assignedFamilyName}` : ""}
+                      {" · "}
+                      <span className={days >= 7 ? "text-amber-600 font-medium" : ""}>
+                        {days}j
+                      </span>
+                    </p>
+                  </div>
+                  <span className="shrink-0 text-xs font-medium text-icc-violet bg-icc-violet/10 px-2.5 py-1 rounded-full group-hover:bg-icc-violet group-hover:text-white transition-colors whitespace-nowrap">
+                    {action} →
+                  </span>
+                </Link>
+              );
+            })}
+            {actionable.length > 6 && (
+              <p className="text-xs text-gray-400 text-center pt-0.5">
+                + {actionable.length - 6} autres demandes à traiter
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Filtres statut */}
       <div className="flex flex-wrap gap-2">
         {STATUS_FILTERS.map((f) => {
@@ -105,7 +166,11 @@ export default function IntegrationDashboard({ requests, isScoped }: Props) {
               }`}
             >
               {f.label}
-              <span className={`text-xs px-1.5 py-0.5 rounded-full ${active ? "bg-white/20" : "bg-gray-100 text-gray-500"}`}>
+              <span
+                className={`text-xs px-1.5 py-0.5 rounded-full ${
+                  active ? "bg-white/20" : "bg-gray-100 text-gray-500"
+                }`}
+              >
                 {count}
               </span>
             </button>
@@ -113,23 +178,23 @@ export default function IntegrationDashboard({ requests, isScoped }: Props) {
         })}
       </div>
 
-      {/* Recherche */}
-      <input
-        type="search"
-        placeholder="Rechercher par nom, téléphone, famille…"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        className="w-full sm:w-80 border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet"
-      />
+      {/* Recherche + scope notice */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <input
+          type="search"
+          placeholder="Rechercher par nom, téléphone, famille…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full sm:w-80 border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet"
+        />
+        {isScoped && (
+          <p className="text-sm text-gray-500 bg-blue-50 border border-blue-100 rounded-lg px-3 py-2 self-start">
+            Affichage limité aux demandes de votre famille.
+          </p>
+        )}
+      </div>
 
-      {/* Message scope berger */}
-      {isScoped && (
-        <p className="text-sm text-gray-500 bg-blue-50 border border-blue-100 rounded-lg px-3 py-2">
-          Affichage limité aux demandes de votre famille.
-        </p>
-      )}
-
-      {/* Tableau */}
+      {/* Liste */}
       {filtered.length === 0 ? (
         <div className="bg-white rounded-xl border border-gray-200 p-8 text-center text-gray-400 text-sm">
           Aucune demande{statusFilter ? " avec ce statut" : ""}.
@@ -142,105 +207,158 @@ export default function IntegrationDashboard({ requests, isScoped }: Props) {
               <thead>
                 <tr className="border-b border-gray-100 bg-gray-50 text-left text-xs text-gray-500 uppercase tracking-wide">
                   <th className="px-4 py-3 font-medium">Personne</th>
-                  <th className="px-4 py-3 font-medium">Profil</th>
                   <th className="px-4 py-3 font-medium">Statut</th>
-                  <th className="px-4 py-3 font-medium">Famille</th>
-                  <th className="px-4 py-3 font-medium">Berger</th>
-                  <th className="px-4 py-3 font-medium">Soumis le</th>
+                  <th className="px-4 py-3 font-medium">Famille · Berger</th>
+                  <th className="px-4 py-3 font-medium">Depuis</th>
                   <th className="px-4 py-3"></th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
-                {filtered.map((r) => (
-                  <tr key={r.id} className="hover:bg-gray-50 transition-colors">
-                    <td className="px-4 py-3">
-                      <p className="font-medium text-gray-900">{r.firstName} {r.lastName}</p>
-                      {r.phone && <p className="text-xs text-gray-400">{r.phone}</p>}
-                      {r.pastoralCareRequested && (
-                        <span className="inline-block mt-0.5 text-xs text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded">
-                          Soin pastoral
+                {filtered.map((r) => {
+                  const days = daysSince(r.submittedAt);
+                  const isYours = r.assignedBerger?.id === currentUserId;
+                  const nextAction = getNextAction(r, isIntegration, currentUserId);
+                  return (
+                    <tr
+                      key={r.id}
+                      className={`hover:bg-gray-50 transition-colors ${isYours ? "bg-icc-violet/[0.02]" : ""}`}
+                    >
+                      <td className="px-4 py-3">
+                        <p className="font-medium text-gray-900">
+                          {r.firstName} {r.lastName}
+                        </p>
+                        <div className="flex flex-wrap gap-1 mt-0.5">
+                          {isYours && (
+                            <span className="text-xs text-icc-violet bg-icc-violet/10 px-1.5 py-0.5 rounded font-medium">
+                              Vous
+                            </span>
+                          )}
+                          {r.pastoralCareRequested && (
+                            <span className="text-xs text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded">
+                              Soin pastoral
+                            </span>
+                          )}
+                          {r.salvationCall && (
+                            <span className="text-xs text-purple-700 bg-purple-50 px-1.5 py-0.5 rounded">
+                              Appel au salut
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
+                            STATUS_COLORS[r.status] ?? "bg-gray-100 text-gray-600"
+                          }`}
+                        >
+                          {STATUS_LABELS[r.status] ?? r.status}
                         </span>
-                      )}
-                      {r.salvationCall && (
-                        <span className="inline-block mt-0.5 text-xs text-purple-700 bg-purple-50 px-1.5 py-0.5 rounded">
-                          Appel au salut
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-500">
+                        {r.assignedFamilyName ? (
+                          <div>
+                            <p className="font-medium text-gray-700">{r.assignedFamilyName}</p>
+                            {r.assignedBerger?.name && (
+                              <p className="text-gray-400">{r.assignedBerger.name}</p>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="text-gray-300">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <span
+                          className={`text-xs ${
+                            days >= 7 ? "text-amber-600 font-semibold" : "text-gray-400"
+                          }`}
+                        >
+                          {days}j
                         </span>
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-gray-500">
-                      <p>{AGE_LABELS[r.ageRange] ?? r.ageRange}</p>
-                      <p className="text-xs">{CHURCH_STATUS_LABELS[r.churchStatus] ?? r.churchStatus}</p>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[r.status] ?? "bg-gray-100 text-gray-600"}`}>
-                        {STATUS_LABELS[r.status] ?? r.status}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-gray-500 text-xs">
-                      {r.assignedFamilyName ?? <span className="text-gray-300">—</span>}
-                    </td>
-                    <td className="px-4 py-3 text-gray-500 text-xs">
-                      {r.assignedBerger?.name ?? <span className="text-gray-300">—</span>}
-                    </td>
-                    <td className="px-4 py-3 text-gray-400 text-xs whitespace-nowrap">
-                      {new Date(r.submittedAt).toLocaleDateString("fr-FR", { day: "2-digit", month: "short", year: "numeric" })}
-                    </td>
-                    <td className="px-4 py-3">
-                      <Link
-                        href={`/integration/requests/${r.id}`}
-                        className="text-icc-violet text-xs font-medium hover:underline whitespace-nowrap"
-                      >
-                        Voir →
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        {nextAction ? (
+                          <Link
+                            href={`/integration/requests/${r.id}`}
+                            className="text-xs font-medium text-icc-violet bg-icc-violet/10 px-2.5 py-1 rounded-full hover:bg-icc-violet hover:text-white transition-colors whitespace-nowrap"
+                          >
+                            {nextAction} →
+                          </Link>
+                        ) : (
+                          <Link
+                            href={`/integration/requests/${r.id}`}
+                            className="text-xs font-medium text-icc-violet border border-icc-violet/40 px-2.5 py-1 rounded-full hover:bg-icc-violet hover:text-white transition-colors whitespace-nowrap"
+                          >
+                            Voir →
+                          </Link>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
 
           {/* Mobile cards */}
           <div className="md:hidden divide-y divide-gray-100">
-            {filtered.map((r) => (
-              <Link
-                key={r.id}
-                href={`/integration/requests/${r.id}`}
-                className="block px-4 py-3 hover:bg-gray-50 transition-colors"
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="min-w-0">
-                    <p className="font-medium text-gray-900">{r.firstName} {r.lastName}</p>
-                    {r.phone && <p className="text-xs text-gray-400 mt-0.5">{r.phone}</p>}
-                    <div className="flex flex-wrap gap-1.5 mt-1.5">
-                      <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[r.status] ?? "bg-gray-100 text-gray-600"}`}>
-                        {STATUS_LABELS[r.status] ?? r.status}
-                      </span>
-                      {r.pastoralCareRequested && (
-                        <span className="inline-flex px-2 py-0.5 rounded-full text-xs bg-amber-50 text-amber-600">
-                          Soin pastoral
+            {filtered.map((r) => {
+              const days = daysSince(r.submittedAt);
+              const isYours = r.assignedBerger?.id === currentUserId;
+              const nextAction = getNextAction(r, isIntegration, currentUserId);
+              return (
+                <Link
+                  key={r.id}
+                  href={`/integration/requests/${r.id}`}
+                  className="block px-4 py-3 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5 flex-wrap">
+                        <p className="font-medium text-gray-900">
+                          {r.firstName} {r.lastName}
+                        </p>
+                        {isYours && (
+                          <span className="text-xs text-icc-violet bg-icc-violet/10 px-1.5 py-0.5 rounded font-medium">
+                            Vous
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex flex-wrap gap-1.5 mt-1.5">
+                        <span
+                          className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
+                            STATUS_COLORS[r.status] ?? "bg-gray-100 text-gray-600"
+                          }`}
+                        >
+                          {STATUS_LABELS[r.status] ?? r.status}
                         </span>
-                      )}
-                      {r.salvationCall && (
-                        <span className="inline-flex px-2 py-0.5 rounded-full text-xs bg-purple-50 text-purple-700">
-                          Appel au salut
-                        </span>
+                        {nextAction && (
+                          <span className="text-xs font-medium text-icc-violet bg-icc-violet/10 px-2 py-0.5 rounded-full">
+                            {nextAction} →
+                          </span>
+                        )}
+                      </div>
+                      {r.assignedFamilyName && (
+                        <p className="text-xs text-gray-500 mt-1">{r.assignedFamilyName}</p>
                       )}
                     </div>
-                    {r.assignedFamilyName && (
-                      <p className="text-xs text-gray-500 mt-1">{r.assignedFamilyName}</p>
-                    )}
+                    <span
+                      className={`text-xs shrink-0 mt-0.5 ${
+                        days >= 7 ? "text-amber-600 font-semibold" : "text-gray-400"
+                      }`}
+                    >
+                      {days}j
+                    </span>
                   </div>
-                  <span className="text-xs text-gray-400 shrink-0">
-                    {new Date(r.submittedAt).toLocaleDateString("fr-FR", { day: "2-digit", month: "short" })}
-                  </span>
-                </div>
-              </Link>
-            ))}
+                </Link>
+              );
+            })}
           </div>
         </div>
       )}
 
-      <p className="text-xs text-gray-400 text-right">{filtered.length} demande{filtered.length !== 1 ? "s" : ""}</p>
+      <p className="text-xs text-gray-400 text-right">
+        {filtered.length} demande{filtered.length !== 1 ? "s" : ""}
+      </p>
     </div>
   );
 }

--- a/src/app/(auth)/integration/requests/PublicFormBanner.tsx
+++ b/src/app/(auth)/integration/requests/PublicFormBanner.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function PublicFormBanner({ slug }: { slug: string }) {
   const [copied, setCopied] = useState(false);
-  const url = `${typeof window !== "undefined" ? window.location.origin : ""}/rejoindre/${slug}`;
+  const [origin, setOrigin] = useState("");
+  useEffect(() => { setOrigin(window.location.origin); }, []);
+  const url = `${origin}/rejoindre/${slug}`;
 
   function copy() {
     navigator.clipboard.writeText(url).then(() => {

--- a/src/app/(auth)/integration/requests/[id]/RequestDetail.tsx
+++ b/src/app/(auth)/integration/requests/[id]/RequestDetail.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { useRouter } from "next/navigation";
 import Modal from "@/components/ui/Modal";
 
-// ── Labels ───────────────────────────────────────────────────────────────────
+// ── Labels ────────────────────────────────────────────────────────────────────
 
 const STATUS_LABELS: Record<string, string> = {
   SUBMITTED:      "En attente",
@@ -25,10 +25,10 @@ const STATUS_COLORS: Record<string, string> = {
 };
 
 const AGE_LABELS: Record<string, string> = {
-  YOUTH: "Jeune (−18 ans)",
-  YOUNG_ADULT: "Jeune adulte (18–30 ans)",
-  ADULT: "Adulte (30–60 ans)",
-  SENIOR: "Senior (60+ ans)",
+  YOUTH:        "Jeune (−18 ans)",
+  YOUNG_ADULT:  "Jeune adulte (18–30 ans)",
+  ADULT:        "Adulte (30–60 ans)",
+  SENIOR:       "Senior (60+ ans)",
 };
 
 const CHURCH_STATUS_LABELS: Record<string, string> = {
@@ -37,17 +37,6 @@ const CHURCH_STATUS_LABELS: Record<string, string> = {
   ENGAGED: "Engagé — je sers",
 };
 
-const WORKFLOW_STEPS = [
-  { status: "SUBMITTED",      label: "Soumise",         tsKey: "submittedAt" },
-  { status: "ASSIGNED",       label: "Assignée",         tsKey: "assignedAt" },
-  { status: "CONTACTED",      label: "Contacté·e",       tsKey: "contactedAt" },
-  { status: "WHATSAPP_ADDED", label: "Ajouté dans le groupe WhatsApp famille",  tsKey: "whatsappAddedAt" },
-  { status: "INTEGRATED",     label: "Intégré·e",        tsKey: "integratedAt" },
-];
-
-const STATUS_ORDER = ["SUBMITTED", "ASSIGNED", "CONTACTED", "WHATSAPP_ADDED", "INTEGRATED"];
-
-// ── MSDP labels ───────────────────────────────────────────────────────────────
 
 const MSDP_STATUS_LABELS: Record<string, string> = {
   SUBMITTED:    "Appel reçu",
@@ -67,17 +56,31 @@ const MSDP_STATUS_COLORS: Record<string, string> = {
   ABANDONED:    "bg-red-100 text-red-600",
 };
 
-const MSDP_WORKFLOW_STEPS = [
-  { status: "SUBMITTED",    label: "Appel reçu",          tsKey: "createdAt" },
-  { status: "ASSIGNED",     label: "Conseiller assigné",  tsKey: "assignedAt" },
-  { status: "CONTACTED",    label: "Premier contact",     tsKey: "contactedAt" },
-  { status: "IN_FORMATION", label: "En formation",   tsKey: "inFormationAt" },
-  { status: "COMPLETED",    label: "Terminé",             tsKey: "completedAt" },
-];
 
-const MSDP_STATUS_ORDER = ["SUBMITTED", "ASSIGNED", "CONTACTED", "IN_FORMATION", "COMPLETED"];
+// ── Milestones ─────────────────────────────────────────────────────────────────
+
+const MILESTONES = [
+  { key: "integratedInFamily" as const, label: "Famille",    tsKey: "familyIntegratedAt" as const },
+  { key: "followsPcnc"        as const, label: "PCNC",       tsKey: "pcncStartedAt"      as const },
+  { key: "isStar"             as const, label: "Service",    tsKey: "starSince"           as const },
+  { key: "inDiscipleship"     as const, label: "Discipolat", tsKey: "discipleshipSince"   as const },
+] as const;
+
+type MilestoneKey = (typeof MILESTONES)[number]["key"];
 
 // ── Types ─────────────────────────────────────────────────────────────────────
+
+interface PersonJourneyData {
+  id: string;
+  integratedInFamily: boolean;
+  familyIntegratedAt: Date | string | null;
+  followsPcnc: boolean;
+  pcncStartedAt: Date | string | null;
+  isStar: boolean;
+  starSince: Date | string | null;
+  inDiscipleship: boolean;
+  discipleshipSince: Date | string | null;
+}
 
 interface MsdpFollowUpType {
   id: string;
@@ -123,11 +126,17 @@ interface Request {
   lat: number | null;
   lng: number | null;
   msdpFollowUp: MsdpFollowUpType | null;
-  personJourney: { id: string } | null;
+  personJourney: PersonJourneyData | null;
 }
 
 interface Family { id: number; name: string; }
-interface Leader { id: string; userId: string; familyId: number; role: string; user: { id: string; name: string | null; email: string | null }; }
+interface Leader {
+  id: string;
+  userId: string;
+  familyId: number;
+  role: string;
+  user: { id: string; name: string | null; email: string | null };
+}
 
 interface Props {
   request: Request;
@@ -143,77 +152,205 @@ function fmt(d: Date | string | null) {
   return new Date(d).toLocaleDateString("fr-FR", { day: "2-digit", month: "long", year: "numeric" });
 }
 
-function fmtFull(d: Date | string | null) {
+function fmtShort(d: Date | string | null) {
   if (!d) return null;
-  return new Date(d).toLocaleString("fr-FR", { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" });
+  return new Date(d).toLocaleDateString("fr-FR", { day: "2-digit", month: "short" });
 }
 
-// ── Section card ──────────────────────────────────────────────────────────────
 
-function Card({ title, children }: { title: string; children: React.ReactNode }) {
+// ── Timeline ──────────────────────────────────────────────────────────────────
+
+interface StepData {
+  label: string;
+  done: boolean;
+  current: boolean;
+  ts: Date | string | null;
+}
+
+const TRACK_THEME = {
+  violet: {
+    circleCurrent: "bg-icc-violet text-white ring-2 ring-icc-violet/20",
+    circleDone:    "bg-icc-violet/15 text-icc-violet",
+    circlePending: "bg-gray-100 text-gray-400",
+    lineActive:    "bg-icc-violet",
+    linePending:   "bg-gray-200",
+    dotActive:     "bg-icc-violet",
+    dotDone:       "bg-icc-violet/35",
+    dotPending:    "bg-gray-200",
+  },
+  purple: {
+    circleCurrent: "bg-purple-600 text-white ring-2 ring-purple-200",
+    circleDone:    "bg-purple-100 text-purple-700",
+    circlePending: "bg-gray-100 text-gray-400",
+    lineActive:    "bg-purple-500",
+    linePending:   "bg-gray-200",
+    dotActive:     "bg-purple-600",
+    dotDone:       "bg-purple-200",
+    dotPending:    "bg-gray-200",
+  },
+} as const;
+
+function TrackTimeline({ steps, theme = "violet" }: { steps: StepData[]; theme?: keyof typeof TRACK_THEME }) {
+  const t = TRACK_THEME[theme];
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-4 md:p-5 space-y-3">
-      <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide">{title}</h2>
-      {children}
+    <>
+      {/* Desktop: frise horizontale complète */}
+      <div className="hidden sm:flex items-start">
+        {steps.map((step, i) => (
+          <Fragment key={i}>
+            {i > 0 && (
+              <div
+                className={`flex-1 h-0.5 self-start mt-[9px] ${
+                  steps[i - 1].done ? t.lineActive : t.linePending
+                }`}
+              />
+            )}
+            <div className="flex flex-col items-center" style={{ minWidth: 56 }}>
+              <div
+                className={`w-[18px] h-[18px] rounded-full flex items-center justify-center text-[10px] font-bold ${
+                  step.current ? t.circleCurrent : step.done ? t.circleDone : t.circlePending
+                }`}
+              >
+                {step.done && !step.current ? "✓" : i + 1}
+              </div>
+              <p
+                className={`text-[11px] text-center mt-1 leading-snug max-w-[52px] ${
+                  step.done ? "text-gray-700 font-medium" : "text-gray-400"
+                }`}
+              >
+                {step.label}
+              </p>
+              {step.ts && (
+                <p className="text-[10px] text-gray-400 mt-0.5 text-center">{fmtShort(step.ts)}</p>
+              )}
+            </div>
+          </Fragment>
+        ))}
+      </div>
+
+      {/* Mobile: ligne compacte */}
+      <div className="sm:hidden flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
+          {steps.map((step, i) => (
+            <div
+              key={i}
+              className={`w-2.5 h-2.5 rounded-full ${
+                step.current ? t.dotActive : step.done ? t.dotDone : t.dotPending
+              }`}
+            />
+          ))}
+        </div>
+        <span className="text-xs text-gray-600">
+          {steps.find((s) => s.current)?.label ??
+            (steps.every((s) => s.done)
+              ? "Terminé ✓"
+              : steps.filter((s) => s.done).at(-1)?.label ?? "—")}
+        </span>
+      </div>
+    </>
+  );
+}
+
+// ── Milestone chips ───────────────────────────────────────────────────────────
+
+function MilestoneChips({
+  journey,
+  canToggle,
+  onToggle,
+}: {
+  journey: PersonJourneyData | null;
+  canToggle: boolean;
+  onToggle: (key: MilestoneKey, currentValue: boolean) => void;
+}) {
+  if (!journey) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        {MILESTONES.map((m) => (
+          <span
+            key={m.key}
+            className="px-3 py-1.5 rounded-full border border-dashed border-gray-200 text-xs text-gray-300"
+          >
+            {m.label}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {MILESTONES.map((m) => {
+        const done = journey[m.key];
+        const ts = journey[m.tsKey];
+        const base = done
+          ? "bg-emerald-100 text-emerald-800 border-emerald-200"
+          : "bg-gray-50 text-gray-400 border-gray-200";
+        const interactive =
+          canToggle && !done
+            ? "hover:border-icc-violet hover:text-icc-violet cursor-pointer"
+            : canToggle && done
+            ? "hover:bg-emerald-200 cursor-pointer"
+            : "cursor-default";
+
+        return (
+          <button
+            key={m.key}
+            type="button"
+            disabled={!canToggle}
+            onClick={canToggle ? () => onToggle(m.key, done) : undefined}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-medium transition-all ${base} ${interactive}`}
+          >
+            {done ? (
+              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+              </svg>
+            ) : (
+              <svg className="w-3 h-3 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+            )}
+            {m.label}
+            {done && ts && (
+              <span className="font-normal text-emerald-600 ml-0.5">{fmtShort(ts)}</span>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }
 
-function Row({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
-      <span className="text-xs text-gray-400 shrink-0 sm:w-36">{label}</span>
-      <span className="text-sm text-gray-800">{value ?? <span className="text-gray-300">—</span>}</span>
-    </div>
-  );
-}
+// ── MSDP actions (tab content) ────────────────────────────────────────────────
 
-// ── MSDP Section ──────────────────────────────────────────────────────────────
-
-interface MsdpSectionProps {
-  initialFollowUp: MsdpFollowUpType | null;
+interface MsdpActionsProps {
+  followUp: MsdpFollowUpType | null;
+  onFollowUpChange: (f: MsdpFollowUpType) => void;
   requestId: string;
   churchId: string;
-  isIntegrationMember: boolean;
-  currentUserId: string;
+  canAct: boolean;
+  hideStatus?: boolean;
 }
 
-function MsdpSection({ initialFollowUp, requestId, churchId, isIntegrationMember, currentUserId }: MsdpSectionProps) {
-  const [followUp, setFollowUp] = useState<MsdpFollowUpType | null>(initialFollowUp);
+function MsdpActions({ followUp, onFollowUpChange, requestId, churchId, canAct, hideStatus = false }: MsdpActionsProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [msdpNotes, setMsdpNotes] = useState(initialFollowUp?.notes ?? "");
+  const [msdpNotes, setMsdpNotes] = useState(followUp?.notes ?? "");
   const [notesLoading, setNotesLoading] = useState(false);
+  const [pendingTransition, setPendingTransition] = useState<{
+    action: string;
+    label: string;
+    description: string;
+    variant?: "danger";
+  } | null>(null);
+  const [transitionLoading, setTransitionLoading] = useState(false);
 
-  // Assign counselor modal
   const [assignOpen, setAssignOpen] = useState(false);
   const [counselors, setCounselors] = useState<{ id: string; name: string | null; email: string | null }[]>([]);
   const [selectedCounselorId, setSelectedCounselorId] = useState("");
   const [assignLoading, setAssignLoading] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
-
-  // Complete modal
   const [completeOpen, setCompleteOpen] = useState(false);
   const [completeLoading, setCompleteLoading] = useState(false);
-
-  const isCounselor = followUp?.assignedConseillerMsdpId === currentUserId;
-  const canAct = isIntegrationMember || isCounselor;
-
-  async function create() {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch("/api/integration/msdp", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ requestId, churchId }),
-      });
-      const json = await res.json();
-      if (!res.ok) { setError(json.error ?? "Erreur"); return; }
-      setFollowUp(json);
-    } catch { setError("Erreur réseau"); }
-    finally { setLoading(false); }
-  }
 
   async function patch(body: Record<string, unknown>) {
     if (!followUp) return false;
@@ -227,7 +364,7 @@ function MsdpSection({ initialFollowUp, requestId, churchId, isIntegrationMember
       });
       const json = await res.json();
       if (!res.ok) { setError(json.error ?? "Erreur"); return false; }
-      setFollowUp(json);
+      onFollowUpChange(json);
       return true;
     } catch { setError("Erreur réseau"); return false; }
     finally { setLoading(false); }
@@ -267,156 +404,158 @@ function MsdpSection({ initialFollowUp, requestId, churchId, isIntegrationMember
     setNotesLoading(false);
   }
 
-  const currentIdx = followUp ? MSDP_STATUS_ORDER.indexOf(followUp.status) : -1;
+  const isCounselor = followUp?.assignedConseillerMsdpId !== undefined;
   const isAbandoned = followUp?.status === "ABANDONED";
   const isCompleted = followUp?.status === "COMPLETED";
 
+  if (!followUp) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-gray-500">Aucun suivi MSDP démarré.</p>
+        {canAct && (
+          <button
+            onClick={async () => {
+              setLoading(true);
+              try {
+                const res = await fetch("/api/integration/msdp", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ requestId, churchId }),
+                });
+                const json = await res.json();
+                if (!res.ok) { setError(json.error ?? "Erreur"); return; }
+                onFollowUpChange(json);
+              } catch { setError("Erreur réseau"); }
+              finally { setLoading(false); }
+            }}
+            disabled={loading}
+            className="px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
+          >
+            {loading ? "Création…" : "Démarrer le suivi MSDP"}
+          </button>
+        )}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </div>
+    );
+  }
+
   return (
-    <Card title="Suivi MSDP">
-      {!followUp ? (
-        <div className="space-y-3">
-          <p className="text-sm text-gray-500">Aucun suivi MSDP démarré pour cette demande.</p>
-          {isIntegrationMember && (
-            <button
-              onClick={create}
-              disabled={loading}
-              className="px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-            >
-              {loading ? "Création…" : "Démarrer le suivi MSDP"}
-            </button>
+    <div className="space-y-4">
+      {!hideStatus && (
+        <div className="flex flex-wrap items-center gap-3">
+          <span className={`inline-flex px-3 py-1 rounded-full text-sm font-medium ${MSDP_STATUS_COLORS[followUp.status] ?? "bg-gray-100 text-gray-600"}`}>
+            {MSDP_STATUS_LABELS[followUp.status] ?? followUp.status}
+          </span>
+          {followUp.assignedConseillerMsdp && (
+            <span className="text-sm text-gray-600">
+              Conseiller : <strong>{followUp.assignedConseillerMsdp.name ?? followUp.assignedConseillerMsdp.email}</strong>
+            </span>
           )}
         </div>
-      ) : (
-        <div className="space-y-4">
-          {/* Status + conseiller */}
-          <div className="flex flex-wrap items-center gap-3">
-            <span className={`inline-flex px-3 py-1 rounded-full text-sm font-medium ${MSDP_STATUS_COLORS[followUp.status] ?? "bg-gray-100 text-gray-600"}`}>
-              {MSDP_STATUS_LABELS[followUp.status] ?? followUp.status}
-            </span>
-            {followUp.assignedConseillerMsdp && (
-              <span className="text-sm text-gray-600">
-                Conseiller : <strong>{followUp.assignedConseillerMsdp.name ?? followUp.assignedConseillerMsdp.email}</strong>
-              </span>
-            )}
-          </div>
+      )}
+      {hideStatus && followUp.assignedConseillerMsdp && (
+        <p className="text-xs text-gray-500">
+          Conseiller : <strong className="text-gray-700">{followUp.assignedConseillerMsdp.name ?? followUp.assignedConseillerMsdp.email}</strong>
+        </p>
+      )}
 
-          {/* Action buttons */}
-          {canAct && (
-            <div className="flex flex-wrap gap-2">
-              {isIntegrationMember && (followUp.status === "SUBMITTED" || followUp.status === "ASSIGNED") && (
-                <button
-                  onClick={openAssignModal}
-                  disabled={loading}
-                  className="px-3 py-1.5 bg-purple-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-                >
-                  {followUp.status === "ASSIGNED" ? "Réaffecter conseiller" : "Assigner conseiller"}
-                </button>
-              )}
-              {canAct && followUp.status === "ASSIGNED" && (
-                <button
-                  onClick={() => patch({ action: "contact" })}
-                  disabled={loading}
-                  className="px-3 py-1.5 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-                >
-                  Marquer contacté
-                </button>
-              )}
-              {canAct && followUp.status === "CONTACTED" && (
-                <button
-                  onClick={() => patch({ action: "in_formation" })}
-                  disabled={loading}
-                  className="px-3 py-1.5 bg-purple-700 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-                >
-                  En formation
-                </button>
-              )}
-              {canAct && followUp.status === "IN_FORMATION" && (
-                <button
-                  onClick={() => setCompleteOpen(true)}
-                  disabled={loading}
-                  className="px-3 py-1.5 bg-emerald-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-                >
-                  Marquer terminé ✓
-                </button>
-              )}
-              {isIntegrationMember && isAbandoned && (
-                <button
-                  onClick={() => patch({ action: "reopen" })}
-                  disabled={loading}
-                  className="px-3 py-1.5 bg-gray-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-                >
-                  Rouvrir
-                </button>
-              )}
-              {canAct && !isCompleted && !isAbandoned && (
-                <button
-                  onClick={() => patch({ action: "abandon" })}
-                  disabled={loading}
-                  className="px-3 py-1.5 bg-white text-red-600 border border-red-200 text-sm font-medium rounded-lg hover:bg-red-50 disabled:opacity-50 transition-colors"
-                >
-                  Abandonner
-                </button>
-              )}
-            </div>
+      {/* Actions */}
+      {canAct && (
+        <div className="flex flex-wrap gap-2">
+          {(followUp.status === "SUBMITTED" || followUp.status === "ASSIGNED") && (
+            <button onClick={openAssignModal} disabled={loading}
+              className="px-3 py-1.5 bg-purple-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity">
+              {followUp.status === "ASSIGNED" ? "Réaffecter conseiller" : "Assigner conseiller"}
+            </button>
           )}
-
-          {/* Timeline */}
-          {isAbandoned ? (
-            <div className="flex items-center gap-2 text-sm text-red-600">
-              <span className="w-5 h-5 rounded-full bg-red-100 flex items-center justify-center text-xs">✕</span>
-              Abandonné le {fmt(followUp.abandonedAt)}
-            </div>
-          ) : (
-            <ol className="space-y-1.5">
-              {MSDP_WORKFLOW_STEPS.map((step, i) => {
-                const ts = followUp[step.tsKey as keyof MsdpFollowUpType] as Date | string | null;
-                const done = i <= currentIdx;
-                const current = MSDP_STATUS_ORDER[currentIdx] === step.status;
-                return (
-                  <li key={step.status} className="flex items-start gap-2">
-                    <span className={`mt-0.5 w-5 h-5 shrink-0 rounded-full flex items-center justify-center text-xs font-bold ${
-                      done ? (current ? "bg-purple-600 text-white" : "bg-emerald-100 text-emerald-700") : "bg-gray-100 text-gray-400"
-                    }`}>
-                      {done && !current ? "✓" : i + 1}
-                    </span>
-                    <div>
-                      <p className={`text-sm ${done ? "text-gray-800 font-medium" : "text-gray-400"}`}>{step.label}</p>
-                      {ts && <p className="text-xs text-gray-400">{fmtFull(ts)}</p>}
-                    </div>
-                  </li>
-                );
+          {(followUp.status === "ASSIGNED" || isCounselor) && followUp.status === "ASSIGNED" && (
+            <button
+              onClick={() => setPendingTransition({
+                action: "contact",
+                label: "Marquer contacté",
+                description: "Confirmer que le premier contact a été établi avec la personne ?",
               })}
-            </ol>
+              disabled={loading}
+              className="px-3 py-1.5 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
+            >
+              Marquer contacté
+            </button>
           )}
-
-          {/* Notes */}
-          {canAct && (
-            <div className="space-y-2 pt-1">
-              <label className="block text-xs font-medium text-gray-500 uppercase tracking-wide">Notes MSDP</label>
-              <textarea
-                value={msdpNotes}
-                onChange={(e) => setMsdpNotes(e.target.value)}
-                rows={3}
-                placeholder="Notes du conseiller MSDP…"
-                className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500 resize-none"
-              />
-              <div className="flex justify-end">
-                <button
-                  onClick={saveMsdpNotes}
-                  disabled={notesLoading}
-                  className="px-3 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm font-medium rounded-lg disabled:opacity-50 transition-colors"
-                >
-                  {notesLoading ? "Sauvegarde…" : "Enregistrer"}
-                </button>
-              </div>
-            </div>
+          {followUp.status === "CONTACTED" && (
+            <button
+              onClick={() => setPendingTransition({
+                action: "in_formation",
+                label: "Passer en formation",
+                description: "Confirmer que la personne est maintenant en formation MSDP ?",
+              })}
+              disabled={loading}
+              className="px-3 py-1.5 bg-purple-700 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
+            >
+              En formation
+            </button>
+          )}
+          {followUp.status === "IN_FORMATION" && (
+            <button onClick={() => setCompleteOpen(true)} disabled={loading}
+              className="px-3 py-1.5 bg-emerald-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity">
+              Marquer terminé ✓
+            </button>
+          )}
+          {isAbandoned && (
+            <button
+              onClick={() => setPendingTransition({
+                action: "reopen",
+                label: "Rouvrir le suivi MSDP",
+                description: "Rouvrir ce suivi MSDP et le repasser en cours ?",
+              })}
+              disabled={loading}
+              className="px-3 py-1.5 bg-gray-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
+            >
+              Rouvrir
+            </button>
+          )}
+          {!isCompleted && !isAbandoned && (
+            <button
+              onClick={() => setPendingTransition({
+                action: "abandon",
+                label: "Abandonner le suivi MSDP",
+                description: "Marquer ce suivi MSDP comme abandonné ? Il pourra être rouvert si nécessaire.",
+                variant: "danger",
+              })}
+              disabled={loading}
+              className="px-3 py-1.5 bg-white text-red-600 border border-red-200 text-sm font-medium rounded-lg hover:bg-red-50 disabled:opacity-50 transition-colors"
+            >
+              Abandonner
+            </button>
           )}
         </div>
       )}
 
-      {error && <p className="text-sm text-red-600 mt-2">{error}</p>}
+      {/* Notes MSDP */}
+      <div className="space-y-2">
+        <label className="block text-xs font-medium text-gray-500 uppercase tracking-wide">Notes MSDP</label>
+        {canAct ? (
+          <>
+            <textarea
+              value={msdpNotes}
+              onChange={(e) => setMsdpNotes(e.target.value)}
+              rows={4}
+              placeholder="Notes du conseiller MSDP…"
+              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500 resize-none"
+            />
+            <div className="flex justify-end">
+              <button onClick={saveMsdpNotes} disabled={notesLoading}
+                className="px-3 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm font-medium rounded-lg disabled:opacity-50 transition-colors">
+                {notesLoading ? "Sauvegarde…" : "Enregistrer"}
+              </button>
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-gray-600">{followUp.notes || <span className="text-gray-300 italic">Aucune note</span>}</p>
+        )}
+      </div>
 
-      {/* Modal : Assigner conseiller */}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
       <Modal open={assignOpen} onClose={() => setAssignOpen(false)} title="Assigner un conseiller MSDP">
         {modalLoading ? (
           <p className="text-sm text-gray-400 text-center py-6">Chargement…</p>
@@ -434,7 +573,7 @@ function MsdpSection({ initialFollowUp, requestId, churchId, isIntegrationMember
                   <option key={c.id} value={c.id}>{c.name ?? c.email}</option>
                 ))}
               </select>
-              {counselors.length === 0 && !modalLoading && (
+              {counselors.length === 0 && (
                 <p className="text-xs text-amber-600 mt-1">
                   Aucun conseiller MSDP trouvé. Assurez-vous que des membres sont rattachés au département MSDP.
                 </p>
@@ -442,11 +581,8 @@ function MsdpSection({ initialFollowUp, requestId, churchId, isIntegrationMember
             </div>
             <div className="flex gap-2 justify-end pt-1">
               <button onClick={() => setAssignOpen(false)} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">Annuler</button>
-              <button
-                onClick={submitAssign}
-                disabled={assignLoading || !selectedCounselorId}
-                className="px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-              >
+              <button onClick={submitAssign} disabled={assignLoading || !selectedCounselorId}
+                className="px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity">
                 {assignLoading ? "Enregistrement…" : "Assigner"}
               </button>
             </div>
@@ -454,30 +590,58 @@ function MsdpSection({ initialFollowUp, requestId, churchId, isIntegrationMember
         )}
       </Modal>
 
-      {/* Modal : Terminer */}
       <Modal open={completeOpen} onClose={() => setCompleteOpen(false)} title="Clôturer le suivi MSDP">
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
-            Le suivi MSDP sera marqué comme terminé. Les jalons du parcours (famille, PCNC, service, discipolat)
-            peuvent être mis à jour depuis la section <strong>Parcours</strong>.
+            Le suivi MSDP sera marqué comme terminé. Les jalons du parcours peuvent être mis à jour
+            directement sur cette fiche ou depuis la section <strong>Parcours</strong>.
           </p>
           <div className="flex gap-2 justify-end pt-1">
             <button onClick={() => setCompleteOpen(false)} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">Annuler</button>
-            <button
-              onClick={submitComplete}
-              disabled={completeLoading}
-              className="px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-            >
+            <button onClick={submitComplete} disabled={completeLoading}
+              className="px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity">
               {completeLoading ? "Enregistrement…" : "Clôturer"}
             </button>
           </div>
         </div>
       </Modal>
-    </Card>
+
+      <Modal
+        open={pendingTransition !== null}
+        onClose={() => setPendingTransition(null)}
+        title={pendingTransition?.label ?? ""}
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">{pendingTransition?.description}</p>
+          <div className="flex gap-2 justify-end">
+            <button onClick={() => setPendingTransition(null)} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">
+              Annuler
+            </button>
+            <button
+              onClick={async () => {
+                if (!pendingTransition) return;
+                setTransitionLoading(true);
+                await patch({ action: pendingTransition.action });
+                setTransitionLoading(false);
+                setPendingTransition(null);
+              }}
+              disabled={transitionLoading}
+              className={`px-4 py-2 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity ${
+                pendingTransition?.variant === "danger" ? "bg-red-600" : "bg-purple-600"
+              }`}
+            >
+              {transitionLoading ? "Enregistrement…" : "Confirmer"}
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </div>
   );
 }
 
 // ── Main component ────────────────────────────────────────────────────────────
+
+type TabId = "contact" | "profil" | "famille" | "notes";
 
 export default function RequestDetail({ request: initial, churchId, isScoped, currentUserId }: Props) {
   const router = useRouter();
@@ -486,36 +650,32 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
   const [error, setError] = useState<string | null>(null);
   const [notes, setNotes] = useState(initial.notes ?? "");
   const [notesLoading, setNotesLoading] = useState(false);
+  const [msdpFollowUp, setMsdpFollowUp] = useState(initial.msdpFollowUp);
+  const [activeTab, setActiveTab] = useState<TabId>("contact");
 
-  // Création dossier parcours
-  const [journeyId, setJourneyId] = useState<string | null>(initial.personJourney?.id ?? null);
+  // Confirmation modale transitions workflow
+  const [pendingTransition, setPendingTransition] = useState<{
+    action: string;
+    label: string;
+    description: string;
+    variant?: "danger";
+  } | null>(null);
+  const [transitionLoading, setTransitionLoading] = useState(false);
+
+  // PersonJourney state
+  const [journey, setJourney] = useState<PersonJourneyData | null>(initial.personJourney ?? null);
   const [journeyLoading, setJourneyLoading] = useState(false);
   const [journeyError, setJourneyError] = useState<string | null>(null);
 
-  async function createJourney() {
-    setJourneyLoading(true);
-    setJourneyError(null);
-    try {
-      const res = await fetch("/api/integration/parcours", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          churchId,
-          firstName: req.firstName,
-          lastName: req.lastName,
-          phone: req.phone ?? undefined,
-          email: req.email ?? undefined,
-          sourceRequestId: req.id,
-        }),
-      });
-      const json = await res.json();
-      if (!res.ok) { setJourneyError(json.error ?? "Erreur"); return; }
-      setJourneyId(json.id);
-    } catch { setJourneyError("Erreur réseau"); }
-    finally { setJourneyLoading(false); }
-  }
+  // Milestone toggle modal
+  const [milestoneModal, setMilestoneModal] = useState<{
+    key: MilestoneKey;
+    label: string;
+    currentValue: boolean;
+  } | null>(null);
+  const [milestoneLoading, setMilestoneLoading] = useState(false);
 
-  // Assign modal state
+  // Assign modal
   const [assignOpen, setAssignOpen] = useState(false);
   const [families, setFamilies] = useState<Family[]>([]);
   const [leaders, setLeaders] = useState<Leader[]>([]);
@@ -542,7 +702,7 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
   });
   const [editLoading, setEditLoading] = useState(false);
 
-  // ── API helpers ─────────────────────────────────────────────────────────────
+  // ── API helpers ──────────────────────────────────────────────────────────────
 
   async function patch(body: Record<string, unknown>) {
     setLoading(true);
@@ -562,6 +722,48 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
     finally { setLoading(false); }
   }
 
+  async function createJourney() {
+    setJourneyLoading(true);
+    setJourneyError(null);
+    try {
+      const res = await fetch("/api/integration/parcours", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          churchId,
+          firstName: req.firstName,
+          lastName: req.lastName,
+          phone: req.phone ?? undefined,
+          email: req.email ?? undefined,
+          sourceRequestId: req.id,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) { setJourneyError(json.error ?? "Erreur"); return; }
+      setJourney(json);
+    } catch { setJourneyError("Erreur réseau"); }
+    finally { setJourneyLoading(false); }
+  }
+
+  async function confirmMilestoneToggle() {
+    if (!milestoneModal || !journey) return;
+    setMilestoneLoading(true);
+    try {
+      const res = await fetch(`/api/integration/parcours/${journey.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ [milestoneModal.key]: !milestoneModal.currentValue }),
+      });
+      const json = await res.json();
+      if (!res.ok) return;
+      setJourney(json);
+    } catch { /* silent */ }
+    finally {
+      setMilestoneLoading(false);
+      setMilestoneModal(null);
+    }
+  }
+
   async function openAssignModal() {
     setAssignOpen(true);
     setModalLoading(true);
@@ -573,8 +775,16 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
         fetch(`/api/integration/leaders?churchId=${churchId}`),
       ]);
       const [famJson, leadJson] = await Promise.all([famRes.json(), leadRes.json()]);
-      setFamilies(famJson.families ?? []);
+      const loadedFamilies: Family[] = famJson.families ?? [];
+      setFamilies(loadedFamilies);
       setLeaders(leadJson ?? []);
+      // Pré-sélectionner la famille suggérée si aucune famille n'est encore assignée
+      if (!req.assignedFamilyId && req.suggestedFamilyName) {
+        const suggested = loadedFamilies.find(
+          (f) => f.name.toLowerCase() === req.suggestedFamilyName!.toLowerCase()
+        );
+        if (suggested) setAssignFamilyId(suggested.id.toString());
+      }
     } catch { /* silently ignore */ }
     finally { setModalLoading(false); }
   }
@@ -609,79 +819,91 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
 
   async function saveNotes() {
     setNotesLoading(true);
-    const res = await fetch(`/api/integration/requests/${req.id}`, {
+    await fetch(`/api/integration/requests/${req.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ action: "note", notes }),
     });
     setNotesLoading(false);
-    if (!res.ok) setError("Erreur lors de la sauvegarde des notes");
   }
-
-  // ── Filtered leaders for selected family ────────────────────────────────────
-
-  const filteredLeaders = assignFamilyId
-    ? leaders.filter((l) => l.familyId === parseInt(assignFamilyId))
-    : leaders;
 
   // ── Role helpers ─────────────────────────────────────────────────────────────
 
   const isIntegrationMember = !isScoped;
   const isAssignedBerger = req.assignedBerger?.id === currentUserId;
   const canActAsBerger = isIntegrationMember || isAssignedBerger;
-
-  // ── Status position ──────────────────────────────────────────────────────────
-
-  const currentIdx = STATUS_ORDER.indexOf(req.status);
   const isAbandoned = req.status === "ABANDONED";
+
+  // ── Timeline steps ───────────────────────────────────────────────────────────
+
+  const integrationSteps: StepData[] = [
+    { label: "Soumise",     done: true,                                                                    current: req.status === "SUBMITTED",      ts: req.submittedAt },
+    { label: "Assignée",    done: ["ASSIGNED","CONTACTED","WHATSAPP_ADDED","INTEGRATED"].includes(req.status), current: req.status === "ASSIGNED",   ts: req.assignedAt },
+    { label: "Contacté·e",  done: ["CONTACTED","WHATSAPP_ADDED","INTEGRATED"].includes(req.status),        current: req.status === "CONTACTED",      ts: req.contactedAt },
+    { label: "WhatsApp",    done: ["WHATSAPP_ADDED","INTEGRATED"].includes(req.status),                    current: req.status === "WHATSAPP_ADDED", ts: req.whatsappAddedAt },
+    { label: "Intégré·e",   done: req.status === "INTEGRATED",                                            current: req.status === "INTEGRATED",     ts: req.integratedAt },
+  ];
+
+  const msdpSteps: StepData[] | null = msdpFollowUp ? [
+    { label: "Reçu",       done: true,                                                                             current: msdpFollowUp.status === "SUBMITTED",    ts: msdpFollowUp.createdAt },
+    { label: "Conseiller", done: ["ASSIGNED","CONTACTED","IN_FORMATION","COMPLETED"].includes(msdpFollowUp.status), current: msdpFollowUp.status === "ASSIGNED",    ts: msdpFollowUp.assignedAt },
+    { label: "Contact",    done: ["CONTACTED","IN_FORMATION","COMPLETED"].includes(msdpFollowUp.status),           current: msdpFollowUp.status === "CONTACTED",    ts: msdpFollowUp.contactedAt },
+    { label: "Formation",  done: ["IN_FORMATION","COMPLETED"].includes(msdpFollowUp.status),                       current: msdpFollowUp.status === "IN_FORMATION", ts: msdpFollowUp.inFormationAt },
+    { label: "Terminé",    done: msdpFollowUp.status === "COMPLETED",                                              current: msdpFollowUp.status === "COMPLETED",    ts: msdpFollowUp.completedAt },
+  ] : null;
+
+  // ── Tabs config ──────────────────────────────────────────────────────────────
+
+  const tabs: { id: TabId; label: string }[] = [
+    { id: "contact", label: "Contact" },
+    { id: "profil",  label: "Profil" },
+    { id: "famille", label: "Famille" },
+    { id: "notes",   label: "Notes" },
+  ];
+
+  const filteredLeaders = assignFamilyId
+    ? leaders.filter((l) => l.familyId === parseInt(assignFamilyId))
+    : leaders;
 
   // ── Render ───────────────────────────────────────────────────────────────────
 
   return (
     <div className="space-y-4 max-w-3xl">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 bg-white rounded-xl border border-gray-200 p-4 md:p-5">
-        <div>
+
+      {/* ── Header ── */}
+      <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3 bg-white rounded-xl border border-gray-200 p-4 md:p-5">
+        <div className="space-y-1">
           <h1 className="text-xl font-bold text-gray-900">{req.firstName} {req.lastName}</h1>
-          <p className="text-sm text-gray-500 mt-0.5">{fmt(req.submittedAt)}</p>
-          {journeyId ? (
-            <a
-              href="/integration/parcours"
-              className="inline-flex items-center gap-1 mt-1 text-xs text-icc-violet hover:underline"
-            >
+          <p className="text-sm text-gray-400">{fmt(req.submittedAt)}</p>
+          <div className="flex flex-wrap gap-1.5 mt-1">
+            {req.salvationCall && (
+              <span className="text-xs text-purple-700 bg-purple-50 px-2 py-0.5 rounded-full border border-purple-100">
+                Appel au salut
+              </span>
+            )}
+            {req.pastoralCareRequested && (
+              <span className="text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full border border-amber-100">
+                Soin pastoral
+              </span>
+            )}
+          </div>
+          {journey && (
+            <a href="/integration/parcours" className="inline-flex items-center gap-1 text-xs text-icc-violet hover:underline mt-1">
               <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
               Voir le dossier parcours
             </a>
-          ) : isIntegrationMember ? (
-            <div className="mt-1 flex items-center gap-2">
-              <button
-                onClick={createJourney}
-                disabled={journeyLoading}
-                className="text-xs text-icc-violet hover:underline disabled:opacity-50"
-              >
-                {journeyLoading ? "Création…" : "+ Créer le dossier parcours"}
-              </button>
-              {journeyError && <span className="text-xs text-red-500">{journeyError}</span>}
-            </div>
-          ) : null}
+          )}
         </div>
-        <div className="flex items-center gap-2 self-start sm:self-center">
-          <span className={`inline-flex px-3 py-1 rounded-full text-sm font-medium ${STATUS_COLORS[req.status] ?? "bg-gray-100 text-gray-600"}`}>
-            {STATUS_LABELS[req.status] ?? req.status}
-          </span>
+        <div className="flex items-center gap-2 self-start">
           {canActAsBerger && req.status !== "INTEGRATED" && req.status !== "ABANDONED" && (
             <button
               onClick={() => {
                 setEditForm({
-                  firstName: req.firstName,
-                  lastName: req.lastName,
-                  phone: req.phone ?? "",
-                  email: req.email ?? "",
-                  address: req.address ?? "",
-                  ageRange: req.ageRange,
-                  churchStatus: req.churchStatus,
+                  firstName: req.firstName, lastName: req.lastName,
+                  phone: req.phone ?? "", email: req.email ?? "",
+                  address: req.address ?? "", ageRange: req.ageRange, churchStatus: req.churchStatus,
                 });
                 setEditOpen(true);
               }}
@@ -700,214 +922,413 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
         <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">{error}</p>
       )}
 
-      {/* Actions workflow */}
-      {canActAsBerger && (
-        <div className="space-y-2">
-          {/* Bandeau contextuel pour le berger */}
-          {isAssignedBerger && !isIntegrationMember && (
-            <div className="flex items-center gap-2 text-xs text-icc-violet bg-icc-violet/5 border border-icc-violet/20 rounded-lg px-3 py-2">
-              <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              Vous êtes le berger assigné à cette demande.
-            </div>
-          )}
-          <div className="flex flex-wrap gap-2">
-            {/* Actions membres intégration uniquement */}
-            {isIntegrationMember && (req.status === "SUBMITTED" || req.status === "ASSIGNED") && (
-              <button
-                onClick={openAssignModal}
-                disabled={loading}
-                className="px-4 py-2 bg-icc-violet text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-              >
-                {req.status === "ASSIGNED" ? "Réaffecter" : "Assigner"}
-              </button>
-            )}
-            {isIntegrationMember && req.status === "ABANDONED" && (
-              <button
-                onClick={() => patch({ action: "reopen" })}
-                disabled={loading}
-                className="px-4 py-2 bg-gray-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-              >
-                Rouvrir
-              </button>
-            )}
+      {/* ── Card 1 : Intégration famille ── */}
+      <div className="bg-white rounded-xl border border-gray-200 p-4 md:p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-700">Intégration famille</h2>
+          <span className={`inline-flex px-2.5 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[req.status] ?? "bg-gray-100 text-gray-600"}`}>
+            {STATUS_LABELS[req.status] ?? req.status}
+          </span>
+        </div>
 
-            {/* Actions berger (et manager) */}
-            {canActAsBerger && req.status === "ASSIGNED" && (
-              <button
-                onClick={() => patch({ action: "contact" })}
-                disabled={loading}
-                className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-              >
-                Marquer contacté
-              </button>
-            )}
-            {canActAsBerger && req.status === "CONTACTED" && (
-              <button
-                onClick={() => patch({ action: "whatsapp" })}
-                disabled={loading}
-                className="px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-              >
-                Ajouté dans le groupe WhatsApp
-              </button>
-            )}
-            {canActAsBerger && req.status === "WHATSAPP_ADDED" && (
-              <button
-                onClick={() => patch({ action: "integrate" })}
-                disabled={loading}
-                className="px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-              >
-                Marquer intégré ✓
-              </button>
-            )}
-            {canActAsBerger && req.status !== "INTEGRATED" && req.status !== "ABANDONED" && (
-              <button
-                onClick={() => setAbandonOpen(true)}
-                disabled={loading}
-                className="px-4 py-2 bg-white text-red-600 border border-red-200 text-sm font-medium rounded-lg hover:bg-red-50 disabled:opacity-50 transition-colors"
-              >
-                Abandonner
-              </button>
+        {isAbandoned ? (
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 text-sm text-red-600">
+              <span className="w-5 h-5 rounded-full bg-red-100 flex items-center justify-center text-xs font-bold">✕</span>
+              Abandonné{req.abandonedAt ? ` le ${fmt(req.abandonedAt)}` : ""}
+            </div>
+            {req.abandonReason && (
+              <p className="text-xs text-gray-400 pl-7">{req.abandonReason}</p>
             )}
           </div>
+        ) : (
+          <TrackTimeline steps={integrationSteps} theme="violet" />
+        )}
+
+        {(req.assignedFamilyName || req.assignedBerger?.name) && (
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500 pt-2 border-t border-gray-100">
+            {req.assignedFamilyName && (
+              <span>Famille&nbsp;: <strong className="text-gray-700">{req.assignedFamilyName}</strong></span>
+            )}
+            {req.assignedBerger?.name && (
+              <span>Berger&nbsp;: <strong className="text-gray-700">{req.assignedBerger.name}</strong></span>
+            )}
+          </div>
+        )}
+
+        {canActAsBerger && (
+          <div className="space-y-2 pt-1">
+            {isAssignedBerger && !isIntegrationMember && (
+              <div className="flex items-center gap-2 text-xs text-icc-violet bg-icc-violet/5 border border-icc-violet/20 rounded-lg px-3 py-2">
+                <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Vous êtes le berger assigné à cette demande.
+              </div>
+            )}
+            <div className="flex flex-wrap gap-2">
+              {isIntegrationMember && (req.status === "SUBMITTED" || req.status === "ASSIGNED") && (
+                <button onClick={openAssignModal} disabled={loading}
+                  className="px-4 py-2 bg-icc-violet text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity">
+                  {req.status === "ASSIGNED" ? "Réaffecter" : "Assigner"}
+                </button>
+              )}
+              {isIntegrationMember && req.status === "ABANDONED" && (
+                <button
+                  onClick={() => setPendingTransition({
+                    action: "reopen",
+                    label: "Rouvrir la demande",
+                    description: `Rouvrir la demande de ${req.firstName} ${req.lastName} ? Elle repassera en statut "En attente".`,
+                  })}
+                  disabled={loading}
+                  className="px-4 py-2 bg-gray-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
+                >
+                  Rouvrir
+                </button>
+              )}
+              {canActAsBerger && req.status === "ASSIGNED" && (
+                <button
+                  onClick={() => setPendingTransition({
+                    action: "contact",
+                    label: "Marquer contacté·e",
+                    description: `Confirmer que ${req.firstName} ${req.lastName} a été contacté·e ?`,
+                  })}
+                  disabled={loading}
+                  className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
+                >
+                  Marquer contacté
+                </button>
+              )}
+              {canActAsBerger && req.status === "CONTACTED" && (
+                <button
+                  onClick={() => setPendingTransition({
+                    action: "whatsapp",
+                    label: "Ajouté dans le groupe WhatsApp",
+                    description: `Confirmer que ${req.firstName} ${req.lastName} a été ajouté·e dans le groupe WhatsApp famille ?`,
+                  })}
+                  disabled={loading}
+                  className="px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
+                >
+                  Ajouté dans le groupe WhatsApp
+                </button>
+              )}
+              {canActAsBerger && req.status === "WHATSAPP_ADDED" && (
+                <button
+                  onClick={() => setPendingTransition({
+                    action: "integrate",
+                    label: "Marquer intégré·e",
+                    description: `Confirmer l'intégration de ${req.firstName} ${req.lastName} dans la famille ? Cette étape est définitive.`,
+                  })}
+                  disabled={loading}
+                  className="px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
+                >
+                  Marquer intégré ✓
+                </button>
+              )}
+              {canActAsBerger && req.status !== "INTEGRATED" && req.status !== "ABANDONED" && (
+                <button onClick={() => setAbandonOpen(true)} disabled={loading}
+                  className="px-4 py-2 bg-white text-red-600 border border-red-200 text-sm font-medium rounded-lg hover:bg-red-50 disabled:opacity-50 transition-colors">
+                  Abandonner
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ── Card 2 : Appel au salut — MSDP ── */}
+      {req.salvationCall && (
+        <div className="bg-white rounded-xl border border-purple-100 p-4 md:p-5 space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-purple-500 shrink-0" />
+              <h2 className="text-sm font-semibold text-gray-700">Appel au salut — MSDP</h2>
+            </div>
+            {msdpFollowUp && (
+              <span className={`inline-flex px-2.5 py-0.5 rounded-full text-xs font-medium ${MSDP_STATUS_COLORS[msdpFollowUp.status] ?? "bg-gray-100 text-gray-600"}`}>
+                {MSDP_STATUS_LABELS[msdpFollowUp.status] ?? msdpFollowUp.status}
+              </span>
+            )}
+          </div>
+
+          {msdpSteps && (
+            msdpFollowUp?.status === "ABANDONED" ? (
+              <div className="flex items-center gap-2 text-sm text-red-500">
+                <span className="w-5 h-5 rounded-full bg-red-100 flex items-center justify-center text-xs font-bold">✕</span>
+                Abandonné{msdpFollowUp.abandonedAt ? ` le ${fmt(msdpFollowUp.abandonedAt)}` : ""}
+              </div>
+            ) : (
+              <TrackTimeline steps={msdpSteps} theme="purple" />
+            )
+          )}
+
+          <MsdpActions
+            followUp={msdpFollowUp}
+            onFollowUpChange={setMsdpFollowUp}
+            requestId={req.id}
+            churchId={churchId}
+            canAct={isIntegrationMember || msdpFollowUp?.assignedConseillerMsdpId === currentUserId}
+            hideStatus
+          />
         </div>
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {/* Contact */}
-        <Card title="Contact">
-          <Row label="Téléphone" value={req.phone ? <a href={`tel:${req.phone}`} className="text-icc-violet hover:underline">{req.phone}</a> : null} />
-          <Row label="Email" value={req.email ? <a href={`mailto:${req.email}`} className="text-icc-violet hover:underline">{req.email}</a> : null} />
-          <Row label="Adresse" value={req.address} />
-          {req.member && (
-            <Row label="Membre Koinonia" value={`${req.member.firstName} ${req.member.lastName}`} />
+      {/* ── Card 3 : Étapes clés du parcours ── */}
+      <div className="bg-white rounded-xl border border-gray-200 p-4 md:p-5 space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-700">Étapes clés du parcours</h2>
+          {journey && (
+            <a href="/integration/parcours" className="text-xs text-icc-violet hover:underline">
+              Dossier complet →
+            </a>
           )}
-        </Card>
-
-        {/* Profil */}
-        <Card title="Profil">
-          <Row label="Tranche d'âge" value={AGE_LABELS[req.ageRange] ?? req.ageRange} />
-          <Row label="Situation" value={CHURCH_STATUS_LABELS[req.churchStatus] ?? req.churchStatus} />
-          <Row label="Appel au salut" value={req.salvationCall ? (
-            <span className="inline-flex items-center gap-1.5">
-              <span className="w-2 h-2 rounded-full bg-purple-500 shrink-0" />
-              Oui
-            </span>
-          ) : "Non"} />
-          <Row label="Soin pastoral" value={req.pastoralCareRequested ? (
-            <span className="inline-flex items-center gap-1.5">
-              <span className="w-2 h-2 rounded-full bg-amber-400 shrink-0" />
-              Demandé
-              {req.appointmentRequest && (
-                <span className="ml-1 text-xs text-gray-400">({req.appointmentRequest.status})</span>
-              )}
-            </span>
-          ) : "Non"} />
-        </Card>
-
-        {/* Famille */}
-        <Card title="Famille">
-          {req.suggestedFamilyName && (
-            <Row label="Suggestion géo" value={
-              <span className="text-gray-500 italic">{req.suggestedFamilyName}</span>
-            } />
-          )}
-          {req.lat && req.lng && (
-            <Row label="Coordonnées" value={
-              <a
-                href={`https://maps.google.com/?q=${req.lat},${req.lng}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-icc-violet hover:underline text-xs"
-              >
-                Voir sur la carte ↗
-              </a>
-            } />
-          )}
-          <Row label="Famille assignée" value={req.assignedFamilyName ? (
-            <span className="font-medium text-icc-violet">{req.assignedFamilyName}</span>
-          ) : null} />
-          <Row label="Berger" value={req.assignedBerger?.name ?? null} />
-        </Card>
-
-        {/* Timeline */}
-        <Card title="Progression">
-          {isAbandoned ? (
-            <div className="space-y-2">
-              <div className="flex items-center gap-2 text-sm text-red-600">
-                <span className="w-5 h-5 rounded-full bg-red-100 flex items-center justify-center text-xs">✕</span>
-                Abandonné le {fmt(req.abandonedAt)}
-              </div>
-              {req.abandonReason && (
-                <p className="text-xs text-gray-500 pl-7">{req.abandonReason}</p>
-              )}
-            </div>
-          ) : (
-            <ol className="space-y-2">
-              {WORKFLOW_STEPS.map((step, i) => {
-                const ts = req[step.tsKey as keyof Request] as Date | string | null;
-                const done = i <= currentIdx;
-                const current = STATUS_ORDER[currentIdx] === step.status;
-                return (
-                  <li key={step.status} className="flex items-start gap-2.5">
-                    <span className={`mt-0.5 w-5 h-5 shrink-0 rounded-full flex items-center justify-center text-xs font-bold ${
-                      done
-                        ? current
-                          ? "bg-icc-violet text-white"
-                          : "bg-emerald-100 text-emerald-700"
-                        : "bg-gray-100 text-gray-400"
-                    }`}>
-                      {done && !current ? "✓" : i + 1}
-                    </span>
-                    <div>
-                      <p className={`text-sm ${done ? "text-gray-800 font-medium" : "text-gray-400"}`}>
-                        {step.label}
-                      </p>
-                      {ts && <p className="text-xs text-gray-400">{fmtFull(ts)}</p>}
-                    </div>
-                  </li>
-                );
-              })}
-            </ol>
-          )}
-        </Card>
+        </div>
+        <MilestoneChips
+          journey={journey}
+          canToggle={isIntegrationMember && journey !== null}
+          onToggle={(key, currentValue) => {
+            const milestone = MILESTONES.find((m) => m.key === key)!;
+            setMilestoneModal({ key, label: milestone.label, currentValue });
+          }}
+        />
+        {!journey && isIntegrationMember && (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={createJourney}
+              disabled={journeyLoading}
+              className="text-xs text-icc-violet hover:underline disabled:opacity-50"
+            >
+              {journeyLoading ? "Création…" : "+ Créer le dossier parcours"}
+            </button>
+            {journeyError && <span className="text-xs text-red-500">{journeyError}</span>}
+          </div>
+        )}
       </div>
 
-      {/* Suivi MSDP */}
-      {req.salvationCall && (
-        <MsdpSection
-          initialFollowUp={req.msdpFollowUp}
-          requestId={req.id}
-          churchId={churchId}
-          isIntegrationMember={isIntegrationMember}
-          currentUserId={currentUserId}
-        />
-      )}
-
-      {/* Notes internes */}
-      {canActAsBerger && (
-        <Card title="Notes internes">
-          <textarea
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            rows={4}
-            placeholder="Notes visibles uniquement par l'équipe intégration…"
-            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet resize-none"
-          />
-          <div className="flex justify-end">
+      {/* ── Onglets ── */}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        {/* Tab bar */}
+        <div className="flex border-b border-gray-100 overflow-x-auto">
+          {tabs.map((tab) => (
             <button
-              onClick={saveNotes}
-              disabled={notesLoading}
-              className="px-4 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm font-medium rounded-lg disabled:opacity-50 transition-colors"
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-4 py-3 text-sm font-medium whitespace-nowrap transition-colors border-b-2 -mb-px ${
+                activeTab === tab.id
+                  ? "border-icc-violet text-icc-violet"
+                  : "border-transparent text-gray-500 hover:text-gray-800"
+              }`}
             >
-              {notesLoading ? "Sauvegarde…" : "Enregistrer les notes"}
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        <div className="p-4 md:p-5">
+
+          {/* Contact */}
+          {activeTab === "contact" && (
+            <div className="space-y-3">
+              {req.phone ? (
+                <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                  <span className="text-xs text-gray-400 sm:w-28 shrink-0">Téléphone</span>
+                  <a href={`tel:${req.phone}`} className="text-sm text-icc-violet hover:underline">{req.phone}</a>
+                </div>
+              ) : null}
+              {req.email ? (
+                <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                  <span className="text-xs text-gray-400 sm:w-28 shrink-0">Email</span>
+                  <a href={`mailto:${req.email}`} className="text-sm text-icc-violet hover:underline">{req.email}</a>
+                </div>
+              ) : null}
+              {req.address && (
+                <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                  <span className="text-xs text-gray-400 sm:w-28 shrink-0">Adresse</span>
+                  <span className="text-sm text-gray-800">{req.address}</span>
+                </div>
+              )}
+              {req.member && (
+                <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                  <span className="text-xs text-gray-400 sm:w-28 shrink-0">Membre Koinonia</span>
+                  <span className="text-sm text-gray-800">{req.member.firstName} {req.member.lastName}</span>
+                </div>
+              )}
+              {!req.phone && !req.email && !req.address && !req.member && (
+                <p className="text-sm text-gray-400 italic">Aucune information de contact renseignée.</p>
+              )}
+            </div>
+          )}
+
+          {/* Profil */}
+          {activeTab === "profil" && (
+            <div className="space-y-3">
+              <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                <span className="text-xs text-gray-400 sm:w-28 shrink-0">Tranche d'âge</span>
+                <span className="text-sm text-gray-800">{AGE_LABELS[req.ageRange] ?? req.ageRange}</span>
+              </div>
+              <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                <span className="text-xs text-gray-400 sm:w-28 shrink-0">Situation</span>
+                <span className="text-sm text-gray-800">{CHURCH_STATUS_LABELS[req.churchStatus] ?? req.churchStatus}</span>
+              </div>
+              <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                <span className="text-xs text-gray-400 sm:w-28 shrink-0">Appel au salut</span>
+                <span className="text-sm text-gray-800">
+                  {req.salvationCall ? (
+                    <span className="inline-flex items-center gap-1.5">
+                      <span className="w-2 h-2 rounded-full bg-purple-500 shrink-0" />Oui
+                    </span>
+                  ) : "Non"}
+                </span>
+              </div>
+              <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                <span className="text-xs text-gray-400 sm:w-28 shrink-0">Soin pastoral</span>
+                <span className="text-sm text-gray-800">
+                  {req.pastoralCareRequested ? (
+                    <span className="inline-flex items-center gap-1.5">
+                      <span className="w-2 h-2 rounded-full bg-amber-400 shrink-0" />
+                      Demandé
+                      {req.appointmentRequest && (
+                        <span className="text-xs text-gray-400 ml-1">({req.appointmentRequest.status})</span>
+                      )}
+                    </span>
+                  ) : "Non"}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Famille */}
+          {activeTab === "famille" && (
+            <div className="space-y-3">
+              {req.suggestedFamilyName && (
+                <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                  <span className="text-xs text-gray-400 sm:w-28 shrink-0">Suggestion géo</span>
+                  <span className="text-sm text-gray-500 italic">{req.suggestedFamilyName}</span>
+                </div>
+              )}
+              {req.lat && req.lng && (
+                <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                  <span className="text-xs text-gray-400 sm:w-28 shrink-0">Carte familles</span>
+                  <a
+                    href={`https://familles.iccrennes.fr/carte?lat=${req.lat}&lng=${req.lng}&label=${encodeURIComponent(req.address ?? `${req.lat}, ${req.lng}`)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-icc-violet hover:underline"
+                  >
+                    Voir sur la carte familles ↗
+                  </a>
+                </div>
+              )}
+              <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                <span className="text-xs text-gray-400 sm:w-28 shrink-0">Famille assignée</span>
+                <span className="text-sm font-medium text-icc-violet">
+                  {req.assignedFamilyName ?? <span className="text-gray-300 font-normal">—</span>}
+                </span>
+              </div>
+              <div className="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-3">
+                <span className="text-xs text-gray-400 sm:w-28 shrink-0">Berger</span>
+                <span className="text-sm text-gray-800">
+                  {req.assignedBerger?.name ?? <span className="text-gray-300">—</span>}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Notes */}
+          {activeTab === "notes" && (
+            <div className="space-y-3">
+              {canActAsBerger ? (
+                <>
+                  <textarea
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                    rows={5}
+                    placeholder="Notes visibles uniquement par l'équipe intégration…"
+                    className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet resize-none"
+                  />
+                  <div className="flex justify-end">
+                    <button onClick={saveNotes} disabled={notesLoading}
+                      className="px-4 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm font-medium rounded-lg disabled:opacity-50 transition-colors">
+                      {notesLoading ? "Sauvegarde…" : "Enregistrer les notes"}
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <p className="text-sm text-gray-500">{req.notes || <span className="italic text-gray-300">Aucune note</span>}</p>
+              )}
+            </div>
+          )}
+
+        </div>
+      </div>
+
+      {/* ── Modals ── */}
+
+      {/* Confirmation transition workflow */}
+      <Modal
+        open={pendingTransition !== null}
+        onClose={() => setPendingTransition(null)}
+        title={pendingTransition?.label ?? ""}
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">{pendingTransition?.description}</p>
+          <div className="flex gap-2 justify-end">
+            <button
+              onClick={() => setPendingTransition(null)}
+              className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
+            >
+              Annuler
+            </button>
+            <button
+              onClick={async () => {
+                if (!pendingTransition) return;
+                setTransitionLoading(true);
+                await patch({ action: pendingTransition.action });
+                setTransitionLoading(false);
+                setPendingTransition(null);
+              }}
+              disabled={transitionLoading}
+              className={`px-4 py-2 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity ${
+                pendingTransition?.variant === "danger" ? "bg-red-600" : "bg-icc-violet"
+              }`}
+            >
+              {transitionLoading ? "Enregistrement…" : "Confirmer"}
             </button>
           </div>
-        </Card>
-      )}
+        </div>
+      </Modal>
 
-      {/* Modal : Assigner */}
+      {/* Milestone toggle */}
+      <Modal
+        open={milestoneModal !== null}
+        onClose={() => setMilestoneModal(null)}
+        title={milestoneModal?.currentValue ? "Désactiver le jalon" : "Activer le jalon"}
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            {milestoneModal?.currentValue
+              ? `Désactiver le jalon "${milestoneModal.label}" pour ${req.firstName} ${req.lastName} ?`
+              : `Activer le jalon "${milestoneModal?.label}" pour ${req.firstName} ${req.lastName} ?`}
+          </p>
+          <div className="flex gap-2 justify-end">
+            <button onClick={() => setMilestoneModal(null)} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">
+              Annuler
+            </button>
+            <button
+              onClick={confirmMilestoneToggle}
+              disabled={milestoneLoading}
+              className={`px-4 py-2 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity ${
+                milestoneModal?.currentValue ? "bg-gray-500" : "bg-emerald-600"
+              }`}
+            >
+              {milestoneLoading ? "Enregistrement…" : "Confirmer"}
+            </button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Assigner famille/berger */}
       <Modal open={assignOpen} onClose={() => setAssignOpen(false)} title="Assigner la demande">
         {modalLoading ? (
           <p className="text-sm text-gray-400 text-center py-6">Chargement…</p>
@@ -921,15 +1342,12 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
                 className="w-full border-2 border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:border-icc-violet"
               >
                 <option value="">Choisir une famille…</option>
-                {families.map((f) => (
-                  <option key={f.id} value={f.id}>{f.name}</option>
-                ))}
+                {families.map((f) => <option key={f.id} value={f.id}>{f.name}</option>)}
               </select>
               {req.suggestedFamilyName && (
                 <p className="text-xs text-gray-400 mt-1">Suggestion géo : {req.suggestedFamilyName}</p>
               )}
             </div>
-
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Berger / co-berger</label>
               <select
@@ -952,14 +1370,8 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
                 </p>
               )}
             </div>
-
             <div className="flex gap-2 justify-end pt-2">
-              <button
-                onClick={() => setAssignOpen(false)}
-                className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
-              >
-                Annuler
-              </button>
+              <button onClick={() => setAssignOpen(false)} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">Annuler</button>
               <button
                 onClick={submitAssign}
                 disabled={assignLoading || !assignFamilyId || !assignBergerId}
@@ -972,55 +1384,40 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
         )}
       </Modal>
 
-      {/* Modal : Modifier */}
+      {/* Modifier */}
       <Modal open={editOpen} onClose={() => setEditOpen(false)} title="Modifier la demande">
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-3">
             <div>
               <label className="block text-xs font-medium text-gray-700 mb-1">Prénom</label>
-              <input
-                type="text"
-                value={editForm.firstName}
+              <input type="text" value={editForm.firstName}
                 onChange={(e) => setEditForm((f) => ({ ...f, firstName: e.target.value }))}
-                className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet"
-              />
+                className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet" />
             </div>
             <div>
               <label className="block text-xs font-medium text-gray-700 mb-1">Nom</label>
-              <input
-                type="text"
-                value={editForm.lastName}
+              <input type="text" value={editForm.lastName}
                 onChange={(e) => setEditForm((f) => ({ ...f, lastName: e.target.value }))}
-                className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet"
-              />
+                className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet" />
             </div>
           </div>
           <div>
             <label className="block text-xs font-medium text-gray-700 mb-1">Téléphone</label>
-            <input
-              type="tel"
-              value={editForm.phone}
+            <input type="tel" value={editForm.phone}
               onChange={(e) => setEditForm((f) => ({ ...f, phone: e.target.value }))}
-              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet"
-            />
+              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet" />
           </div>
           <div>
             <label className="block text-xs font-medium text-gray-700 mb-1">Email</label>
-            <input
-              type="email"
-              value={editForm.email}
+            <input type="email" value={editForm.email}
               onChange={(e) => setEditForm((f) => ({ ...f, email: e.target.value }))}
-              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet"
-            />
+              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet" />
           </div>
           <div>
             <label className="block text-xs font-medium text-gray-700 mb-1">Adresse</label>
-            <input
-              type="text"
-              value={editForm.address}
+            <input type="text" value={editForm.address}
               onChange={(e) => setEditForm((f) => ({ ...f, address: e.target.value }))}
-              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet"
-            />
+              className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet" />
           </div>
           <div>
             <label className="block text-xs font-medium text-gray-700 mb-2">Tranche d&apos;âge</label>
@@ -1046,18 +1443,15 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
           </div>
           <div className="flex gap-2 justify-end pt-1">
             <button onClick={() => setEditOpen(false)} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">Annuler</button>
-            <button
-              onClick={submitEdit}
-              disabled={editLoading || !editForm.firstName || !editForm.lastName}
-              className="px-4 py-2 bg-icc-violet text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-            >
+            <button onClick={submitEdit} disabled={editLoading || !editForm.firstName || !editForm.lastName}
+              className="px-4 py-2 bg-icc-violet text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity">
               {editLoading ? "Enregistrement…" : "Enregistrer"}
             </button>
           </div>
         </div>
       </Modal>
 
-      {/* Modal : Abandonner */}
+      {/* Abandonner */}
       <Modal open={abandonOpen} onClose={() => setAbandonOpen(false)} title="Abandonner la demande">
         <div className="space-y-4">
           <p className="text-sm text-gray-600">
@@ -1074,22 +1468,15 @@ export default function RequestDetail({ request: initial, churchId, isScoped, cu
             />
           </div>
           <div className="flex gap-2 justify-end">
-            <button
-              onClick={() => setAbandonOpen(false)}
-              className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
-            >
-              Annuler
-            </button>
-            <button
-              onClick={submitAbandon}
-              disabled={abandonLoading}
-              className="px-4 py-2 bg-red-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
-            >
+            <button onClick={() => setAbandonOpen(false)} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">Annuler</button>
+            <button onClick={submitAbandon} disabled={abandonLoading}
+              className="px-4 py-2 bg-red-600 text-white text-sm font-medium rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity">
               {abandonLoading ? "Abandon…" : "Confirmer l'abandon"}
             </button>
           </div>
         </div>
       </Modal>
+
     </div>
   );
 }

--- a/src/app/(auth)/integration/requests/[id]/page.tsx
+++ b/src/app/(auth)/integration/requests/[id]/page.tsx
@@ -26,7 +26,19 @@ export default async function IntegrationRequestDetailPage({
           assignedConseillerMsdp: { select: { id: true, name: true, email: true } },
         },
       },
-      personJourney: { select: { id: true } },
+      personJourney: {
+        select: {
+          id: true,
+          integratedInFamily: true,
+          familyIntegratedAt: true,
+          followsPcnc: true,
+          pcncStartedAt: true,
+          isStar: true,
+          starSince: true,
+          inDiscipleship: true,
+          discipleshipSince: true,
+        },
+      },
     },
   });
 

--- a/src/app/(auth)/integration/requests/page.tsx
+++ b/src/app/(auth)/integration/requests/page.tsx
@@ -43,7 +43,11 @@ export default async function IntegrationRequestsPage() {
           <PublicFormBanner slug={church.slug} />
         </div>
       )}
-      <IntegrationDashboard requests={requests} isScoped={scope.scoped} />
+      <IntegrationDashboard
+        requests={requests}
+        isScoped={scope.scoped}
+        currentUserId={session.user.id!}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Dashboard** : bandeau « À traiter » role-aware (actions contextuelles par rôle), pill « Voir → » plus visible, badge berger assigné, compteurs par statut
- **Fiche** : restructuration en 3 cartes autonomes — *Intégration famille* (frise + boutons d'action directement dessous), *Appel au salut / MSDP* (carte toujours visible si `salvationCall`, l'onglet MSDP disparaît), *Étapes clés du parcours* (ex « Jalons du parcours »)
- **Modales de confirmation** sur toutes les transitions de statut (évite les changements involontaires)
- **Assignation** : pré-sélection automatique de la famille suggérée par géolocalisation
- **Fix** hydratation `PublicFormBanner` (`typeof window` en render → `useEffect`)
- **Carte familles** : lien depuis l'onglet Famille qui positionne l'adresse via `?lat=&lng=&label=`

## Test plan

- [ ] Dashboard : vérifier le bandeau « À traiter » selon le rôle (conseiller intégration vs berger)
- [ ] Fiche sans `salvationCall` : la card MSDP n'apparaît pas
- [ ] Fiche avec `salvationCall` : la card MSDP est visible immédiatement, les actions MSDP fonctionnent
- [ ] Toutes les transitions déclenchent bien une modale de confirmation
- [ ] Modal assignation : la famille suggérée est pré-sélectionnée si aucune famille n'est encore assignée
- [ ] Lien carte familles s'ouvre avec le marqueur positionné sur l'adresse

🤖 Generated with [Claude Code](https://claude.com/claude-code)