### PR TITLE
fix(ci): permissions manquantes et shim sharp pour TS7016

### DIFF
--- a/src/core/__tests__/permissions.test.ts
+++ b/src/core/__tests__/permissions.test.ts
@@ -4,6 +4,7 @@ import { buildRolePermissions, roleHasPermission } from "../permissions";
 import { coreModule } from "@/modules/core";
 import { planningModule } from "@/modules/planning";
 import { discipleshipModule } from "@/modules/discipleship";
+import { accountingModule } from "@/modules/accounting";
 // Matrice de référence (source de vérité actuelle)
 import { hasPermission } from "@/lib/permissions";
 import type { Role } from "@/generated/prisma/client";
@@ -23,6 +24,7 @@ function buildFullRegistry() {
   r.register(coreModule);
   r.register(planningModule);
   r.register(discipleshipModule);
+  r.register(accountingModule);
   return r;
 }
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -17,6 +17,9 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "discipleship:export",
     "reports:view",
     "reports:edit",
+    "accounting:view",
+    "accounting:manage",
+    "accounting:submit",
   ],
   ADMIN: [
     "planning:view",
@@ -31,6 +34,9 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "discipleship:manage",
     "reports:view",
     "reports:edit",
+    "accounting:view",
+    "accounting:manage",
+    "accounting:submit",
   ],
   SECRETARY: [
     "planning:view",
@@ -64,6 +70,7 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "departments:view",
     "discipleship:view",
     "accounting:view",
+    "accounting:submit",
   ],
   DISCIPLE_MAKER: [
     "discipleship:view",

--- a/src/modules/accounting/index.ts
+++ b/src/modules/accounting/index.ts
@@ -9,7 +9,7 @@ export const accountingModule = defineModule({
     // Soumettre une demande (resp. et co-resp. de département, admins)
     "accounting:submit":  ["SUPER_ADMIN", "ADMIN", "DEPARTMENT_HEAD"],
     // Consulter les demandes (compta = global, dept_head = son département)
-    "accounting:view":    ["SUPER_ADMIN", "ADMIN", "ACCOUNTANT", "DEPARTMENT_HEAD"],
+    "accounting:view":    ["SUPER_ADMIN", "ADMIN", "ACCOUNTANT", "MINISTER", "DEPARTMENT_HEAD"],
     // Traiter les demandes (changer statut, valider, rejeter, saisir paiements)
     "accounting:manage":  ["SUPER_ADMIN", "ADMIN", "ACCOUNTANT"],
   },

--- a/src/types/sharp.d.ts
+++ b/src/types/sharp.d.ts
@@ -1,0 +1,17 @@
+declare module "sharp" {
+  interface Metadata {
+    width?: number;
+    height?: number;
+    format?: string;
+  }
+  interface Sharp {
+    rotate(): Sharp;
+    resize(width?: number | null, height?: number | null, options?: Record<string, unknown>): Sharp;
+    jpeg(options?: Record<string, unknown>): Sharp;
+    webp(options?: Record<string, unknown>): Sharp;
+    toBuffer(): Promise<Buffer>;
+    metadata(): Promise<Metadata>;
+  }
+  function sharp(input: Buffer): Sharp;
+  export = sharp;
+}


### PR DESCRIPTION
- Permissions accounting manquantes dans `permissions.ts` pour SUPER_ADMIN, ADMIN, DEPARTMENT_HEAD
- MINISTER ajouté à `accounting:view` dans le module
- Test de parité inclut désormais `accountingModule`
- Shim `src/types/sharp.d.ts` pour corriger `TS7016` avec sharp 0.35.0