### PR TITLE
feat(jobs): module emploi — offres d'emploi, stage et alternance

### DIFF
--- a/prisma/migrations/20260612100000_jobs_module/migration.sql
+++ b/prisma/migrations/20260612100000_jobs_module/migration.sql
@@ -1,0 +1,38 @@
+-- CreateEnum
+CREATE TABLE IF NOT EXISTS `__prisma_migrations` (id VARCHAR(36) NOT NULL, checksum VARCHAR(64) NOT NULL, finished_at DATETIME(3) NULL, migration_name VARCHAR(255) NOT NULL, logs TEXT NULL, rolled_back_at DATETIME(3) NULL, started_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), applied_steps_count INT UNSIGNED NOT NULL DEFAULT 0, PRIMARY KEY (`id`)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable: job_offers
+CREATE TABLE `job_offers` (
+  `id`           VARCHAR(191) NOT NULL,
+  `title`        VARCHAR(200) NOT NULL,
+  `type`         ENUM('EMPLOI', 'STAGE', 'ALTERNANCE') NOT NULL,
+  `company`      VARCHAR(150) NOT NULL,
+  `location`     VARCHAR(150) NULL,
+  `description`  TEXT NOT NULL,
+  `duration`     VARCHAR(100) NULL,
+  `deadline`     DATETIME(3) NULL,
+  `contactEmail` VARCHAR(150) NULL,
+  `contactUrl`   VARCHAR(500) NULL,
+  `status`       ENUM('PUBLISHED', 'ARCHIVED') NOT NULL DEFAULT 'PUBLISHED',
+  `authorId`     VARCHAR(191) NOT NULL,
+  `createdAt`    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt`    DATETIME(3) NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `job_offers_status_type_idx` (`status`, `type`),
+  INDEX `job_offers_authorId_idx` (`authorId`),
+  CONSTRAINT `job_offers_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `users` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable: job_notification_subscriptions
+CREATE TABLE `job_notification_subscriptions` (
+  `id`             VARCHAR(191) NOT NULL,
+  `userId`         VARCHAR(191) NOT NULL,
+  `inApp`          BOOLEAN NOT NULL DEFAULT true,
+  `email`          BOOLEAN NOT NULL DEFAULT false,
+  `wantEmploi`     BOOLEAN NOT NULL DEFAULT true,
+  `wantStage`      BOOLEAN NOT NULL DEFAULT true,
+  `wantAlternance` BOOLEAN NOT NULL DEFAULT true,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `job_notification_subscriptions_userId_key` (`userId`),
+  CONSTRAINT `job_notification_subscriptions_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -162,6 +162,9 @@ model User {
   financialRequestsProcessed   FinancialRequest[]   @relation("FinancialRequestProcessor")
   financialPaymentsReleased    FinancialPayment[]   @relation("FinancialPaymentReleaser")
   financialAttachmentsUploaded FinancialAttachment[] @relation("AccountingAttachmentsUploaded")
+  // Module emploi
+  jobOffers                    JobOffer[]
+  jobNotificationSubscription  JobNotificationSubscription?
 
   @@map("users")
 }
@@ -1434,6 +1437,56 @@ model WelcomeDutyAssignment {
   @@unique([eventId, welcomeDutyFamilyId])
   @@index([churchId])
   @@map("welcome_duty_assignments")
+}
+
+// ─── Module emploi ────────────────────────────────────────────────
+
+enum JobOfferType {
+  EMPLOI
+  STAGE
+  ALTERNANCE
+}
+
+enum JobOfferStatus {
+  PUBLISHED
+  ARCHIVED
+}
+
+/// Offre d'emploi, de stage ou d'alternance publiée sur la plateforme.
+model JobOffer {
+  id           String         @id @default(cuid())
+  title        String         @db.VarChar(200)
+  type         JobOfferType
+  company      String         @db.VarChar(150)
+  location     String?        @db.VarChar(150)
+  description  String         @db.Text
+  duration     String?        @db.VarChar(100)
+  deadline     DateTime?
+  contactEmail String?        @db.VarChar(150)
+  contactUrl   String?        @db.VarChar(500)
+  status       JobOfferStatus @default(PUBLISHED)
+  authorId     String
+  author       User           @relation(fields: [authorId], references: [id])
+  createdAt    DateTime       @default(now())
+  updatedAt    DateTime       @updatedAt
+
+  @@index([status, type])
+  @@index([authorId])
+  @@map("job_offers")
+}
+
+/// Préférences de notifications pour les offres d'emploi.
+model JobNotificationSubscription {
+  id             String  @id @default(cuid())
+  userId         String  @unique
+  inApp          Boolean @default(true)
+  email          Boolean @default(false)
+  wantEmploi     Boolean @default(true)
+  wantStage      Boolean @default(true)
+  wantAlternance Boolean @default(true)
+  user           User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("job_notification_subscriptions")
 }
 
 /// Association berger/co-berger à une famille (référentiel externe).

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -55,6 +55,9 @@ export const prismaMock = {
   // Module service d'accueil
   welcomeDutyFamily: createModelMock(),
   welcomeDutyAssignment: createModelMock(),
+  // Module emploi
+  jobOffer: createModelMock(),
+  jobNotificationSubscription: createModelMock(),
   $transaction: vi.fn((fn: (tx: typeof prismaMock) => Promise<unknown>) =>
     fn(prismaMock)
   ),

--- a/src/app/(auth)/admin/jobs/AdminJobsClient.tsx
+++ b/src/app/(auth)/admin/jobs/AdminJobsClient.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+type JobType = "EMPLOI" | "STAGE" | "ALTERNANCE";
+
+interface Job {
+  id: string;
+  title: string;
+  type: JobType;
+  company: string;
+  status: "PUBLISHED" | "ARCHIVED";
+  deadline: string | null;
+  createdAt: string;
+  author: { id: string; name: string | null; displayName: string | null; image: string | null };
+}
+
+const TYPE_LABELS: Record<JobType, string> = {
+  EMPLOI:     "Emploi",
+  STAGE:      "Stage",
+  ALTERNANCE: "Alternance",
+};
+
+const TYPE_COLORS: Record<JobType, string> = {
+  EMPLOI:     "bg-icc-violet/10 text-icc-violet",
+  STAGE:      "bg-icc-bleu/10 text-icc-bleu",
+  ALTERNANCE: "bg-icc-jaune/20 text-amber-700",
+};
+
+export default function AdminJobsClient({ jobs }: { jobs: Job[] }) {
+  const router = useRouter();
+  const [filter, setFilter] = useState<"ALL" | "PUBLISHED" | "ARCHIVED">("ALL");
+  const [loading, setLoading] = useState<string | null>(null);
+
+  const filtered = jobs.filter((j) => filter === "ALL" || j.status === filter);
+  const publishedCount = jobs.filter((j) => j.status === "PUBLISHED").length;
+  const archivedCount  = jobs.filter((j) => j.status === "ARCHIVED").length;
+
+  async function toggleStatus(job: Job) {
+    setLoading(job.id);
+    try {
+      const newStatus = job.status === "PUBLISHED" ? "ARCHIVED" : "PUBLISHED";
+      const res = await fetch(`/api/jobs/${job.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur"); return; }
+      router.refresh();
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm("Supprimer définitivement cette offre ?")) return;
+    setLoading(id);
+    try {
+      const res = await fetch(`/api/jobs/${id}`, { method: "DELETE" });
+      if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur"); return; }
+      router.refresh();
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  return (
+    <div>
+      {/* Filter tabs */}
+      <div className="flex gap-1 mb-6 border-b border-gray-200">
+        {([
+          { key: "ALL",       label: "Tout",    count: jobs.length },
+          { key: "PUBLISHED", label: "Publiées",count: publishedCount },
+          { key: "ARCHIVED",  label: "Archivées",count: archivedCount },
+        ] as const).map(({ key, label, count }) => (
+          <button
+            key={key}
+            onClick={() => setFilter(key)}
+            className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              filter === key
+                ? "border-icc-violet text-icc-violet"
+                : "border-transparent text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            {label} <span className="ml-1 text-xs text-gray-400">({count})</span>
+          </button>
+        ))}
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="text-center text-gray-400 py-12">Aucune offre.</p>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map((job) => {
+            const author      = job.author.displayName ?? job.author.name ?? "Inconnu";
+            const deadline    = job.deadline ? new Date(job.deadline) : null;
+            const isArchived  = job.status === "ARCHIVED";
+
+            return (
+              <div
+                key={job.id}
+                className={`bg-white rounded-lg border-2 p-4 flex items-center gap-4 ${isArchived ? "border-gray-100 opacity-60" : "border-gray-200"}`}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap mb-0.5">
+                    <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${TYPE_COLORS[job.type]}`}>
+                      {TYPE_LABELS[job.type]}
+                    </span>
+                    {isArchived && (
+                      <span className="text-xs bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full">Archivée</span>
+                    )}
+                  </div>
+                  <Link href={`/jobs/${job.id}`} className="font-semibold text-gray-900 hover:text-icc-violet text-sm">
+                    {job.title}
+                  </Link>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    {job.company} — par {author}
+                    {deadline && ` — expire le ${deadline.toLocaleDateString("fr-FR")}`}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <button
+                    onClick={() => toggleStatus(job)}
+                    disabled={loading === job.id}
+                    className="px-3 py-1.5 text-xs font-semibold border-2 border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors"
+                  >
+                    {loading === job.id ? "…" : isArchived ? "Republier" : "Archiver"}
+                  </button>
+                  <button
+                    onClick={() => handleDelete(job.id)}
+                    disabled={loading === job.id}
+                    className="px-3 py-1.5 text-xs font-semibold border-2 border-icc-rouge/30 text-icc-rouge rounded-lg hover:bg-icc-rouge/5 disabled:opacity-50 transition-colors"
+                  >
+                    {loading === job.id ? "…" : "Supprimer"}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(auth)/admin/jobs/page.tsx
+++ b/src/app/(auth)/admin/jobs/page.tsx
@@ -1,0 +1,34 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import { rolePermissions } from "@/lib/registry";
+import AdminJobsClient from "./AdminJobsClient";
+
+export default async function AdminJobsPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/");
+
+  const userRoles   = session.user.churchRoles.map((r) => r.role);
+  const permissions = new Set(userRoles.flatMap((r) => rolePermissions[r] ?? []));
+  if (!session.user.isSuperAdmin && !permissions.has("jobs:manage")) redirect("/jobs");
+
+  const jobs = await prisma.jobOffer.findMany({
+    include: {
+      author: { select: { id: true, name: true, displayName: true, image: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Modération — Emploi</h1>
+      <p className="text-sm text-gray-500 mb-6">Gérez les offres publiées par les membres de la communauté.</p>
+      <AdminJobsClient jobs={jobs.map((j) => ({
+        ...j,
+        deadline:  j.deadline  ? j.deadline.toISOString()  : null,
+        createdAt: j.createdAt.toISOString(),
+        updatedAt: j.updatedAt.toISOString(),
+      }))} />
+    </div>
+  );
+}

--- a/src/app/(auth)/jobs/JobsListClient.tsx
+++ b/src/app/(auth)/jobs/JobsListClient.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+type JobType = "EMPLOI" | "STAGE" | "ALTERNANCE";
+
+interface Job {
+  id: string;
+  title: string;
+  type: JobType;
+  company: string;
+  location: string | null;
+  duration: string | null;
+  deadline: string | null;
+  description: string;
+  contactEmail: string | null;
+  contactUrl: string | null;
+  status: string;
+  createdAt: string;
+  author: { id: string; name: string | null; displayName: string | null; image: string | null };
+}
+
+const TYPE_LABELS: Record<JobType, string> = {
+  EMPLOI:     "Emploi",
+  STAGE:      "Stage",
+  ALTERNANCE: "Alternance",
+};
+
+const TYPE_COLORS: Record<JobType, string> = {
+  EMPLOI:     "bg-icc-violet/10 text-icc-violet",
+  STAGE:      "bg-icc-bleu/10 text-icc-bleu",
+  ALTERNANCE: "bg-icc-jaune/20 text-amber-700",
+};
+
+export default function JobsListClient({
+  jobs,
+  currentUserId,
+  nowMs,
+}: {
+  jobs: Job[];
+  currentUserId: string;
+  nowMs: number;
+}) {
+  const [filter, setFilter] = useState<JobType | "ALL">("ALL");
+
+  const filtered = filter === "ALL" ? jobs : jobs.filter((j) => j.type === filter);
+
+  return (
+    <div>
+      {/* Tabs */}
+      <div className="flex gap-1 mb-6 border-b border-gray-200">
+        {(["ALL", "EMPLOI", "STAGE", "ALTERNANCE"] as const).map((t) => {
+          const count = t === "ALL" ? jobs.length : jobs.filter((j) => j.type === t).length;
+          return (
+            <button
+              key={t}
+              onClick={() => setFilter(t)}
+              className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                filter === t
+                  ? "border-icc-violet text-icc-violet"
+                  : "border-transparent text-gray-500 hover:text-gray-700"
+              }`}
+            >
+              {t === "ALL" ? "Tout" : TYPE_LABELS[t]}
+              <span className="ml-1.5 text-xs text-gray-400">({count})</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-16 text-gray-400">
+          <p className="text-lg font-medium">Aucune offre pour le moment</p>
+          <p className="text-sm mt-1">Soyez le premier à publier !</p>
+          <Link href="/jobs/new" className="inline-block mt-4 px-4 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 transition-colors">
+            Publier une offre
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {filtered.map((job) => (
+            <JobCard key={job.id} job={job} isOwn={job.author.id === currentUserId} nowMs={nowMs} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function JobCard({ job, isOwn, nowMs }: { job: Job; isOwn: boolean; nowMs: number }) {
+  const deadlineDate = job.deadline ? new Date(job.deadline) : null;
+  const createdDate  = new Date(job.createdAt);
+  const isExpiringSoon = deadlineDate
+    ? deadlineDate.getTime() - nowMs < 7 * 24 * 60 * 60 * 1000
+    : false;
+
+  return (
+    <Link
+      href={`/jobs/${job.id}`}
+      className="block bg-white rounded-lg border-2 border-gray-100 p-5 hover:border-icc-violet/30 hover:shadow-sm transition-all"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
+            <span className={`inline-block text-xs font-semibold px-2.5 py-0.5 rounded-full ${TYPE_COLORS[job.type]}`}>
+              {TYPE_LABELS[job.type]}
+            </span>
+            {isOwn && (
+              <span className="text-xs text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">Ma publication</span>
+            )}
+          </div>
+          <h3 className="font-semibold text-gray-900 text-base leading-snug">{job.title}</h3>
+          <p className="text-sm text-gray-600 mt-0.5">{job.company}</p>
+          {job.location && (
+            <p className="text-xs text-gray-400 mt-0.5">{job.location}</p>
+          )}
+        </div>
+        <div className="text-right shrink-0">
+          <p className="text-xs text-gray-400">
+            {createdDate.toLocaleDateString("fr-FR", { day: "numeric", month: "short" })}
+          </p>
+          {deadlineDate && (
+            <p className={`text-xs mt-0.5 ${isExpiringSoon ? "text-icc-rouge font-medium" : "text-gray-400"}`}>
+              Expire le {deadlineDate.toLocaleDateString("fr-FR", { day: "numeric", month: "short" })}
+            </p>
+          )}
+        </div>
+      </div>
+      <p className="text-sm text-gray-500 mt-2 line-clamp-2">{job.description}</p>
+    </Link>
+  );
+}

--- a/src/app/(auth)/jobs/[id]/JobDetailClient.tsx
+++ b/src/app/(auth)/jobs/[id]/JobDetailClient.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+type JobType = "EMPLOI" | "STAGE" | "ALTERNANCE";
+
+interface Job {
+  id: string;
+  title: string;
+  type: JobType;
+  company: string;
+  location: string | null;
+  description: string;
+  duration: string | null;
+  deadline: string | null;
+  contactEmail: string | null;
+  contactUrl: string | null;
+  status: "PUBLISHED" | "ARCHIVED";
+  createdAt: string;
+  updatedAt: string;
+  author: { id: string; name: string | null; displayName: string | null; image: string | null };
+}
+
+const TYPE_LABELS: Record<JobType, string> = {
+  EMPLOI:     "Emploi",
+  STAGE:      "Stage",
+  ALTERNANCE: "Alternance",
+};
+
+const TYPE_COLORS: Record<JobType, string> = {
+  EMPLOI:     "bg-icc-violet/10 text-icc-violet",
+  STAGE:      "bg-icc-bleu/10 text-icc-bleu",
+  ALTERNANCE: "bg-icc-jaune/20 text-amber-700",
+};
+
+export default function JobDetailClient({
+  job,
+  canManage,
+  isAuthor,
+}: {
+  job: Job;
+  canManage: boolean;
+  isAuthor: boolean;
+}) {
+  const router = useRouter();
+  const [archiving, setArchiving] = useState(false);
+  const [deleting,  setDeleting]  = useState(false);
+
+  const isArchived = job.status === "ARCHIVED";
+
+  async function toggleArchive() {
+    setArchiving(true);
+    try {
+      const res = await fetch(`/api/jobs/${job.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: isArchived ? "PUBLISHED" : "ARCHIVED" }),
+      });
+      if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur"); return; }
+      router.refresh();
+    } finally {
+      setArchiving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm("Supprimer définitivement cette offre ?")) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/jobs/${job.id}`, { method: "DELETE" });
+      if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur"); return; }
+      router.push("/jobs");
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const deadlineDate = job.deadline ? new Date(job.deadline) : null;
+  const createdDate  = new Date(job.createdAt);
+  const authorName   = job.author.displayName ?? job.author.name ?? "Anonyme";
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-4">
+        <Link href="/jobs" className="text-sm text-gray-400 hover:text-gray-600">← Toutes les offres</Link>
+      </div>
+
+      <div className="bg-white rounded-lg border-2 border-gray-200 p-6">
+        {isArchived && (
+          <div className="mb-4 px-4 py-2 bg-gray-100 text-gray-500 text-sm rounded-lg">
+            Cette offre est archivée et n&apos;est plus visible dans la liste.
+          </div>
+        )}
+
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <div>
+            <span className={`inline-block text-xs font-semibold px-2.5 py-0.5 rounded-full mb-2 ${TYPE_COLORS[job.type]}`}>
+              {TYPE_LABELS[job.type]}
+            </span>
+            <h1 className="text-xl font-bold text-gray-900">{job.title}</h1>
+            <p className="text-gray-600 mt-0.5">{job.company}</p>
+            {job.location && <p className="text-sm text-gray-400 mt-0.5">{job.location}</p>}
+          </div>
+
+          {(canManage || isAuthor) && (
+            <div className="flex gap-2 shrink-0">
+              {isAuthor && !isArchived && (
+                <Link
+                  href={`/jobs/${job.id}/edit`}
+                  className="px-3 py-1.5 text-xs font-semibold border-2 border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+                >
+                  Modifier
+                </Link>
+              )}
+              {(canManage || isAuthor) && (
+                <button
+                  onClick={toggleArchive}
+                  disabled={archiving}
+                  className="px-3 py-1.5 text-xs font-semibold border-2 border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors"
+                >
+                  {archiving ? "…" : isArchived ? "Republier" : "Archiver"}
+                </button>
+              )}
+              {(canManage || isAuthor) && (
+                <button
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="px-3 py-1.5 text-xs font-semibold border-2 border-icc-rouge/30 text-icc-rouge rounded-lg hover:bg-icc-rouge/5 disabled:opacity-50 transition-colors"
+                >
+                  {deleting ? "…" : "Supprimer"}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Metadata */}
+        <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-500 mb-5 py-3 border-y border-gray-100">
+          {job.duration && <span>Durée : <strong className="text-gray-700">{job.duration}</strong></span>}
+          {deadlineDate && (
+            <span>
+              Date limite : <strong className="text-gray-700">{deadlineDate.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}</strong>
+            </span>
+          )}
+          <span>
+            Publié par <strong className="text-gray-700">{authorName}</strong> le {createdDate.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}
+          </span>
+        </div>
+
+        {/* Description */}
+        <div className="prose prose-sm max-w-none">
+          <p className="text-gray-700 whitespace-pre-wrap">{job.description}</p>
+        </div>
+
+        {/* Contact */}
+        {(job.contactEmail || job.contactUrl) && (
+          <div className="mt-6 pt-5 border-t border-gray-100">
+            <p className="text-sm font-semibold text-gray-700 mb-2">Candidature</p>
+            {job.contactEmail && (
+              <a
+                href={`mailto:${job.contactEmail}`}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 transition-colors"
+              >
+                Envoyer un email →
+              </a>
+            )}
+            {job.contactUrl && (
+              <a
+                href={job.contactUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 transition-colors"
+              >
+                Postuler en ligne ↗
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/jobs/[id]/edit/page.tsx
+++ b/src/app/(auth)/jobs/[id]/edit/page.tsx
@@ -1,0 +1,39 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect, notFound } from "next/navigation";
+import JobFormClient from "../../new/JobFormClient";
+
+export default async function EditJobPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/");
+
+  const { id } = await params;
+
+  const job = await prisma.jobOffer.findUnique({
+    where: { id },
+    select: {
+      id: true, title: true, type: true, company: true, location: true,
+      description: true, duration: true, deadline: true,
+      contactEmail: true, contactUrl: true, authorId: true,
+    },
+  });
+
+  if (!job) notFound();
+  if (job.authorId !== session.user.id) redirect(`/jobs/${id}`);
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Modifier l&apos;offre</h1>
+      <JobFormClient
+        initial={{
+          ...job,
+          deadline: job.deadline ? job.deadline.toISOString() : null,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/(auth)/jobs/[id]/page.tsx
+++ b/src/app/(auth)/jobs/[id]/page.tsx
@@ -1,0 +1,45 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect, notFound } from "next/navigation";
+import JobDetailClient from "./JobDetailClient";
+import { rolePermissions } from "@/lib/registry";
+
+export default async function JobDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/");
+
+  const { id } = await params;
+
+  const job = await prisma.jobOffer.findUnique({
+    where: { id },
+    include: {
+      author: { select: { id: true, name: true, displayName: true, image: true } },
+    },
+  });
+
+  if (!job) notFound();
+
+  const userRoles    = session.user.churchRoles.map((r) => r.role);
+  const permissions  = new Set(userRoles.flatMap((r) => rolePermissions[r] ?? []));
+  const canManage    = session.user.isSuperAdmin || permissions.has("jobs:manage");
+  const isAuthor     = job.authorId === session.user.id;
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <JobDetailClient
+        job={{
+          ...job,
+          deadline:  job.deadline  ? job.deadline.toISOString()  : null,
+          createdAt: job.createdAt.toISOString(),
+          updatedAt: job.updatedAt.toISOString(),
+        }}
+        canManage={canManage}
+        isAuthor={isAuthor}
+      />
+    </div>
+  );
+}

--- a/src/app/(auth)/jobs/new/JobFormClient.tsx
+++ b/src/app/(auth)/jobs/new/JobFormClient.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type JobType = "EMPLOI" | "STAGE" | "ALTERNANCE";
+
+export default function JobFormClient({ initial }: { initial?: {
+  id: string;
+  title: string;
+  type: JobType;
+  company: string;
+  location: string | null;
+  description: string;
+  duration: string | null;
+  deadline: string | null;
+  contactEmail: string | null;
+  contactUrl: string | null;
+}}) {
+  const router = useRouter();
+  const isEdit = !!initial;
+
+  const [title,        setTitle]        = useState(initial?.title        ?? "");
+  const [type,         setType]         = useState<JobType>(initial?.type ?? "EMPLOI");
+  const [company,      setCompany]      = useState(initial?.company      ?? "");
+  const [location,     setLocation]     = useState(initial?.location     ?? "");
+  const [description,  setDescription]  = useState(initial?.description  ?? "");
+  const [duration,     setDuration]     = useState(initial?.duration     ?? "");
+  const [deadline,     setDeadline]     = useState(
+    initial?.deadline ? new Date(initial.deadline).toISOString().slice(0, 10) : ""
+  );
+  const [contactEmail, setContactEmail] = useState(initial?.contactEmail ?? "");
+  const [contactUrl,   setContactUrl]   = useState(initial?.contactUrl   ?? "");
+  const [saving,       setSaving]       = useState(false);
+  const [error,        setError]        = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    const body = {
+      title:        title.trim(),
+      type,
+      company:      company.trim(),
+      location:     location.trim() || null,
+      description:  description.trim(),
+      duration:     duration.trim() || null,
+      deadline:     deadline ? new Date(deadline).toISOString() : null,
+      contactEmail: contactEmail.trim() || null,
+      contactUrl:   contactUrl.trim() || null,
+    };
+
+    try {
+      const url    = isEdit ? `/api/jobs/${initial!.id}` : "/api/jobs";
+      const method = isEdit ? "PATCH" : "POST";
+      const res    = await fetch(url, { method, headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+      const data   = await res.json();
+      if (!res.ok) { setError(data.error || "Erreur lors de la publication"); return; }
+      router.push(`/jobs/${data.id}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-white rounded-lg border-2 border-gray-200 p-6 space-y-5">
+      {error && (
+        <div className="bg-icc-rouge/10 text-icc-rouge text-sm px-4 py-3 rounded-lg">{error}</div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="col-span-2">
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Intitulé du poste *</label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+            maxLength={200}
+            placeholder="Ex: Développeur React, Comptable..."
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Type *</label>
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value as JobType)}
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          >
+            <option value="EMPLOI">Emploi</option>
+            <option value="STAGE">Stage</option>
+            <option value="ALTERNANCE">Alternance</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Entreprise / Organisme *</label>
+          <input
+            type="text"
+            value={company}
+            onChange={(e) => setCompany(e.target.value)}
+            required
+            maxLength={150}
+            placeholder="Nom de l'entreprise"
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Lieu</label>
+          <input
+            type="text"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            maxLength={150}
+            placeholder="Ville, région ou télétravail"
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Durée / Rythme</label>
+          <input
+            type="text"
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            maxLength={100}
+            placeholder="Ex: 6 mois, CDI, 2 ans..."
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+
+        <div className="col-span-2">
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Description *</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            required
+            rows={6}
+            placeholder="Décrivez le poste, les missions, les compétences requises..."
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet resize-y"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Date limite de candidature</label>
+          <input
+            type="date"
+            value={deadline}
+            onChange={(e) => setDeadline(e.target.value)}
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+          <p className="text-xs text-gray-400 mt-1">L&apos;offre sera automatiquement archivée après cette date.</p>
+        </div>
+
+        <div />
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Email de contact</label>
+          <input
+            type="email"
+            value={contactEmail}
+            onChange={(e) => setContactEmail(e.target.value)}
+            placeholder="recrutement@exemple.fr"
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Lien de candidature</label>
+          <input
+            type="url"
+            value={contactUrl}
+            onChange={(e) => setContactUrl(e.target.value)}
+            placeholder="https://..."
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={saving}
+          className="px-5 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 disabled:opacity-50 transition-colors"
+        >
+          {saving ? "Publication…" : isEdit ? "Enregistrer" : "Publier l'offre"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="px-5 py-2 border-2 border-gray-200 text-gray-700 text-sm font-semibold rounded-lg hover:bg-gray-50 transition-colors"
+        >
+          Annuler
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(auth)/jobs/new/page.tsx
+++ b/src/app/(auth)/jobs/new/page.tsx
@@ -1,0 +1,15 @@
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import JobFormClient from "./JobFormClient";
+
+export default async function NewJobPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/");
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Publier une offre</h1>
+      <JobFormClient />
+    </div>
+  );
+}

--- a/src/app/(auth)/jobs/page.tsx
+++ b/src/app/(auth)/jobs/page.tsx
@@ -1,0 +1,48 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import JobsListClient from "./JobsListClient";
+
+export default async function JobsPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/");
+
+  const now = new Date();
+
+  const jobs = await prisma.jobOffer.findMany({
+    where: {
+      status: "PUBLISHED",
+      OR: [{ deadline: null }, { deadline: { gte: now } }],
+    },
+    include: {
+      author: { select: { id: true, name: true, displayName: true, image: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const serialized = jobs.map((j) => ({
+    ...j,
+    deadline:  j.deadline  ? j.deadline.toISOString()  : null,
+    createdAt: j.createdAt.toISOString(),
+  }));
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Emploi</h1>
+          <p className="text-sm text-gray-500 mt-1">Offres d&apos;emploi, stages et alternances de la communauté</p>
+        </div>
+        <Link
+          href="/jobs/new"
+          className="px-4 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 transition-colors"
+        >
+          Publier une offre
+        </Link>
+      </div>
+
+      <JobsListClient jobs={serialized} currentUserId={session.user.id!} nowMs={now.getTime()} />
+    </div>
+  );
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -270,6 +270,8 @@ export default async function AuthLayout({
 
   const hasDiscipleship = userPermissions.has("discipleship:view");
   const hasAccounting = userPermissions.has("accounting:view");
+  const hasJobs = userPermissions.has("jobs:view");
+  const hasJobsManage = userPermissions.has("jobs:manage");
   const hasEventsAccess = userPermissions.has("events:view");
   const hasEventsManage = userPermissions.has("events:manage");
   const hasPlanningAccess = userPermissions.has("planning:view");
@@ -300,6 +302,8 @@ export default async function AuthLayout({
       mrbsAdminLink={mrbsAdminLink}
       hasDiscipleship={hasDiscipleship}
       hasAccounting={hasAccounting}
+      hasJobs={hasJobs}
+      hasJobsManage={hasJobsManage}
       hasEventsAccess={hasEventsAccess}
       hasEventsManage={hasEventsManage}
       hasPlanningAccess={hasPlanningAccess}

--- a/src/app/(auth)/profile/JobSubscriptionClient.tsx
+++ b/src/app/(auth)/profile/JobSubscriptionClient.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface Subscription {
+  id: string;
+  inApp: boolean;
+  email: boolean;
+  wantEmploi: boolean;
+  wantStage: boolean;
+  wantAlternance: boolean;
+}
+
+export default function JobSubscriptionClient() {
+  const [sub,     setSub]     = useState<Subscription | null>(null);
+  const [saving,  setSaving]  = useState(false);
+  const [loaded,  setLoaded]  = useState(false);
+
+  useEffect(() => {
+    fetch("/api/jobs/subscription")
+      .then((r) => r.json())
+      .then((data) => { setSub(data); setLoaded(true); })
+      .catch(() => setLoaded(true));
+  }, []);
+
+  async function update(patch: Partial<Subscription>) {
+    if (!sub) return;
+    const next = { ...sub, ...patch };
+    setSub(next);
+    setSaving(true);
+    try {
+      const res = await fetch("/api/jobs/subscription", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSub(data);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!loaded) {
+    return (
+      <div className="bg-white rounded-lg border-2 border-gray-200 p-6 mb-6">
+        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-4">Notifications — Emploi</h2>
+        <p className="text-sm text-gray-400">Chargement…</p>
+      </div>
+    );
+  }
+
+  if (!sub) return null;
+
+  return (
+    <div className="bg-white rounded-lg border-2 border-gray-200 p-6 mb-6">
+      <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-1">Notifications — Emploi</h2>
+      <p className="text-xs text-gray-400 mb-5">Recevez une notification quand une nouvelle offre est publiée.</p>
+
+      {/* Channels */}
+      <div className="space-y-3 mb-5">
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={sub.inApp}
+            onChange={(e) => update({ inApp: e.target.checked })}
+            disabled={saving}
+            className="w-4 h-4 text-icc-violet rounded accent-icc-violet"
+          />
+          <div>
+            <span className="text-sm font-medium text-gray-800">Notification dans l&apos;app</span>
+            <p className="text-xs text-gray-400">Badge sur la cloche de notifications</p>
+          </div>
+        </label>
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={sub.email}
+            onChange={(e) => update({ email: e.target.checked })}
+            disabled={saving}
+            className="w-4 h-4 text-icc-violet rounded accent-icc-violet"
+          />
+          <div>
+            <span className="text-sm font-medium text-gray-800">Email</span>
+            <p className="text-xs text-gray-400">Envoyé à votre adresse Google</p>
+          </div>
+        </label>
+      </div>
+
+      {/* Types */}
+      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">Types d&apos;offres</p>
+      <div className="flex flex-wrap gap-3">
+        {([
+          { key: "wantEmploi",     label: "Emploi" },
+          { key: "wantStage",      label: "Stage" },
+          { key: "wantAlternance", label: "Alternance" },
+        ] as const).map(({ key, label }) => (
+          <label
+            key={key}
+            className={`flex items-center gap-2 px-3 py-1.5 rounded-full border-2 cursor-pointer transition-colors text-sm font-medium ${
+              sub[key]
+                ? "border-icc-violet bg-icc-violet/10 text-icc-violet"
+                : "border-gray-200 text-gray-500 hover:border-gray-300"
+            }`}
+          >
+            <input
+              type="checkbox"
+              checked={sub[key]}
+              onChange={(e) => update({ [key]: e.target.checked })}
+              disabled={saving}
+              className="sr-only"
+            />
+            {label}
+          </label>
+        ))}
+      </div>
+      {saving && <p className="text-xs text-gray-400 mt-3">Enregistrement…</p>}
+    </div>
+  );
+}

--- a/src/app/(auth)/profile/page.tsx
+++ b/src/app/(auth)/profile/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import ProfileClient from "./ProfileClient";
+import JobSubscriptionClient from "./JobSubscriptionClient";
 
 export default async function ProfilePage() {
   const session = await auth();
@@ -151,6 +152,9 @@ export default async function ProfilePage() {
           </div>
         </div>
       )}
+
+      {/* Abonnements Emploi */}
+      <JobSubscriptionClient />
 
       {/* Nouvelle demande */}
       {unlinkableChurches.length > 0 && (

--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -1,0 +1,110 @@
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { z } from "zod";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    await requireAuth();
+    const { id } = await params;
+
+    const job = await prisma.jobOffer.findUnique({
+      where: { id },
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+    });
+
+    if (!job) throw new ApiError(404, "Offre introuvable");
+
+    return successResponse(job);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+const patchSchema = z.object({
+  title:        z.string().min(1).max(200).optional(),
+  type:         z.enum(["EMPLOI", "STAGE", "ALTERNANCE"]).optional(),
+  company:      z.string().min(1).max(150).optional(),
+  location:     z.string().max(150).nullable().optional(),
+  description:  z.string().min(1).optional(),
+  duration:     z.string().max(100).nullable().optional(),
+  deadline:     z.string().datetime().nullable().optional(),
+  contactEmail: z.string().email().max(150).nullable().optional(),
+  contactUrl:   z.string().url().max(500).nullable().optional(),
+  status:       z.enum(["PUBLISHED", "ARCHIVED"]).optional(),
+});
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await requireAuth();
+    const { id } = await params;
+
+    const job = await prisma.jobOffer.findUnique({ where: { id }, select: { id: true, authorId: true } });
+    if (!job) throw new ApiError(404, "Offre introuvable");
+
+    const isAuthor  = job.authorId === session.user.id;
+    const canManage = session.user.isSuperAdmin ||
+      session.user.churchRoles?.some((r) =>
+        ["SUPER_ADMIN", "ADMIN", "SECRETARY"].includes(r.role)
+      );
+
+    if (!isAuthor && !canManage) {
+      throw new ApiError(403, "Accès refusé");
+    }
+
+    const body = await request.json();
+    const data = patchSchema.parse(body);
+
+    const updated = await prisma.jobOffer.update({
+      where: { id },
+      data: {
+        ...data,
+        ...(data.deadline !== undefined ? { deadline: data.deadline ? new Date(data.deadline) : null } : {}),
+      },
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+    });
+
+    return successResponse(updated);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await requireAuth();
+    const { id } = await params;
+
+    const job = await prisma.jobOffer.findUnique({ where: { id }, select: { id: true, authorId: true } });
+    if (!job) throw new ApiError(404, "Offre introuvable");
+
+    const isAuthor  = job.authorId === session.user.id;
+    const canManage = session.user.isSuperAdmin ||
+      session.user.churchRoles?.some((r) =>
+        ["SUPER_ADMIN", "ADMIN", "SECRETARY"].includes(r.role)
+      );
+
+    if (!isAuthor && !canManage) {
+      throw new ApiError(403, "Accès refusé");
+    }
+
+    await prisma.jobOffer.delete({ where: { id } });
+
+    return successResponse({ success: true });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/jobs/__tests__/jobs.test.ts
+++ b/src/app/api/jobs/__tests__/jobs.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createAdminSession } from "@/__mocks__/auth";
+
+const mockRequireAuth       = vi.fn();
+const mockRequirePermission = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  requireAuth:       (...args: unknown[]) => mockRequireAuth(...args),
+  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/email",  () => ({
+  sendEmail:       vi.fn(),
+  buildJobOfferEmail: vi.fn().mockReturnValue({ subject: "s", html: "h" }),
+}));
+
+// ─── /api/jobs ──────────────────────────────────────────────────────────────
+
+const { GET: getJobs, POST: postJob } = await import("../route");
+
+describe("GET /api/jobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+  });
+
+  it("returns published unexpired jobs", async () => {
+    prismaMock.jobOffer.findMany.mockResolvedValue([
+      { id: "j1", title: "Dev", type: "EMPLOI", company: "ACME", status: "PUBLISHED", createdAt: new Date(), updatedAt: new Date(), author: { id: "u1", name: "Alice", displayName: null, image: null } },
+    ] as never);
+
+    const res = await getJobs(new Request("http://localhost/api/jobs"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].type).toBe("EMPLOI");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireAuth.mockRejectedValue(new Error("UNAUTHORIZED"));
+    const res = await getJobs(new Request("http://localhost/api/jobs"));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/jobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequirePermission.mockResolvedValue(createAdminSession());
+    prismaMock.jobNotificationSubscription.findMany.mockResolvedValue([]);
+  });
+
+  it("creates a job offer", async () => {
+    prismaMock.jobOffer.create.mockResolvedValue({
+      id: "j1", title: "Dev React", type: "STAGE", company: "Corp", status: "PUBLISHED",
+      location: "Paris", description: "Desc", duration: null, deadline: null,
+      contactEmail: null, contactUrl: null, authorId: "u1", createdAt: new Date(), updatedAt: new Date(),
+      author: { id: "u1", name: "Alice", displayName: null, image: null },
+    } as never);
+
+    const req = new Request("http://localhost/api/jobs", {
+      method: "POST",
+      body: JSON.stringify({ title: "Dev React", type: "STAGE", company: "Corp", description: "Desc" }),
+    });
+    const res = await postJob(req);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.title).toBe("Dev React");
+  });
+
+  it("returns 400 on invalid type", async () => {
+    const req = new Request("http://localhost/api/jobs", {
+      method: "POST",
+      body: JSON.stringify({ title: "Dev", type: "INVALID", company: "Corp", description: "Desc" }),
+    });
+    const res = await postJob(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when permission denied", async () => {
+    mockRequirePermission.mockRejectedValue(new Error("FORBIDDEN"));
+    const req = new Request("http://localhost/api/jobs", {
+      method: "POST",
+      body: JSON.stringify({ title: "Dev", type: "EMPLOI", company: "Corp", description: "Desc" }),
+    });
+    const res = await postJob(req);
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── /api/jobs/[id] ─────────────────────────────────────────────────────────
+
+const { GET: getJob, PATCH: patchJob, DELETE: deleteJob } = await import("../[id]/route");
+
+describe("GET /api/jobs/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+  });
+
+  it("returns job detail", async () => {
+    prismaMock.jobOffer.findUnique.mockResolvedValue({
+      id: "j1", title: "Dev", type: "EMPLOI", company: "ACME", status: "PUBLISHED",
+      author: { id: "u1", name: "Alice", displayName: null, image: null },
+    } as never);
+
+    const res = await getJob(new Request("http://localhost/api/jobs/j1"), { params: Promise.resolve({ id: "j1" }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("j1");
+  });
+
+  it("returns 404 for unknown job", async () => {
+    prismaMock.jobOffer.findUnique.mockResolvedValue(null);
+    const res = await getJob(new Request("http://localhost/api/jobs/nope"), { params: Promise.resolve({ id: "nope" }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/jobs/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+  });
+
+  it("allows admin to update any job", async () => {
+    // createAdminSession() returns user.id = "user-1" with ADMIN role
+    prismaMock.jobOffer.findUnique.mockResolvedValue({ id: "j1", authorId: "someone-else" } as never);
+    prismaMock.jobOffer.update.mockResolvedValue({ id: "j1", status: "ARCHIVED", author: {} } as never);
+
+    const req = new Request("http://localhost/api/jobs/j1", {
+      method: "PATCH",
+      body: JSON.stringify({ status: "ARCHIVED" }),
+    });
+    const res = await patchJob(req, { params: Promise.resolve({ id: "j1" }) });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 for non-author non-manager", async () => {
+    // Override session to a regular user who doesn't own the job
+    mockRequireAuth.mockResolvedValue({ user: { id: "other-user", isSuperAdmin: false, churchRoles: [{ role: "STAR" }] } });
+    prismaMock.jobOffer.findUnique.mockResolvedValue({ id: "j1", authorId: "user-admin" } as never);
+
+    const req = new Request("http://localhost/api/jobs/j1", {
+      method: "PATCH",
+      body: JSON.stringify({ status: "ARCHIVED" }),
+    });
+    const res = await patchJob(req, { params: Promise.resolve({ id: "j1" }) });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("DELETE /api/jobs/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+  });
+
+  it("allows author to delete", async () => {
+    prismaMock.jobOffer.findUnique.mockResolvedValue({ id: "j1", authorId: "user-admin" } as never);
+    prismaMock.jobOffer.delete.mockResolvedValue({} as never);
+
+    const res = await deleteJob(new Request("http://localhost/api/jobs/j1", { method: "DELETE" }), { params: Promise.resolve({ id: "j1" }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 404 for unknown job", async () => {
+    prismaMock.jobOffer.findUnique.mockResolvedValue(null);
+    const res = await deleteJob(new Request("http://localhost/api/jobs/nope", { method: "DELETE" }), { params: Promise.resolve({ id: "nope" }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── /api/jobs/subscription ─────────────────────────────────────────────────
+
+const { GET: getSub, PUT: putSub } = await import("../subscription/route");
+
+describe("GET /api/jobs/subscription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+  });
+
+  it("creates subscription if not exists and returns it", async () => {
+    prismaMock.jobNotificationSubscription.upsert.mockResolvedValue({
+      id: "s1", userId: "user-admin", inApp: true, email: false,
+      wantEmploi: true, wantStage: true, wantAlternance: true,
+    } as never);
+
+    const res = await getSub();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.inApp).toBe(true);
+  });
+});
+
+describe("PUT /api/jobs/subscription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+  });
+
+  it("updates subscription preferences", async () => {
+    prismaMock.jobNotificationSubscription.upsert.mockResolvedValue({
+      id: "s1", userId: "user-admin", inApp: false, email: true,
+      wantEmploi: true, wantStage: false, wantAlternance: false,
+    } as never);
+
+    const req = new Request("http://localhost/api/jobs/subscription", {
+      method: "PUT",
+      body: JSON.stringify({ inApp: false, email: true, wantStage: false, wantAlternance: false }),
+    });
+    const res = await putSub(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.email).toBe(true);
+    expect(body.wantStage).toBe(false);
+  });
+});

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,0 +1,133 @@
+import { prisma } from "@/lib/prisma";
+import { requireAuth, requirePermission } from "@/lib/auth";
+import { successResponse, errorResponse } from "@/lib/api-utils";
+import { sendEmail, buildJobOfferEmail } from "@/lib/email";
+import { z } from "zod";
+
+const jobSchema = z.object({
+  title:        z.string().min(1).max(200),
+  type:         z.enum(["EMPLOI", "STAGE", "ALTERNANCE"]),
+  company:      z.string().min(1).max(150),
+  location:     z.string().max(150).optional().nullable(),
+  description:  z.string().min(1),
+  duration:     z.string().max(100).optional().nullable(),
+  deadline:     z.string().datetime().optional().nullable(),
+  contactEmail: z.string().email().max(150).optional().nullable(),
+  contactUrl:   z.string().url().max(500).optional().nullable(),
+});
+
+export async function GET(request: Request) {
+  try {
+    await requireAuth();
+
+    const { searchParams } = new URL(request.url);
+    const type   = searchParams.get("type");
+    const status = searchParams.get("status") ?? "PUBLISHED";
+
+    const now = new Date();
+
+    const jobs = await prisma.jobOffer.findMany({
+      where: {
+        status: status === "ARCHIVED" ? "ARCHIVED" : "PUBLISHED",
+        ...(type ? { type: type as "EMPLOI" | "STAGE" | "ALTERNANCE" } : {}),
+        ...(status !== "ARCHIVED" ? { OR: [{ deadline: null }, { deadline: { gte: now } }] } : {}),
+      },
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return successResponse(jobs);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await requirePermission("jobs:post");
+    const body = await request.json();
+    const data = jobSchema.parse(body);
+
+    const job = await prisma.jobOffer.create({
+      data: {
+        ...data,
+        deadline:  data.deadline  ? new Date(data.deadline)  : null,
+        authorId:  session.user.id!,
+      },
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+    });
+
+    // Fire-and-forget notifications
+    void notifySubscribers(job).catch(() => null);
+
+    return successResponse(job, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+async function notifySubscribers(job: {
+  id: string;
+  title: string;
+  type: "EMPLOI" | "STAGE" | "ALTERNANCE";
+  company: string;
+  location: string | null;
+  duration: string | null;
+  deadline: Date | null;
+  description: string;
+  contactEmail: string | null;
+  contactUrl: string | null;
+}) {
+  const typeField =
+    job.type === "EMPLOI"
+      ? { wantEmploi: true }
+      : job.type === "STAGE"
+        ? { wantStage: true }
+        : { wantAlternance: true };
+
+  const subs = await prisma.jobNotificationSubscription.findMany({
+    where: typeField,
+    include: { user: { select: { id: true, name: true, displayName: true, email: true } } },
+  });
+
+  const appUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+  const jobUrl = `${appUrl}/jobs/${job.id}`;
+
+  const typeLabel = job.type === "EMPLOI" ? "Emploi" : job.type === "STAGE" ? "Stage" : "Alternance";
+
+  await Promise.allSettled(
+    subs.map(async (sub) => {
+      if (sub.inApp) {
+        await prisma.notification.create({
+          data: {
+            userId:  sub.userId,
+            type:    "JOB_OFFER",
+            title:   `Nouvelle offre ${typeLabel}`,
+            message: `${job.title} chez ${job.company}`,
+            link:    `/jobs/${job.id}`,
+          },
+        });
+      }
+      if (sub.email && sub.user.email) {
+        const { subject, html } = buildJobOfferEmail({
+          subscriberName: sub.user.displayName ?? sub.user.name ?? null,
+          jobTitle:       job.title,
+          company:        job.company,
+          type:           job.type,
+          location:       job.location,
+          duration:       job.duration,
+          deadline:       job.deadline,
+          description:    job.description,
+          contactEmail:   job.contactEmail,
+          contactUrl:     job.contactUrl,
+          jobUrl,
+        });
+        await sendEmail({ to: sub.user.email, subject, html });
+      }
+    })
+  );
+}

--- a/src/app/api/jobs/subscription/route.ts
+++ b/src/app/api/jobs/subscription/route.ts
@@ -1,0 +1,46 @@
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { successResponse, errorResponse } from "@/lib/api-utils";
+import { z } from "zod";
+
+export async function GET() {
+  try {
+    const session = await requireAuth();
+
+    const sub = await prisma.jobNotificationSubscription.upsert({
+      where:  { userId: session.user.id! },
+      create: { userId: session.user.id! },
+      update: {},
+    });
+
+    return successResponse(sub);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+const subSchema = z.object({
+  inApp:          z.boolean().optional(),
+  email:          z.boolean().optional(),
+  wantEmploi:     z.boolean().optional(),
+  wantStage:      z.boolean().optional(),
+  wantAlternance: z.boolean().optional(),
+});
+
+export async function PUT(request: Request) {
+  try {
+    const session = await requireAuth();
+    const body = await request.json();
+    const data = subSchema.parse(body);
+
+    const sub = await prisma.jobNotificationSubscription.upsert({
+      where:  { userId: session.user.id! },
+      create: { userId: session.user.id!, ...data },
+      update: data,
+    });
+
+    return successResponse(sub);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/components/AuthLayoutShell.tsx
+++ b/src/components/AuthLayoutShell.tsx
@@ -36,6 +36,8 @@ interface AuthLayoutShellProps {
   hasReports: boolean;
   hasMyPlanning?: boolean;
   hasAccounting?: boolean;
+  hasJobs?: boolean;
+  hasJobsManage?: boolean;
   headerColor?: string;
   userRole: RoleKey;
   header: React.ReactNode;
@@ -69,6 +71,8 @@ export default function AuthLayoutShell({
   hasReports,
   hasMyPlanning = false,
   hasAccounting = false,
+  hasJobs = false,
+  hasJobsManage = false,
   headerColor = "#5E17EB",
   userRole,
   header,
@@ -131,6 +135,8 @@ export default function AuthLayoutShell({
             hasReports={hasReports}
             hasMyPlanning={hasMyPlanning}
             hasAccounting={hasAccounting}
+            hasJobs={hasJobs}
+            hasJobsManage={hasJobsManage}
             onClose={closeSidebar}
           />
         </div>
@@ -153,6 +159,8 @@ export default function AuthLayoutShell({
           hasReports={hasReports}
           hasMyPlanning={hasMyPlanning}
           hasAccounting={hasAccounting}
+          hasJobs={hasJobs}
+          hasJobsManage={hasJobsManage}
           open={sidebarOpen}
           onClose={closeSidebar}
         />

--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 
-type SheetView = "root" | "planning" | "events" | "requests" | "media" | "agenda" | "integration" | "config";
+type SheetView = "root" | "planning" | "events" | "requests" | "media" | "agenda" | "integration" | "jobs" | "config";
 
 interface MobileNavSheetProps {
   departments: { id: string; name: string; ministryName?: string }[];
@@ -23,6 +23,8 @@ interface MobileNavSheetProps {
   hasReports?: boolean;
   hasMyPlanning?: boolean;
   hasAccounting?: boolean;
+  hasJobs?: boolean;
+  hasJobsManage?: boolean;
   open: boolean;
   onClose: () => void;
 }
@@ -242,6 +244,8 @@ export default function MobileNavSheet({
   hasReports = false,
   hasMyPlanning = false,
   hasAccounting = false,
+  hasJobs = false,
+  hasJobsManage = false,
   open,
   onClose,
 }: MobileNavSheetProps) {
@@ -391,6 +395,15 @@ export default function MobileNavSheet({
             onClick={() => setView("integration")}
           />
         )}
+        {hasJobs && (
+          <RootRow
+            label="Emploi"
+            icon={<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>}
+            hasChildren
+            isActive={pathname.startsWith("/jobs") || pathname.startsWith("/admin/jobs")}
+            onClick={() => setView("jobs")}
+          />
+        )}
         {mrbsUrl && (
           <RootRow
             label="Salles"
@@ -518,6 +531,21 @@ export default function MobileNavSheet({
     );
   }
 
+  function renderJobs() {
+    return (
+      <>
+        <SheetSubHeader title="Emploi" onBack={() => setView("root")} />
+        <div>
+          <SubRow href="/jobs" label="Offres" isActive={pathname === "/jobs"} onClose={onClose} />
+          <SubRow href="/jobs/new" label="Publier" isActive={pathname === "/jobs/new"} onClose={onClose} />
+          {hasJobsManage && (
+            <SubRow href="/admin/jobs" label="Modérer" isActive={pathname.startsWith("/admin/jobs")} onClose={onClose} />
+          )}
+        </div>
+      </>
+    );
+  }
+
   function renderContent() {
     switch (view) {
       case "planning": return renderPlanning();
@@ -526,6 +554,7 @@ export default function MobileNavSheet({
       case "media":        return renderLinks("Médias", mediaLinks);
       case "integration":  return renderLinks("Intégration", integrationLinks);
       case "agenda":       return renderLinks("Agenda pastoral", agendaLinks);
+      case "jobs":         return renderJobs();
       case "config":   return renderConfigLinks(configLinks);
       default:         return renderRoot();
     }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,6 +21,8 @@ interface SidebarProps {
   hasReports?: boolean;
   hasMyPlanning?: boolean;
   hasAccounting?: boolean;
+  hasJobs?: boolean;
+  hasJobsManage?: boolean;
   onClose?: () => void;
 }
 
@@ -103,6 +105,14 @@ function IconAccounting({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z" />
+    </svg>
+  );
+}
+
+function IconJobs({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
     </svg>
   );
 }
@@ -326,6 +336,8 @@ export default function Sidebar({
   hasReports = false,
   hasMyPlanning = false,
   hasAccounting = false,
+  hasJobs = false,
+  hasJobsManage = false,
   onClose,
 }: SidebarProps) {
   const searchParams = useSearchParams();
@@ -350,6 +362,7 @@ export default function Sidebar({
     pathname.startsWith("/communication");
   const isIntegrationActive = pathname.startsWith("/integration");
   const isAccountingActive = pathname.startsWith("/accounting");
+  const isJobsActive = pathname.startsWith("/jobs") || pathname.startsWith("/admin/jobs");
   const isAgendaActive =
     (pathname.startsWith("/agenda") || pathname.startsWith("/admin/pastoral-profiles")) &&
     pathname !== "/agenda/request";
@@ -361,7 +374,8 @@ export default function Sidebar({
     !pathname.startsWith("/admin/members") &&
     !pathname.startsWith("/admin/discipleship") &&
     !pathname.startsWith("/admin/pastoral-profiles") &&
-    !pathname.startsWith("/admin/welcome-duty");
+    !pathname.startsWith("/admin/welcome-duty") &&
+    !pathname.startsWith("/admin/jobs");
 
   function activeSection() {
     if (isEventsActive) return "events";
@@ -370,6 +384,7 @@ export default function Sidebar({
     if (isMediaActive) return "media";
     if (isIntegrationActive) return "integration";
     if (isAgendaActive) return "agenda";
+    if (isJobsActive) return "jobs";
     if (isConfigActive) return "config";
     return "planning";
   }
@@ -599,7 +614,32 @@ export default function Sidebar({
         </Link>
       )}
 
-      {/* 10. Réservation de salles (module MRBS optionnel) */}
+      {/* 10. Emploi */}
+      {hasJobs && (
+        <AccordionSection
+          title="Emploi"
+          icon={<IconJobs className="w-4 h-4" />}
+          open={openSection === "jobs"}
+          onToggle={() => toggle("jobs")}
+          isActive={isJobsActive}
+        >
+          <nav className="space-y-0.5 pl-6">
+            <NavLink href="/jobs" active={pathname === "/jobs"} onClose={onClose}>
+              Offres
+            </NavLink>
+            <NavLink href="/jobs/new" active={pathname === "/jobs/new"} onClose={onClose}>
+              Publier
+            </NavLink>
+            {hasJobsManage && (
+              <NavLink href="/admin/jobs" active={pathname.startsWith("/admin/jobs")} onClose={onClose}>
+                Modérer
+              </NavLink>
+            )}
+          </nav>
+        </AccordionSection>
+      )}
+
+      {/* 11. Réservation de salles (module MRBS optionnel) */}
       {(mrbsUrl || mrbsAdminLink) && (
         <AccordionSection
           title="Salles"

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -377,6 +377,65 @@ export function buildAccountingPaymentEmail(params: {
   };
 }
 
+export function buildJobOfferEmail(params: {
+  subscriberName: string | null;
+  jobTitle: string;
+  company: string;
+  type: string;
+  location: string | null;
+  duration: string | null;
+  deadline: Date | null;
+  description: string;
+  contactEmail: string | null;
+  contactUrl: string | null;
+  jobUrl: string;
+}) {
+  const typeLabel = params.type === "EMPLOI" ? "Emploi" : params.type === "STAGE" ? "Stage" : "Alternance";
+  const title = escapeHtml(params.jobTitle);
+  const company = escapeHtml(params.company);
+  const location = params.location ? `<tr><td style="padding:6px 0;color:#6b7280;width:130px;">Lieu</td><td style="padding:6px 0;">${escapeHtml(params.location)}</td></tr>` : "";
+  const duration = params.duration ? `<tr><td style="padding:6px 0;color:#6b7280;">Durée</td><td style="padding:6px 0;">${escapeHtml(params.duration)}</td></tr>` : "";
+  const deadlineStr = params.deadline ? new Date(params.deadline).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" }) : null;
+  const deadline = deadlineStr ? `<tr><td style="padding:6px 0;color:#6b7280;">Date limite</td><td style="padding:6px 0;">${deadlineStr}</td></tr>` : "";
+  const contact = params.contactEmail
+    ? `<p style="margin-top:16px;font-size:14px;">Candidature : <a href="mailto:${escapeHtml(params.contactEmail)}" style="color:#5E17EB;">${escapeHtml(params.contactEmail)}</a></p>`
+    : params.contactUrl
+      ? `<p style="margin-top:16px;font-size:14px;"><a href="${escapeHtml(params.contactUrl)}" style="color:#5E17EB;">Postuler en ligne →</a></p>`
+      : "";
+  const greeting = params.subscriberName ? `<p>Bonjour <strong>${escapeHtml(params.subscriberName)}</strong>,</p>` : "<p>Bonjour,</p>";
+
+  return {
+    subject: `[Emploi] ${typeLabel} — ${params.jobTitle} chez ${params.company}`,
+    html: `
+      <div style="font-family: Montserrat, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background: #5E17EB; color: white; padding: 20px; border-radius: 8px 8px 0 0;">
+          <h1 style="margin: 0; font-size: 20px;">Koinonia — Nouvelle offre ${typeLabel}</h1>
+        </div>
+        <div style="padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+          ${greeting}
+          <p>Une nouvelle offre a été publiée sur Koinonia :</p>
+          <table style="width:100%;border-collapse:collapse;font-size:14px;margin:16px 0;">
+            <tr><td style="padding:6px 0;color:#6b7280;width:130px;">Poste</td><td style="padding:6px 0;font-weight:600;">${title}</td></tr>
+            <tr><td style="padding:6px 0;color:#6b7280;">Entreprise</td><td style="padding:6px 0;">${company}</td></tr>
+            <tr><td style="padding:6px 0;color:#6b7280;">Type</td><td style="padding:6px 0;">${typeLabel}</td></tr>
+            ${location}${duration}${deadline}
+          </table>
+          ${contact}
+          <p style="margin-top:20px;">
+            <a href="${params.jobUrl}" style="display:inline-block;background:#5E17EB;color:white;padding:10px 20px;border-radius:6px;text-decoration:none;font-size:14px;">
+              Voir l&apos;offre complète →
+            </a>
+          </p>
+          <p style="color: #6b7280; font-size: 13px; margin-top: 24px;">
+            Vous recevez cet email car vous êtes abonné aux notifications d&apos;offres d&apos;emploi sur Koinonia.
+            Gérez vos préférences depuis votre profil.
+          </p>
+        </div>
+      </div>
+    `,
+  };
+}
+
 export function buildReminderEmail(params: {
   memberName: string;
   eventTitle: string;

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -8,6 +8,7 @@ import { mrbsModule } from "@/modules/mrbs";
 import { agendaModule } from "@/modules/agenda";
 import { integrationModule } from "@/modules/integration";
 import { accountingModule } from "@/modules/accounting";
+import { jobsModule } from "@/modules/jobs";
 
 /**
  * Registry singleton — chargé une fois au démarrage du process.
@@ -16,7 +17,7 @@ import { accountingModule } from "@/modules/accounting";
  * Source de vérité pour les permissions dans les contrôles d'accès API.
  */
 export const registry = boot({
-  modules: [coreModule, planningModule, discipleshipModule, mediaModule, mrbsModule, agendaModule, integrationModule, accountingModule],
+  modules: [coreModule, planningModule, discipleshipModule, mediaModule, mrbsModule, agendaModule, integrationModule, accountingModule, jobsModule],
 });
 
 /**

--- a/src/modules/jobs/index.ts
+++ b/src/modules/jobs/index.ts
@@ -1,0 +1,23 @@
+import { defineModule } from "@/core/module-registry";
+
+/**
+ * Module emploi — transversal, ouvert à tous les utilisateurs authentifiés.
+ *
+ * Périmètre :
+ *   - Offres d'emploi, de stage et d'alternance
+ *   - Abonnements aux notifications par type
+ *   - Modération (archivage) par les admins et secrétaires
+ *
+ * Dépendances : core
+ */
+export const jobsModule = defineModule({
+  name: "jobs",
+  version: "1.0.0",
+  dependsOn: ["core"],
+
+  permissions: {
+    "jobs:view":   ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD", "DISCIPLE_MAKER", "REPORTER", "STAR", "AGENDA_QUALIFIER", "ACCOUNTANT"],
+    "jobs:post":   ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD", "DISCIPLE_MAKER", "REPORTER", "STAR", "AGENDA_QUALIFIER", "ACCOUNTANT"],
+    "jobs:manage": ["SUPER_ADMIN", "ADMIN", "SECRETARY"],
+  },
+});


### PR DESCRIPTION
## Summary

- Nouveau module transversal `jobs` ouvert à tous les utilisateurs authentifiés
- Publication directe d'offres d'emploi, stage ou alternance
- Expiration automatique après date limite, modération (archivage) par admin/secrétariat
- Abonnements aux notifications par type (in-app + email) depuis le profil
- Section "Emploi" dédiée dans la sidebar (accordion avec Offres, Publier, Modérer)

## Pages

| Route | Description |
|---|---|
| `/jobs` | Liste des offres actives, filtrées par type (tabs) |
| `/jobs/new` | Formulaire de publication |
| `/jobs/[id]` | Détail de l'offre + actions auteur/admin |
| `/jobs/[id]/edit` | Modification par l'auteur |
| `/admin/jobs` | Dashboard de modération |
| `/profile` | Section abonnement notifications emploi |

## API

- `GET/POST /api/jobs` — liste et création
- `GET/PATCH/DELETE /api/jobs/[id]` — détail, archivage, suppression
- `GET/PUT /api/jobs/subscription` — préférences notifications

## Test plan

- [ ] Vérifier CI : typecheck + lint + tests (351 tests)
- [ ] Appliquer la migration en base
- [ ] Créer une offre → vérifier les notifications in-app des abonnés
- [ ] Archiver une offre en tant qu'admin → vérifier qu'elle disparaît de la liste
- [ ] Tester l'expiration automatique (offre avec deadline passée)
- [ ] Vérifier les préférences d'abonnement sur le profil

🤖 Generated with [Claude Code](https://claude.com/claude-code)