### PR TITLE
feat(accounting): statistiques financières

### DIFF
--- a/prisma/migrations/20260322000002_add_department_function/migration.sql
+++ b/prisma/migrations/20260322000002_add_department_function/migration.sql
@@ -1,0 +1,29 @@
+-- Colonnes et tables ajoutées via db push, jamais capturées en migration.
+-- IF NOT EXISTS les rend idempotentes sur les environnements où elles existent déjà.
+ALTER TABLE `departments` ADD COLUMN IF NOT EXISTS `function` VARCHAR(191) NULL;
+ALTER TABLE `events` ADD COLUMN IF NOT EXISTS `allowAnnouncements` BOOLEAN NOT NULL DEFAULT false;
+
+-- service_requests existait en production avant d'être remplacée par requests.
+-- Nécessaire pour la shadow DB : la migration unifiée fait un INSERT ... SELECT FROM service_requests.
+CREATE TABLE IF NOT EXISTS `service_requests` (
+    `id`              VARCHAR(191) NOT NULL,
+    `churchId`        VARCHAR(191) NOT NULL,
+    `type`            VARCHAR(191) NOT NULL,
+    `status`          VARCHAR(191) NOT NULL DEFAULT 'EN_ATTENTE',
+    `title`           VARCHAR(191) NULL,
+    `brief`           TEXT NULL,
+    `format`          VARCHAR(191) NULL,
+    `deadline`        DATETIME(3) NULL,
+    `deliveryLink`    VARCHAR(191) NULL,
+    `submittedById`   VARCHAR(191) NOT NULL,
+    `assignedDeptId`  VARCHAR(191) NULL,
+    `announcementId`  VARCHAR(191) NULL,
+    `parentRequestId` VARCHAR(191) NULL,
+    `reviewNotes`     TEXT NULL,
+    `reviewedById`    VARCHAR(191) NULL,
+    `reviewedAt`      DATETIME(3) NULL,
+    `submittedAt`     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt`       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/src/app/(auth)/accounting/AccountingNav.tsx
+++ b/src/app/(auth)/accounting/AccountingNav.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+
+export default function AccountingNav({
+  canViewStats,
+  active,
+}: {
+  canViewStats: boolean;
+  active: "requests" | "stats";
+}) {
+  if (!canViewStats) return null;
+
+  return (
+    <div className="flex gap-1 border-b border-gray-200">
+      <Link
+        href="/accounting/requests"
+        className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+          active === "requests"
+            ? "border-icc-violet text-icc-violet"
+            : "border-transparent text-gray-500 hover:text-gray-700"
+        }`}
+      >
+        Demandes
+      </Link>
+      <Link
+        href="/accounting/stats"
+        className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+          active === "stats"
+            ? "border-icc-violet text-icc-violet"
+            : "border-transparent text-gray-500 hover:text-gray-700"
+        }`}
+      >
+        Statistiques
+      </Link>
+    </div>
+  );
+}

--- a/src/app/(auth)/accounting/requests/page.tsx
+++ b/src/app/(auth)/accounting/requests/page.tsx
@@ -3,6 +3,7 @@ import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import AccountingDashboard from "./AccountingDashboard";
+import AccountingNav from "../AccountingNav";
 
 export default async function AccountingRequestsPage() {
   const session = await requireAuth();
@@ -17,6 +18,7 @@ export default async function AccountingRequestsPage() {
 
   const canManage = perms.includes("accounting:manage");
   const canSubmit = perms.includes("accounting:submit");
+  const canViewStats = perms.includes("accounting:stats") || (session.user.pastoralChurchIds ?? []).includes(churchId);
 
   // Scope : DEPARTMENT_HEAD → ses départements uniquement
   let deptFilter: string[] | undefined;
@@ -76,6 +78,8 @@ export default async function AccountingRequestsPage() {
           </Link>
         )}
       </div>
+
+      <AccountingNav canViewStats={canViewStats} active="requests" />
 
       <AccountingDashboard
         requests={requests.map((r) => ({

--- a/src/app/(auth)/accounting/stats/AccountingStats.tsx
+++ b/src/app/(auth)/accounting/stats/AccountingStats.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+
+const MONTH_NAMES = ["Jan", "Fév", "Mar", "Avr", "Mai", "Jun", "Jul", "Aoû", "Sep", "Oct", "Nov", "Déc"];
+
+const STATUS_LABELS: Record<string, string> = {
+  SUBMITTED: "Soumise",
+  PROCESSING: "En cours",
+  APPROVED: "Validée",
+  REJECTED: "Rejetée",
+  CANCELLED: "Annulée",
+};
+const STATUS_COLORS: Record<string, string> = {
+  SUBMITTED: "bg-amber-400",
+  PROCESSING: "bg-blue-400",
+  APPROVED: "bg-emerald-500",
+  REJECTED: "bg-red-400",
+  CANCELLED: "bg-gray-300",
+};
+
+type Period = "month" | "quarter" | "year";
+
+interface Overview {
+  totalRequests: number;
+  totalAmount: number;
+  approvedAmount: number;
+  releasedAmount: number;
+  pendingAmount: number;
+  rejectedCount: number;
+  cancelledCount: number;
+  approvalRate: number | null;
+}
+
+interface StatsData {
+  period: Period;
+  dateRange: { from: string; to: string };
+  overview: Overview;
+  byStatus: { status: string; count: number; amount: number }[];
+  byType: { type: string; count: number; amount: number }[];
+  byDepartment: { name: string; count: number; amount: number; released: number }[];
+  byMonth: { month: string; submitted: number; released: number }[];
+  overduePayments: { id: string; requestId: string; requestLabel: string; amount: number; scheduledDate: string }[];
+}
+
+function fmt(amount: number) {
+  return new Intl.NumberFormat("fr-FR", { style: "currency", currency: "EUR", maximumFractionDigits: 0 }).format(amount);
+}
+
+function KpiCard({
+  label,
+  value,
+  sub,
+  accent,
+  warning,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  accent?: boolean;
+  warning?: boolean;
+}) {
+  return (
+    <div
+      className={`bg-white rounded-xl border p-4 sm:p-5 ${
+        accent
+          ? "border-icc-violet/30 bg-icc-violet/5"
+          : warning
+          ? "border-amber-200 bg-amber-50"
+          : "border-gray-200"
+      }`}
+    >
+      <p className="text-xs text-gray-500 font-medium mb-1">{label}</p>
+      <p
+        className={`text-2xl font-bold ${
+          accent ? "text-icc-violet" : warning ? "text-amber-700" : "text-gray-900"
+        }`}
+      >
+        {value}
+      </p>
+      {sub && <p className="text-xs text-gray-400 mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5">
+      <h2 className="text-sm font-semibold text-gray-700 mb-4">{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+function HBar({ label, value, max, sub }: { label: string; value: number; max: number; sub?: string }) {
+  const pct = max > 0 ? Math.round((value / max) * 100) : 0;
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-xs text-gray-600 w-28 shrink-0 truncate" title={label}>{label}</span>
+      <div className="flex-1 bg-gray-100 rounded-full h-2">
+        <div className="bg-icc-violet rounded-full h-2 transition-all" style={{ width: `${pct}%` }} />
+      </div>
+      <span className="text-xs font-medium text-gray-800 w-20 text-right shrink-0">{sub ?? fmt(value)}</span>
+    </div>
+  );
+}
+
+export default function AccountingStats({
+  initialData,
+  churchId,
+}: {
+  initialData: StatsData;
+  churchId: string;
+}) {
+  const [data, setData] = useState<StatsData>(initialData);
+  const [period, setPeriod] = useState<Period>(initialData.period);
+  const [loading, setLoading] = useState(false);
+
+  const fetchStats = useCallback(
+    async (p: Period) => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/accounting/stats?churchId=${churchId}&period=${p}`);
+        if (res.ok) {
+          setData(await res.json());
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [churchId]
+  );
+
+  const handlePeriod = (p: Period) => {
+    setPeriod(p);
+    fetchStats(p);
+  };
+
+  const { overview, byStatus, byType, byDepartment, byMonth, overduePayments, dateRange } = data;
+
+  const PERIOD_LABELS: Record<Period, string> = {
+    month: "Ce mois",
+    quarter: "Ce trimestre",
+    year: "Cette année",
+  };
+
+  const dateLabel = dateRange
+    ? `${new Date(dateRange.from).toLocaleDateString("fr-FR", { day: "numeric", month: "short", year: "numeric" })} – ${new Date(dateRange.to).toLocaleDateString("fr-FR", { day: "numeric", month: "short", year: "numeric" })}`
+    : null;
+
+  const maxDeptAmount = Math.max(...byDepartment.map((d) => d.amount), 1);
+
+  const periodFrom = dateRange ? new Date(dateRange.from) : null;
+  const periodTo = dateRange ? new Date(dateRange.to) : null;
+
+  const chartData = byMonth
+    .filter((m) => {
+      if (!periodFrom || !periodTo) return true;
+      const [y, mo] = m.month.split("-");
+      const monthStart = new Date(parseInt(y), parseInt(mo) - 1, 1);
+      const fromMonth = new Date(periodFrom.getFullYear(), periodFrom.getMonth(), 1);
+      const toMonth = new Date(periodTo.getFullYear(), periodTo.getMonth(), 1);
+      return monthStart >= fromMonth && monthStart <= toMonth;
+    })
+    .map((m) => {
+      const [y, mo] = m.month.split("-");
+      return {
+        label: MONTH_NAMES[parseInt(mo) - 1] + (y !== String(new Date().getFullYear()) ? ` ${y.slice(2)}` : ""),
+        submitted: Math.round(m.submitted * 100) / 100,
+        released: Math.round(m.released * 100) / 100,
+      };
+    });
+
+  return (
+    <div className={`space-y-6 transition-opacity ${loading ? "opacity-60 pointer-events-none" : ""}`}>
+      {/* Sélecteur de période */}
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+      <div className="flex gap-1 bg-gray-100 rounded-lg p-1 w-fit">
+        {(["month", "quarter", "year"] as Period[]).map((p) => (
+          <button
+            key={p}
+            onClick={() => handlePeriod(p)}
+            className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+              period === p ? "bg-white text-icc-violet shadow-sm" : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            {PERIOD_LABELS[p]}
+          </button>
+        ))}
+      </div>
+      {dateLabel && (
+        <span className="text-xs text-gray-400">{dateLabel}</span>
+      )}
+      </div>
+
+      {/* KPIs */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <KpiCard
+          label="Montant soumis"
+          value={fmt(overview.totalAmount)}
+          sub={`${overview.totalRequests} demande${overview.totalRequests > 1 ? "s" : ""}`}
+          accent
+        />
+        <KpiCard label="Montant versé" value={fmt(overview.releasedAmount)} sub="Paiements confirmés" />
+        <KpiCard
+          label="En attente"
+          value={fmt(overview.pendingAmount)}
+          sub={`${(byStatus.find((s) => s.status === "SUBMITTED")?.count ?? 0) + (byStatus.find((s) => s.status === "PROCESSING")?.count ?? 0)} demandes`}
+          warning={overview.pendingAmount > 0}
+        />
+        <KpiCard
+          label="Taux d'approbation"
+          value={overview.approvalRate !== null ? `${overview.approvalRate}%` : "–"}
+          sub={`${overview.rejectedCount} rejetée${overview.rejectedCount > 1 ? "s" : ""}`}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Par statut */}
+        <Section title="Répartition par statut">
+          {byStatus.length === 0 ? (
+            <p className="text-sm text-gray-400">Aucune donnée sur la période</p>
+          ) : (
+            <div className="space-y-3">
+              {byStatus
+                .sort((a, b) => b.count - a.count)
+                .map((s) => (
+                  <div key={s.status} className="flex items-center gap-3">
+                    <div
+                      className={`w-2.5 h-2.5 rounded-full shrink-0 ${STATUS_COLORS[s.status] ?? "bg-gray-300"}`}
+                    />
+                    <span className="text-xs text-gray-600 w-24 shrink-0">
+                      {STATUS_LABELS[s.status] ?? s.status}
+                    </span>
+                    <div className="flex-1 bg-gray-100 rounded-full h-2">
+                      <div
+                        className={`${STATUS_COLORS[s.status] ?? "bg-gray-300"} rounded-full h-2 transition-all`}
+                        style={{
+                          width: `${Math.round((s.count / overview.totalRequests) * 100)}%`,
+                        }}
+                      />
+                    </div>
+                    <span className="text-xs font-medium text-gray-800 w-6 text-right shrink-0">
+                      {s.count}
+                    </span>
+                    <span className="text-xs text-gray-400 w-20 text-right shrink-0">{fmt(s.amount)}</span>
+                  </div>
+                ))}
+            </div>
+          )}
+        </Section>
+
+        {/* Par type */}
+        <Section title="Type de demande">
+          {byType.length === 0 ? (
+            <p className="text-sm text-gray-400">Aucune donnée sur la période</p>
+          ) : (
+            <div className="space-y-4">
+              {byType.map((t) => (
+                <div key={t.type} className="space-y-1">
+                  <div className="flex justify-between text-xs">
+                    <span className="font-medium text-gray-700">
+                      {t.type === "EXPENSE_REPORT" ? "Note de frais" : "Avance de budget"}
+                    </span>
+                    <span className="text-gray-500">
+                      {t.count} demande{t.count > 1 ? "s" : ""} · {fmt(t.amount)}
+                    </span>
+                  </div>
+                  <div className="bg-gray-100 rounded-full h-2">
+                    <div
+                      className={`rounded-full h-2 ${t.type === "EXPENSE_REPORT" ? "bg-icc-violet" : "bg-icc-bleu"}`}
+                      style={{
+                        width: `${Math.round((t.count / overview.totalRequests) * 100)}%`,
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </Section>
+      </div>
+
+      {/* Tendance mensuelle */}
+      <Section title={`Tendance — montants soumis vs versés (€) · ${PERIOD_LABELS[period].toLowerCase()}`}>
+        {chartData.every((d) => d.submitted === 0 && d.released === 0) ? (
+          <p className="text-sm text-gray-400">Aucune donnée sur les 12 derniers mois</p>
+        ) : (
+          <ResponsiveContainer width="100%" height={260}>
+            <BarChart data={chartData} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f0f0f0" />
+              <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+              <YAxis tick={{ fontSize: 11 }} tickFormatter={(v) => `${v}€`} width={60} />
+              <Tooltip
+                formatter={(value, name) => [
+                  typeof value === "number" ? fmt(value) : value,
+                  name === "submitted" ? "Soumis" : "Versé",
+                ]}
+              />
+              <Legend
+                formatter={(value) => (value === "submitted" ? "Soumis" : "Versé")}
+                wrapperStyle={{ fontSize: 12 }}
+              />
+              <Bar dataKey="submitted" fill="#5E17EB" radius={[3, 3, 0, 0]} />
+              <Bar dataKey="released" fill="#38B6FF" radius={[3, 3, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </Section>
+
+      {/* Par département */}
+      <Section title="Par département — montant soumis vs versé">
+        {byDepartment.length === 0 ? (
+          <p className="text-sm text-gray-400">Aucune donnée sur la période</p>
+        ) : (
+          <div className="space-y-4">
+            {byDepartment.map((d) => (
+              <div key={d.name} className="space-y-1.5">
+                <div className="flex justify-between text-xs">
+                  <span className="font-medium text-gray-700">{d.name}</span>
+                  <span className="text-gray-400">{d.count} demande{d.count > 1 ? "s" : ""}</span>
+                </div>
+                <HBar label="Soumis" value={d.amount} max={maxDeptAmount} />
+                <HBar label="Versé" value={d.released} max={maxDeptAmount} />
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      {/* Paiements en retard */}
+      {overduePayments.length > 0 && (
+        <Section title={`Paiements en retard (${overduePayments.length})`}>
+          <div className="space-y-2">
+            {overduePayments.map((p) => {
+              const daysLate = Math.floor(
+                (Date.now() - new Date(p.scheduledDate).getTime()) / 86_400_000
+              );
+              return (
+                <div
+                  key={p.id}
+                  className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-gray-800">{p.requestLabel}</p>
+                    <p className="text-xs text-red-500">
+                      Prévu le {new Date(p.scheduledDate).toLocaleDateString("fr-FR")} · {daysLate}j
+                      de retard
+                    </p>
+                  </div>
+                  <span className="text-sm font-semibold text-gray-900">{fmt(p.amount)}</span>
+                </div>
+              );
+            })}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/src/app/(auth)/accounting/stats/page.tsx
+++ b/src/app/(auth)/accounting/stats/page.tsx
@@ -1,0 +1,181 @@
+import { requireAuth, getCurrentChurchId, requireChurchPermission } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import AccountingStats from "./AccountingStats";
+import AccountingNav from "../AccountingNav";
+
+function getPeriodRange() {
+  const now = new Date();
+  const from = new Date(now.getFullYear(), 0, 1, 0, 0, 0, 0);
+  const to = new Date(now);
+  to.setHours(23, 59, 59, 999);
+  return { from, to };
+}
+
+export default async function AccountingStatsPage() {
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p className="p-4 text-gray-500">Aucune église sélectionnée.</p>;
+
+  try {
+    await requireChurchPermission("accounting:stats", churchId);
+  } catch {
+    return <p className="p-4 text-gray-500">Accès non autorisé.</p>;
+  }
+
+  const { from, to } = getPeriodRange();
+
+  const [requests, overdueRaw] = await Promise.all([
+    prisma.financialRequest.findMany({
+      where: { churchId, createdAt: { gte: from, lte: to } },
+      include: {
+        department: { select: { id: true, name: true } },
+        payments: {
+          select: { amount: true, releasedAt: true, releasedAmount: true, scheduledDate: true },
+        },
+      },
+    }),
+    prisma.financialPayment.findMany({
+      where: {
+        request: { churchId },
+        scheduledDate: { lt: new Date() },
+        releasedAt: null,
+      },
+      include: { request: { select: { id: true, label: true } } },
+      orderBy: { scheduledDate: "asc" },
+    }),
+  ]);
+
+  // Overview
+  const allPayments = requests.flatMap((r) => r.payments);
+  const releasedAmount = allPayments
+    .filter((p) => p.releasedAt !== null)
+    .reduce((s, p) => s + Number(p.releasedAmount ?? p.amount), 0);
+  const totalAmount = requests
+    .filter((r) => r.status !== "CANCELLED" && r.status !== "REJECTED")
+    .reduce((s, r) => s + Number(r.amount), 0);
+  const approvedAmount = requests
+    .filter((r) => r.status === "APPROVED")
+    .reduce((s, r) => s + Number(r.amount), 0);
+  const pendingAmount = requests
+    .filter((r) => r.status === "SUBMITTED" || r.status === "PROCESSING")
+    .reduce((s, r) => s + Number(r.amount), 0);
+  const rejectedCount = requests.filter((r) => r.status === "REJECTED").length;
+  const cancelledCount = requests.filter((r) => r.status === "CANCELLED").length;
+  const eligibleCount = requests.filter((r) => r.status !== "CANCELLED").length;
+  const approvalRate =
+    eligibleCount > 0
+      ? Math.round(
+          (requests.filter((r) => r.status === "APPROVED").length / eligibleCount) * 100
+        )
+      : null;
+
+  // By status
+  const statusMap: Record<string, { count: number; amount: number }> = {};
+  for (const r of requests) {
+    if (!statusMap[r.status]) statusMap[r.status] = { count: 0, amount: 0 };
+    statusMap[r.status].count++;
+    statusMap[r.status].amount += Number(r.amount);
+  }
+  const byStatus = Object.entries(statusMap).map(([status, v]) => ({ status, ...v }));
+
+  // By type
+  const typeMap: Record<string, { count: number; amount: number }> = {};
+  for (const r of requests) {
+    if (!typeMap[r.type]) typeMap[r.type] = { count: 0, amount: 0 };
+    typeMap[r.type].count++;
+    typeMap[r.type].amount += Number(r.amount);
+  }
+  const byType = Object.entries(typeMap).map(([type, v]) => ({ type, ...v }));
+
+  // By department
+  const deptMap: Record<string, { name: string; count: number; amount: number; released: number }> =
+    {};
+  for (const r of requests) {
+    const key = r.departmentId;
+    if (!deptMap[key]) deptMap[key] = { name: r.department.name, count: 0, amount: 0, released: 0 };
+    deptMap[key].count++;
+    deptMap[key].amount += Number(r.amount);
+    deptMap[key].released += r.payments
+      .filter((p) => p.releasedAt !== null)
+      .reduce((s, p) => s + Number(p.releasedAmount ?? p.amount), 0);
+  }
+  const byDepartment = Object.values(deptMap).sort((a, b) => b.amount - a.amount);
+
+  // Monthly trend (last 12 months)
+  const trendSince = new Date();
+  trendSince.setMonth(trendSince.getMonth() - 11);
+  trendSince.setDate(1);
+  trendSince.setHours(0, 0, 0, 0);
+
+  const [trendRequests, trendPayments] = await Promise.all([
+    prisma.financialRequest.findMany({
+      where: { churchId, createdAt: { gte: trendSince } },
+      select: { createdAt: true, amount: true },
+    }),
+    prisma.financialPayment.findMany({
+      where: { request: { churchId }, releasedAt: { gte: trendSince, not: null } },
+      select: { releasedAt: true, releasedAmount: true, amount: true },
+    }),
+  ]);
+
+  const monthSubmitted: Record<string, number> = {};
+  const monthReleased: Record<string, number> = {};
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(trendSince);
+    d.setMonth(d.getMonth() + i);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    monthSubmitted[key] = 0;
+    monthReleased[key] = 0;
+  }
+  for (const r of trendRequests) {
+    const key = `${r.createdAt.getFullYear()}-${String(r.createdAt.getMonth() + 1).padStart(2, "0")}`;
+    if (key in monthSubmitted) monthSubmitted[key] += Number(r.amount);
+  }
+  for (const p of trendPayments) {
+    if (!p.releasedAt) continue;
+    const key = `${p.releasedAt.getFullYear()}-${String(p.releasedAt.getMonth() + 1).padStart(2, "0")}`;
+    if (key in monthReleased) monthReleased[key] += Number(p.releasedAmount ?? p.amount);
+  }
+  const byMonth = Object.keys(monthSubmitted)
+    .sort()
+    .map((month) => ({ month, submitted: monthSubmitted[month], released: monthReleased[month] }));
+
+  const overduePayments = overdueRaw.map((p) => ({
+    id: p.id,
+    requestId: p.request.id,
+    requestLabel: p.request.label,
+    amount: Number(p.amount),
+    scheduledDate: p.scheduledDate.toISOString(),
+  }));
+
+  const initialData = {
+    period: "year" as const,
+    dateRange: { from: from.toISOString(), to: to.toISOString() },
+    overview: {
+      totalRequests: requests.length,
+      totalAmount,
+      approvedAmount,
+      releasedAmount,
+      pendingAmount,
+      rejectedCount,
+      cancelledCount,
+      approvalRate,
+    },
+    byStatus,
+    byType,
+    byDepartment,
+    byMonth,
+    overduePayments,
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Comptabilité</h1>
+        <p className="text-sm text-gray-500 mt-0.5">Vue d&apos;ensemble des demandes et paiements</p>
+      </div>
+      <AccountingNav canViewStats active="stats" />
+      <AccountingStats initialData={initialData} churchId={churchId} />
+    </div>
+  );
+}

--- a/src/app/api/accounting/stats/route.ts
+++ b/src/app/api/accounting/stats/route.ts
@@ -1,0 +1,191 @@
+import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireChurchPermission } from "@/lib/auth";
+
+type Period = "month" | "quarter" | "year";
+
+function getPeriodRange(period: Period): { from: Date; to: Date } {
+  const now = new Date();
+  const to = new Date(now);
+  to.setHours(23, 59, 59, 999);
+
+  const from = new Date(now);
+  if (period === "month") {
+    from.setDate(1);
+  } else if (period === "quarter") {
+    from.setMonth(Math.floor(now.getMonth() / 3) * 3, 1);
+  } else {
+    from.setMonth(0, 1);
+  }
+  from.setHours(0, 0, 0, 0);
+
+  return { from, to };
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const churchId = searchParams.get("churchId");
+    const period = (searchParams.get("period") ?? "year") as Period;
+
+    if (!churchId) throw new ApiError(400, "churchId requis");
+    if (!["month", "quarter", "year"].includes(period)) throw new ApiError(400, "period invalide");
+
+    await requireChurchPermission("accounting:stats", churchId);
+
+    const { from, to } = getPeriodRange(period);
+
+    // ── Demandes de la période ────────────────────────────────────────────────
+    const requests = await prisma.financialRequest.findMany({
+      where: { churchId, createdAt: { gte: from, lte: to } },
+      include: {
+        department: { select: { id: true, name: true } },
+        payments: {
+          select: { amount: true, releasedAt: true, releasedAmount: true, scheduledDate: true },
+        },
+      },
+    });
+
+    // ── Vue d'ensemble ────────────────────────────────────────────────────────
+    const allPayments = requests.flatMap((r) => r.payments);
+    const releasedAmount = allPayments
+      .filter((p) => p.releasedAt !== null)
+      .reduce((s, p) => s + Number(p.releasedAmount ?? p.amount), 0);
+
+    const totalAmount = requests
+      .filter((r) => r.status !== "CANCELLED" && r.status !== "REJECTED")
+      .reduce((s, r) => s + Number(r.amount), 0);
+
+    const approvedAmount = requests
+      .filter((r) => r.status === "APPROVED")
+      .reduce((s, r) => s + Number(r.amount), 0);
+
+    const pendingAmount = requests
+      .filter((r) => r.status === "SUBMITTED" || r.status === "PROCESSING")
+      .reduce((s, r) => s + Number(r.amount), 0);
+
+    const rejectedCount = requests.filter((r) => r.status === "REJECTED").length;
+    const cancelledCount = requests.filter((r) => r.status === "CANCELLED").length;
+    const eligibleCount = requests.filter((r) => r.status !== "CANCELLED").length;
+    const approvalRate =
+      eligibleCount > 0
+        ? Math.round(
+            (requests.filter((r) => r.status === "APPROVED").length / eligibleCount) * 100
+          )
+        : null;
+
+    // ── Par statut ────────────────────────────────────────────────────────────
+    const statusMap: Record<string, { count: number; amount: number }> = {};
+    for (const r of requests) {
+      if (!statusMap[r.status]) statusMap[r.status] = { count: 0, amount: 0 };
+      statusMap[r.status].count++;
+      statusMap[r.status].amount += Number(r.amount);
+    }
+    const byStatus = Object.entries(statusMap).map(([status, v]) => ({ status, ...v }));
+
+    // ── Par type ──────────────────────────────────────────────────────────────
+    const typeMap: Record<string, { count: number; amount: number }> = {};
+    for (const r of requests) {
+      if (!typeMap[r.type]) typeMap[r.type] = { count: 0, amount: 0 };
+      typeMap[r.type].count++;
+      typeMap[r.type].amount += Number(r.amount);
+    }
+    const byType = Object.entries(typeMap).map(([type, v]) => ({ type, ...v }));
+
+    // ── Par département ───────────────────────────────────────────────────────
+    const deptMap: Record<string, { name: string; count: number; amount: number; released: number }> =
+      {};
+    for (const r of requests) {
+      const key = r.departmentId;
+      if (!deptMap[key]) deptMap[key] = { name: r.department.name, count: 0, amount: 0, released: 0 };
+      deptMap[key].count++;
+      deptMap[key].amount += Number(r.amount);
+      deptMap[key].released += r.payments
+        .filter((p) => p.releasedAt !== null)
+        .reduce((s, p) => s + Number(p.releasedAmount ?? p.amount), 0);
+    }
+    const byDepartment = Object.values(deptMap).sort((a, b) => b.amount - a.amount);
+
+    // ── Tendance mensuelle (12 derniers mois, indépendant de la période) ──────
+    const trendSince = new Date();
+    trendSince.setMonth(trendSince.getMonth() - 11);
+    trendSince.setDate(1);
+    trendSince.setHours(0, 0, 0, 0);
+
+    const [trendRequests, trendPayments] = await Promise.all([
+      prisma.financialRequest.findMany({
+        where: { churchId, createdAt: { gte: trendSince } },
+        select: { createdAt: true, amount: true },
+      }),
+      prisma.financialPayment.findMany({
+        where: {
+          request: { churchId },
+          releasedAt: { gte: trendSince, not: null },
+        },
+        select: { releasedAt: true, releasedAmount: true, amount: true },
+      }),
+    ]);
+
+    const monthSubmitted: Record<string, number> = {};
+    const monthReleased: Record<string, number> = {};
+    for (let i = 0; i < 12; i++) {
+      const d = new Date(trendSince);
+      d.setMonth(d.getMonth() + i);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+      monthSubmitted[key] = 0;
+      monthReleased[key] = 0;
+    }
+    for (const r of trendRequests) {
+      const key = `${r.createdAt.getFullYear()}-${String(r.createdAt.getMonth() + 1).padStart(2, "0")}`;
+      if (key in monthSubmitted) monthSubmitted[key] += Number(r.amount);
+    }
+    for (const p of trendPayments) {
+      if (!p.releasedAt) continue;
+      const key = `${p.releasedAt.getFullYear()}-${String(p.releasedAt.getMonth() + 1).padStart(2, "0")}`;
+      if (key in monthReleased) monthReleased[key] += Number(p.releasedAmount ?? p.amount);
+    }
+    const byMonth = Object.keys(monthSubmitted)
+      .sort()
+      .map((month) => ({ month, submitted: monthSubmitted[month], released: monthReleased[month] }));
+
+    // ── Paiements en retard ───────────────────────────────────────────────────
+    const overdueRaw = await prisma.financialPayment.findMany({
+      where: {
+        request: { churchId },
+        scheduledDate: { lt: new Date() },
+        releasedAt: null,
+      },
+      include: { request: { select: { id: true, label: true } } },
+      orderBy: { scheduledDate: "asc" },
+    });
+    const overduePayments = overdueRaw.map((p) => ({
+      id: p.id,
+      requestId: p.request.id,
+      requestLabel: p.request.label,
+      amount: Number(p.amount),
+      scheduledDate: p.scheduledDate.toISOString(),
+    }));
+
+    return successResponse({
+      period,
+      dateRange: { from: from.toISOString(), to: to.toISOString() },
+      overview: {
+        totalRequests: requests.length,
+        totalAmount,
+        approvedAmount,
+        releasedAmount,
+        pendingAmount,
+        rejectedCount,
+        cancelledCount,
+        approvalRate,
+      },
+      byStatus,
+      byType,
+      byDepartment,
+      byMonth,
+      overduePayments,
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -364,6 +364,7 @@ const PASTORAL_READ_PERMISSIONS = new Set([
   "events:view",
   "discipleship:view",
   "planning:view",
+  "accounting:stats",
 ]);
 
 export async function requireChurchPermission(

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -19,6 +19,7 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "reports:edit",
     "accounting:view",
     "accounting:manage",
+    "accounting:stats",
     "accounting:submit",
   ],
   ADMIN: [
@@ -36,6 +37,7 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "reports:edit",
     "accounting:view",
     "accounting:manage",
+    "accounting:stats",
     "accounting:submit",
   ],
   SECRETARY: [
@@ -49,6 +51,7 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "discipleship:export",
     "reports:view",
     "reports:edit",
+    "accounting:stats",
   ],
   MINISTER: [
     "planning:view",
@@ -91,6 +94,7 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
   ACCOUNTANT: [
     "accounting:view",
     "accounting:manage",
+    "accounting:stats",
   ],
 };
 

--- a/src/modules/accounting/index.ts
+++ b/src/modules/accounting/index.ts
@@ -12,6 +12,8 @@ export const accountingModule = defineModule({
     "accounting:view":    ["SUPER_ADMIN", "ADMIN", "ACCOUNTANT", "MINISTER", "DEPARTMENT_HEAD"],
     // Traiter les demandes (changer statut, valider, rejeter, saisir paiements)
     "accounting:manage":  ["SUPER_ADMIN", "ADMIN", "ACCOUNTANT"],
+    // Consulter les statistiques financières (compta, admins, secrétaires)
+    "accounting:stats":   ["SUPER_ADMIN", "ADMIN", "ACCOUNTANT", "SECRETARY"],
   },
 
   navigation: [


### PR DESCRIPTION
## Summary

- Nouvelle permission `accounting:stats` accordée aux SUPER_ADMIN, ADMIN, ACCOUNTANT et SECRETARY ; les profils pastoraux y ont également accès en lecture
- Endpoint `GET /api/accounting/stats?churchId=&period=month|quarter|year` avec KPIs, répartition par statut/type/département, tendance mensuelle et paiements en retard
- Page `/accounting/stats` (server component + client Recharts) avec filtre de période interactif et affichage de la plage de dates active
- Onglets "Demandes / Statistiques" dans la navigation de la section comptabilité
- Migration `20260322000002` : rattrapage des colonnes `departments.function` et `events.allowAnnouncements` manquantes dans la shadow DB (ajoutées via `db push` sans migration capturée)

## Test plan

- [ ] Vérifier l'accès à `/accounting/stats` avec les rôles ACCOUNTANT, ADMIN, SECRETARY, profil pastoral
- [ ] Vérifier que les rôles DEPARTMENT_HEAD, MINISTER, STAR n'ont pas accès
- [ ] Tester les 3 filtres de période (mois / trimestre / année) — les KPIs, graphes et tendance doivent se mettre à jour
- [ ] Vérifier que le graphe tendance affiche 1 barre (mois), 3 barres (trimestre), jusqu'à 12 barres (année)
- [ ] Vérifier l'affichage des paiements en retard si applicable
- [ ] Vérifier que `npm run db:migrate:deploy` passe sans erreur en staging (migration 20260322000002)

🤖 Generated with [Claude Code](https://claude.com/claude-code)