### PR TITLE
chore: release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.6.1] - 2026-06-11
+
+### Corrigé
+
+- **Comptabilité** : `require()` dans `file-storage.ts` remplacé par `import()` dynamique — corrige l'erreur ESLint `no-require-imports` qui faisait échouer la CI (#365)
+
 ## [v1.6.0] - 2026-06-11
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Bump version `1.6.0` → `1.6.1` et mise à jour du CHANGELOG.