### PR TITLE
feat(accounting): email de réception des demandes à l'adresse comptabilité

### DIFF
--- a/src/app/(auth)/admin/churches/[churchId]/ChurchEditClient.tsx
+++ b/src/app/(auth)/admin/churches/[churchId]/ChurchEditClient.tsx
@@ -6,7 +6,7 @@ import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 
 interface Props {
-  church: { id: string; name: string; slug: string; secretariatEmail: string; primaryColor: string };
+  church: { id: string; name: string; slug: string; secretariatEmail: string; accountingEmail: string; primaryColor: string };
 }
 
 export default function ChurchEditClient({ church }: Props) {
@@ -14,6 +14,7 @@ export default function ChurchEditClient({ church }: Props) {
   const [name, setName] = useState(church.name);
   const [slug, setSlug] = useState(church.slug);
   const [secretariatEmail, setSecretariatEmail] = useState(church.secretariatEmail);
+  const [accountingEmail, setAccountingEmail] = useState(church.accountingEmail);
   const [primaryColor, setPrimaryColor] = useState(church.primaryColor || "#5E17EB");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -29,7 +30,7 @@ export default function ChurchEditClient({ church }: Props) {
       const res = await fetch(`/api/churches/${church.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, slug, secretariatEmail: secretariatEmail || null, primaryColor }),
+        body: JSON.stringify({ name, slug, secretariatEmail: secretariatEmail || null, accountingEmail: accountingEmail || null, primaryColor }),
       });
 
       if (!res.ok) {
@@ -67,6 +68,13 @@ export default function ChurchEditClient({ church }: Props) {
           value={secretariatEmail}
           onChange={(e) => setSecretariatEmail(e.target.value)}
           placeholder="secretariat@eglise.fr"
+        />
+        <Input
+          label="Email comptabilité (réception des demandes)"
+          type="email"
+          value={accountingEmail}
+          onChange={(e) => setAccountingEmail(e.target.value)}
+          placeholder="comptabilite@eglise.fr"
         />
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/src/app/(auth)/admin/churches/[churchId]/page.tsx
+++ b/src/app/(auth)/admin/churches/[churchId]/page.tsx
@@ -22,7 +22,7 @@ export default async function ChurchDetailPage({
       <h1 className="text-2xl font-bold text-gray-900 mb-6">
         Modifier l&apos;église
       </h1>
-      <ChurchEditClient church={{ id: church.id, name: church.name, slug: church.slug, secretariatEmail: church.secretariatEmail ?? "", primaryColor: church.primaryColor ?? "#5E17EB" }} />
+      <ChurchEditClient church={{ id: church.id, name: church.name, slug: church.slug, secretariatEmail: church.secretariatEmail ?? "", accountingEmail: church.accountingEmail ?? "", primaryColor: church.primaryColor ?? "#5E17EB" }} />
     </div>
   );
 }

--- a/src/app/api/accounting/requests/route.ts
+++ b/src/app/api/accounting/requests/route.ts
@@ -2,6 +2,7 @@ import { requirePermission, getCurrentChurchId } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { rolePermissions } from "@/lib/registry";
+import { sendEmail, buildAccountingNewRequestEmail } from "@/lib/email";
 import { z } from "zod";
 
 const createSchema = z.object({
@@ -100,7 +101,7 @@ export async function POST(request: Request) {
     });
 
     // Notification email compta + in-app (best-effort)
-    notifyAccountingTeam(churchId, req.id, req.label, req.type).catch(() => {});
+    notifyAccountingTeam(churchId, req).catch(() => {});
 
     return successResponse(req, 201);
   } catch (error) {
@@ -110,9 +111,7 @@ export async function POST(request: Request) {
 
 async function notifyAccountingTeam(
   churchId: string,
-  requestId: string,
-  label: string,
-  type: string
+  req: { id: string; label: string; type: string; description: string | null; amount: unknown; department: { name: string }; submittedBy: { name: string | null; email: string | null } }
 ) {
   const church = await prisma.church.findUnique({
     where: { id: churchId },
@@ -131,15 +130,27 @@ async function notifyAccountingTeam(
         userId,
         type:    "ACCOUNTING_NEW_REQUEST",
         title:   "Nouvelle demande financière",
-        message: `${type === "EXPENSE_REPORT" ? "Note de frais" : "Avance de budget"} : ${label}`,
-        link:    `/accounting/requests/${requestId}`,
+        message: `${req.type === "EXPENSE_REPORT" ? "Note de frais" : "Avance de budget"} : ${req.label}`,
+        link:    `/accounting/requests/${req.id}`,
       })),
     });
   }
 
-  // Email compta (TODO: brancher sur le service email existant)
+  // Email à l'adresse comptabilité configurée
   if (church?.accountingEmail) {
-    // emailService.send(...)
-    void church;
+    const appUrl = process.env.APP_URL ?? "http://localhost:3000";
+    const amount = Number(req.amount).toLocaleString("fr-FR", { style: "currency", currency: "EUR" });
+    const { subject, html } = buildAccountingNewRequestEmail({
+      requestLabel:   req.label,
+      requestAmount:  amount,
+      requestType:    req.type,
+      departmentName: req.department.name,
+      submitterName:  req.submittedBy.name ?? req.submittedBy.email ?? "—",
+      description:    req.description,
+      churchName:     church.name,
+      requestUrl:     `${appUrl}/accounting/requests/${req.id}`,
+    });
+    sendEmail({ to: church.accountingEmail, subject, html })
+      .catch((err) => console.error("[accounting] sendEmail to accountingEmail failed:", err?.message ?? err));
   }
 }

--- a/src/app/api/churches/[churchId]/route.ts
+++ b/src/app/api/churches/[churchId]/route.ts
@@ -8,6 +8,7 @@ const updateSchema = z.object({
   name: z.string().min(1, "Le nom est requis"),
   slug: z.string().min(1, "Le slug est requis"),
   secretariatEmail: z.string().email("Email invalide").nullish(),
+  accountingEmail:  z.string().email("Email invalide").nullish(),
   primaryColor: z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur hexadécimale invalide").optional(),
 });
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -226,6 +226,55 @@ export function buildAppointmentScheduledEmail(params: {
   };
 }
 
+export function buildAccountingNewRequestEmail(params: {
+  requestLabel: string;
+  requestAmount: string;
+  requestType: string;
+  departmentName: string;
+  submitterName: string;
+  description?: string | null;
+  churchName: string;
+  requestUrl: string;
+}) {
+  const label      = escapeHtml(params.requestLabel);
+  const amount     = escapeHtml(params.requestAmount);
+  const type       = params.requestType === "EXPENSE_REPORT" ? "Note de frais" : "Avance de budget";
+  const dept       = escapeHtml(params.departmentName);
+  const submitter  = escapeHtml(params.submitterName);
+  const church     = escapeHtml(params.churchName);
+  const desc       = params.description ? `<p style="color:#374151;font-size:14px;margin-top:12px;"><strong>Description :</strong> ${escapeHtml(params.description)}</p>` : "";
+
+  return {
+    subject: `[Compta] Nouvelle demande — ${label} (${amount}) — ${church}`,
+    html: `
+      <div style="font-family: Montserrat, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background: #5E17EB; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
+          <h1 style="margin: 0; font-size: 20px;">Koinonia — Nouvelle demande financière</h1>
+          <p style="margin: 4px 0 0; font-size: 13px; opacity: 0.85;">${church}</p>
+        </div>
+        <div style="padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+          <table style="width:100%;border-collapse:collapse;font-size:14px;margin-bottom:16px;">
+            <tr><td style="padding:6px 0;color:#6b7280;width:140px;">Type</td><td style="padding:6px 0;font-weight:600;">${type}</td></tr>
+            <tr><td style="padding:6px 0;color:#6b7280;">Intitulé</td><td style="padding:6px 0;font-weight:600;">${label}</td></tr>
+            <tr><td style="padding:6px 0;color:#6b7280;">Montant</td><td style="padding:6px 0;font-weight:600;color:#5E17EB;">${amount}</td></tr>
+            <tr><td style="padding:6px 0;color:#6b7280;">Département</td><td style="padding:6px 0;">${dept}</td></tr>
+            <tr><td style="padding:6px 0;color:#6b7280;">Demandeur</td><td style="padding:6px 0;">${submitter}</td></tr>
+          </table>
+          ${desc}
+          <p style="margin-top:20px;">
+            <a href="${params.requestUrl}" style="display:inline-block;background:#5E17EB;color:white;padding:10px 20px;border-radius:6px;text-decoration:none;font-size:14px;">
+              Traiter la demande →
+            </a>
+          </p>
+          <p style="color: #6b7280; font-size: 13px; margin-top: 24px;">
+            Vous recevez cet email car vous êtes l'adresse comptabilité de ${church}.
+          </p>
+        </div>
+      </div>
+    `,
+  };
+}
+
 export function buildAccountingStatusEmail(params: {
   userName: string;
   requestLabel: string;


### PR DESCRIPTION
- Template email avec récap complet (type, montant, département, demandeur, description) et bouton **Traiter la demande →**
- Envoi à `church.accountingEmail` à chaque nouvelle soumission
- Champ configurable dans **Admin > Églises > Modifier**