### PR TITLE
chore: workflow spec-driven development

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,46 @@
+---
+description: Exécute les tâches d'une feature spécifiée, vérifie, et prépare la PR
+argument-hint: [numéro ou slug de la feature — défaut : la plus récente]
+---
+
+Tu vas **implémenter** une feature à partir de ses tâches.
+
+## Cible
+
+- Argument fourni (`$ARGUMENTS`) : le dossier `specs/NNN-*` correspondant.
+- **Sans argument** : la feature la plus récemment modifiée qui possède un `tasks.md`. En cas de doute, demande.
+
+## Avant de commencer
+
+1. **Lis** `specs/constitution.md`, puis `spec.md`, `plan.md`, `tasks.md` de la feature.
+2. **Crée la branche** si elle n'existe pas encore : `feat/<slug>` (jamais travailler sur `main`).
+   Si l'utilisateur suit une stratégie multi-PR (branche `feat/X` de base), demande la branche cible.
+
+## Exécution
+
+3. **Traite les tâches dans l'ordre** de `tasks.md`. Coche `- [x]` chaque tâche terminée dans le fichier.
+4. **Respecte la constitution à chaque tâche** :
+   - Migration Prisma (`npm run db:migrate`) pour tout changement de schéma — **jamais** `db push`.
+   - Routes protégées (`requireAuth`/`requirePermission`), multi-tenant `churchId`.
+   - Permissions via `rolePermissions` (`@/lib/registry`), validation Zod, `ApiError`.
+   - Imports modules via l'index (`@/modules/X`), enums depuis `@/generated/prisma/client`, `await params`.
+   - Réutilise `src/components/ui/` ; lis un fichier avant de le modifier.
+5. **Pas de sur-ingénierie** : le minimum pour satisfaire les critères d'acceptation de la spec.
+
+## Vérification
+
+6. Lance et fais passer :
+   ```
+   npm run typecheck && npm run lint && npm run lint:boundaries && npm run test
+   ```
+7. Relis les **critères d'acceptation** de `spec.md` un par un et confirme qu'ils sont satisfaits.
+8. Mets le **statut** de la spec à `Implémentée`.
+
+## Livraison
+
+9. Commit avec un message conventionnel (`feat:`/`fix:`), pousse la branche.
+10. **Demande** avant d'ouvrir la PR si l'utilisateur ne l'a pas déjà autorisé. Rédige un corps de
+    PR qui référence la spec (`specs/NNN-slug/`).
+
+Reste en français. Si une tâche révèle que le plan est incomplet ou faux, **arrête-toi** et
+signale-le plutôt que d'improviser une entorse à la spec.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,39 @@
+---
+description: Traduit une spec validée en plan technique conforme à la constitution
+argument-hint: [numéro ou slug de la feature — défaut : la plus récente]
+---
+
+Tu vas produire le **plan technique** d'une feature déjà spécifiée.
+
+## Cible
+
+- Argument fourni (`$ARGUMENTS`) : utilise le dossier `specs/NNN-*` correspondant au numéro ou au slug.
+- **Sans argument** : prends la feature la plus récemment modifiée dans `specs/` qui possède un
+  `spec.md` mais pas encore de `plan.md` (ou dont le plan est à refaire). En cas de doute, demande.
+
+## Étapes
+
+1. **Lis** dans l'ordre : `specs/constitution.md`, la `spec.md` de la feature, et
+   `specs/templates/plan-template.md`.
+2. **Vérifie la spec** : si elle contient des `[À CLARIFIER]` non résolus, **arrête-toi** et
+   pose les questions avant de planifier.
+3. **Explore le code existant** pertinent (modules, routes, schéma Prisma, composants UI) pour
+   ancrer le plan dans la réalité du repo — ne planifie pas dans le vide.
+4. **Rédige `plan.md`** à partir du template :
+   - Coche honnêtement la **checklist de conformité** à la constitution.
+   - Détaille : modèle de données (+ migration Prisma si besoin), endpoints API (+ permission + Zod),
+     services métier, UI (en réutilisant `src/components/ui/`).
+   - Consigne les **décisions techniques** et les **alternatives écartées** avec leur justification.
+   - Liste risques et **stratégie de tests**.
+5. **Respecte impérativement la constitution** : frontières modules (`@/modules/X`), `requireAuth`/
+   `requirePermission`, `rolePermissions`, validation Zod, migration Prisma (jamais `db push`),
+   enums depuis `@/generated/prisma/client`, `await params`.
+6. **Ne code rien.** Le plan décrit ; il n'implémente pas.
+
+## Après création
+
+- Affiche le chemin du `plan.md` et un résumé des choix structurants.
+- Signale tout point où la spec force une entorse à la constitution (à arbitrer avec l'utilisateur).
+- Rappelle que l'étape suivante est `/tasks`.
+
+Reste en français.

--- a/.claude/commands/specify.md
+++ b/.claude/commands/specify.md
@@ -1,0 +1,35 @@
+---
+description: Crée la spécification d'une nouvelle feature (quoi/pourquoi, sans technique)
+argument-hint: <description de la feature en langage naturel>
+---
+
+Tu vas créer la **spécification** d'une nouvelle fonctionnalité de Koinonia à partir de
+la description suivante :
+
+> $ARGUMENTS
+
+## Étapes
+
+1. **Lis** `specs/constitution.md` et `specs/templates/spec-template.md`.
+2. **Détermine le numéro** de la feature : liste les dossiers `specs/NNN-*` existants et
+   prends le prochain entier disponible (format 3 chiffres, ex. `007`). S'il n'y en a
+   aucun, commence à `001`.
+3. **Choisis un slug** court en kebab-case dérivé de la description (ex. `indisponibilite-plage`).
+4. **Crée** le dossier `specs/NNN-slug/` et le fichier `spec.md` à partir du template.
+5. **Remplis la spec** :
+   - Décris uniquement le **comportement observable** et le **pourquoi**.
+   - **Interdit** : noms de tables, librairies, endpoints, composants, ou toute décision technique.
+   - Identifie les **rôles concernés** parmi ceux de Koinonia (Super Admin, Admin, Secrétaire,
+     Ministre, Resp. département, STAR, Faiseur de Disciples, Reporter).
+   - Rédige des **scénarios** concrets (principal + cas limites) et des **critères d'acceptation** binaires.
+   - Note explicitement ce qui est **hors périmètre**.
+   - Marque les zones d'incertitude avec `[À CLARIFIER: …]`.
+6. **Ne code rien.** Ne touche pas au schéma, aux modules, ni au code applicatif.
+
+## Après création
+
+- Affiche le chemin du fichier créé et un résumé de la spec.
+- Si des `[À CLARIFIER]` subsistent, **pose les questions** à l'utilisateur avant de considérer la spec prête.
+- Rappelle que l'étape suivante est `/plan`.
+
+Reste en français. Respecte `specs/constitution.md`.

--- a/.claude/commands/tasks.md
+++ b/.claude/commands/tasks.md
@@ -1,0 +1,34 @@
+---
+description: Découpe un plan technique en tâches ordonnées et vérifiables
+argument-hint: [numéro ou slug de la feature — défaut : la plus récente]
+---
+
+Tu vas transformer un plan technique en **liste de tâches** exécutables.
+
+## Cible
+
+- Argument fourni (`$ARGUMENTS`) : le dossier `specs/NNN-*` correspondant.
+- **Sans argument** : la feature la plus récemment modifiée qui a un `plan.md` mais pas encore
+  de `tasks.md`. En cas de doute, demande.
+
+## Étapes
+
+1. **Lis** : `spec.md`, `plan.md` de la feature, et `specs/templates/tasks-template.md`.
+2. **Découpe le travail** en tâches atomiques, chacune :
+   - vérifiable (on sait dire si elle est faite),
+   - avec le(s) **fichier(s)** cible(s) indiqué(s),
+   - ordonnée selon les dépendances naturelles : **migration → services → API → UI → tests**.
+3. **Marque `[P]`** les tâches réellement parallélisables (fichiers indépendants).
+4. **Inclus les tests** comme tâches à part entière (Vitest), pas en option.
+5. **Termine par la checklist de vérification** : typecheck, lint, lint:boundaries, test, critères
+   d'acceptation de la spec, PR.
+6. Écris le tout dans `tasks.md`. **Ne code rien.**
+
+## Après création
+
+- Affiche le chemin du `tasks.md` et le nombre de tâches.
+- Vérifie que chaque **critère d'acceptation** de la spec est couvert par au moins une tâche ;
+  signale les manques.
+- Rappelle que l'étape suivante est `/implement`.
+
+Reste en français.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,20 @@ npm run dev
 
 ## Workflow contributeur
 
+### Spec-Driven Development
+
+Les fonctionnalites non triviales sont specifiees avant d'etre codees. Le flux :
+
+```
+/specify <description>  →  /plan  →  /tasks  →  /implement
+     spec.md                plan.md   tasks.md    code + PR
+```
+
+- Les specs vivent dans `specs/NNN-nom-feature/` (voir `specs/README.md`).
+- `specs/constitution.md` = principes non-negociables que toute spec/plan/implementation respecte.
+- La `spec.md` decrit QUOI/POURQUOI (aucune technique) ; le `plan.md` decrit COMMENT ; le `tasks.md` decoupe.
+- Un fix trivial ne necessite pas de spec.
+
 ### Conventions de branches
 
 | Prefixe | Usage |

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,69 @@
+# Spec-Driven Development — Koinonia
+
+Ce dossier contient les **spécifications** des fonctionnalités de Koinonia.
+Chaque feature non triviale est décrite avant d'être codée, selon le flux :
+
+```
+/specify  →  /plan  →  /tasks  →  /implement
+  spec.md     plan.md   tasks.md    (code + PR)
+```
+
+## Le principe
+
+Le code n'est pas la source de vérité de l'intention — la **spec** l'est.
+On écrit d'abord *ce qu'on veut* et *pourquoi* (sans technique), puis *comment*
+(le plan), puis *le découpage* (les tâches), et seulement ensuite on implémente.
+Cela force la réflexion en amont, documente les décisions, et rend l'implémentation
+par l'agent IA beaucoup plus fiable.
+
+## Structure
+
+```
+specs/
+├── constitution.md          # principes non-négociables (lus par toutes les commandes)
+├── README.md                # ce fichier
+├── templates/               # gabarits
+│   ├── spec-template.md
+│   ├── plan-template.md
+│   └── tasks-template.md
+└── NNN-nom-feature/         # un dossier par feature (numéroté)
+    ├── spec.md              # QUOI & POURQUOI — comportement, critères d'acceptation
+    ├── plan.md              # COMMENT — approche technique, fichiers, migrations
+    └── tasks.md             # DÉCOUPAGE — tâches ordonnées et vérifiables
+```
+
+## Les commandes
+
+| Commande | Rôle | Produit |
+|---|---|---|
+| `/specify <description>` | Décrit une nouvelle feature (quoi/pourquoi) | `specs/NNN-nom/spec.md` |
+| `/plan` | Traduit la spec en approche technique | `specs/NNN-nom/plan.md` |
+| `/tasks` | Découpe le plan en tâches exécutables | `specs/NNN-nom/tasks.md` |
+| `/implement` | Exécute les tâches, vérifie, ouvre la PR | code + branche |
+
+Chaque commande sans argument opère sur la **feature la plus récente** (dossier `specs/`
+modifié en dernier). On peut cibler une feature précise en passant son numéro ou son slug.
+
+## Exemple de bout en bout
+
+```
+/specify Permettre à un STAR de signaler son indisponibilité sur une plage de dates
+# → crée specs/012-indisponibilite-plage/spec.md
+
+/plan
+# → lit la spec + la constitution, produit plan.md (modèle Prisma, API, UI, migration)
+
+/tasks
+# → produit tasks.md : migration → service → route API → composant → tests
+
+/implement
+# → crée la branche feat/indisponibilite-plage, exécute les tâches,
+#   lance typecheck/lint/test, ouvre la PR
+```
+
+## Règles
+
+- La **spec** ne contient aucune décision technique (pas de nom de table, de lib, d'endpoint).
+- Le **plan** respecte `constitution.md` (migrations Prisma, frontières modules, `requireAuth`, Zod…).
+- Une feature triviale (fix d'une ligne, renommage) ne nécessite pas de spec.
+- Les specs sont versionnées avec le code : elles vivent dans le repo et évoluent en PR.

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -1,0 +1,54 @@
+# Constitution — Koinonia
+
+Principes **non-négociables** qui encadrent toute spécification, tout plan et toute
+implémentation. Les slash commands `/specify`, `/plan`, `/tasks`, `/implement` doivent
+respecter cette constitution. En cas de conflit entre une spec et la constitution,
+la constitution l'emporte.
+
+> Cette constitution complète `CLAUDE.md` (conventions détaillées). Elle en extrait
+> ce qui est **invariant** : ce qui ne doit jamais être violé sans discussion explicite.
+
+## I. Architecture modulaire
+
+- `src/app/` n'importe un module **que via son index** (`@/modules/X`) — jamais de chemin interne.
+- La logique métier vit dans `src/modules/X/services/`, pas dans les route handlers.
+- Toute nouvelle dépendance entre modules doit passer `npm run lint:boundaries`.
+- L'infrastructure (`src/core/`) reste framework-agnostic.
+
+## II. Sécurité par défaut
+
+- **Toute route API** est protégée par `requireAuth()` ou `requirePermission(...)`.
+- Multi-tenant strict : chaque donnée est rattachée à une église via `churchId` ; jamais de fuite cross-tenant.
+- Les permissions viennent de `rolePermissions` (`@/lib/registry`) — **jamais** de `hasPermission` (déprécié).
+- Les mutations (POST/PUT/PATCH) valident leur body avec **Zod** avant tout accès BDD.
+
+## III. Contrats de données
+
+- Tout changement de schéma passe par une **migration Prisma** (`prisma migrate dev`), jamais `db push`.
+- Les types enum viennent de `@/generated/prisma/client` (pas `@prisma/client`).
+- Les erreurs métier utilisent `ApiError(status, message)` ; les réponses passent par `successResponse` / `errorResponse`.
+
+## IV. Conventions Next.js 16 / React 19
+
+- Route handlers : **toujours** `const { id } = await params` (params est une Promise).
+- Server Components par défaut ; `"use client"` réservé aux interactions/formulaires.
+- Réutiliser les composants de `src/components/ui/` avant d'en créer.
+
+## V. Qualité et livraison
+
+- Avant toute PR : `npm run typecheck && npm run lint && npm run lint:boundaries && npm run test` doivent passer.
+- Jamais de push direct sur `main`. Branches `feat/<nom>`, `fix/<nom>`, `chore/<nom>`.
+- Les features longues suivent la stratégie multi-PR : branche `feat/X` de base, sous-PRs vers `feat/X`, une seule PR finale vers `main`.
+- Pas de sur-ingénierie : le minimum nécessaire pour la fonctionnalité spécifiée.
+
+## VI. Traçabilité spec-driven
+
+- Toute feature non triviale commence par une **spec** (`/specify`) avant tout code.
+- Le flux est : `spec.md` (quoi/pourquoi) → `plan.md` (comment) → `tasks.md` (découpage) → implémentation.
+- La spec décrit le **comportement observable** et les critères d'acceptation, pas la technique.
+- Les décisions techniques et les alternatives écartées sont consignées dans `plan.md`.
+
+---
+
+*Modifier cette constitution est un acte délibéré : toute évolution doit être discutée
+et reflétée dans `CLAUDE.md` si elle touche les conventions de code.*

--- a/specs/templates/plan-template.md
+++ b/specs/templates/plan-template.md
@@ -1,0 +1,60 @@
+# Plan technique — [NOM DE LA FEATURE]
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Brouillon | Validé
+- **Mis à jour le** : AAAA-MM-JJ
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [ ] **Frontières modules** : les imports `src/app/` → module passent par l'index (`@/modules/X`)
+- [ ] **Sécurité** : toutes les routes protégées par `requireAuth`/`requirePermission` ; multi-tenant `churchId` respecté
+- [ ] **Permissions** via `rolePermissions` (`@/lib/registry`)
+- [ ] **Validation** Zod sur toutes les mutations
+- [ ] **Migration** Prisma prévue si le schéma change (pas de `db push`)
+- [ ] **Enums** importés depuis `@/generated/prisma/client`
+- [ ] **UI** : composants `src/components/ui/` réutilisés avant création
+
+## Approche générale
+
+*En quelques phrases : comment on s'y prend, quel est le fil directeur.*
+
+## Modèle de données
+
+*Nouveaux modèles / champs Prisma, relations, migration. `[Aucun changement]` si applicable.*
+
+```prisma
+// esquisse des modifications de schema.prisma
+```
+
+## API
+
+*Endpoints ajoutés/modifiés, méthode, permission requise, schéma Zod (entrée/sortie).*
+
+| Endpoint | Méthode | Permission | Entrée | Sortie |
+|---|---|---|---|---|
+| `/api/…` | POST | `x:manage` | `{…}` | `{…}` |
+
+## Services / logique métier
+
+*Fonctions dans `src/modules/X/services/`, événements sur le bus si concerné.*
+
+## UI / composants
+
+*Pages, composants serveur/client, réutilisation `components/ui/`.*
+
+## Décisions & alternatives écartées
+
+*Choix techniques notables et pourquoi les autres options ont été rejetées.*
+
+- **Choix** : … — *Pourquoi* : …
+- **Écarté** : … — *Raison* : …
+
+## Risques & points d'attention
+
+- …
+
+## Stratégie de tests
+
+*Ce qui sera couvert par des tests unitaires (Vitest) et comment.*

--- a/specs/templates/spec-template.md
+++ b/specs/templates/spec-template.md
@@ -1,0 +1,52 @@
+# Spec — [NOM DE LA FEATURE]
+
+- **Numéro** : NNN
+- **Statut** : Brouillon | En revue | Validée | Implémentée
+- **Créée le** : AAAA-MM-JJ
+- **Branche suggérée** : `feat/nom-feature`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+*Quel problème résout-on ? Pour qui ? Pourquoi maintenant ? Que se passe-t-il aujourd'hui sans cette feature ?*
+
+## Utilisateurs concernés
+
+*Quels rôles sont impactés ? (Super Admin, Admin, Secrétaire, Ministre, Resp. département, STAR, Faiseur de Disciples, Reporter…) Que peut faire chacun ?*
+
+## Comportement attendu
+
+*Décrire les scénarios utilisateur du point de vue observable. Un scénario = une histoire du début à la fin.*
+
+### Scénario principal
+
+1. …
+2. …
+3. …
+
+### Scénarios alternatifs / cas limites
+
+- **Si …** alors …
+- **Quand …** le système doit …
+
+## Critères d'acceptation
+
+*Liste vérifiable. Chaque critère est un test binaire (réussi/échoué).*
+
+- [ ] …
+- [ ] …
+- [ ] …
+
+## Hors périmètre
+
+*Ce que cette feature ne fait PAS (pour éviter le scope creep).*
+
+- …
+
+## Questions ouvertes
+
+*Points à trancher avant/pendant le plan. `[À CLARIFIER: …]` pour ce qui bloque.*
+
+- …

--- a/specs/templates/tasks-template.md
+++ b/specs/templates/tasks-template.md
@@ -1,0 +1,43 @@
+# Tâches — [NOM DE LA FEATURE]
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : À faire | En cours | Terminé
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : migration → services → API → UI → tests. Les tâches `[P]` sont parallélisables.
+
+## Prérequis
+
+- [ ] Branche créée : `feat/nom-feature`
+- [ ] Migration Prisma générée (si schéma modifié)
+
+## Tâches
+
+### 1. Données & migration
+
+- [ ] **T1** — … *(fichier : `prisma/schema.prisma`)*
+
+### 2. Logique métier (services)
+
+- [ ] **T2** — … *(fichier : `src/modules/X/services/…`)*
+
+### 3. API (route handlers)
+
+- [ ] **T3** — … *(fichier : `src/app/api/…/route.ts`)*
+
+### 4. UI
+
+- [ ] **T4** [P] — … *(fichier : `src/app/(auth)/…`)*
+
+### 5. Tests
+
+- [ ] **T5** — … *(fichier : `…test.ts`)*
+
+## Vérification finale
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run lint:boundaries`
+- [ ] `npm run test`
+- [ ] Tous les critères d'acceptation de `spec.md` satisfaits
+- [ ] PR ouverte vers la branche cible


### PR DESCRIPTION
## Résumé

Met en place un workflow de spec-driven development pour les fonctionnalités développées avec les agents IA :

- **Slash commands** (`.claude/commands/`) : `/specify`, `/plan`, `/tasks`, `/implement` — couvrent le cycle complet depuis la définition du besoin jusqu'à l'implémentation
- **Structure `specs/`** : `constitution.md` (principes non-négociables du projet), `README.md` (explication du workflow), `templates/` (gabarits pour `spec.md`, `plan.md`, `tasks.md`)
- **`CLAUDE.md`** : nouvelle section décrivant le workflow spec-driven development

## Flux

`spec.md` (quoi/pourquoi) → `plan.md` (comment) → `tasks.md` (découpage) → implémentation.

La constitution encode les principes non-négociables du projet (frontières entre modules, `requireAuth`, `rolePermissions`, validation Zod, migrations Prisma) afin que chaque commande du workflow les respecte automatiquement.

## Test plan

- [ ] Vérifier que les slash commands `/specify`, `/plan`, `/tasks`, `/implement` s'affichent correctement dans Claude Code
- [ ] Dérouler le workflow complet sur une petite fonctionnalité de test pour valider l'enchaînement spec → plan → tasks → implémentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)