### PR TITLE
fix(media): wrap sharp.toBuffer() pour SharedArrayBuffer Node.js 22

### DIFF
--- a/src/modules/media/services/image.ts
+++ b/src/modules/media/services/image.ts
@@ -19,16 +19,19 @@ export async function processImage(buffer: Buffer): Promise<ProcessedImage> {
     throw new ApiError(400, "Impossible de lire les métadonnées de l'image");
   }
 
-  const original = await image.rotate().jpeg({ quality: 90 }).toBuffer();
-  const thumbnail = await sharp(buffer)
+  // Node.js 22 : sharp.toBuffer() peut retourner un Buffer backed par SharedArrayBuffer.
+  // Buffer.from(new Uint8Array(x)) force une copie vers un ArrayBuffer ordinaire,
+  // nécessaire pour le AWS SDK (PutObjectCommand accède à buffer.buffer en interne).
+  const originalRaw = await image.rotate().jpeg({ quality: 90 }).toBuffer();
+  const thumbnailRaw = await sharp(buffer)
     .rotate()
     .resize(1200, null, { withoutEnlargement: true })
     .webp({ quality: 80 })
     .toBuffer();
 
   return {
-    original,
-    thumbnail,
+    original: Buffer.from(new Uint8Array(originalRaw)),
+    thumbnail: Buffer.from(new Uint8Array(thumbnailRaw)),
     metadata: { width: metadata.width, height: metadata.height, format: metadata.format },
   };
 }


### PR DESCRIPTION
## Problème

Sur Node.js 22, `sharp.toBuffer()` retourne parfois un Buffer backed par **SharedArrayBuffer**.
Quand ce Buffer est passé au AWS SDK (`PutObjectCommand`), la lib accède à `buffer.buffer` en interne et lève :

```
Unhandled error: The "input" argument must be ArrayBuffer. Received type object ([object SharedArrayBuffer])
```

Ce crash silencieux (SIGSEGV libvips) se produisait **après** la création de l'enregistrement en DB mais **avant** l'update des clés S3, laissant des photos avec `originalKey = ''` et `thumbnailKey = ''`.

## Fix

Dans `processImage()`, les sorties de `toBuffer()` sont wrappées avec `Buffer.from(new Uint8Array(x))` pour forcer une copie vers un ArrayBuffer ordinaire :

```typescript
const originalRaw = await image.rotate().jpeg({ quality: 90 }).toBuffer();
const thumbnailRaw = await sharp(buffer)...toBuffer();

return {
  original: Buffer.from(new Uint8Array(originalRaw)),
  thumbnail: Buffer.from(new Uint8Array(thumbnailRaw)),
  ...
};
```

## Contexte

Les mêmes fixes ont déjà été appliqués dans v1.9.1 sur :
- `file.arrayBuffer()` → `photos/route.ts` et `accounting/attachments/route.ts`
- chunks de streaming S3 → `s3.ts` `downloadFile()`

Ce dernier point (`processImage`) était la source restante des erreurs observées en prod le 01/07 à 12:28:59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)