### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.7.0] - 2026-06-12
+
+### Ajouté
+
+- **Module Emploi** : offres d'emploi, stages et alternances accessibles à tous les utilisateurs authentifiés (#374)
+  - Publication directe d'offres avec titre, type, entreprise, lieu, description, durée, date limite, contact
+  - Expiration automatique après la date limite (offre filtrée de la liste publique)
+  - Modération (archivage / suppression) par les administrateurs et secrétaires via `/admin/jobs`
+  - Abonnements aux notifications par type (Emploi / Stage / Alternance) et canal (in-app + email)
+  - Préférences d'abonnement gérables depuis le profil utilisateur
+  - Section "Emploi" dédiée dans la sidebar (Offres, Publier, Modérer)
+
 ## [v1.6.4] - 2026-06-11
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Release v1.7.0

- Bump version `1.6.4` → `1.7.0`
- Mise à jour `CHANGELOG.md`

### Contenu

- **Module Emploi** (#374) — offres d'emploi, stages et alternances transversaux, notifications par abonnement, modération admin/secrétariat

🤖 Generated with [Claude Code](https://claude.com/claude-code)