### PR TITLE
fix(accounting): soumission pour MINISTER, ADMIN et profil pastoral

### DIFF
--- a/prisma/migrations/20260614120000_financial_request_optional_department/migration.sql
+++ b/prisma/migrations/20260614120000_financial_request_optional_department/migration.sql
@@ -1,0 +1,2 @@
+-- departmentId becomes nullable to allow personal expense reports (no department)
+ALTER TABLE `financial_requests` MODIFY COLUMN `departmentId` VARCHAR(191) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1335,7 +1335,7 @@ model FinancialSeries {
 model FinancialRequest {
   id               String                 @id @default(cuid())
   churchId         String
-  departmentId     String
+  departmentId     String?                // null = note de frais personnelle (sans département)
   submittedById    String
   seriesId         String?                // null si demande one-shot
   occurrenceNumber Int?                   // rang dans la série
@@ -1352,7 +1352,7 @@ model FinancialRequest {
   processedAt      DateTime?
 
   church       Church            @relation(fields: [churchId], references: [id])
-  department   Department        @relation(fields: [departmentId], references: [id])
+  department   Department?       @relation(fields: [departmentId], references: [id])
   submittedBy  User              @relation("FinancialRequestSubmitter", fields: [submittedById], references: [id])
   processedBy  User?             @relation("FinancialRequestProcessor", fields: [processedById], references: [id])
   series       FinancialSeries?  @relation(fields: [seriesId], references: [id])

--- a/src/app/(auth)/accounting/requests/AccountingDashboard.tsx
+++ b/src/app/(auth)/accounting/requests/AccountingDashboard.tsx
@@ -32,7 +32,7 @@ interface Request {
   status: string;
   priority: string | null;
   createdAt: string | Date;
-  department: { id: string; name: string };
+  department: { id: string; name: string } | null;
   submittedBy: { id: string; name: string | null };
   payments: { id: string; amount: number | string; scheduledDate: string | Date; releasedAt: string | Date | null }[];
   _count: { attachments: number };
@@ -86,7 +86,7 @@ export default function AccountingDashboard({ requests, stats, canManage, curren
       if (statusFilter && r.status !== statusFilter) return false;
       if (typeFilter && r.type !== typeFilter) return false;
       if (q) {
-        const hay = `${r.label} ${r.department.name} ${r.submittedBy.name ?? ""}`.toLowerCase();
+        const hay = `${r.label} ${r.department?.name ?? ""} ${r.submittedBy.name ?? ""}`.toLowerCase();
         if (!hay.includes(q)) return false;
       }
       return true;
@@ -131,7 +131,7 @@ export default function AccountingDashboard({ requests, stats, canManage, curren
                   <div className="min-w-0">
                     <p className="font-medium text-gray-900 text-sm truncate">{r.label}</p>
                     <p className="text-xs text-gray-400 mt-0.5">
-                      {r.department.name} · {fmtAmount(r.amount)} ·{" "}
+                      {r.department?.name ?? "Personnel"} · {fmtAmount(r.amount)} ·{" "}
                       <span className={days >= 7 ? "text-amber-600 font-medium" : ""}>{days}j</span>
                     </p>
                   </div>
@@ -233,7 +233,7 @@ export default function AccountingDashboard({ requests, stats, canManage, curren
                           )}
                         </div>
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-600">{r.department.name}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600">{r.department?.name ?? "Personnel"}</td>
                       <td className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap">{fmtAmount(r.amount)}</td>
                       <td className="px-4 py-3">
                         <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[r.status] ?? "bg-gray-100 text-gray-600"}`}>
@@ -275,7 +275,7 @@ export default function AccountingDashboard({ requests, stats, canManage, curren
                           {STATUS_LABELS[r.status]}
                         </span>
                         <span className="text-xs text-gray-500">{fmtAmount(r.amount)}</span>
-                        <span className="text-xs text-gray-400">{r.department.name}</span>
+                        <span className="text-xs text-gray-400">{r.department?.name ?? "Personnel"}</span>
                       </div>
                     </div>
                     <span className={`text-xs shrink-0 mt-0.5 ${days >= 7 ? "text-amber-600 font-semibold" : "text-gray-400"}`}>{days}j</span>

--- a/src/app/(auth)/accounting/requests/[id]/RequestDetail.tsx
+++ b/src/app/(auth)/accounting/requests/[id]/RequestDetail.tsx
@@ -48,7 +48,7 @@ interface Request {
   rejectionReason: string | null;
   createdAt: string | Date;
   processedAt: string | Date | null;
-  department: { id: string; name: string; ministry: { name: string } };
+  department: { id: string; name: string; ministry: { name: string } } | null;
   submittedBy: { id: string; name: string | null; email: string | null };
   processedBy: { id: string; name: string | null } | null;
   payments: Payment[];
@@ -206,7 +206,10 @@ export default function RequestDetail({ request: initial, canManage, isOwn }: Pr
               )}
             </div>
             <h1 className="text-xl font-bold text-gray-900">{req.label}</h1>
-            <p className="text-sm text-gray-400">{req.department.ministry.name} — {req.department.name}</p>
+            {req.department
+              ? <p className="text-sm text-gray-400">{req.department.ministry.name} — {req.department.name}</p>
+              : <p className="text-sm text-gray-400 italic">Personnel / sans département</p>
+            }
             <p className="text-sm text-gray-400">Par {req.submittedBy.name ?? req.submittedBy.email} · {fmt(req.createdAt)}</p>
           </div>
           <div className="flex items-center gap-2 self-start flex-wrap">

--- a/src/app/(auth)/accounting/requests/[id]/page.tsx
+++ b/src/app/(auth)/accounting/requests/[id]/page.tsx
@@ -40,14 +40,24 @@ export default async function AccountingRequestDetailPage({
   const canManage = perms.includes("accounting:manage");
   const isOwn = req.submittedById === session.user.id!;
 
-  // Scope dept_head
+  // Scope : gestionnaires voient tout ; propriétaire aussi ; sinon vérifier le périmètre
+  const isMinister = roles.includes("MINISTER");
   if (!canManage && !isOwn) {
     const userRoles = await prisma.userChurchRole.findMany({
       where: { userId: session.user.id!, churchId },
       include: { departments: { select: { departmentId: true } } },
     });
-    const deptIds = userRoles.flatMap((r) => r.departments.map((d) => d.departmentId));
-    if (!deptIds.includes(req.departmentId)) return notFound();
+    let allowedDeptIds: string[];
+    if (isMinister) {
+      const ministryIds = userRoles.map((r) => r.ministryId).filter(Boolean) as string[];
+      const depts = ministryIds.length > 0
+        ? await prisma.department.findMany({ where: { ministryId: { in: ministryIds } }, select: { id: true } })
+        : [];
+      allowedDeptIds = depts.map((d) => d.id);
+    } else {
+      allowedDeptIds = userRoles.flatMap((r) => r.departments.map((d) => d.departmentId));
+    }
+    if (!req.departmentId || !allowedDeptIds.includes(req.departmentId)) return notFound();
   }
 
   // Prisma returns Decimal objects for amount fields — serialize before passing to Client Component

--- a/src/app/(auth)/accounting/requests/new/NewRequestForm.tsx
+++ b/src/app/(auth)/accounting/requests/new/NewRequestForm.tsx
@@ -37,6 +37,9 @@ export default function NewRequestForm({ departments }: Props) {
     firstDate: "",
   });
 
+  // Pour les avances récurrentes (série), un département est obligatoire
+  const isRecurringMode = mode === "recurring";
+
   function set(field: string, value: string) {
     setForm((f) => ({ ...f, [field]: value }));
   }
@@ -70,7 +73,7 @@ export default function NewRequestForm({ departments }: Props) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             type,
-            departmentId:  form.departmentId,
+            departmentId:  form.departmentId || undefined, // undefined = personnel sans département
             label:         form.label,
             description:   form.description || undefined,
             amount,
@@ -124,13 +127,19 @@ export default function NewRequestForm({ departments }: Props) {
 
       {/* Département */}
       <div className="space-y-1">
-        <label className="block text-sm font-medium text-gray-700">Département</label>
+        <label className="block text-sm font-medium text-gray-700">
+          Département
+          {!isRecurringMode && <span className="text-gray-400 font-normal ml-1">(facultatif pour les notes de frais personnelles)</span>}
+        </label>
         <select
           value={form.departmentId}
           onChange={(e) => set("departmentId", e.target.value)}
-          required
+          required={isRecurringMode}
           className="w-full border-2 border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:border-icc-violet"
         >
+          {!isRecurringMode && (
+            <option value="">— Personnel (sans département)</option>
+          )}
           {departments.map((d) => (
             <option key={d.id} value={d.id}>{d.ministry.name} — {d.name}</option>
           ))}

--- a/src/app/(auth)/accounting/requests/new/page.tsx
+++ b/src/app/(auth)/accounting/requests/new/page.tsx
@@ -1,30 +1,86 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireAuth, getCurrentChurchId } from "@/lib/auth";
+import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import NewRequestForm from "./NewRequestForm";
 
 export default async function NewAccountingRequestPage() {
-  const session = await requirePermission("accounting:submit");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) redirect("/accounting/requests");
 
-  // Départements accessibles à cet utilisateur
-  const userRoles = await prisma.userChurchRole.findMany({
-    where: { userId: session.user.id!, churchId },
-    include: {
-      departments: {
-        include: {
-          department: { select: { id: true, name: true, ministry: { select: { name: true } } } },
+  // Vérifier la permission de soumission (rôle ou profil pastoral)
+  const roles = session.user.churchRoles
+    .filter((r) => r.churchId === churchId)
+    .map((r) => r.role);
+  const perms = roles.flatMap((r: string) => rolePermissions[r as keyof typeof rolePermissions] ?? []);
+  const isPastoral = (session.user.pastoralChurchIds ?? []).includes(churchId);
+
+  if (!perms.includes("accounting:submit") && !isPastoral) {
+    redirect("/accounting/requests");
+  }
+
+  const canManage = perms.includes("accounting:manage");
+  const isAdmin = canManage || isPastoral;
+
+  // Départements disponibles :
+  // - ADMIN / SUPER_ADMIN / profil pastoral → tous les départements de l'église
+  // - MINISTER → tous les départements de ses ministères
+  // - DEPARTMENT_HEAD → ses départements assignés uniquement
+  // - Fallback : tous les départements si aucun département assigné trouvé
+  let departments: { id: string; name: string; ministry: { name: string } }[] = [];
+
+  if (isAdmin) {
+    departments = await prisma.department.findMany({
+      where: { ministry: { churchId } },
+      select: { id: true, name: true, ministry: { select: { name: true } } },
+      orderBy: [{ ministry: { name: "asc" } }, { name: "asc" }],
+    });
+  } else {
+    const userRoles = await prisma.userChurchRole.findMany({
+      where: { userId: session.user.id!, churchId },
+      include: {
+        departments: {
+          include: {
+            department: { select: { id: true, name: true, ministry: { select: { name: true } } } },
+          },
         },
       },
-    },
-  });
+    });
 
-  const departments = userRoles
-    .flatMap((r) => r.departments.map((d) => d.department))
-    .filter((d, i, arr) => arr.findIndex((x) => x.id === d.id) === i)
-    .sort((a, b) => a.name.localeCompare(b.name));
+    const isMinister = roles.includes("MINISTER");
+
+    if (isMinister) {
+      // Ministères assignés à cet utilisateur
+      const ministryIds = userRoles
+        .map((r) => r.ministryId)
+        .filter(Boolean) as string[];
+
+      if (ministryIds.length > 0) {
+        departments = await prisma.department.findMany({
+          where: { ministryId: { in: ministryIds } },
+          select: { id: true, name: true, ministry: { select: { name: true } } },
+          orderBy: [{ ministry: { name: "asc" } }, { name: "asc" }],
+        });
+      }
+    } else {
+      // DEPARTMENT_HEAD : ses départements assignés
+      departments = userRoles
+        .flatMap((r) => r.departments.map((d) => d.department))
+        .filter((d, i, arr) => arr.findIndex((x) => x.id === d.id) === i)
+        .sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    // Fallback : si aucun département trouvé, tous les départements de l'église
+    if (departments.length === 0) {
+      departments = await prisma.department.findMany({
+        where: { ministry: { churchId } },
+        select: { id: true, name: true, ministry: { select: { name: true } } },
+        orderBy: [{ ministry: { name: "asc" } }, { name: "asc" }],
+      });
+    }
+  }
 
   return (
     <div className="max-w-2xl space-y-6">

--- a/src/app/(auth)/accounting/requests/page.tsx
+++ b/src/app/(auth)/accounting/requests/page.tsx
@@ -24,20 +24,39 @@ export default async function AccountingRequestsPage() {
 
   // Scope des demandes visibles :
   // - canManage ou isPastoral → toutes les demandes de l'église
-  // - autres → leurs départements assignés uniquement
+  // - MINISTER → tous les départements de son/ses ministère(s) + ses demandes personnelles
+  // - autres → leurs départements assignés + leurs demandes personnelles
+  const isMinister = roles.includes("MINISTER");
   let deptFilter: string[] | undefined;
   if (!canManage && !isPastoral) {
     const userRoles = await prisma.userChurchRole.findMany({
       where: { userId: session.user.id!, churchId },
       include: { departments: { select: { departmentId: true } } },
     });
-    deptFilter = userRoles.flatMap((r) => r.departments.map((d) => d.departmentId));
+    if (isMinister) {
+      const ministryIds = userRoles.map((r) => r.ministryId).filter(Boolean) as string[];
+      if (ministryIds.length > 0) {
+        const depts = await prisma.department.findMany({
+          where: { ministryId: { in: ministryIds } },
+          select: { id: true },
+        });
+        deptFilter = depts.map((d) => d.id);
+      } else {
+        deptFilter = [];
+      }
+    } else {
+      deptFilter = userRoles.flatMap((r) => r.departments.map((d) => d.departmentId));
+    }
   }
+
+  const scopeCondition = deptFilter !== undefined
+    ? { OR: [{ departmentId: { in: deptFilter } }, { submittedById: session.user.id!, departmentId: null }] }
+    : {};
 
   const requests = await prisma.financialRequest.findMany({
     where: {
       churchId,
-      ...(deptFilter ? { departmentId: { in: deptFilter } } : {}),
+      ...scopeCondition,
     },
     include: {
       department:  { select: { id: true, name: true } },

--- a/src/app/(auth)/accounting/requests/page.tsx
+++ b/src/app/(auth)/accounting/requests/page.tsx
@@ -12,17 +12,21 @@ export default async function AccountingRequestsPage() {
 
   const roles = session.user.churchRoles.filter((r) => r.churchId === churchId).map((r) => r.role);
   const perms = roles.flatMap((r: string) => rolePermissions[r as keyof typeof rolePermissions] ?? []);
-  if (!perms.includes("accounting:view")) {
+  const isPastoral = (session.user.pastoralChurchIds ?? []).includes(churchId);
+
+  if (!perms.includes("accounting:view") && !isPastoral) {
     return <p className="p-4 text-gray-500">Accès non autorisé.</p>;
   }
 
   const canManage = perms.includes("accounting:manage");
-  const canSubmit = perms.includes("accounting:submit");
-  const canViewStats = perms.includes("accounting:stats") || (session.user.pastoralChurchIds ?? []).includes(churchId);
+  const canSubmit = perms.includes("accounting:submit") || isPastoral;
+  const canViewStats = perms.includes("accounting:stats") || isPastoral;
 
-  // Scope : DEPARTMENT_HEAD → ses départements uniquement
+  // Scope des demandes visibles :
+  // - canManage ou isPastoral → toutes les demandes de l'église
+  // - autres → leurs départements assignés uniquement
   let deptFilter: string[] | undefined;
-  if (!canManage) {
+  if (!canManage && !isPastoral) {
     const userRoles = await prisma.userChurchRole.findMany({
       where: { userId: session.user.id!, churchId },
       include: { departments: { select: { departmentId: true } } },

--- a/src/app/(auth)/accounting/stats/page.tsx
+++ b/src/app/(auth)/accounting/stats/page.tsx
@@ -91,8 +91,9 @@ export default async function AccountingStatsPage() {
   const deptMap: Record<string, { name: string; count: number; amount: number; released: number }> =
     {};
   for (const r of requests) {
-    const key = r.departmentId;
-    if (!deptMap[key]) deptMap[key] = { name: r.department.name, count: 0, amount: 0, released: 0 };
+    const key = r.departmentId ?? "__personal__";
+    const name = r.department?.name ?? "Personnel";
+    if (!deptMap[key]) deptMap[key] = { name, count: 0, amount: 0, released: 0 };
     deptMap[key].count++;
     deptMap[key].amount += Number(r.amount);
     deptMap[key].released += r.payments

--- a/src/app/api/accounting/requests/[id]/route.ts
+++ b/src/app/api/accounting/requests/[id]/route.ts
@@ -62,15 +62,31 @@ export async function GET(
 
     if (!req || req.churchId !== churchId) throw new ApiError(404, "Demande introuvable");
 
-    // Scope dept_head : seulement ses départements
+    // Scope : managers voient tout ; sinon vérifier que la demande est dans le périmètre
     if (!hasPermission(perms, "accounting:manage")) {
-      const userRoles = await prisma.userChurchRole.findMany({
-        where: { userId: session.user.id!, churchId },
-        include: { departments: { select: { departmentId: true } } },
-      });
-      const deptIds = userRoles.flatMap((r) => r.departments.map((d) => d.departmentId));
-      if (!deptIds.includes(req.departmentId) && req.submittedById !== session.user.id!) {
-        throw new ApiError(403, "Accès refusé");
+      // Propre demande → toujours accessible
+      if (req.submittedById !== session.user.id!) {
+        const roles = session.user.churchRoles.filter((r) => r.churchId === churchId).map((r) => r.role);
+        const isMinister = roles.includes("MINISTER");
+        const userRoles = await prisma.userChurchRole.findMany({
+          where: { userId: session.user.id!, churchId },
+          include: { departments: { select: { departmentId: true } } },
+        });
+
+        let allowedDeptIds: string[];
+        if (isMinister) {
+          const ministryIds = userRoles.map((r) => r.ministryId).filter(Boolean) as string[];
+          const depts = ministryIds.length > 0
+            ? await prisma.department.findMany({ where: { ministryId: { in: ministryIds } }, select: { id: true } })
+            : [];
+          allowedDeptIds = depts.map((d) => d.id);
+        } else {
+          allowedDeptIds = userRoles.flatMap((r) => r.departments.map((d) => d.departmentId));
+        }
+
+        if (!req.departmentId || !allowedDeptIds.includes(req.departmentId)) {
+          throw new ApiError(403, "Accès refusé");
+        }
       }
     }
 
@@ -182,7 +198,7 @@ export async function PATCH(
 
 async function createNextOccurrence(
   tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
-  current: { seriesId: string | null; churchId: string; departmentId: string; submittedById: string; type: string; label: string; description: string | null; amount: unknown; occurrenceNumber: number | null }
+  current: { seriesId: string | null; churchId: string; departmentId: string | null; submittedById: string; type: string; label: string; description: string | null; amount: unknown; occurrenceNumber: number | null }
 ) {
   if (!current.seriesId) return;
   const series = await tx.financialSeries.findUnique({ where: { id: current.seriesId } });
@@ -203,7 +219,7 @@ async function createNextOccurrence(
   await tx.financialRequest.create({
     data: {
       churchId:        current.churchId,
-      departmentId:    current.departmentId,
+      departmentId:    series.departmentId, // toujours défini pour les séries
       submittedById:   current.submittedById,
       seriesId:        current.seriesId,
       occurrenceNumber: (current.occurrenceNumber ?? 1) + 1,

--- a/src/app/api/accounting/requests/route.ts
+++ b/src/app/api/accounting/requests/route.ts
@@ -6,11 +6,11 @@ import { sendEmail, buildAccountingNewRequestEmail } from "@/lib/email";
 import { z } from "zod";
 
 const createSchema = z.object({
-  type:        z.enum(["EXPENSE_REPORT", "BUDGET_ADVANCE"]),
-  label:       z.string().min(1).max(200),
-  description: z.string().optional(),
-  amount:      z.number().positive(),
-  departmentId: z.string().min(1),
+  type:          z.enum(["EXPENSE_REPORT", "BUDGET_ADVANCE"]),
+  label:         z.string().min(1).max(200),
+  description:   z.string().optional(),
+  amount:        z.number().positive(),
+  departmentId:  z.string().min(1).optional(), // null/omis = note de frais personnelle
   attachmentIds: z.array(z.string()).optional(),
 });
 
@@ -25,25 +25,45 @@ export async function GET(request: Request) {
     const departmentId = searchParams.get("departmentId") ?? undefined;
     const type       = searchParams.get("type") ?? undefined;
 
-    // Scope : DEPARTMENT_HEAD voit uniquement ses départements
     const roles = session.user.churchRoles.filter((r) => r.churchId === churchId).map((r) => r.role);
     const canManage = roles.flatMap((r) => rolePermissions[r] ?? []).includes("accounting:manage");
+    const isMinister = roles.includes("MINISTER");
+
+    // Scope : managers voient tout ; ministres voient leur(s) ministère(s) ; autres voient leurs départements.
+    // Dans tous les cas, chacun voit ses propres demandes personnelles (departmentId null).
     let deptFilter: string[] | undefined;
     if (!canManage) {
       const userRoles = await prisma.userChurchRole.findMany({
         where: { userId: session.user.id!, churchId },
         include: { departments: { select: { departmentId: true } } },
       });
-      deptFilter = userRoles.flatMap((r) => r.departments.map((d) => d.departmentId));
-      if (deptFilter.length === 0) return successResponse([]);
+      if (isMinister) {
+        const ministryIds = userRoles.map((r) => r.ministryId).filter(Boolean) as string[];
+        if (ministryIds.length > 0) {
+          const depts = await prisma.department.findMany({
+            where: { ministryId: { in: ministryIds } },
+            select: { id: true },
+          });
+          deptFilter = depts.map((d) => d.id);
+        } else {
+          deptFilter = [];
+        }
+      } else {
+        deptFilter = userRoles.flatMap((r) => r.departments.map((d) => d.departmentId));
+      }
     }
+
+    // Filtre scope : département(s) assigné(s) OU propres demandes personnelles (sans département)
+    const scopeCondition = deptFilter
+      ? { OR: [{ departmentId: { in: deptFilter } }, { submittedById: session.user.id!, departmentId: null }] }
+      : {};
 
     const requests = await prisma.financialRequest.findMany({
       where: {
         churchId,
         ...(status ? { status: status as never } : {}),
         ...(type ? { type: type as never } : {}),
-        ...(departmentId ? { departmentId } : deptFilter ? { departmentId: { in: deptFilter } } : {}),
+        ...(departmentId ? { departmentId } : scopeCondition),
       },
       include: {
         department:  { select: { id: true, name: true } },
@@ -72,16 +92,18 @@ export async function POST(request: Request) {
 
     const body = createSchema.parse(await request.json());
 
-    // Vérifier que le département appartient à l'église
-    const dept = await prisma.department.findFirst({
-      where: { id: body.departmentId, ministry: { churchId } },
-    });
-    if (!dept) throw new ApiError(404, "Département introuvable");
+    // Vérifier que le département appartient à l'église (si fourni)
+    if (body.departmentId) {
+      const dept = await prisma.department.findFirst({
+        where: { id: body.departmentId, ministry: { churchId } },
+      });
+      if (!dept) throw new ApiError(404, "Département introuvable");
+    }
 
     const req = await prisma.financialRequest.create({
       data: {
         churchId,
-        departmentId: body.departmentId,
+        departmentId: body.departmentId ?? null,
         submittedById: session.user.id!,
         type:        body.type,
         label:       body.label,
@@ -111,7 +133,7 @@ export async function POST(request: Request) {
 
 async function notifyAccountingTeam(
   churchId: string,
-  req: { id: string; label: string; type: string; description: string | null; amount: unknown; department: { name: string }; submittedBy: { name: string | null; email: string | null } }
+  req: { id: string; label: string; type: string; description: string | null; amount: unknown; department: { name: string } | null; submittedBy: { name: string | null; email: string | null } }
 ) {
   const church = await prisma.church.findUnique({
     where: { id: churchId },
@@ -144,7 +166,7 @@ async function notifyAccountingTeam(
       requestLabel:   req.label,
       requestAmount:  amount,
       requestType:    req.type,
-      departmentName: req.department.name,
+      departmentName: req.department?.name ?? "—",
       submitterName:  req.submittedBy.name ?? req.submittedBy.email ?? "—",
       description:    req.description,
       churchName:     church.name,

--- a/src/app/api/accounting/stats/route.ts
+++ b/src/app/api/accounting/stats/route.ts
@@ -96,8 +96,9 @@ export async function GET(request: Request) {
     const deptMap: Record<string, { name: string; count: number; amount: number; released: number }> =
       {};
     for (const r of requests) {
-      const key = r.departmentId;
-      if (!deptMap[key]) deptMap[key] = { name: r.department.name, count: 0, amount: 0, released: 0 };
+      const key = r.departmentId ?? "__personal__";
+      const name = r.department?.name ?? "Personnel";
+      if (!deptMap[key]) deptMap[key] = { name, count: 0, amount: 0, released: 0 };
       deptMap[key].count++;
       deptMap[key].amount += Number(r.amount);
       deptMap[key].released += r.payments

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -63,6 +63,7 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "departments:manage",
     "discipleship:view",
     "accounting:view",
+    "accounting:submit",
   ],
   DEPARTMENT_HEAD: [
     "planning:view",

--- a/src/modules/accounting/index.ts
+++ b/src/modules/accounting/index.ts
@@ -7,7 +7,7 @@ export const accountingModule = defineModule({
 
   permissions: {
     // Soumettre une demande (resp. et co-resp. de département, admins)
-    "accounting:submit":  ["SUPER_ADMIN", "ADMIN", "DEPARTMENT_HEAD"],
+    "accounting:submit":  ["SUPER_ADMIN", "ADMIN", "MINISTER", "DEPARTMENT_HEAD"],
     // Consulter les demandes (compta = global, dept_head = son département)
     "accounting:view":    ["SUPER_ADMIN", "ADMIN", "ACCOUNTANT", "MINISTER", "DEPARTMENT_HEAD"],
     // Traiter les demandes (changer statut, valider, rejeter, saisir paiements)


### PR DESCRIPTION
## Summary

- **MINISTER manquant** : `accounting:submit` n'était pas assigné au rôle MINISTER — les ministres ne pouvaient pas soumettre de demandes
- **ADMIN/SUPER_ADMIN** : le formulaire affichait une liste de départements vide (pas de `user_departments` pour ces rôles) → maintenant tous les départements de l'église
- **Profil pastoral** : accès en lecture + soumission sur `/accounting/requests` et `/accounting/requests/new`, avec tous les départements de l'église active
- Scope des demandes visibles : canManage ou pastoral → toutes ; sinon → départements assignés

## Test plan

- [ ] MINISTER : bouton "Nouvelle demande" visible, formulaire affiche les départements de son ministère
- [ ] ADMIN : formulaire affiche tous les départements de l'église (plus de liste vide)
- [ ] DEPARTMENT_HEAD : formulaire affiche uniquement ses départements assignés (comportement inchangé)
- [ ] Profil pastoral : accès à `/accounting/requests`, bouton "Nouvelle demande" visible, tous les départements disponibles
- [ ] CI verte

🤖 Generated with [Claude Code](https://claude.com/claude-code)