### PR TITLE
fix(mobile): ergonomie vues tableaux et cartes admin

### DIFF
--- a/src/app/(auth)/admin/audit-logs/AuditLogsClient.tsx
+++ b/src/app/(auth)/admin/audit-logs/AuditLogsClient.tsx
@@ -79,6 +79,7 @@ export default function AuditLogsClient() {
   return (
     <div>
       <div className="bg-white rounded-lg shadow overflow-hidden">
+        <div className="overflow-x-auto">
         <table className="w-full">
           <thead>
             <tr className="bg-gray-50 border-b">
@@ -121,6 +122,7 @@ export default function AuditLogsClient() {
             })}
           </tbody>
         </table>
+        </div>
       </div>
 
       {totalPages > 1 && (

--- a/src/app/(auth)/admin/events/EventsClient.tsx
+++ b/src/app/(auth)/admin/events/EventsClient.tsx
@@ -313,13 +313,13 @@ export default function EventsClient({ initialEvents, churches }: Props) {
       {/* Toolbar */}
       <div className="mb-4 flex flex-wrap items-center gap-3">
         <Button onClick={openCreate}>Nouvel événement</Button>
-        <div className="relative">
+        <div className="relative w-full sm:w-auto">
           <svg xmlns="http://www.w3.org/2000/svg" className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
           </svg>
-          <input type="text" value={searchQuery} onChange={(e) => handleSearchChange(e.target.value)} placeholder="Rechercher..." className="border-2 border-gray-300 rounded-lg shadow-sm pl-9 pr-3 py-2 text-sm focus:ring-2 focus:ring-icc-violet focus:border-icc-violet focus:outline-none" />
+          <input type="text" value={searchQuery} onChange={(e) => handleSearchChange(e.target.value)} placeholder="Rechercher..." className="w-full border-2 border-gray-300 rounded-lg shadow-sm pl-9 pr-3 py-2 text-sm focus:ring-2 focus:ring-icc-violet focus:border-icc-violet focus:outline-none" />
         </div>
-        <input type="month" value={monthFilter} onChange={(e) => handleMonthChange(e.target.value)} className="border-2 border-gray-300 rounded-lg shadow-sm px-3 py-2 text-sm focus:ring-2 focus:ring-icc-violet focus:border-icc-violet focus:outline-none capitalize" />
+        <input type="month" value={monthFilter} onChange={(e) => handleMonthChange(e.target.value)} className="w-full sm:w-auto border-2 border-gray-300 rounded-lg shadow-sm px-3 py-2 text-sm focus:ring-2 focus:ring-icc-violet focus:border-icc-violet focus:outline-none capitalize" />
         {(monthFilter !== defaultMonth() || searchQuery) && (
           <button type="button" onClick={() => { handleMonthChange(defaultMonth()); handleSearchChange(""); }} className="text-sm text-gray-500 hover:text-gray-700 underline">
             Réinitialiser
@@ -377,49 +377,52 @@ export default function EventsClient({ initialEvents, churches }: Props) {
                   <span className="text-xl font-black text-white leading-none mt-0.5">{dayNum}</span>
                 </div>
 
-                {/* Content */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    <span className="font-semibold text-gray-900 text-sm">{ev.title}</span>
-                    {isRecurrent && <span className="text-icc-violet text-sm" title={`Récurrent${ev.recurrenceRule ? ` — ${RECURRENCE_LABELS[ev.recurrenceRule] ?? ev.recurrenceRule}` : ""}`}>↻</span>}
-                    <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded-full ${getEventTypeBadge(ev.type)}`}>
-                      {getEventTypeLabel(ev.type)}
-                    </span>
-                  </div>
-                  <p className="text-xs text-gray-500 mt-0.5">{dateLabel} {timeStr} — {ev.church.name}</p>
-                  {ev.eventDepts.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-1.5">
-                      {ev.eventDepts.map((ed) => (
-                        <span key={ed.department.id} className="text-[11px] bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
-                          {ed.department.name}
-                        </span>
-                      ))}
+                {/* Content + Actions */}
+                <div className="flex-1 min-w-0 flex flex-col sm:flex-row sm:items-start gap-2">
+                  {/* Content */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="font-semibold text-gray-900 text-sm">{ev.title}</span>
+                      {isRecurrent && <span className="text-icc-violet text-sm" title={`Récurrent${ev.recurrenceRule ? ` — ${RECURRENCE_LABELS[ev.recurrenceRule] ?? ev.recurrenceRule}` : ""}`}>↻</span>}
+                      <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded-full ${getEventTypeBadge(ev.type)}`}>
+                        {getEventTypeLabel(ev.type)}
+                      </span>
                     </div>
-                  )}
-                </div>
+                    <p className="text-xs text-gray-500 mt-0.5">{dateLabel} {timeStr} — {ev.church.name}</p>
+                    {ev.eventDepts.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-1.5">
+                        {ev.eventDepts.map((ed) => (
+                          <span key={ed.department.id} className="text-[11px] bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
+                            {ed.department.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
 
-                {/* Actions */}
-                <div className="flex flex-wrap gap-1 shrink-0 justify-end items-start">
-                  <Link href={`/events/${ev.id}/star-view`}>
-                    <Button variant="secondary" size="sm">Planning</Button>
-                  </Link>
-                  {seriesParentId && seriesParentId !== ev.id && (
-                    <Link href={`/admin/events/${seriesParentId}`}>
-                      <Button variant="secondary" size="sm" title="Configurer toute la série">Série</Button>
+                  {/* Actions */}
+                  <div className="flex flex-wrap gap-1 shrink-0 justify-end items-center">
+                    <Link href={`/events/${ev.id}/star-view`}>
+                      <Button variant="secondary" size="sm">Planning</Button>
                     </Link>
-                  )}
-                  <Link href={`/admin/events/${ev.id}`}>
-                    <Button variant="secondary" size="sm">Config</Button>
-                  </Link>
-                  <Button variant="info" size="sm" onClick={() => openDuplicate(ev)} title="Dupliquer le planning">
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg>
-                  </Button>
-                  <Button variant="edit" size="sm" onClick={() => openEdit(ev)} title="Modifier">
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>
-                  </Button>
-                  <Button variant="danger" size="sm" onClick={() => handleDelete(ev)} title="Supprimer">
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path d="M3 6h18" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /><line x1="10" y1="11" x2="10" y2="17" /><line x1="14" y1="11" x2="14" y2="17" /></svg>
-                  </Button>
+                    {seriesParentId && seriesParentId !== ev.id && (
+                      <Link href={`/admin/events/${seriesParentId}`}>
+                        <Button variant="secondary" size="sm" title="Configurer toute la série">Série</Button>
+                      </Link>
+                    )}
+                    <Link href={`/admin/events/${ev.id}`}>
+                      <Button variant="secondary" size="sm">Config</Button>
+                    </Link>
+                    <Button variant="info" size="sm" onClick={() => openDuplicate(ev)} title="Dupliquer le planning">
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg>
+                    </Button>
+                    <Button variant="edit" size="sm" onClick={() => openEdit(ev)} title="Modifier">
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>
+                    </Button>
+                    <Button variant="danger" size="sm" onClick={() => handleDelete(ev)} title="Supprimer">
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path d="M3 6h18" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /><line x1="10" y1="11" x2="10" y2="17" /><line x1="14" y1="11" x2="14" y2="17" /></svg>
+                    </Button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/app/(auth)/admin/mrbs-links/MrbsLinksManager.tsx
+++ b/src/app/(auth)/admin/mrbs-links/MrbsLinksManager.tsx
@@ -130,6 +130,7 @@ export default function MrbsLinksManager({ mrbsUsers, koinoniaUsers, linkedByKoi
         <p className="text-sm text-gray-400 text-center py-8">Aucun compte MRBS trouvé dans la base de données.</p>
       ) : (
         <div className="border border-gray-200 rounded-xl overflow-hidden">
+          <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 border-b border-gray-200">
               <tr>
@@ -206,6 +207,7 @@ export default function MrbsLinksManager({ mrbsUsers, koinoniaUsers, linkedByKoi
               })}
             </tbody>
           </table>
+          </div>
         </div>
       )}
     </div>

--- a/src/app/(auth)/admin/pastoral-profiles/PastoralProfilesAdmin.tsx
+++ b/src/app/(auth)/admin/pastoral-profiles/PastoralProfilesAdmin.tsx
@@ -90,7 +90,7 @@ export default function PastoralProfilesAdmin({ churchId, profiles: initial, use
       {/* Formulaire */}
       <div className="bg-white rounded-lg shadow border border-gray-100 p-5">
         <h2 className="font-semibold text-gray-900 mb-4">{editId ? "Modifier le profil" : "Nouveau profil"}</h2>
-        <div className="grid grid-cols-2 gap-4 mb-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
           <div>
             <label className="block text-xs font-medium text-gray-700 mb-1">Nom <span className="text-red-500">*</span></label>
             <input
@@ -147,6 +147,7 @@ export default function PastoralProfilesAdmin({ churchId, profiles: initial, use
         <p className="text-sm text-gray-500 text-center py-6">Aucun profil pastoral configuré.</p>
       ) : (
         <div className="bg-white rounded-lg shadow border border-gray-100 overflow-hidden">
+          <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 border-b border-gray-100">
               <tr>
@@ -176,6 +177,7 @@ export default function PastoralProfilesAdmin({ churchId, profiles: initial, use
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
     </div>

--- a/src/app/(auth)/admin/welcome-duty/WelcomeDutyPoolClient.tsx
+++ b/src/app/(auth)/admin/welcome-duty/WelcomeDutyPoolClient.tsx
@@ -128,6 +128,7 @@ export default function WelcomeDutyPoolClient() {
         </div>
       ) : (
         <div className="bg-white rounded-lg shadow overflow-hidden">
+          <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 border-b border-gray-100">
               <tr>
@@ -154,6 +155,7 @@ export default function WelcomeDutyPoolClient() {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 
@@ -161,6 +163,7 @@ export default function WelcomeDutyPoolClient() {
         <div className="mt-6">
           <h3 className="text-sm font-semibold text-gray-500 mb-3">Familles désactivées</h3>
           <div className="bg-white rounded-lg shadow overflow-hidden">
+            <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <tbody className="divide-y divide-gray-50">
                 {inactive.map((f) => (
@@ -187,6 +190,7 @@ export default function WelcomeDutyPoolClient() {
                 ))}
               </tbody>
             </table>
+            </div>
           </div>
         </div>
       )}

--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -160,7 +160,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
           />
         ) : (
           <div className="p-8 text-center text-gray-400 border-2 border-gray-200 border-dashed rounded-lg">
-            Sélectionnez un département dans la barre latérale
+            Sélectionnez un département dans le menu
           </div>
         )
       ) : view === "tasks" ? (
@@ -172,7 +172,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
           />
         ) : (
           <div className="p-8 text-center text-gray-400 border-2 border-gray-200 border-dashed rounded-lg">
-            Sélectionnez un département dans la barre latérale
+            Sélectionnez un département dans le menu
           </div>
         )
       ) : view === "month" ? (
@@ -180,7 +180,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
           <MonthlyPlanningView departmentId={selectedDeptId} departmentName={selectedDepartment?.name} churchName={churchName} />
         ) : (
           <div className="p-8 text-center text-gray-400 border-2 border-gray-200 border-dashed rounded-lg">
-            Sélectionnez un département dans la barre latérale
+            Sélectionnez un département dans le menu
           </div>
         )
       ) : selectedEventId && selectedDeptId ? (
@@ -188,7 +188,7 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
       ) : (
         <div className="p-8 text-center text-gray-400 border-2 border-gray-200 border-dashed rounded-lg">
           {!selectedDeptId
-            ? "Sélectionnez un département dans la barre latérale"
+            ? "Sélectionnez un département dans le menu"
             : "Sélectionnez un événement ci-dessus"}
         </div>
       )}

--- a/src/app/(auth)/dashboard/stats/StatsClient.tsx
+++ b/src/app/(auth)/dashboard/stats/StatsClient.tsx
@@ -318,6 +318,7 @@ export default function StatsClient({ departments, initialDeptId }: Props) {
                   <h3 className="text-sm font-semibold text-gray-700 px-4 py-3 border-b">
                     Détail par STAR
                   </h3>
+                  <div className="overflow-x-auto">
                   <table className="w-full">
                     <thead>
                       <tr className="bg-gray-50">
@@ -364,6 +365,7 @@ export default function StatsClient({ departments, initialDeptId }: Props) {
                       ))}
                     </tbody>
                   </table>
+                  </div>
                 </div>
               )}
             </>


### PR DESCRIPTION
## Summary

- **Tableaux sans scroll horizontal** (🔴 bloquant) : ajout `overflow-x-auto` sur AuditLogs, PastoralProfilesAdmin, WelcomeDuty (×2), MrbsLinks, StatsClient — les colonnes de droite n'étaient plus accessibles sur mobile
- **Formulaire PastoralProfilesAdmin** : grille `grid-cols-2` → `grid-cols-1 sm:grid-cols-2` pour éviter des champs trop étroits sur petit écran
- **Dashboard** : message "barre latérale" → "menu" (la sidebar n'existe pas sur mobile)
- **EventsClient — barre de filtres** : inputs recherche + mois passent en `w-full` sur mobile
- **EventsClient — cartes événement** : actions basculées sous le contenu sur mobile (`flex-col` → `sm:flex-row`) pour ne plus écraser le titre/date

## Test plan

- [ ] Vérifier sur mobile (375px) que les tableaux admin sont scrollables horizontalement
- [ ] Vérifier que le formulaire profils pastoraux s'affiche en 1 colonne sur mobile
- [ ] Vérifier que la liste d'événements affiche correctement titre + actions en colonne sur mobile
- [ ] Vérifier que la barre de filtres événements passe en pleine largeur sur mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)