### PR TITLE
feat(nav): clarté navigation — Intégration + Gestion pastorale + Ressources

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -195,12 +195,12 @@ export default async function AuthLayout({
     }).then((c) => c > 0);
 
     if (isIntegrationMember || isBerger) {
-      integrationLinks.push({ href: "/integration/requests", label: "Demandes" });
+      integrationLinks.push({ href: "/integration/requests", label: "Intégration" });
     }
     if (isIntegrationMember) {
-      integrationLinks.push({ href: "/integration/leaders", label: "Bergers" });
-      integrationLinks.push({ href: "/integration/parcours", label: "Parcours" });
-      integrationLinks.push({ href: "/integration/stats", label: "Statistiques" });
+      integrationLinks.push({ href: "/integration/leaders", label: "Bergers de famille" });
+      integrationLinks.push({ href: "/integration/parcours", label: "Parcours d'intégration" });
+      integrationLinks.push({ href: "/integration/stats", label: "Statistiques intégration" });
     }
   }
 

--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -564,9 +564,14 @@ export default function MobileNavSheet({
       <>
         <SheetSubHeader title="Gestion pastorale" onBack={() => setView("root")} />
         <div>
-          {agendaLinks.map((link) => (
-            <SubRow key={link.href} href={link.href} label={link.label} isActive={pathname.startsWith(link.href)} onClose={onClose} />
-          ))}
+          {agendaLinks.map((link) => {
+            const hasChildLink = agendaLinks.some(l => l.href !== link.href && l.href.startsWith(link.href + "/"));
+            return (
+              <SubRow key={link.href} href={link.href} label={link.label}
+                isActive={pathname === link.href || (!hasChildLink && pathname.startsWith(link.href + "/"))}
+                onClose={onClose} />
+            );
+          })}
         </div>
       </>
     );

--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 
-type SheetView = "root" | "planning" | "evenements" | "communaute" | "operations" | "ressources" | "config";
+type SheetView = "root" | "planning" | "evenements" | "pastoral" | "communaute" | "operations" | "ressources" | "config";
 
 interface MobileNavSheetProps {
   departments: { id: string; name: string; ministryName?: string }[];
@@ -310,7 +310,8 @@ export default function MobileNavSheet({
     pathname.startsWith("/admin/members") ||
     pathname.startsWith("/admin/discipleship") ||
     isIntegrationActive;
-  const isEvenementsActive = isEventsActive || isAgendaActive;
+  const isEvenementsActive = isEventsActive;
+  const isGestionPastoraleActive = isAgendaActive;
   const isOperationsActive = isRequestsActive || isMediaActive;
   const isRessourcesActive = isAccountingActive || isJobsActive || isMrbsActive;
 
@@ -340,11 +341,11 @@ export default function MobileNavSheet({
         />
         {agendaLinks.length > 0 && (
           <RootRow
-            label="Agenda pastoral"
+            label="Gestion pastorale"
             icon={<IconDiscipleship className="w-5 h-5" />}
             hasChildren
-            isActive={isAgendaActive}
-            onClick={() => setView("evenements")}
+            isActive={isGestionPastoraleActive}
+            onClick={() => setView("pastoral")}
           />
         )}
         {hasDiscipleship && (
@@ -425,6 +426,15 @@ export default function MobileNavSheet({
             hasChildren
             isActive={isEvenementsActive}
             onClick={() => setView("evenements")}
+          />
+        )}
+        {agendaLinks.length > 0 && (
+          <RootRow
+            label="Gestion pastorale"
+            icon={<IconDiscipleship className="w-5 h-5" />}
+            hasChildren
+            isActive={isGestionPastoraleActive}
+            onClick={() => setView("pastoral")}
           />
         )}
         {hasOperations && (
@@ -544,14 +554,19 @@ export default function MobileNavSheet({
           {hasReports && (
             <SubRow href="/admin/reports" label="Comptes rendus" isActive={pathname.startsWith("/admin/reports")} onClose={onClose} />
           )}
-          {agendaLinks.length > 0 && (
-            <>
-              <SubDivider />
-              {agendaLinks.map((link) => (
-                <SubRow key={link.href} href={link.href} label={link.label} isActive={pathname.startsWith(link.href)} onClose={onClose} />
-              ))}
-            </>
-          )}
+        </div>
+      </>
+    );
+  }
+
+  function renderGestionPastorale() {
+    return (
+      <>
+        <SheetSubHeader title="Gestion pastorale" onBack={() => setView("root")} />
+        <div>
+          {agendaLinks.map((link) => (
+            <SubRow key={link.href} href={link.href} label={link.label} isActive={pathname.startsWith(link.href)} onClose={onClose} />
+          ))}
         </div>
       </>
     );
@@ -593,9 +608,8 @@ export default function MobileNavSheet({
             <>
               {(mrbsUrl || mrbsAdminLink || hasAccounting) && <SubDivider />}
               <SubRow href="/jobs" label="Offres" isActive={pathname === "/jobs"} onClose={onClose} />
-              <SubRow href="/jobs/new" label="Publier" isActive={pathname === "/jobs/new"} onClose={onClose} />
               {hasJobsManage && (
-                <SubRow href="/admin/jobs" label="Modérer" isActive={pathname.startsWith("/admin/jobs")} onClose={onClose} />
+                <SubRow href="/admin/jobs" label="Modération offres" isActive={pathname.startsWith("/admin/jobs")} onClose={onClose} />
               )}
             </>
           )}
@@ -622,6 +636,7 @@ export default function MobileNavSheet({
       case "planning":    return renderPlanning();
       case "communaute":  return renderCommunaute();
       case "evenements":  return renderEvenements();
+      case "pastoral":    return renderGestionPastorale();
       case "operations":  return renderOperations();
       case "ressources":  return renderRessources();
       case "config":      return renderConfig();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -365,11 +365,13 @@ export default function Sidebar({
 
   // ── Sections composites ─────────────────────────────────
   const isCommunauteActive = isMembersActive || isDiscipleshipActive || isIntegrationActive;
-  const isEvenementsActive = isEventsActive || isAgendaActive;
+  const isEvenementsActive = isEventsActive;
+  const isGestionPastoraleActive = isAgendaActive;
   const isOperationsActive = isRequestsActive || isMediaActive;
   const isRessourcesActive = isAccountingActive || isJobsActive || pathname.startsWith("/admin/mrbs");
 
   function activeSection() {
+    if (isGestionPastoraleActive) return "pastoral";
     if (isEvenementsActive) return "evenements";
     if (isCommunauteActive) return "communaute";
     if (isOperationsActive) return "operations";
@@ -580,7 +582,7 @@ export default function Sidebar({
         </AccordionSection>
       )}
 
-      {/* 3. Événements — Événements + Agenda pastoral */}
+      {/* 3. Événements */}
       {hasEventsAccess && (
         <AccordionSection
           title="Événements"
@@ -610,21 +612,30 @@ export default function Sidebar({
                 </NavLink>
               </span>
             )}
-            {agendaLinks.length > 0 && (
-              <>
-                <hr className="my-1 border-gray-100" />
-                {agendaLinks.map((link) => (
-                  <NavLink key={link.href} href={link.href} active={pathname.startsWith(link.href)} onClose={onClose}>
-                    {link.label}
-                  </NavLink>
-                ))}
-              </>
-            )}
           </nav>
         </AccordionSection>
       )}
 
-      {/* 4. Opérations — Demandes + Médias */}
+      {/* 4. Gestion pastorale — Agenda pastoral */}
+      {agendaLinks.length > 0 && (
+        <AccordionSection
+          title="Gestion pastorale"
+          icon={<IconAgenda className="w-4 h-4" />}
+          open={openSection === "pastoral"}
+          onToggle={() => toggle("pastoral")}
+          isActive={isGestionPastoraleActive}
+        >
+          <nav className="space-y-0.5 pl-6">
+            {agendaLinks.map((link) => (
+              <NavLink key={link.href} href={link.href} active={pathname.startsWith(link.href)} onClose={onClose}>
+                {link.label}
+              </NavLink>
+            ))}
+          </nav>
+        </AccordionSection>
+      )}
+
+      {/* 5. Opérations — Demandes + Médias */}
       {hasOperations && (
         <AccordionSection
           title="Opérations"
@@ -690,10 +701,9 @@ export default function Sidebar({
               <>
                 {(mrbsUrl || mrbsAdminLink || hasAccounting) && <hr className="my-1 border-gray-100" />}
                 <NavLink href="/jobs" active={pathname === "/jobs"} onClose={onClose}>Offres</NavLink>
-                <NavLink href="/jobs/new" active={pathname === "/jobs/new"} onClose={onClose}>Publier</NavLink>
                 {hasJobsManage && (
                   <NavLink href="/admin/jobs" active={pathname.startsWith("/admin/jobs")} onClose={onClose}>
-                    Modérer
+                    Modération offres
                   </NavLink>
                 )}
               </>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -421,11 +421,16 @@ export default function Sidebar({
           <AccordionSection title="Agenda pastoral" icon={<IconAgenda className="w-4 h-4" />}
             open={openSection === "agenda"} onToggle={() => toggle("agenda")} isActive={isPastoralAgenda}>
             <nav className="space-y-0.5 pl-6">
-              {agendaLinks.map((link) => (
-                <NavLink key={link.href} href={link.href} active={pathname.startsWith(link.href)} onClose={onClose}>
-                  {link.label}
-                </NavLink>
-              ))}
+              {agendaLinks.map((link) => {
+                const hasChildLink = agendaLinks.some(l => l.href !== link.href && l.href.startsWith(link.href + "/"));
+                return (
+                  <NavLink key={link.href} href={link.href}
+                    active={pathname === link.href || (!hasChildLink && pathname.startsWith(link.href + "/"))}
+                    onClose={onClose}>
+                    {link.label}
+                  </NavLink>
+                );
+              })}
             </nav>
           </AccordionSection>
         )}
@@ -626,11 +631,16 @@ export default function Sidebar({
           isActive={isGestionPastoraleActive}
         >
           <nav className="space-y-0.5 pl-6">
-            {agendaLinks.map((link) => (
-              <NavLink key={link.href} href={link.href} active={pathname.startsWith(link.href)} onClose={onClose}>
-                {link.label}
-              </NavLink>
-            ))}
+            {agendaLinks.map((link) => {
+              const hasChildLink = agendaLinks.some(l => l.href !== link.href && l.href.startsWith(link.href + "/"));
+              return (
+                <NavLink key={link.href} href={link.href}
+                  active={pathname === link.href || (!hasChildLink && pathname.startsWith(link.href + "/"))}
+                  onClose={onClose}>
+                  {link.label}
+                </NavLink>
+              );
+            })}
           </nav>
         </AccordionSection>
       )}


### PR DESCRIPTION
## Summary

- **Labels Intégration** : Demandes→Intégration, Bergers→Bergers de famille, Parcours→Parcours d'intégration, Statistiques→Statistiques intégration
- **Nouvelle section « Gestion pastorale »** (Sidebar + MobileNavSheet) placée entre Événements et Opérations, contenant les liens agenda pastoral (Mon agenda, Vue agenda, Qualification, Planification, Nouvelle entrée)
- **Ressources** : suppression du lien « Publier une offre », renommage « Modérer » → « Modération offres »

## Test plan

- [ ] Utilisateur avec accès agenda : vérifier que la section « Gestion pastorale » s'affiche bien entre Événements et Opérations (sidebar desktop + sheet mobile)
- [ ] Vérifier que les liens intégration dans Communauté affichent les nouveaux labels
- [ ] Vérifier que la section Ressources ne contient plus « Publier » et affiche « Modération offres »
- [ ] Mode pastoral inchangé (son propre accordion « Agenda pastoral » reste)

🤖 Generated with [Claude Code](https://claude.com/claude-code)