### PR TITLE
feat(accounting): emails de notification aux demandeurs

### DIFF
--- a/src/app/api/accounting/payments/[id]/route.ts
+++ b/src/app/api/accounting/payments/[id]/route.ts
@@ -2,6 +2,7 @@ import { requireAuth, getCurrentChurchId } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { rolePermissions } from "@/lib/registry";
+import { sendEmail, buildAccountingPaymentEmail } from "@/lib/email";
 import { z } from "zod";
 
 const releaseSchema = z.object({
@@ -26,7 +27,7 @@ export async function PATCH(
 
     const payment = await prisma.financialPayment.findUnique({
       where: { id },
-      include: { request: { select: { churchId: true, label: true, submittedById: true } } },
+      include: { request: { select: { churchId: true, label: true, submittedById: true, amount: true } } },
     });
     if (!payment || payment.request.churchId !== churchId) throw new ApiError(404, "Paiement introuvable");
     if (payment.releasedAt) throw new ApiError(400, "Ce paiement a déjà été confirmé");
@@ -69,7 +70,7 @@ export async function PATCH(
       return { updated, residual };
     });
 
-    // Notif demandeur
+    // Notif demandeur (in-app)
     const partialMsg = isPartial
       ? ` (partiel : ${released} € sur ${planned} €, solde de ${remainder} € reporté)`
       : "";
@@ -82,6 +83,31 @@ export async function PATCH(
         link:    `/accounting/requests/${payment.requestId}`,
       },
     });
+
+    // Email — fire-and-forget
+    const appUrl = process.env.APP_URL ?? "http://localhost:3000";
+    const trancheNumber = await prisma.financialPayment.count({
+      where: { requestId: payment.requestId, scheduledDate: { lte: payment.scheduledDate } },
+    });
+    prisma.user.findUnique({ where: { id: payment.request.submittedById }, select: { name: true, email: true } })
+      .then(async (user) => {
+        if (!user?.email) return;
+        const church = await prisma.church.findUnique({ where: { id: churchId }, select: { name: true } });
+        const fmt = (n: number) => n.toLocaleString("fr-FR", { style: "currency", currency: "EUR" });
+        const { subject, html } = buildAccountingPaymentEmail({
+          userName:       user.name ?? user.email,
+          requestLabel:   payment.request.label,
+          trancheNumber,
+          releasedAmount: fmt(released),
+          plannedAmount:  fmt(planned),
+          isPartial,
+          residualAmount: isPartial ? fmt(remainder) : undefined,
+          churchName:     church?.name ?? "Koinonia",
+          requestUrl:     `${appUrl}/accounting/requests/${payment.requestId}`,
+        });
+        return sendEmail({ to: user.email, subject, html });
+      })
+      .catch((err) => console.error("[accounting/payments] sendEmail failed:", err?.message ?? err));
 
     return successResponse(result);
   } catch (error) {

--- a/src/app/api/accounting/requests/[id]/route.ts
+++ b/src/app/api/accounting/requests/[id]/route.ts
@@ -2,6 +2,7 @@ import { requireAuth, getCurrentChurchId } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { rolePermissions } from "@/lib/registry";
+import { sendEmail, buildAccountingStatusEmail } from "@/lib/email";
 import { z } from "zod";
 
 const patchSchema = z.discriminatedUnion("action", [
@@ -169,7 +170,7 @@ export async function PATCH(
           processedAt:     new Date(),
         },
       });
-      await notifySubmitter(existing, "REJECTED", churchId);
+      await notifySubmitter(existing, "REJECTED", churchId, undefined, undefined, body.rejectionReason);
       return successResponse(updated);
     }
 
@@ -216,11 +217,12 @@ async function createNextOccurrence(
 }
 
 async function notifySubmitter(
-  req: { submittedById: string; id: string; label: string },
+  req: { submittedById: string; id: string; label: string; amount: unknown; churchId: string },
   status: string,
   _churchId: string,
   priority?: string,
-  priorityNote?: string
+  priorityNote?: string,
+  rejectionReason?: string
 ) {
   const messages: Record<string, string> = {
     PROCESSING: priority === "URGENT"
@@ -247,4 +249,26 @@ async function notifySubmitter(
       link:    `/accounting/requests/${req.id}`,
     },
   });
+
+  // Email — fire-and-forget, ne bloque pas la réponse
+  const appUrl = process.env.APP_URL ?? "http://localhost:3000";
+  prisma.user.findUnique({ where: { id: req.submittedById }, select: { name: true, email: true } })
+    .then(async (user) => {
+      if (!user?.email) return;
+      const church = await prisma.church.findUnique({ where: { id: req.churchId }, select: { name: true } });
+      const amount = Number(req.amount).toLocaleString("fr-FR", { style: "currency", currency: "EUR" });
+      const { subject, html } = buildAccountingStatusEmail({
+        userName:        user.name ?? user.email,
+        requestLabel:    req.label,
+        requestAmount:   amount,
+        status:          status as "PROCESSING" | "APPROVED" | "REJECTED" | "CANCELLED",
+        priority,
+        priorityNote,
+        rejectionReason,
+        churchName:      church?.name ?? "Koinonia",
+        requestUrl:      `${appUrl}/accounting/requests/${req.id}`,
+      });
+      return sendEmail({ to: user.email, subject, html });
+    })
+    .catch((err) => console.error("[accounting] sendEmail failed:", err?.message ?? err));
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -226,6 +226,108 @@ export function buildAppointmentScheduledEmail(params: {
   };
 }
 
+export function buildAccountingStatusEmail(params: {
+  userName: string;
+  requestLabel: string;
+  requestAmount: string;
+  status: "PROCESSING" | "APPROVED" | "REJECTED" | "CANCELLED";
+  priority?: string | null;
+  priorityNote?: string | null;
+  rejectionReason?: string | null;
+  churchName: string;
+  requestUrl: string;
+}) {
+  const name = escapeHtml(params.userName);
+  const label = escapeHtml(params.requestLabel);
+  const amount = escapeHtml(params.requestAmount);
+  const church = escapeHtml(params.churchName);
+  const url = params.requestUrl;
+
+  const subjects: Record<string, string> = {
+    PROCESSING: `Votre demande est prise en charge — ${church}`,
+    APPROVED:   `Votre demande a été validée ✓ — ${church}`,
+    REJECTED:   `Votre demande n'a pas pu être retenue — ${church}`,
+    CANCELLED:  `Votre demande a été annulée — ${church}`,
+  };
+
+  const intros: Record<string, string> = {
+    PROCESSING: params.priority === "URGENT"
+      ? `Votre demande <strong>« ${label} »</strong> (${amount}) est en cours de traitement en priorité urgente${params.priorityNote ? ` : <em>${escapeHtml(params.priorityNote)}</em>` : ""}.`
+      : `Votre demande <strong>« ${label} »</strong> (${amount}) est en cours de traitement. Elle sera traitée dans les meilleurs délais.`,
+    APPROVED:   `Votre demande <strong>« ${label} »</strong> (${amount}) a été validée. Consultez le plan de paiement pour connaître les dates de remise.`,
+    REJECTED:   `Votre demande <strong>« ${label} »</strong> (${amount}) n'a malheureusement pas pu être retenue.${params.rejectionReason ? `<br><br>Motif : <em>${escapeHtml(params.rejectionReason)}</em>` : ""}`,
+    CANCELLED:  `Votre demande <strong>« ${label} »</strong> (${amount}) a été annulée.`,
+  };
+
+  return {
+    subject: subjects[params.status],
+    html: `
+      <div style="font-family: Montserrat, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background: #5E17EB; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
+          <h1 style="margin: 0; font-size: 20px;">Koinonia — Comptabilité</h1>
+          <p style="margin: 4px 0 0; font-size: 13px; opacity: 0.85;">${church}</p>
+        </div>
+        <div style="padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+          <p>Bonjour <strong>${name}</strong>,</p>
+          <p>${intros[params.status]}</p>
+          <p>
+            <a href="${url}" style="display:inline-block;background:#5E17EB;color:white;padding:10px 20px;border-radius:6px;text-decoration:none;font-size:14px;">
+              Voir ma demande →
+            </a>
+          </p>
+          <p style="color: #6b7280; font-size: 13px; margin-top: 24px;">
+            Vous recevez cet email car vous avez soumis une demande financière sur Koinonia.
+          </p>
+        </div>
+      </div>
+    `,
+  };
+}
+
+export function buildAccountingPaymentEmail(params: {
+  userName: string;
+  requestLabel: string;
+  trancheNumber: number;
+  releasedAmount: string;
+  plannedAmount: string;
+  isPartial: boolean;
+  residualAmount?: string;
+  churchName: string;
+  requestUrl: string;
+}) {
+  const name = escapeHtml(params.userName);
+  const label = escapeHtml(params.requestLabel);
+  const church = escapeHtml(params.churchName);
+
+  const body = params.isPartial
+    ? `Un versement partiel de <strong>${escapeHtml(params.releasedAmount)}</strong> sur <strong>${escapeHtml(params.plannedAmount)}</strong> a été confirmé pour la tranche ${params.trancheNumber} de votre demande <strong>« ${label} »</strong>.${params.residualAmount ? ` Le solde restant de <strong>${escapeHtml(params.residualAmount)}</strong> a été reporté en nouvelle tranche.` : ""}`
+    : `La tranche ${params.trancheNumber} de votre demande <strong>« ${label} »</strong> a été remise : <strong>${escapeHtml(params.releasedAmount)}</strong>.`;
+
+  return {
+    subject: `Fonds remis${params.isPartial ? " (partiel)" : ""} — ${label} — ${church}`,
+    html: `
+      <div style="font-family: Montserrat, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background: #5E17EB; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
+          <h1 style="margin: 0; font-size: 20px;">Koinonia — Comptabilité</h1>
+          <p style="margin: 4px 0 0; font-size: 13px; opacity: 0.85;">${church}</p>
+        </div>
+        <div style="padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+          <p>Bonjour <strong>${name}</strong>,</p>
+          <p>${body}</p>
+          <p>
+            <a href="${params.requestUrl}" style="display:inline-block;background:#5E17EB;color:white;padding:10px 20px;border-radius:6px;text-decoration:none;font-size:14px;">
+              Voir ma demande →
+            </a>
+          </p>
+          <p style="color: #6b7280; font-size: 13px; margin-top: 24px;">
+            Vous recevez cet email car vous avez soumis une demande financière sur Koinonia.
+          </p>
+        </div>
+      </div>
+    `,
+  };
+}
+
 export function buildReminderEmail(params: {
   memberName: string;
   eventTitle: string;


### PR DESCRIPTION
Emails envoyés en fire-and-forget à chaque étape du workflow :

- **Prise en charge** (normale ou urgente avec note)
- **Validation** avec lien vers le plan de paiement
- **Rejet** avec motif
- **Annulation**
- **Remise** de fonds (totale ou partielle — mentionne le solde reporté)

Utilise `APP_URL` comme base + le SMTP configuré.