### PR TITLE
fix: SharedArrayBuffer incompatible avec sharp/Buffer sur Node 22

### DIFF
--- a/src/app/api/accounting/attachments/route.ts
+++ b/src/app/api/accounting/attachments/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: Request) {
 
     const ext = file.name.split(".").pop()?.toLowerCase() ?? "bin";
     const s3Key = `accounting/${churchId}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
-    const buffer = Buffer.from(await file.arrayBuffer());
+    const buffer = Buffer.from(new Uint8Array(await file.arrayBuffer()));
 
     await storeFile(s3Key, buffer, file.type);
 

--- a/src/app/api/media-events/[id]/photos/route.ts
+++ b/src/app/api/media-events/[id]/photos/route.ts
@@ -72,7 +72,7 @@ export async function POST(
       try {
         validatePhotoFile(file.name, file.type, file.size);
 
-        const buffer = Buffer.from(await file.arrayBuffer());
+        const buffer = Buffer.from(new Uint8Array(await file.arrayBuffer()));
         const processed = await processImage(buffer);
         const ext = getExtensionFromMimeType(file.type);
 

--- a/src/modules/media/services/s3.ts
+++ b/src/modules/media/services/s3.ts
@@ -87,9 +87,11 @@ export async function fileExists(key: string): Promise<boolean> {
 export async function downloadFile(key: string): Promise<Buffer> {
   const resp = await s3Client.send(new GetObjectCommand({ Bucket: BUCKET, Key: key }));
   if (!resp.Body) throw new Error(`S3 object not found: ${key}`);
-  const chunks: Uint8Array[] = [];
+  const chunks: Buffer[] = [];
   for await (const chunk of resp.Body as AsyncIterable<Uint8Array>) {
-    chunks.push(chunk);
+    // Node.js 22 : les chunks du SDK S3 peuvent être backed par SharedArrayBuffer
+    // Buffer.from(new Uint8Array(chunk)) force une copie vers un ArrayBuffer ordinaire
+    chunks.push(Buffer.from(new Uint8Array(chunk)));
   }
   return Buffer.concat(chunks);
 }


### PR DESCRIPTION
## Problème

Sur Node.js 22, `File.arrayBuffer()` retourne un `SharedArrayBuffer` au lieu d'un `ArrayBuffer` ordinaire. `Buffer.from(sharedArrayBuffer)` crée un Buffer dont le backing reste un `SharedArrayBuffer` — quand `sharp` le transmet à libvips (code natif), ça explose :

```
Unhandled error: The "input" argument must be ArrayBuffer. Received type object ([object SharedArrayBuffer])
```

Symptôme côté utilisateur : images téléchargées mais qui ne s'affichent plus (le traitement échoue silencieusement).

## Fix

Remplacer `Buffer.from(await file.arrayBuffer())` par `Buffer.from(new Uint8Array(await file.arrayBuffer()))` — `Uint8Array` accepte les deux types et la conversion force une copie avec un `ArrayBuffer` standard.

**Fichiers corrigés :**
- `src/app/api/media-events/[id]/photos/route.ts` — upload photos média
- `src/app/api/accounting/attachments/route.ts` — pièces jointes comptabilité

🤖 Generated with [Claude Code](https://claude.com/claude-code)