### PR TITLE
chore: release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.9.1] - 2026-07-01
+
+### Corrigé
+
+- **Upload médias / pièces jointes** : crash SIGSEGV de libvips sur Node.js 22 (#392)
+  - `File.arrayBuffer()` et les chunks du streaming S3 SDK peuvent retourner des `SharedArrayBuffer`
+  - `Buffer.from(new Uint8Array(...))` force une copie vers `ArrayBuffer` ordinaire avant sharp
+  - Fichiers corrigés : upload photos média, pièces jointes comptabilité, `downloadFile` S3
+
 ## [v1.9.0] - 2026-06-28
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v1.9.1 — Hotfix

### Corrigé
- **Upload médias / pièces jointes** : crash SIGSEGV de libvips sur Node.js 22 (#392)
  - `File.arrayBuffer()` et les chunks du streaming S3 SDK peuvent retourner des `SharedArrayBuffer`
  - sharp (libvips natif) segfault sur SharedArrayBuffer → process crash silencieux → photos créées en DB avec clés vides → thumbnails manquants
  - Fix : `Buffer.from(new Uint8Array(...))` force une copie vers `ArrayBuffer` ordinaire

🤖 Generated with [Claude Code](https://claude.com/claude-code)