### PR TITLE
feat(ci): environnement de recette (staging) déployé manuellement

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,139 @@
+# Workflow de deploiement de l'environnement de RECETTE (staging).
+#
+# Independant de deploy.yml (production) : ce workflow ne se declenche
+# JAMAIS automatiquement, uniquement a la demande (workflow_dispatch).
+#
+# Pour deployer une branche sur la VM de recette :
+#   GitHub -> Actions -> "Deploy Staging" -> "Run workflow"
+#   -> choisir la branche a valider -> Run workflow
+#
+# Le build part de la ref selectionnee dans l'UI (comportement par defaut
+# de actions/checkout en workflow_dispatch). Voir docs/staging.md.
+
+name: Deploy Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      note:
+        description: "Note libre (raison du deploiement, ex: validation feat/X)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      NEXT_TELEMETRY_DISABLED: "1"
+      DATABASE_URL: "mysql://dummy:dummy@localhost/dummy"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Determine version
+        id: version
+        run: |
+          PKG=$(node -p "require('./package.json').version")
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "version=${PKG}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - run: npm ci
+      - run: npx prisma generate
+      - run: npm run build
+
+      - name: Package artifact
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          tar czf "koinonia-${VERSION}.tar.gz" \
+            --exclude='prisma/scripts' \
+            .next/standalone .next/static \
+            prisma prisma.config.ts public package.json \
+            node_modules
+          echo "Built koinonia-${VERSION}.tar.gz"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: koinonia-${{ steps.version.outputs.version }}
+          path: koinonia-${{ steps.version.outputs.version }}.tar.gz
+          retention-days: 14
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: staging
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: koinonia-${{ needs.build.outputs.version }}
+
+      - name: Upload artifact to server
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: koinonia-${{ needs.build.outputs.version }}.tar.gz
+          target: /tmp
+
+      - name: Deploy artifact via SSH
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: VERSION,DEPLOY_PATH
+          script: |
+            set -e
+            DEPLOY_PATH="${DEPLOY_PATH:-/opt/koinonia}"
+
+            echo "Deploying staging v${VERSION}..."
+
+            # 1. Prepare release directory
+            mkdir -p "$DEPLOY_PATH/releases/koinonia-${VERSION}"
+            cd "$DEPLOY_PATH/releases/koinonia-${VERSION}"
+
+            # 2. Extract pre-built artifact
+            tar xzf "/tmp/koinonia-${VERSION}.tar.gz"
+            rm "/tmp/koinonia-${VERSION}.tar.gz"
+
+            # 3. Assemble standalone bundle (Next.js standalone output)
+            cp -r .next/static .next/standalone/.next/static
+            cp -r public .next/standalone/public
+            ln -sf "$DEPLOY_PATH/shared/.env" .next/standalone/.env
+
+            # 4. Run migrations
+            set -a; source "$DEPLOY_PATH/shared/.env"; set +a
+            ./node_modules/.bin/prisma migrate deploy --schema=prisma/schema.prisma
+
+            # 5. Activate release
+            ln -sfn "$DEPLOY_PATH/releases/koinonia-${VERSION}" "$DEPLOY_PATH/current"
+
+            # 6. Restart
+            sudo systemctl restart koinonia
+
+            # 7. Cleanup: keep last 3 releases
+            cd "$DEPLOY_PATH/releases"
+            ls -1dt koinonia-*/ | tail -n +4 | xargs rm -rf || true
+
+            echo "Deploy staging v${VERSION} OK"

--- a/docs/production.md
+++ b/docs/production.md
@@ -821,6 +821,12 @@ Pour mettre à jour une instance existante, consulter le guide de migration corr
 
 - [Migration v0.19.x → v1.0.0](migration-v1.0.md)
 
+## Environnement de recette
+
+Avant de tagger une version et de la deployer en production, il est recommande de la valider sur un **environnement de recette dedie** (VM separee, identique a la production). Le deploiement s'y fait manuellement via le workflow GitHub Actions `Deploy Staging` (`workflow_dispatch`), independamment du pipeline de production decrit ci-dessus.
+
+Voir [docs/staging.md](staging.md) pour la mise en place complete (provisionnement, secrets, declenchement).
+
 ## Checklist de production
 
 - [ ] Variables d'environnement configurees dans `shared/.env`

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,0 +1,155 @@
+# Environnement de recette (staging)
+
+Guide de mise en place d'une VM de recette dediee pour valider un deploiement avant la bascule en production.
+
+## Objectif
+
+L'environnement de recette est une **VM dediee, distincte du serveur de production**, mais configuree de maniere identique (memes chemins, meme service systemd `koinonia`, meme Traefik, meme MariaDB). Elle permet de deployer et valider une branche **avant** de la tagger et de la mettre en production.
+
+Flux de travail :
+
+1. On deploie une branche sur la recette **manuellement** (workflow `Deploy Staging`, `workflow_dispatch`)
+2. On valide fonctionnellement sur `https://recette.votre-domaine.com`
+3. Une fois valide, on tagge (`git tag vX.Y.Z && git push origin vX.Y.Z`)
+4. La production se deploie automatiquement via le pipeline habituel (`deploy.yml`, voir [docs/production.md](production.md))
+
+La recette n'intervient jamais dans le pipeline de production : ce sont deux workflows, deux VMs et deux jeux de secrets totalement independants.
+
+## Provisionnement de la VM
+
+L'installation de base (utilisateur systeme, structure Capistrano-like `/opt/koinonia`, service systemd `koinonia`, durcissement, Node.js 22, MariaDB) est **identique** a la production. Suivre integralement [docs/production.md](production.md) sections "Prerequis" a "Service systemd", puis appliquer uniquement les differences ci-dessous.
+
+### Sous-domaine dedie
+
+Utiliser un sous-domaine distinct, par exemple `recette.votre-domaine.com` :
+
+- Ajouter une entree DNS `recette.votre-domaine.com` pointant vers l'IP de la VM de recette
+- Creer un router Traefik dedie (fichier separe, ex. `/etc/traefik/dynamic/koinonia-staging.yml`) pointant vers le port local de l'instance de recette :
+
+```yaml
+http:
+  routers:
+    koinonia-staging:
+      rule: "Host(`recette.votre-domaine.com`)"
+      entryPoints:
+        - websecure
+      service: koinonia-staging
+      tls:
+        certResolver: letsencrypt
+
+  services:
+    koinonia-staging:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:3001" # adapter selon PORT dans shared/.env de la recette
+```
+
+### `shared/.env` propre a la recette
+
+Ne jamais reutiliser le `.env` de production. Creer un fichier `/opt/koinonia/shared/.env` dedie sur la VM de recette avec :
+
+```bash
+DATABASE_URL=mysql://koinonia_staging:MOT_DE_PASSE@localhost:3306/koinonia_staging
+AUTH_SECRET=GENERER_AVEC_OPENSSL_DISTINCT_DE_LA_PROD
+AUTH_URL=https://recette.votre-domaine.com
+AUTH_TRUST_HOST=true
+PORT=3001
+GOOGLE_CLIENT_ID=votre-google-client-id
+GOOGLE_CLIENT_SECRET=votre-google-client-secret
+SUPER_ADMIN_EMAILS=admin-test@votre-eglise.com
+```
+
+Points d'attention :
+
+- **Base de donnees dediee** : `koinonia_staging`, avec un utilisateur MariaDB dedie (`CREATE DATABASE`/`CREATE USER` comme en production, voir section "Base de donnees" de production.md, en adaptant les noms)
+- **`AUTH_SECRET` distinct** de celui de production : `openssl rand -base64 32`
+- **`SUPER_ADMIN_EMAILS`** doit pointer vers des adresses de test, pas les vrais super admins de production
+
+### Bucket S3 media separe
+
+**Ne jamais pointer la recette sur le bucket S3 de production.** Creer un bucket dedie, par exemple `koinonia-media-staging`, avec ses propres credentials S3 :
+
+```bash
+MEDIA_S3_ENDPOINT=https://s3.gra.io.cloud.ovh.net
+MEDIA_S3_REGION=gra
+MEDIA_S3_BUCKET=koinonia-media-staging
+MEDIA_S3_ACCESS_KEY_ID=<access-key-media-staging>
+MEDIA_S3_SECRET_ACCESS_KEY=<secret-key-media-staging>
+```
+
+Si les backups S3 sont actives sur la recette (voir garde-fous ci-dessous), utiliser de meme un bucket `koinonia-backups-staging` distinct, avec ses propres credentials.
+
+### URI de redirection Google OAuth
+
+Dans la [console Google Cloud](https://console.cloud.google.com/apis/credentials), ajouter l'URI de redirection de recette en plus de celle de production :
+
+```
+https://recette.votre-domaine.com/api/auth/callback/google
+```
+
+### Timers cron/backup — garde-fou non negociable
+
+Les timers systemd `koinonia-cron.timer` (rappels email) et `koinonia-backup.timer` (backup BDD) **ne doivent pas etre actives tels quels sur la recette**, sous peine de :
+
+- Envoyer de **vrais emails** de rappel de service a de vrais STAR (si la base de recette contient des donnees reelles restaurees depuis la production)
+- **Ecraser les backups de production** si le bucket S3 backups n'est pas correctement separe
+
+Deux options, a choisir selon le besoin :
+
+1. **Ne pas activer les timers** sur la VM de recette (`sudo systemctl disable --now koinonia-cron.timer koinonia-backup.timer` ou simplement ne jamais les creer) — recommande si la recette sert uniquement a valider un deploiement technique
+2. **Rediriger le SMTP vers un catch-all de test** (ex. [Mailtrap](https://mailtrap.io)) dans le `shared/.env` de la recette, si l'on souhaite quand meme valider les emails :
+
+```bash
+SMTP_HOST=sandbox.smtp.mailtrap.io
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=<user-mailtrap>
+SMTP_PASS=<pass-mailtrap>
+SMTP_FROM=Koinonia Recette <noreply@recette.votre-domaine.com>
+```
+
+Dans tous les cas, le bucket `BACKUP_S3_*` de la recette (si utilise) doit etre distinct de celui de production — jamais de partage.
+
+## Configuration GitHub — Environment `staging`
+
+Le workflow `Deploy Staging` utilise une [GitHub Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) nommee `staging` pour injecter les secrets propres a la VM de recette.
+
+1. Aller dans les **Settings** du repository GitHub → **Environments** → **New environment** → nommer `staging`
+2. Ajouter les secrets suivants (propres a la VM de recette, distincts des secrets `production`) :
+
+| Secret | Description |
+|--------|-------------|
+| `DEPLOY_HOST` | Adresse IP ou domaine de la VM de recette |
+| `DEPLOY_PORT` | Port SSH de la VM de recette |
+| `DEPLOY_USER` | `koinonia` |
+| `DEPLOY_SSH_KEY` | Cle privee SSH dediee a la VM de recette (ne pas reutiliser la cle de production) |
+| `DEPLOY_PATH` | `/opt/koinonia` |
+
+3. Optionnel : ajouter des regles de protection sur l'Environment (ex. reviewers requis avant execution) si l'on souhaite restreindre qui peut declencher un deploiement de recette
+
+## Declencher un deploiement recette
+
+1. GitHub → onglet **Actions** → workflow **"Deploy Staging"**
+2. **"Run workflow"**
+3. Selectionner la branche (ou le tag) a valider dans le menu "Use workflow from"
+4. Renseigner eventuellement le champ `note` (raison du deploiement, libre)
+5. **Run workflow**
+
+Le pipeline :
+
+1. Construit l'artefact (`build`) depuis la ref choisie — pas d'exigence de correspondance de version avec `package.json`, la version est calculee automatiquement (`<version-package.json>-<sha-court>`, ex. `1.9.2-abc1234`)
+2. Deploie (`deploy`) sur la VM de recette en utilisant les secrets de l'Environment `staging` : transfert de l'artefact, extraction, assemblage du bundle standalone, migrations Prisma, bascule du symlink `current`, redemarrage du service `koinonia`, nettoyage (3 dernieres releases conservees)
+
+## Donnees de recette
+
+Pour tester dans des conditions realistes, il est recommande de restaurer periodiquement un backup de production dans la base `koinonia_staging`, en **anonymisant les donnees personnelles** (emails des STAR, noms si necessaire) avant ou apres restauration.
+
+La machinerie de backup/restauration S3 (endpoints `/api/admin/backups`, `/api/admin/backups/restore`) est deja disponible et documentee dans la section ["Procedure de restauration"](production.md#procedure-de-restauration) de `docs/production.md` — s'y referer directement pour la marche a suivre technique, en l'appliquant sur la base et l'environnement de recette.
+
+## Garde-fous
+
+> **A respecter systematiquement lors de toute manipulation sur la recette :**
+>
+> - La recette ne doit **jamais** ecrire dans les buckets S3 de production (`koinonia-media`, `koinonia-backups`) — toujours utiliser des buckets `*-staging` distincts
+> - La recette ne doit **jamais** envoyer de vrais emails aux STAR — desactiver les timers cron/backup ou rediriger le SMTP vers un catch-all de test (Mailtrap)
+> - Tous les secrets (`AUTH_SECRET`, `DEPLOY_SSH_KEY`, credentials S3, `CRON_SECRET`) doivent etre **distincts** de ceux de production


### PR DESCRIPTION
## Résumé

Mise en place d'un environnement de recette (staging) sur une **VM dédiée séparée**, identique à la production, pour valider un déploiement avant la bascule prod.

- **`.github/workflows/deploy-staging.yml`** : nouveau workflow, totalement indépendant de `deploy.yml`. Déclenché **uniquement** via `workflow_dispatch` (input optionnel `note` pour documenter la raison du déploiement). Build depuis la branche/ref sélectionnée dans l'UI Actions, version calculée automatiquement (`<version-package.json>-<sha-court>`, sans exigence de correspondance de tag). Réutilise les mêmes versions d'actions épinglées par SHA que `deploy.yml` (checkout, setup-node, upload/download-artifact, appleboy/scp-action, appleboy/ssh-action) et la même logique de packaging/déploiement (artefact tar.gz, assemblage standalone, migrations Prisma, bascule symlink `current`, redémarrage systemd, nettoyage des anciennes releases).
- **`docs/staging.md`** : guide complet — objectif et flux (recette → validation → tag → prod), provisionnement de la VM (renvoi vers `docs/production.md` pour la base identique + différences : sous-domaine dédié, `.env` propre avec base MariaDB et `AUTH_SECRET` distincts, bucket S3 média séparé), configuration de la GitHub Environment `staging` et ses secrets `DEPLOY_*`, procédure de déclenchement manuel, gestion des données de test (restauration anonymisée), et un encadré de garde-fous non négociables (jamais les buckets S3 prod, jamais de vrais emails, secrets distincts).
- **`docs/production.md`** : ajout d'un court renvoi ("## Environnement de recette") vers `docs/staging.md`, juste avant la checklist de production.

## Ce qui n'est PAS modifié

- `deploy.yml` (pipeline de production) : inchangé
- `ci.yml` : inchangé
- Aucun code applicatif (`src/`) : non touché

## Prérequis avant utilisation

- Provisionner la VM de recette (voir `docs/staging.md`)
- Créer la GitHub Environment `staging` avec ses secrets `DEPLOY_HOST`, `DEPLOY_PORT`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`, `DEPLOY_PATH`

## Test plan

- [ ] YAML validé (`npx js-yaml .github/workflows/deploy-staging.yml`)
- [ ] Vérifier que `deploy.yml` et `ci.yml` sont bien inchangés (`git diff origin/main -- .github/workflows/deploy.yml .github/workflows/ci.yml` doit être vide)
- [ ] Une fois la VM de recette et l'Environment `staging` provisionnés : déclencher `Deploy Staging` manuellement depuis Actions et valider le déploiement de bout en bout

🤖 Generated with [Claude Code](https://claude.com/claude-code)