### PR TITLE
chore: release v1.8.0 (#382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.8.0] - 2026-06-14
+
+### Ajouté
+
+- **Module pastoral multi-église** : un pasteur peut désormais être rattaché à plusieurs églises et superviser des églises tierces (#379, #381)
+  - `PastoralProfile` par église, supervision via `Church.supervisorProfileId`
+  - `pastoralChurchIds[]` en session — inclut les églises directes et supervisées
+  - ChurchSwitcher disponible pour les utilisateurs pastoral-only
+  - Page `/pastoral/members` avec barre de recherche, alignée sur le ChurchSwitcher
+  - Composant `SwitchChurchLink` pour changer d'église depuis les liens du dashboard pastoral
+
+### Modifié
+
+- **Navigation — clarté des sections** (#382)
+  - Labels intégration renommés : Demandes→Intégration, Bergers→Bergers de famille, Parcours→Parcours d'intégration, Statistiques→Statistiques intégration
+  - Nouvelle section « Gestion pastorale » (entre Événements et Opérations) regroupant les liens agenda pastoral
+  - Section Ressources : suppression du lien « Publier une offre », renommage « Modérer » → « Modération offres »
+  - Correction : "Vue agenda" ne reste plus actif en naviguant sur les sous-pages de l'agenda
+
+- **Réorganisation menu** (#380)
+  - 6 sections principales : Planning, Communauté, Événements, Opérations, Ressources, Configuration
+  - Lien « Familles » intégré dans la section Communauté
+  - Navigation mobile refactorisée (bottom nav + sheet drilldown)
+
 ## [v1.7.1] - 2026-06-12
 
 ### Corrigé

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koinonia",
-  "version": "1.3.6",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koinonia",
-      "version": "1.3.6",
+      "version": "1.8.0",
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.2",
         "@aws-sdk/client-s3": "^3.1048.0",
@@ -3936,7 +3936,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -187,7 +187,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       }
 
       // Détection des profils pastoraux (multi-église) : par userId, puis par email (auto-liaison)
-      let pastoralProfiles = await prisma.pastoralProfile.findMany({
+      const pastoralProfiles = await prisma.pastoralProfile.findMany({
         where: { userId: user.id },
         select: { id: true, churchId: true },
       });


### PR DESCRIPTION
## Summary

- Bump version `1.7.1` → `1.8.0`
- Mise à jour `package-lock.json`
- Entrée CHANGELOG v1.8.0

## Contenu de la release

- Module pastoral multi-église (PRs #379, #381)
- Réorganisation navigation (PR #380)
- Clarté navigation : labels intégration, section Gestion pastorale, nettoyage Ressources (PR #382)

🤖 Generated with [Claude Code](https://claude.com/claude-code)