### PR TITLE
fix(mobile): liens Service d'accueil et Emploi manquants dans la nav mobile

### DIFF
--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -281,7 +281,8 @@ export default function MobileNavSheet({
   const isEventsActive =
     pathname.startsWith("/events") ||
     pathname.startsWith("/admin/events") ||
-    pathname.startsWith("/admin/reports");
+    pathname.startsWith("/admin/reports") ||
+    pathname.startsWith("/admin/welcome-duty");
   const isRequestsActive =
     pathname.startsWith("/requests") ||
     pathname.startsWith("/secretariat") ||
@@ -298,7 +299,9 @@ export default function MobileNavSheet({
     !pathname.startsWith("/admin/reports") &&
     !pathname.startsWith("/admin/members") &&
     !pathname.startsWith("/admin/discipleship") &&
-    !pathname.startsWith("/admin/pastoral-profiles");
+    !pathname.startsWith("/admin/pastoral-profiles") &&
+    !pathname.startsWith("/admin/welcome-duty") &&
+    !pathname.startsWith("/admin/jobs");
 
   /* ── Views ── */
 
@@ -483,7 +486,10 @@ export default function MobileNavSheet({
           <SubRow href="/events" label="Liste" isActive={pathname === "/events"} onClose={onClose} />
           <SubRow href="/events/calendar" label="Calendrier" isActive={pathname === "/events/calendar"} onClose={onClose} />
           {hasEventsManage && (
-            <SubRow href="/admin/events" label="Gestion" isActive={pathname.startsWith("/admin/events")} onClose={onClose} />
+            <SubRow href="/admin/events" label="Gestion" isActive={pathname.startsWith("/admin/events") && !pathname.startsWith("/admin/welcome-duty")} onClose={onClose} />
+          )}
+          {hasEventsManage && (
+            <SubRow href="/admin/welcome-duty" label="Service d'accueil" isActive={pathname.startsWith("/admin/welcome-duty")} onClose={onClose} />
           )}
           {hasReports && (
             <SubRow href="/admin/reports" label="Comptes rendus" isActive={pathname.startsWith("/admin/reports")} onClose={onClose} />


### PR DESCRIPTION
## Summary

- Ajoute le lien **Service d'accueil** (`/admin/welcome-duty`) dans le sous-menu Événements de la navigation mobile
- Corrige `isEventsActive` : `/admin/welcome-duty` était absent → la section Événements ne se mettait pas en surbrillance sur cette page
- Corrige `isConfigActive` : `/admin/welcome-duty` et `/admin/jobs` n'étaient pas exclus → la section Configuration se mettait incorrectement en surbrillance
- Corrige `isActive` du lien Gestion : n'exclut plus `/admin/welcome-duty`

## Test plan

- [ ] Mobile : naviguer vers `/admin/welcome-duty` → section Événements active (pas Configuration)
- [ ] Mobile : ouvrir le sous-menu Événements → le lien "Service d'accueil" apparaît
- [ ] Mobile : naviguer vers `/admin/jobs` → section Emploi active (pas Configuration)
- [ ] Mobile : les autres liens (Gestion, Comptes rendus) restent corrects

🤖 Generated with [Claude Code](https://claude.com/claude-code)