### PR TITLE
chore: release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.7.1] - 2026-06-12
+
+### Corrigé
+
+- **Navigation mobile** : liens "Service d'accueil" et "Emploi" absents ou mal surlignés (#376)
+  - Ajout du lien "Service d'accueil" dans le sous-menu Événements mobile
+  - Correction de la surbrillance sur `/admin/welcome-duty` (Événements actif, Configuration inactif)
+  - Correction de la surbrillance sur `/admin/jobs` (Emploi actif, Configuration inactif)
+
 ## [v1.7.0] - 2026-06-12
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

- Bump version `1.7.0` → `1.7.1`
- Mise à jour du CHANGELOG

Fix inclus : navigation mobile — liens Service d'accueil et Emploi (#376)

🤖 Generated with [Claude Code](https://claude.com/claude-code)