### PR TITLE
chore: release v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.9.2] - 2026-07-01
+
+### Corrigé
+
+- **Upload médias** : crash silencieux restant sur Node.js 22 (#394)
+  - `sharp.toBuffer()` peut aussi retourner un Buffer backed par `SharedArrayBuffer`
+  - Les sorties de `processImage()` (original JPEG + miniature WebP) sont maintenant wrappées avec `Buffer.from(new Uint8Array(...))` avant passage au AWS SDK
+
 ## [v1.9.1] - 2026-07-01
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## v1.9.2

### Corrigé

- **Upload médias** : crash silencieux restant sur Node.js 22 (#394)
  - `sharp.toBuffer()` peut aussi retourner un Buffer backed par `SharedArrayBuffer`
  - Les sorties de `processImage()` (original JPEG + miniature WebP) sont maintenant wrappées avec `Buffer.from(new Uint8Array(...))` avant passage au AWS SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)