### PR TITLE
feat(pastoral): schéma supervision + routing dashboard pastoral

### DIFF
--- a/prisma/migrations/20260613000000_church_pastoral_supervision/migration.sql
+++ b/prisma/migrations/20260613000000_church_pastoral_supervision/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable: ajoute responsable et superviseur pastoral sur Church
+ALTER TABLE `churches`
+  ADD COLUMN `responsibleProfileId` VARCHAR(191) NULL,
+  ADD COLUMN `supervisorUserId`     VARCHAR(191) NULL,
+  ADD UNIQUE INDEX `churches_responsibleProfileId_key` (`responsibleProfileId`),
+  ADD INDEX  `churches_supervisorUserId_idx`  (`supervisorUserId`),
+  ADD CONSTRAINT `churches_responsibleProfileId_fkey`
+    FOREIGN KEY (`responsibleProfileId`) REFERENCES `pastoral_profiles` (`id`)
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT `churches_supervisorUserId_fkey`
+    FOREIGN KEY (`supervisorUserId`) REFERENCES `users` (`id`)
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260613000001_church_supervisor_profile/migration.sql
+++ b/prisma/migrations/20260613000001_church_supervisor_profile/migration.sql
@@ -1,0 +1,10 @@
+-- Remplacement supervisorUserId (User) → supervisorProfileId (PastoralProfile)
+ALTER TABLE `churches`
+  DROP FOREIGN KEY  `churches_supervisorUserId_fkey`,
+  DROP INDEX        `churches_supervisorUserId_idx`,
+  DROP COLUMN       `supervisorUserId`,
+  ADD COLUMN        `supervisorProfileId` VARCHAR(191) NULL,
+  ADD INDEX         `churches_supervisorProfileId_idx` (`supervisorProfileId`),
+  ADD CONSTRAINT    `churches_supervisorProfileId_fkey`
+    FOREIGN KEY (`supervisorProfileId`) REFERENCES `pastoral_profiles` (`id`)
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,9 +95,9 @@ model Church {
   welcomeDutyAssignments    WelcomeDutyAssignment[]
   // Module pastoral
   responsibleProfileId      String?  @unique
-  supervisorUserId          String?
+  supervisorProfileId       String?
   responsible               PastoralProfile?     @relation("ChurchResponsibleProfile", fields: [responsibleProfileId], references: [id])
-  supervisor                User?                @relation("ChurchSupervisorUser", fields: [supervisorUserId], references: [id])
+  supervisor                PastoralProfile?     @relation("ChurchSupervisorProfile", fields: [supervisorProfileId], references: [id])
 
   @@map("churches")
 }
@@ -170,8 +170,7 @@ model User {
   // Module emploi
   jobOffers                    JobOffer[]
   jobNotificationSubscription  JobNotificationSubscription?
-  // Module pastoral
-  supervisedChurches           Church[]   @relation("ChurchSupervisorUser")
+  // (relation superviseur église déplacée vers PastoralProfile)
 
   @@map("users")
 }
@@ -1000,6 +999,7 @@ model PastoralProfile {
   entries              AgendaEntry[]
   requests             AppointmentRequest[]
   responsibleForChurch Church?              @relation("ChurchResponsibleProfile")
+  supervisorForChurches Church[]            @relation("ChurchSupervisorProfile")
 
   @@map("pastoral_profiles")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,7 +79,7 @@ model Church {
   // Module mrbs (optionnel)
   mrbsUserLinks            MrbsUserLink[]
   // Module agenda
-  pastoralProfiles         PastoralProfile[]
+  pastoralProfiles         PastoralProfile[]    @relation("ChurchPastoralProfiles")
   appointmentRequests      AppointmentRequest[]
   agendaEntries            AgendaEntry[]
   // Module intégration familles
@@ -93,6 +93,11 @@ model Church {
   // Module service d'accueil
   welcomeDutyFamilies       WelcomeDutyFamily[]
   welcomeDutyAssignments    WelcomeDutyAssignment[]
+  // Module pastoral
+  responsibleProfileId      String?  @unique
+  supervisorUserId          String?
+  responsible               PastoralProfile?     @relation("ChurchResponsibleProfile", fields: [responsibleProfileId], references: [id])
+  supervisor                User?                @relation("ChurchSupervisorUser", fields: [supervisorUserId], references: [id])
 
   @@map("churches")
 }
@@ -165,6 +170,8 @@ model User {
   // Module emploi
   jobOffers                    JobOffer[]
   jobNotificationSubscription  JobNotificationSubscription?
+  // Module pastoral
+  supervisedChurches           Church[]   @relation("ChurchSupervisorUser")
 
   @@map("users")
 }
@@ -988,10 +995,11 @@ model PastoralProfile {
   userId    String?
   createdAt DateTime     @default(now())
 
-  church   Church               @relation(fields: [churchId], references: [id])
-  user     User?                @relation("UserPastoralProfile", fields: [userId], references: [id])
-  entries  AgendaEntry[]
-  requests AppointmentRequest[]
+  church               Church               @relation("ChurchPastoralProfiles", fields: [churchId], references: [id])
+  user                 User?                @relation("UserPastoralProfile", fields: [userId], references: [id])
+  entries              AgendaEntry[]
+  requests             AppointmentRequest[]
+  responsibleForChurch Church?              @relation("ChurchResponsibleProfile")
 
   @@map("pastoral_profiles")
 }

--- a/src/__mocks__/auth.ts
+++ b/src/__mocks__/auth.ts
@@ -11,6 +11,7 @@ export function createSession(overrides: Partial<Session["user"]> = {}): Session
       image: null,
       isSuperAdmin: false,
       hasSeenTour: false,
+      pastoralProfileId: null,
       churchRoles: [
         {
           id: "role-1",

--- a/src/app/(auth)/admin/churches/[churchId]/ChurchEditClient.tsx
+++ b/src/app/(auth)/admin/churches/[churchId]/ChurchEditClient.tsx
@@ -14,7 +14,7 @@ interface Church {
   accountingEmail: string;
   primaryColor: string;
   responsibleProfileId: string;
-  supervisorUserId: string;
+  supervisorProfileId: string;
 }
 
 interface Option {
@@ -36,7 +36,7 @@ export default function ChurchEditClient({ church, profiles, supervisors }: Prop
   const [accountingEmail, setAccountingEmail] = useState(church.accountingEmail);
   const [primaryColor, setPrimaryColor] = useState(church.primaryColor || "#5E17EB");
   const [responsibleProfileId, setResponsibleProfileId] = useState(church.responsibleProfileId);
-  const [supervisorUserId, setSupervisorUserId] = useState(church.supervisorUserId);
+  const [supervisorProfileId, setSupervisorProfileId] = useState(church.supervisorProfileId);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -58,7 +58,7 @@ export default function ChurchEditClient({ church, profiles, supervisors }: Prop
           accountingEmail: accountingEmail || null,
           primaryColor,
           responsibleProfileId: responsibleProfileId || null,
-          supervisorUserId: supervisorUserId || null,
+          supervisorProfileId: supervisorProfileId || null,
         }),
       });
 
@@ -151,8 +151,8 @@ export default function ChurchEditClient({ church, profiles, supervisors }: Prop
             />
             <Select
               label="Superviseur (pasteur superviseur)"
-              value={supervisorUserId}
-              onChange={(e) => setSupervisorUserId(e.target.value)}
+              value={supervisorProfileId}
+              onChange={(e) => setSupervisorProfileId(e.target.value)}
               options={supervisorOptions}
             />
           </div>

--- a/src/app/(auth)/admin/churches/[churchId]/ChurchEditClient.tsx
+++ b/src/app/(auth)/admin/churches/[churchId]/ChurchEditClient.tsx
@@ -4,18 +4,39 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
 
-interface Props {
-  church: { id: string; name: string; slug: string; secretariatEmail: string; accountingEmail: string; primaryColor: string };
+interface Church {
+  id: string;
+  name: string;
+  slug: string;
+  secretariatEmail: string;
+  accountingEmail: string;
+  primaryColor: string;
+  responsibleProfileId: string;
+  supervisorUserId: string;
 }
 
-export default function ChurchEditClient({ church }: Props) {
+interface Option {
+  id: string;
+  label: string;
+}
+
+interface Props {
+  church: Church;
+  profiles: Option[];
+  supervisors: Option[];
+}
+
+export default function ChurchEditClient({ church, profiles, supervisors }: Props) {
   const router = useRouter();
   const [name, setName] = useState(church.name);
   const [slug, setSlug] = useState(church.slug);
   const [secretariatEmail, setSecretariatEmail] = useState(church.secretariatEmail);
   const [accountingEmail, setAccountingEmail] = useState(church.accountingEmail);
   const [primaryColor, setPrimaryColor] = useState(church.primaryColor || "#5E17EB");
+  const [responsibleProfileId, setResponsibleProfileId] = useState(church.responsibleProfileId);
+  const [supervisorUserId, setSupervisorUserId] = useState(church.supervisorUserId);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -30,7 +51,15 @@ export default function ChurchEditClient({ church }: Props) {
       const res = await fetch(`/api/churches/${church.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, slug, secretariatEmail: secretariatEmail || null, accountingEmail: accountingEmail || null, primaryColor }),
+        body: JSON.stringify({
+          name,
+          slug,
+          secretariatEmail: secretariatEmail || null,
+          accountingEmail: accountingEmail || null,
+          primaryColor,
+          responsibleProfileId: responsibleProfileId || null,
+          supervisorUserId: supervisorUserId || null,
+        }),
       });
 
       if (!res.ok) {
@@ -46,6 +75,16 @@ export default function ChurchEditClient({ church }: Props) {
       setLoading(false);
     }
   }
+
+  const profileOptions = [
+    { value: "", label: "— Aucun —" },
+    ...profiles.map((p) => ({ value: p.id, label: p.label })),
+  ];
+
+  const supervisorOptions = [
+    { value: "", label: "— Aucun —" },
+    ...supervisors.map((s) => ({ value: s.id, label: s.label })),
+  ];
 
   return (
     <div className="max-w-md">
@@ -100,6 +139,25 @@ export default function ChurchEditClient({ church }: Props) {
             />
           </div>
         </div>
+
+        <div className="pt-2 border-t border-gray-100">
+          <p className="text-xs text-gray-500 mb-3">Supervision pastorale</p>
+          <div className="space-y-4">
+            <Select
+              label="Responsable pastoral de l'église"
+              value={responsibleProfileId}
+              onChange={(e) => setResponsibleProfileId(e.target.value)}
+              options={profileOptions}
+            />
+            <Select
+              label="Superviseur (pasteur superviseur)"
+              value={supervisorUserId}
+              onChange={(e) => setSupervisorUserId(e.target.value)}
+              options={supervisorOptions}
+            />
+          </div>
+        </div>
+
         {error && <p className="text-sm text-red-600">{error}</p>}
         {success && (
           <p className="text-sm text-green-600">Église mise à jour.</p>

--- a/src/app/(auth)/admin/churches/[churchId]/page.tsx
+++ b/src/app/(auth)/admin/churches/[churchId]/page.tsx
@@ -21,7 +21,7 @@ export default async function ChurchDetailPage({
       accountingEmail: true,
       primaryColor: true,
       responsibleProfileId: true,
-      supervisorUserId: true,
+      supervisorProfileId: true,
     },
   });
 
@@ -34,11 +34,10 @@ export default async function ChurchDetailPage({
     orderBy: [{ role: "asc" }, { name: "asc" }],
   });
 
-  // Utilisateurs ayant un profil pastoral (potentiels superviseurs)
-  const supervisorCandidates = await prisma.user.findMany({
-    where: { pastoralProfiles: { some: {} } },
-    select: { id: true, name: true, displayName: true, email: true },
-    orderBy: { name: "asc" },
+  // Tous les profils pastoraux (potentiels superviseurs, toutes églises)
+  const supervisorCandidates = await prisma.pastoralProfile.findMany({
+    select: { id: true, name: true, role: true, church: { select: { name: true } } },
+    orderBy: [{ role: "asc" }, { name: "asc" }],
   });
 
   const roleLabel: Record<string, string> = {
@@ -61,12 +60,12 @@ export default async function ChurchDetailPage({
           accountingEmail: church.accountingEmail ?? "",
           primaryColor: church.primaryColor ?? "#5E17EB",
           responsibleProfileId: church.responsibleProfileId ?? "",
-          supervisorUserId: church.supervisorUserId ?? "",
+          supervisorProfileId: church.supervisorProfileId ?? "",
         }}
         profiles={profiles.map((p) => ({ id: p.id, label: `${p.name} (${roleLabel[p.role]})` }))}
-        supervisors={supervisorCandidates.map((u) => ({
-          id: u.id,
-          label: u.displayName ?? u.name ?? u.email,
+        supervisors={supervisorCandidates.map((s) => ({
+          id: s.id,
+          label: `${s.name} (${roleLabel[s.role]}) — ${s.church.name}`,
         }))}
       />
     </div>

--- a/src/app/(auth)/admin/churches/[churchId]/page.tsx
+++ b/src/app/(auth)/admin/churches/[churchId]/page.tsx
@@ -13,16 +13,62 @@ export default async function ChurchDetailPage({
 
   const church = await prisma.church.findUnique({
     where: { id: churchId },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      secretariatEmail: true,
+      accountingEmail: true,
+      primaryColor: true,
+      responsibleProfileId: true,
+      supervisorUserId: true,
+    },
   });
 
   if (!church) notFound();
+
+  // Profils pastoraux de cette église (pour le sélecteur responsable)
+  const profiles = await prisma.pastoralProfile.findMany({
+    where: { churchId },
+    select: { id: true, name: true, role: true },
+    orderBy: [{ role: "asc" }, { name: "asc" }],
+  });
+
+  // Utilisateurs ayant un profil pastoral (potentiels superviseurs)
+  const supervisorCandidates = await prisma.user.findMany({
+    where: { pastoralProfiles: { some: {} } },
+    select: { id: true, name: true, displayName: true, email: true },
+    orderBy: { name: "asc" },
+  });
+
+  const roleLabel: Record<string, string> = {
+    PASTEUR: "Pasteur",
+    ASSISTANT_PASTEUR: "Assistant pasteur",
+    BERGER: "Berger",
+  };
 
   return (
     <div>
       <h1 className="text-2xl font-bold text-gray-900 mb-6">
         Modifier l&apos;église
       </h1>
-      <ChurchEditClient church={{ id: church.id, name: church.name, slug: church.slug, secretariatEmail: church.secretariatEmail ?? "", accountingEmail: church.accountingEmail ?? "", primaryColor: church.primaryColor ?? "#5E17EB" }} />
+      <ChurchEditClient
+        church={{
+          id: church.id,
+          name: church.name,
+          slug: church.slug,
+          secretariatEmail: church.secretariatEmail ?? "",
+          accountingEmail: church.accountingEmail ?? "",
+          primaryColor: church.primaryColor ?? "#5E17EB",
+          responsibleProfileId: church.responsibleProfileId ?? "",
+          supervisorUserId: church.supervisorUserId ?? "",
+        }}
+        profiles={profiles.map((p) => ({ id: p.id, label: `${p.name} (${roleLabel[p.role]})` }))}
+        supervisors={supervisorCandidates.map((u) => ({
+          id: u.id,
+          label: u.displayName ?? u.name ?? u.email,
+        }))}
+      />
     </div>
   );
 }

--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -17,6 +17,9 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
   const session = await auth();
   if (!session?.user) redirect("/");
 
+  // Les utilisateurs avec un profil pastoral ont leur propre dashboard
+  if (session.user.pastoralProfileId) redirect("/pastoral");
+
   const {
     dept: selectedDeptId,
     event: selectedEventId,

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -84,8 +84,13 @@ export default async function AuthLayout({
   if (session.user.isSuperAdmin) {
     configLinksDef.forEach((l) => l.permissions.forEach((p) => userPermissions.add(p)));
   }
-  // Utilisateurs avec un profil pastoral : permission transversale pastoral:view
-  if (isPastoral) userPermissions.add("pastoral:view");
+  // Utilisateurs avec un profil pastoral : permissions transversales
+  if (isPastoral) {
+    userPermissions.add("pastoral:view");
+    userPermissions.add("events:view");
+    userPermissions.add("discipleship:view");
+    userPermissions.add("planning:view"); // permet "Mes demandes"
+  }
   const visibleConfigLinks = configLinksDef
     .filter((link) => {
       if (link.superAdminOnly) return session.user.isSuperAdmin;

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -18,6 +18,7 @@ const configLinksDef = [
   { href: "/admin/churches",            label: "Églises",         permissions: ["church:manage"] },
   { href: "/admin/backups",             label: "Sauvegardes",     permissions: [], superAdminOnly: true },
   { href: "/admin/audit-logs",          label: "Historique",      permissions: ["church:manage"] },
+  { href: "/admin/pastoral-profiles",   label: "Profils pastoraux", permissions: ["church:manage"] },
 ];
 
 export default async function AuthLayout({
@@ -203,7 +204,6 @@ export default async function AuthLayout({
   if (hasAgendaQualify) agendaLinks.push({ href: "/agenda/requests", label: "Qualification" });
   if (hasAgendaManage) agendaLinks.push({ href: "/agenda/schedule", label: "Planification" });
   if (hasAgendaManage) agendaLinks.push({ href: "/agenda/new", label: "Nouvelle entrée" });
-  if (userPermissions.has("church:manage")) agendaLinks.push({ href: "/admin/pastoral-profiles", label: "Profils pastoraux" });
 
   const headerContent = (
     <div className="flex items-center w-full min-w-0">

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -308,6 +308,7 @@ export default async function AuthLayout({
       hasAccounting={hasAccounting}
       hasJobs={hasJobs}
       hasJobsManage={hasJobsManage}
+      isPastoral={isPastoral}
       hasEventsAccess={hasEventsAccess}
       hasEventsManage={hasEventsManage}
       hasPlanningAccess={hasPlanningAccess}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -10,15 +10,18 @@ import NotificationBell from "@/components/NotificationBell";
 
 // Liens de la section Configuration (paramétrage — pas les outils quotidiens)
 const configLinksDef = [
-  { href: "/admin/users",               label: "Utilisateurs",    permissions: ["members:manage"] },
-  { href: "/admin/access",              label: "Accès & rôles",   permissions: ["departments:manage"] },
-  { href: "/admin/ministries",          label: "Ministères",      permissions: ["departments:manage"] },
-  { href: "/admin/departments",         label: "Départements",    permissions: ["departments:manage"] },
-  { href: "/admin/departments/functions", label: "Fonctions dép.", permissions: ["events:manage"] },
-  { href: "/admin/churches",            label: "Églises",         permissions: ["church:manage"] },
-  { href: "/admin/backups",             label: "Sauvegardes",     permissions: [], superAdminOnly: true },
-  { href: "/admin/audit-logs",          label: "Historique",      permissions: ["church:manage"] },
-  { href: "/admin/pastoral-profiles",   label: "Profils pastoraux", permissions: ["church:manage"] },
+  // Structure organisationnelle
+  { href: "/admin/churches",              label: "Églises",           permissions: ["church:manage"] },
+  { href: "/admin/ministries",            label: "Ministères",        permissions: ["departments:manage"] },
+  { href: "/admin/departments",           label: "Départements",      permissions: ["departments:manage"] },
+  { href: "/admin/departments/functions", label: "Fonctions dép.",    permissions: ["events:manage"] },
+  // Personnes
+  { href: "/admin/users",                 label: "Utilisateurs",      permissions: ["members:manage"] },
+  { href: "/admin/access",                label: "Accès & rôles",     permissions: ["departments:manage"] },
+  { href: "/admin/pastoral-profiles",     label: "Profils pastoraux", permissions: ["church:manage"] },
+  // Système
+  { href: "/admin/audit-logs",            label: "Historique",        permissions: ["church:manage"] },
+  { href: "/admin/backups",               label: "Sauvegardes",       permissions: [], superAdminOnly: true },
 ];
 
 export default async function AuthLayout({

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -33,7 +33,9 @@ export default async function AuthLayout({
 
   const churchRoles = session.user.churchRoles;
 
-  if (!session.user.isSuperAdmin && churchRoles.length === 0) {
+  const isPastoral = session.user.pastoralProfileId !== null;
+
+  if (!session.user.isSuperAdmin && churchRoles.length === 0 && !isPastoral) {
     redirect("/no-access");
   }
 
@@ -82,6 +84,8 @@ export default async function AuthLayout({
   if (session.user.isSuperAdmin) {
     configLinksDef.forEach((l) => l.permissions.forEach((p) => userPermissions.add(p)));
   }
+  // Utilisateurs avec un profil pastoral : permission transversale pastoral:view
+  if (isPastoral) userPermissions.add("pastoral:view");
   const visibleConfigLinks = configLinksDef
     .filter((link) => {
       if (link.superAdminOnly) return session.user.isSuperAdmin;

--- a/src/app/(auth)/pastoral/members/page.tsx
+++ b/src/app/(auth)/pastoral/members/page.tsx
@@ -23,7 +23,7 @@ export default async function PastoralMembersPage({ searchParams }: Props) {
   if (!profile) redirect("/pastoral");
 
   const supervisedChurches = await prisma.church.findMany({
-    where: { supervisorUserId: session.user.id },
+    where: { supervisorProfileId: session.user.pastoralProfileId },
     select: { id: true, name: true },
   });
 

--- a/src/app/(auth)/pastoral/members/page.tsx
+++ b/src/app/(auth)/pastoral/members/page.tsx
@@ -1,0 +1,136 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+
+interface Props {
+  searchParams: Promise<{ church?: string }>;
+}
+
+export default async function PastoralMembersPage({ searchParams }: Props) {
+  const session = await auth();
+  if (!session?.user) redirect("/");
+  if (!session.user.pastoralProfileId) redirect("/dashboard");
+
+  const { church: churchFilter } = await searchParams;
+
+  const profile = await prisma.pastoralProfile.findUnique({
+    where: { id: session.user.pastoralProfileId },
+    select: {
+      churchId: true,
+      responsibleForChurch: { select: { id: true, name: true } },
+    },
+  });
+  if (!profile) redirect("/pastoral");
+
+  const supervisedChurches = await prisma.church.findMany({
+    where: { supervisorUserId: session.user.id },
+    select: { id: true, name: true },
+  });
+
+  const allChurches = [
+    ...(profile.responsibleForChurch ? [profile.responsibleForChurch] : []),
+    ...supervisedChurches.filter((c) => c.id !== profile.responsibleForChurch?.id),
+  ];
+  const fallbackChurchId = profile.responsibleForChurch?.id ?? profile.churchId;
+  const activeChurchId = (churchFilter && allChurches.some((c) => c.id === churchFilter))
+    ? churchFilter
+    : fallbackChurchId;
+
+  const members = await prisma.member.findMany({
+    where: {
+      departments: { some: { department: { ministry: { churchId: activeChurchId } } } },
+    },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+      phone: true,
+      departments: {
+        where: { isPrimary: true },
+        select: { department: { select: { name: true, ministry: { select: { name: true } } } } },
+      },
+    },
+    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+  });
+
+  const activeChurchName = allChurches.find((c) => c.id === activeChurchId)?.name ?? "";
+
+  return (
+    <div className="p-4 md:p-6 max-w-4xl mx-auto space-y-6">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">Mes membres</h1>
+          {activeChurchName && (
+            <p className="text-sm text-gray-500 mt-0.5">{activeChurchName}</p>
+          )}
+        </div>
+
+        {allChurches.length > 1 && (
+          <div className="flex gap-2 flex-wrap">
+            {allChurches.map((church) => (
+              <a
+                key={church.id}
+                href={`/pastoral/members?church=${church.id}`}
+                className={`px-3 py-1.5 text-sm rounded-full border-2 transition-colors ${
+                  church.id === activeChurchId
+                    ? "border-icc-violet bg-icc-violet text-white"
+                    : "border-gray-200 text-gray-600 hover:border-icc-violet"
+                }`}
+              >
+                {church.name}
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {members.length === 0 ? (
+        <p className="text-gray-400 italic text-sm">Aucun membre trouvé.</p>
+      ) : (
+        <div className="bg-white border border-gray-200 rounded-lg divide-y divide-gray-100">
+          {members.map((member) => {
+            const dept = member.departments[0]?.department;
+            return (
+              <div key={member.id} className="flex items-center gap-3 px-4 py-3">
+                <div className="w-8 h-8 rounded-full bg-icc-violet/10 text-icc-violet flex items-center justify-center text-sm font-semibold shrink-0">
+                  {member.firstName[0]}{member.lastName[0]}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-900">
+                    {member.firstName} {member.lastName}
+                  </p>
+                  {dept && (
+                    <p className="text-xs text-gray-400 truncate">
+                      {dept.ministry.name} · {dept.name}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-3 shrink-0">
+                  {member.email && (
+                    <a href={`mailto:${member.email}`} className="text-gray-400 hover:text-icc-violet transition-colors" title={member.email}>
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                      </svg>
+                    </a>
+                  )}
+                  {member.phone && (
+                    <a href={`tel:${member.phone}`} className="text-gray-400 hover:text-icc-violet transition-colors" title={member.phone}>
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.948V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+                      </svg>
+                    </a>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <p className="text-xs text-gray-400">
+        {members.length} membre{members.length !== 1 ? "s" : ""}
+      </p>
+    </div>
+  );
+}

--- a/src/app/(auth)/pastoral/page.tsx
+++ b/src/app/(auth)/pastoral/page.tsx
@@ -2,10 +2,22 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 
+const roleLabel: Record<string, string> = {
+  PASTEUR: "Pasteur",
+  ASSISTANT_PASTEUR: "Assistant pasteur",
+  BERGER: "Berger",
+};
+
+function formatDate(d: Date) {
+  return d.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric", month: "short" });
+}
+
 export default async function PastoralDashboardPage() {
   const session = await auth();
   if (!session?.user) redirect("/");
   if (!session.user.pastoralProfileId) redirect("/dashboard");
+
+  const now = new Date();
 
   const profile = await prisma.pastoralProfile.findUnique({
     where: { id: session.user.pastoralProfileId },
@@ -13,20 +25,15 @@ export default async function PastoralDashboardPage() {
       id: true,
       role: true,
       name: true,
+      churchId: true,
       church: { select: { id: true, name: true } },
-      responsibleForChurch: {
-        select: {
-          id: true,
-          name: true,
-          supervisor: { select: { id: true, name: true, displayName: true } },
-        },
-      },
+      responsibleForChurch: { select: { id: true, name: true } },
     },
   });
 
   if (!profile) redirect("/dashboard");
 
-  // Églises supervisées par cet utilisateur
+  // Églises supervisées par cet utilisateur (en tant que superviseur externe)
   const supervisedChurches = await prisma.church.findMany({
     where: { supervisorUserId: session.user.id },
     select: {
@@ -36,19 +43,53 @@ export default async function PastoralDashboardPage() {
     },
   });
 
-  const roleLabel: Record<string, string> = {
-    PASTEUR: "Pasteur",
-    ASSISTANT_PASTEUR: "Assistant pasteur",
-    BERGER: "Berger",
-  };
+  // IDs des églises dont ce profil est acteur (responsable ou superviseur)
+  const churchIds = Array.from(new Set([
+    profile.responsibleForChurch?.id,
+    ...supervisedChurches.map((c) => c.id),
+  ].filter(Boolean))) as string[];
 
-  const allChurches = [
-    ...(profile.responsibleForChurch ? [profile.responsibleForChurch] : []),
-    ...supervisedChurches.filter((c) => c.id !== profile.responsibleForChurch?.id),
+  const allChurchIds = churchIds.length > 0 ? churchIds : [profile.churchId];
+
+  // Prochains événements (toutes les églises concernées, 5 max)
+  const upcomingEvents = await prisma.event.findMany({
+    where: { churchId: { in: allChurchIds }, date: { gte: now } },
+    orderBy: { date: "asc" },
+    take: 5,
+    select: { id: true, title: true, type: true, date: true, church: { select: { name: true } } },
+  });
+
+  // Prochaines entrées agenda de ce pasteur (5 max)
+  const upcomingAgenda = await prisma.agendaEntry.findMany({
+    where: { recipientId: profile.id, startsAt: { gte: now } },
+    orderBy: { startsAt: "asc" },
+    take: 5,
+    select: { id: true, title: true, type: true, startsAt: true, location: true },
+  });
+
+  // Nombre de membres par église concernée
+  const memberCounts = await Promise.all(
+    allChurchIds.map(async (cId) => {
+      const count = await prisma.member.count({
+        where: { departments: { some: { department: { ministry: { churchId: cId } } } } },
+      });
+      return { churchId: cId, count };
+    })
+  );
+  const countByChurch = Object.fromEntries(memberCounts.map((m) => [m.churchId, m.count]));
+
+  const churchCards = [
+    ...(profile.responsibleForChurch
+      ? [{ ...profile.responsibleForChurch, isResponsible: true }]
+      : []),
+    ...supervisedChurches
+      .filter((c) => c.id !== profile.responsibleForChurch?.id)
+      .map((c) => ({ ...c, isResponsible: false })),
   ];
 
   return (
-    <div className="p-6 max-w-4xl mx-auto space-y-8">
+    <div className="p-4 md:p-6 max-w-5xl mx-auto space-y-8">
+      {/* En-tête */}
       <div>
         <h1 className="text-2xl font-bold text-gray-900">
           Bonjour, {session.user.displayName ?? session.user.name}
@@ -58,39 +99,112 @@ export default async function PastoralDashboardPage() {
         </p>
       </div>
 
-      {allChurches.length > 0 && (
+      {/* Cartes d'églises */}
+      {churchCards.length > 0 && (
         <section>
-          <h2 className="text-lg font-semibold text-gray-800 mb-3">Mes églises</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            {allChurches.map((church) => (
-              <div
-                key={church.id}
-                className="border-2 border-gray-200 rounded-lg p-4 space-y-1"
-              >
-                <p className="font-semibold text-gray-900">{church.name}</p>
-                {"responsible" in church && church.responsible && (
-                  <p className="text-sm text-gray-500">
-                    Responsable : {church.responsible.name}{" "}
-                    <span className="text-gray-400">
-                      ({roleLabel[church.responsible.role]})
+          <h2 className="text-base font-semibold text-gray-700 mb-3">
+            {churchCards.length === 1 ? "Mon église" : "Mes églises"}
+          </h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {churchCards.map((church) => (
+              <div key={church.id} className="border-2 border-gray-200 rounded-lg p-4 space-y-3 bg-white">
+                <div className="flex items-start justify-between gap-2">
+                  <p className="font-semibold text-gray-900">{church.name}</p>
+                  {"isResponsible" in church && church.isResponsible && (
+                    <span className="shrink-0 text-xs bg-icc-violet/10 text-icc-violet font-medium px-2 py-0.5 rounded-full">
+                      Responsable
                     </span>
+                  )}
+                  {"isResponsible" in church && !church.isResponsible && (
+                    <span className="shrink-0 text-xs bg-gray-100 text-gray-500 font-medium px-2 py-0.5 rounded-full">
+                      Superviseur
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-4 text-sm text-gray-500">
+                  <span className="flex items-center gap-1">
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                    {countByChurch[church.id] ?? 0} membres
+                  </span>
+                </div>
+                {"responsible" in church && church.responsible && (
+                  <p className="text-xs text-gray-400">
+                    Resp. : {church.responsible.name} ({roleLabel[church.responsible.role]})
                   </p>
                 )}
+                <a
+                  href={`/pastoral/members?church=${church.id}`}
+                  className="text-xs text-icc-violet hover:underline"
+                >
+                  Voir les membres →
+                </a>
               </div>
             ))}
           </div>
         </section>
       )}
 
-      <section>
-        <h2 className="text-lg font-semibold text-gray-800 mb-3">Mon agenda pastoral</h2>
-        <a
-          href={`/agenda/${profile.id}`}
-          className="inline-flex items-center gap-2 px-4 py-2 border-2 border-icc-violet text-icc-violet rounded-lg font-medium hover:bg-icc-violet hover:text-white transition-colors"
-        >
-          Voir mon agenda
-        </a>
-      </section>
+      <div className="grid gap-6 md:grid-cols-2">
+        {/* Agenda pastoral */}
+        <section>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-base font-semibold text-gray-700">Mon agenda</h2>
+            <a href={`/agenda/${profile.id}`} className="text-xs text-icc-violet hover:underline">
+              Tout voir →
+            </a>
+          </div>
+          {upcomingAgenda.length === 0 ? (
+            <p className="text-sm text-gray-400 italic">Aucun rendez-vous à venir.</p>
+          ) : (
+            <div className="space-y-2">
+              {upcomingAgenda.map((entry) => (
+                <div key={entry.id} className="flex gap-3 bg-white border border-gray-200 rounded-lg px-3 py-2.5">
+                  <div className="w-14 shrink-0 text-xs text-gray-400 pt-0.5">
+                    {formatDate(entry.startsAt)}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-gray-800 truncate">{entry.title}</p>
+                    {entry.location && (
+                      <p className="text-xs text-gray-400 truncate">{entry.location}</p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Événements à venir */}
+        <section>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-base font-semibold text-gray-700">Événements</h2>
+            <a href="/events" className="text-xs text-icc-violet hover:underline">
+              Calendrier →
+            </a>
+          </div>
+          {upcomingEvents.length === 0 ? (
+            <p className="text-sm text-gray-400 italic">Aucun événement à venir.</p>
+          ) : (
+            <div className="space-y-2">
+              {upcomingEvents.map((event) => (
+                <div key={event.id} className="flex gap-3 bg-white border border-gray-200 rounded-lg px-3 py-2.5">
+                  <div className="w-14 shrink-0 text-xs text-gray-400 pt-0.5">
+                    {formatDate(event.date)}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-gray-800 truncate">{event.title}</p>
+                    {allChurchIds.length > 1 && (
+                      <p className="text-xs text-gray-400 truncate">{event.church.name}</p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
     </div>
   );
 }

--- a/src/app/(auth)/pastoral/page.tsx
+++ b/src/app/(auth)/pastoral/page.tsx
@@ -1,0 +1,96 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+
+export default async function PastoralDashboardPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/");
+  if (!session.user.pastoralProfileId) redirect("/dashboard");
+
+  const profile = await prisma.pastoralProfile.findUnique({
+    where: { id: session.user.pastoralProfileId },
+    select: {
+      id: true,
+      role: true,
+      name: true,
+      church: { select: { id: true, name: true } },
+      responsibleForChurch: {
+        select: {
+          id: true,
+          name: true,
+          supervisor: { select: { id: true, name: true, displayName: true } },
+        },
+      },
+    },
+  });
+
+  if (!profile) redirect("/dashboard");
+
+  // Églises supervisées par cet utilisateur
+  const supervisedChurches = await prisma.church.findMany({
+    where: { supervisorUserId: session.user.id },
+    select: {
+      id: true,
+      name: true,
+      responsible: { select: { id: true, name: true, role: true } },
+    },
+  });
+
+  const roleLabel: Record<string, string> = {
+    PASTEUR: "Pasteur",
+    ASSISTANT_PASTEUR: "Assistant pasteur",
+    BERGER: "Berger",
+  };
+
+  const allChurches = [
+    ...(profile.responsibleForChurch ? [profile.responsibleForChurch] : []),
+    ...supervisedChurches.filter((c) => c.id !== profile.responsibleForChurch?.id),
+  ];
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">
+          Bonjour, {session.user.displayName ?? session.user.name}
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          {roleLabel[profile.role]} · {profile.church.name}
+        </p>
+      </div>
+
+      {allChurches.length > 0 && (
+        <section>
+          <h2 className="text-lg font-semibold text-gray-800 mb-3">Mes églises</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {allChurches.map((church) => (
+              <div
+                key={church.id}
+                className="border-2 border-gray-200 rounded-lg p-4 space-y-1"
+              >
+                <p className="font-semibold text-gray-900">{church.name}</p>
+                {"responsible" in church && church.responsible && (
+                  <p className="text-sm text-gray-500">
+                    Responsable : {church.responsible.name}{" "}
+                    <span className="text-gray-400">
+                      ({roleLabel[church.responsible.role]})
+                    </span>
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">Mon agenda pastoral</h2>
+        <a
+          href={`/agenda/${profile.id}`}
+          className="inline-flex items-center gap-2 px-4 py-2 border-2 border-icc-violet text-icc-violet rounded-lg font-medium hover:bg-icc-violet hover:text-white transition-colors"
+        >
+          Voir mon agenda
+        </a>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(auth)/pastoral/page.tsx
+++ b/src/app/(auth)/pastoral/page.tsx
@@ -33,9 +33,9 @@ export default async function PastoralDashboardPage() {
 
   if (!profile) redirect("/dashboard");
 
-  // Églises supervisées par cet utilisateur (en tant que superviseur externe)
+  // Églises supervisées par ce profil pastoral
   const supervisedChurches = await prisma.church.findMany({
-    where: { supervisorUserId: session.user.id },
+    where: { supervisorProfileId: session.user.pastoralProfileId },
     select: {
       id: true,
       name: true,

--- a/src/app/api/churches/[churchId]/route.ts
+++ b/src/app/api/churches/[churchId]/route.ts
@@ -11,7 +11,7 @@ const updateSchema = z.object({
   accountingEmail:      z.string().email("Email invalide").nullish(),
   primaryColor:         z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur hexadécimale invalide").optional(),
   responsibleProfileId: z.string().nullish(),
-  supervisorUserId:     z.string().nullish(),
+  supervisorProfileId:  z.string().nullish(),
 });
 
 export async function PUT(
@@ -33,6 +33,15 @@ export async function PUT(
       if (!profile || profile.churchId !== churchId) {
         throw new ApiError(400, "Profil pastoral introuvable pour cette église");
       }
+    }
+
+    // Vérifier que le profil superviseur existe (peut être d'une autre église)
+    if (data.supervisorProfileId) {
+      const exists = await prisma.pastoralProfile.findUnique({
+        where: { id: data.supervisorProfileId },
+        select: { id: true },
+      });
+      if (!exists) throw new ApiError(400, "Profil superviseur introuvable");
     }
 
     const church = await prisma.church.update({

--- a/src/app/api/churches/[churchId]/route.ts
+++ b/src/app/api/churches/[churchId]/route.ts
@@ -7,9 +7,11 @@ import { z } from "zod";
 const updateSchema = z.object({
   name: z.string().min(1, "Le nom est requis"),
   slug: z.string().min(1, "Le slug est requis"),
-  secretariatEmail: z.string().email("Email invalide").nullish(),
-  accountingEmail:  z.string().email("Email invalide").nullish(),
-  primaryColor: z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur hexadécimale invalide").optional(),
+  secretariatEmail:     z.string().email("Email invalide").nullish(),
+  accountingEmail:      z.string().email("Email invalide").nullish(),
+  primaryColor:         z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur hexadécimale invalide").optional(),
+  responsibleProfileId: z.string().nullish(),
+  supervisorUserId:     z.string().nullish(),
 });
 
 export async function PUT(
@@ -21,6 +23,17 @@ export async function PUT(
     const session = await requireChurchPermission("church:manage", churchId);
     const body = await request.json();
     const data = updateSchema.parse(body);
+
+    // Vérifier que le profil responsable appartient à cette église
+    if (data.responsibleProfileId) {
+      const profile = await prisma.pastoralProfile.findUnique({
+        where: { id: data.responsibleProfileId },
+        select: { churchId: true },
+      });
+      if (!profile || profile.churchId !== churchId) {
+        throw new ApiError(400, "Profil pastoral introuvable pour cette église");
+      }
+    }
 
     const church = await prisma.church.update({
       where: { id: churchId },

--- a/src/components/AuthLayoutShell.tsx
+++ b/src/components/AuthLayoutShell.tsx
@@ -38,6 +38,7 @@ interface AuthLayoutShellProps {
   hasAccounting?: boolean;
   hasJobs?: boolean;
   hasJobsManage?: boolean;
+  isPastoral?: boolean;
   headerColor?: string;
   userRole: RoleKey;
   header: React.ReactNode;
@@ -73,6 +74,7 @@ export default function AuthLayoutShell({
   hasAccounting = false,
   hasJobs = false,
   hasJobsManage = false,
+  isPastoral = false,
   headerColor = "#5E17EB",
   userRole,
   header,
@@ -137,6 +139,7 @@ export default function AuthLayoutShell({
             hasAccounting={hasAccounting}
             hasJobs={hasJobs}
             hasJobsManage={hasJobsManage}
+            isPastoral={isPastoral}
             onClose={closeSidebar}
           />
         </div>
@@ -161,6 +164,7 @@ export default function AuthLayoutShell({
           hasAccounting={hasAccounting}
           hasJobs={hasJobs}
           hasJobsManage={hasJobsManage}
+          isPastoral={isPastoral}
           open={sidebarOpen}
           onClose={closeSidebar}
         />
@@ -178,6 +182,7 @@ export default function AuthLayoutShell({
       <BottomNav
         hasMembersAccess={hasMembersAccess}
         hasMyPlanning={hasMyPlanning}
+        isPastoral={isPastoral}
         onMenuOpen={() => setSidebarOpen(true)}
       />
 

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -6,11 +6,13 @@ import { usePathname } from "next/navigation";
 interface BottomNavProps {
   hasMembersAccess?: boolean;
   hasMyPlanning?: boolean;
+  isPastoral?: boolean;
   onMenuOpen?: () => void;
 }
 
 // Sections that have a dedicated nav item — "Menu" is active for everything else
 const KNOWN_PREFIXES = ["/planning", "/events"];
+const PASTORAL_KNOWN_PREFIXES = ["/pastoral", "/admin/members", "/agenda"];
 
 function IconPerson({ className }: { className?: string }) {
   return (
@@ -36,11 +38,70 @@ function IconMenu({ className }: { className?: string }) {
   );
 }
 
+function IconHome({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+    </svg>
+  );
+}
+
+function IconMembers({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+    </svg>
+  );
+}
+
 export default function BottomNav({
   hasMyPlanning = false,
+  isPastoral = false,
   onMenuOpen,
 }: BottomNavProps) {
   const pathname = usePathname();
+
+  // Vue pastorale : accueil pastoral + membres
+  if (isPastoral) {
+    const isOnPastoralKnown = PASTORAL_KNOWN_PREFIXES.some((p) => pathname.startsWith(p));
+    const pastoralLinks = [
+      { href: "/pastoral", label: "Accueil", matchPrefix: "/pastoral", icon: <IconHome className="w-5 h-5" /> },
+      { href: "/admin/members", label: "Mes membres", matchPrefix: "/admin/members", icon: <IconMembers className="w-5 h-5" /> },
+    ];
+    return (
+      <nav className="fixed bottom-0 inset-x-0 z-50 bg-white border-t border-gray-200 md:hidden print:hidden">
+        <div className="flex justify-around items-center h-14">
+          {pastoralLinks.map((item) => {
+            const isActive = pathname.startsWith(item.matchPrefix);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
+                  isActive ? "text-icc-violet" : "text-gray-400 hover:text-gray-600"
+                }`}
+              >
+                {item.icon}
+                <span className="text-[11px] font-medium">{item.label}</span>
+              </Link>
+            );
+          })}
+          <button
+            type="button"
+            onClick={onMenuOpen}
+            className={`flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
+              !isOnPastoralKnown ? "text-icc-violet" : "text-gray-400 hover:text-gray-600"
+            }`}
+            aria-label="Ouvrir le menu"
+          >
+            <IconMenu className="w-5 h-5" />
+            <span className="text-[11px] font-medium">Menu</span>
+          </button>
+        </div>
+      </nav>
+    );
+  }
+
   const isOnKnownRoute = KNOWN_PREFIXES.some((p) => pathname.startsWith(p));
 
   const links = [

--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -317,15 +317,13 @@ export default function MobileNavSheet({
           isActive={pathname === "/pastoral"}
           onClose={onClose}
         />
-        {hasMembersAccess && (
-          <RootRow
-            label="Mes membres"
-            icon={<IconMembers className="w-5 h-5" />}
-            href="/admin/members"
-            isActive={pathname.startsWith("/admin/members")}
-            onClose={onClose}
-          />
-        )}
+        <RootRow
+          label="Mes membres"
+          icon={<IconMembers className="w-5 h-5" />}
+          href="/pastoral/members"
+          isActive={pathname.startsWith("/pastoral/members")}
+          onClose={onClose}
+        />
         {agendaLinks.length > 0 && (
           <RootRow
             label="Agenda pastoral"

--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -25,6 +25,7 @@ interface MobileNavSheetProps {
   hasAccounting?: boolean;
   hasJobs?: boolean;
   hasJobsManage?: boolean;
+  isPastoral?: boolean;
   open: boolean;
   onClose: () => void;
 }
@@ -246,6 +247,7 @@ export default function MobileNavSheet({
   hasAccounting = false,
   hasJobs = false,
   hasJobsManage = false,
+  isPastoral = false,
   open,
   onClose,
 }: MobileNavSheetProps) {
@@ -305,7 +307,76 @@ export default function MobileNavSheet({
 
   /* ── Views ── */
 
+  function renderPastoralRoot() {
+    return (
+      <div className="py-1">
+        <RootRow
+          label="Accueil pastoral"
+          icon={<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>}
+          href="/pastoral"
+          isActive={pathname === "/pastoral"}
+          onClose={onClose}
+        />
+        {hasMembersAccess && (
+          <RootRow
+            label="Mes membres"
+            icon={<IconMembers className="w-5 h-5" />}
+            href="/admin/members"
+            isActive={pathname.startsWith("/admin/members")}
+            onClose={onClose}
+          />
+        )}
+        {agendaLinks.length > 0 && (
+          <RootRow
+            label="Agenda pastoral"
+            icon={<IconDiscipleship className="w-5 h-5" />}
+            hasChildren
+            isActive={isAgendaActive}
+            onClick={() => setView("agenda")}
+          />
+        )}
+        {hasDiscipleship && (
+          <RootRow
+            label="Discipolat"
+            icon={<IconDiscipleship className="w-5 h-5" />}
+            href="/admin/discipleship"
+            isActive={pathname.startsWith("/admin/discipleship")}
+            onClose={onClose}
+          />
+        )}
+        {hasEventsAccess && (
+          <RootRow
+            label="Événements"
+            icon={<IconCalendar className="w-5 h-5" />}
+            hasChildren
+            isActive={isEventsActive}
+            onClick={() => setView("events")}
+          />
+        )}
+        {hasJobs && (
+          <RootRow
+            label="Emploi"
+            icon={<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>}
+            hasChildren
+            isActive={pathname.startsWith("/jobs") || pathname.startsWith("/admin/jobs")}
+            onClick={() => setView("jobs")}
+          />
+        )}
+        {configLinks.length > 0 && (
+          <RootRow
+            label="Configuration"
+            icon={<IconConfig className="w-5 h-5" />}
+            hasChildren
+            isActive={isConfigActive}
+            onClick={() => setView("config")}
+          />
+        )}
+      </div>
+    );
+  }
+
   function renderRoot() {
+    if (isPastoral) return renderPastoralRoot();
     return (
       <div className="py-1">
         {hasMyPlanning && (
@@ -552,6 +623,66 @@ export default function MobileNavSheet({
     );
   }
 
+  function renderPastoralRoot() {
+    const rowCls = "flex items-center gap-3 w-full px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors";
+    const activeCls = "bg-icc-violet/10 text-icc-violet font-semibold";
+    const isPastoralHome = pathname === "/pastoral";
+    const isPastoralMembers = pathname.startsWith("/pastoral/members");
+    const isPastoralAgenda = pathname.startsWith("/agenda") && pathname !== "/agenda/request";
+    const isPastoralDiscipleship = pathname.startsWith("/admin/discipleship");
+    const isPastoralJobs = pathname.startsWith("/jobs") || pathname.startsWith("/admin/jobs");
+    const isPastoralConfig = pathname.startsWith("/admin") && !pathname.startsWith("/admin/discipleship") && !pathname.startsWith("/admin/events") && !pathname.startsWith("/admin/reports") && !pathname.startsWith("/admin/welcome-duty") && !pathname.startsWith("/admin/jobs") && !pathname.startsWith("/admin/pastoral-profiles");
+
+    return (
+      <div className="flex-1 overflow-y-auto divide-y divide-gray-100">
+        <Link href="/pastoral" onClick={onClose} className={`${rowCls} ${isPastoralHome ? activeCls : ""}`}>
+          <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+          </svg>
+          Accueil
+        </Link>
+        <Link href="/pastoral/members" onClick={onClose} className={`${rowCls} ${isPastoralMembers ? activeCls : ""}`}>
+          <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+          </svg>
+          Mes membres
+        </Link>
+        {agendaLinks.length > 0 && (
+          <button onClick={() => setView("agenda")} className={`${rowCls} ${isPastoralAgenda ? activeCls : ""}`}>
+            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            Agenda pastoral
+          </button>
+        )}
+        {hasDiscipleship && (
+          <Link href="/admin/discipleship" onClick={onClose} className={`${rowCls} ${isPastoralDiscipleship ? activeCls : ""}`}>
+            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+            </svg>
+            Discipolat
+          </Link>
+        )}
+        {hasJobs && (
+          <Link href="/jobs" onClick={onClose} className={`${rowCls} ${isPastoralJobs ? activeCls : ""}`}>
+            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+            Emploi
+          </Link>
+        )}
+        {configLinks.length > 0 && (
+          <button onClick={() => setView("config")} className={`${rowCls} ${isPastoralConfig ? activeCls : ""}`}>
+            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            Administration
+          </button>
+        )}
+      </div>
+    );
+  }
+
   function renderContent() {
     switch (view) {
       case "planning": return renderPlanning();
@@ -562,7 +693,7 @@ export default function MobileNavSheet({
       case "agenda":       return renderLinks("Agenda pastoral", agendaLinks);
       case "jobs":         return renderJobs();
       case "config":   return renderConfigLinks(configLinks);
-      default:         return renderRoot();
+      default:         return isPastoral ? renderPastoralRoot() : renderRoot();
     }
   }
 

--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -623,66 +623,6 @@ export default function MobileNavSheet({
     );
   }
 
-  function renderPastoralRoot() {
-    const rowCls = "flex items-center gap-3 w-full px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors";
-    const activeCls = "bg-icc-violet/10 text-icc-violet font-semibold";
-    const isPastoralHome = pathname === "/pastoral";
-    const isPastoralMembers = pathname.startsWith("/pastoral/members");
-    const isPastoralAgenda = pathname.startsWith("/agenda") && pathname !== "/agenda/request";
-    const isPastoralDiscipleship = pathname.startsWith("/admin/discipleship");
-    const isPastoralJobs = pathname.startsWith("/jobs") || pathname.startsWith("/admin/jobs");
-    const isPastoralConfig = pathname.startsWith("/admin") && !pathname.startsWith("/admin/discipleship") && !pathname.startsWith("/admin/events") && !pathname.startsWith("/admin/reports") && !pathname.startsWith("/admin/welcome-duty") && !pathname.startsWith("/admin/jobs") && !pathname.startsWith("/admin/pastoral-profiles");
-
-    return (
-      <div className="flex-1 overflow-y-auto divide-y divide-gray-100">
-        <Link href="/pastoral" onClick={onClose} className={`${rowCls} ${isPastoralHome ? activeCls : ""}`}>
-          <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-          </svg>
-          Accueil
-        </Link>
-        <Link href="/pastoral/members" onClick={onClose} className={`${rowCls} ${isPastoralMembers ? activeCls : ""}`}>
-          <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-          </svg>
-          Mes membres
-        </Link>
-        {agendaLinks.length > 0 && (
-          <button onClick={() => setView("agenda")} className={`${rowCls} ${isPastoralAgenda ? activeCls : ""}`}>
-            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
-            Agenda pastoral
-          </button>
-        )}
-        {hasDiscipleship && (
-          <Link href="/admin/discipleship" onClick={onClose} className={`${rowCls} ${isPastoralDiscipleship ? activeCls : ""}`}>
-            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
-            </svg>
-            Discipolat
-          </Link>
-        )}
-        {hasJobs && (
-          <Link href="/jobs" onClick={onClose} className={`${rowCls} ${isPastoralJobs ? activeCls : ""}`}>
-            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-            </svg>
-            Emploi
-          </Link>
-        )}
-        {configLinks.length > 0 && (
-          <button onClick={() => setView("config")} className={`${rowCls} ${isPastoralConfig ? activeCls : ""}`}>
-            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
-            Administration
-          </button>
-        )}
-      </div>
-    );
-  }
-
   function renderContent() {
     switch (view) {
       case "planning": return renderPlanning();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -405,7 +405,7 @@ export default function Sidebar({
   // ── Mode pastoral : navigation simplifiée ────────────────
   if (isPastoral) {
     const isPastoralHome = pathname === "/pastoral";
-    const isPastoralMembers = pathname.startsWith("/admin/members");
+    const isPastoralMembers = pathname.startsWith("/pastoral/members");
     const isPastoralAgenda = pathname.startsWith("/agenda") && pathname !== "/agenda/request";
     const isPastoralDiscipleship = pathname.startsWith("/admin/discipleship");
     const isPastoralEvents = pathname.startsWith("/events") || pathname.startsWith("/admin/events") || pathname.startsWith("/admin/reports") || pathname.startsWith("/admin/welcome-duty");
@@ -422,7 +422,7 @@ export default function Sidebar({
           <span className="flex-1">Accueil</span>
         </Link>
 
-        <Link href="/admin/members" onClick={onClose}
+        <Link href="/pastoral/members" onClick={onClose}
           className={`${sectionHeaderBase} ${isPastoralMembers ? sectionHeaderActive : sectionHeaderIdle} rounded-md`}>
           <IconMembers className="w-4 h-4 shrink-0" />
           <span className="flex-1">Mes membres</span>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ interface SidebarProps {
   hasAccounting?: boolean;
   hasJobs?: boolean;
   hasJobsManage?: boolean;
+  isPastoral?: boolean;
   onClose?: () => void;
 }
 
@@ -338,6 +339,7 @@ export default function Sidebar({
   hasAccounting = false,
   hasJobs = false,
   hasJobsManage = false,
+  isPastoral = false,
   onClose,
 }: SidebarProps) {
   const searchParams = useSearchParams();
@@ -398,6 +400,88 @@ export default function Sidebar({
 
   function toggle(section: string) {
     setOpenSection((prev) => (prev === section ? "" : section));
+  }
+
+  // ── Mode pastoral : navigation simplifiée ────────────────
+  if (isPastoral) {
+    const isPastoralHome = pathname === "/pastoral";
+    const isPastoralMembers = pathname.startsWith("/admin/members");
+    const isPastoralAgenda = pathname.startsWith("/agenda") && pathname !== "/agenda/request";
+    const isPastoralDiscipleship = pathname.startsWith("/admin/discipleship");
+    const isPastoralEvents = pathname.startsWith("/events") || pathname.startsWith("/admin/events") || pathname.startsWith("/admin/reports") || pathname.startsWith("/admin/welcome-duty");
+    const isPastoralJobs = pathname.startsWith("/jobs") || pathname.startsWith("/admin/jobs");
+    const isPastoralConfig = pathname.startsWith("/admin") && !pathname.startsWith("/admin/discipleship") && !pathname.startsWith("/admin/events") && !pathname.startsWith("/admin/reports") && !pathname.startsWith("/admin/welcome-duty") && !pathname.startsWith("/admin/jobs") && !pathname.startsWith("/admin/pastoral-profiles");
+
+    return (
+      <aside className="w-64 min-h-0 md:min-h-[calc(100vh-73px)] bg-white border-r border-gray-200 p-4 pb-20 md:pb-4 space-y-1 overflow-y-auto">
+        <Link href="/pastoral" onClick={onClose}
+          className={`${sectionHeaderBase} ${isPastoralHome ? sectionHeaderActive : sectionHeaderIdle} rounded-md`}>
+          <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+          </svg>
+          <span className="flex-1">Accueil</span>
+        </Link>
+
+        <Link href="/admin/members" onClick={onClose}
+          className={`${sectionHeaderBase} ${isPastoralMembers ? sectionHeaderActive : sectionHeaderIdle} rounded-md`}>
+          <IconMembers className="w-4 h-4 shrink-0" />
+          <span className="flex-1">Mes membres</span>
+        </Link>
+
+        {agendaLinks.length > 0 && (
+          <AccordionSection title="Agenda pastoral" icon={<IconAgenda className="w-4 h-4" />}
+            open={openSection === "agenda"} onToggle={() => toggle("agenda")} isActive={isPastoralAgenda}>
+            <nav className="space-y-0.5 pl-6">
+              {agendaLinks.map((link) => (
+                <NavLink key={link.href} href={link.href} active={pathname.startsWith(link.href)} onClose={onClose}>
+                  {link.label}
+                </NavLink>
+              ))}
+            </nav>
+          </AccordionSection>
+        )}
+
+        {hasDiscipleship && (
+          <Link href="/admin/discipleship" onClick={onClose}
+            className={`${sectionHeaderBase} ${isPastoralDiscipleship ? sectionHeaderActive : sectionHeaderIdle} rounded-md`}>
+            <IconDiscipleship className="w-4 h-4 shrink-0" />
+            <span className="flex-1">Discipolat</span>
+          </Link>
+        )}
+
+        {hasEventsAccess && (
+          <AccordionSection title="Événements" icon={<IconCalendar className="w-4 h-4" />}
+            open={openSection === "events"} onToggle={() => toggle("events")} isActive={isPastoralEvents}>
+            <nav className="space-y-0.5 pl-6">
+              <NavLink href="/events" active={pathname === "/events"} onClose={onClose}>Liste</NavLink>
+              <NavLink href="/events/calendar" active={pathname === "/events/calendar"} onClose={onClose}>Calendrier</NavLink>
+            </nav>
+          </AccordionSection>
+        )}
+
+        {hasJobs && (
+          <AccordionSection title="Emploi" icon={<IconJobs className="w-4 h-4" />}
+            open={openSection === "jobs"} onToggle={() => toggle("jobs")} isActive={isPastoralJobs}>
+            <nav className="space-y-0.5 pl-6">
+              <NavLink href="/jobs" active={pathname === "/jobs"} onClose={onClose}>Offres</NavLink>
+            </nav>
+          </AccordionSection>
+        )}
+
+        {configLinks.length > 0 && (
+          <AccordionSection title="Administration" icon={<IconConfig className="w-4 h-4" />}
+            open={openSection === "config"} onToggle={() => toggle("config")} isActive={isPastoralConfig}>
+            <nav className="space-y-0.5 pl-6">
+              {configLinks.map((link) => (
+                <NavLink key={link.href} href={link.href} active={pathname === link.href} onClose={onClose}>
+                  {link.label}
+                </NavLink>
+              ))}
+            </nav>
+          </AccordionSection>
+        )}
+      </aside>
+    );
   }
 
   return (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -29,6 +29,7 @@ declare module "next-auth" {
       image: string | null;
       isSuperAdmin: boolean;
       hasSeenTour: boolean;
+      pastoralProfileId: string | null;
       churchRoles: {
         id: string;
         churchId: string;
@@ -183,6 +184,26 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           }
         }
       }
+
+      // Détection du profil pastoral : d'abord par userId, puis par email (auto-liaison)
+      let pastoralProfile = await prisma.pastoralProfile.findFirst({
+        where: { userId: user.id },
+        select: { id: true },
+      });
+      if (!pastoralProfile && user.email) {
+        const byEmail = await prisma.pastoralProfile.findFirst({
+          where: { email: user.email, userId: null },
+          select: { id: true },
+        });
+        if (byEmail) {
+          await prisma.pastoralProfile.update({
+            where: { id: byEmail.id },
+            data: { userId: user.id },
+          });
+          pastoralProfile = byEmail;
+        }
+      }
+      session.user.pastoralProfileId = pastoralProfile?.id ?? null;
 
       session.user.churchRoles = churchRoles.map((cr) => {
         const extraDepts = ministerDeptMap.get(cr.id) ?? starDeptMap.get(cr.id);


### PR DESCRIPTION
## Summary

Première brique du module pastoral — schéma et routing.

- **Migration** : `responsibleProfileId` (unique) + `supervisorUserId` sur `Church` avec FK vers `pastoral_profiles` et `users`
- **Session** : détection automatique du profil pastoral à la connexion par `userId`, puis par `email` (auto-liaison one-time)
- **Permission** : `pastoral:view` injectée dynamiquement si profil trouvé (orthogonal aux `UserChurchRole`)
- **Guard no-access** : un pasteur sans rôle opérationnel n'est plus redirigé vers `/no-access`
- **Routing** : `/dashboard` redirige vers `/pastoral` si profil pastoral détecté
- **Page `/pastoral`** : placeholder fonctionnel — affiche les églises (responsable + supervisées) et le lien vers l'agenda pastoral

## Test plan

- [ ] Un utilisateur sans profil pastoral → `/dashboard` comme avant
- [ ] Un utilisateur avec profil pastoral (email correspondant, `userId` null) → auto-liaison + redirect `/pastoral`
- [ ] Un utilisateur avec profil pastoral + rôle ADMIN → `/pastoral` comme home, `/admin` accessible via sidebar
- [ ] Un pasteur superviseur de plusieurs églises → toutes les cartes affichées
- [ ] Typecheck ✅ · 351 tests ✅ · lint warnings seulement (0 erreurs)

## Prochaine étape

Dashboard `/pastoral` complet : membres/STAR par église, stats, agenda intégré, sidebar simplifiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)