### PR TITLE
feat(media): option toutes photos (même non validées) dans les collections

### DIFF
--- a/specs/001-collection-toutes-photos/plan.md
+++ b/specs/001-collection-toutes-photos/plan.md
@@ -1,0 +1,141 @@
+# Plan technique — Téléchargement de toutes les photos (même non validées) dans une collection
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Brouillon
+- **Mis à jour le** : 2026-07-03
+
+> Ce plan traduit la spec en approche technique conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : les 3 routes `src/app/api/media/collection/**` importent déjà le module via `@/modules/media` (dont le type `CollectionConfig`). Le nouveau helper sera exporté par l'index du module — aucun chemin interne.
+- [x] **Sécurité** : la création reste protégée par `requireMediaManageAccess` ; les routes publiques restent régies par la validité du token (`validateMediaShareToken`). Aucune route nouvellement exposée.
+- [x] **Permissions** : inchangées (`media:manage` pour créer) — pas de nouvelle permission.
+- [x] **Validation Zod** : le body de création (`POST /api/admin/media/collections`) sera étendu d'un champ booléen optionnel validé par Zod.
+- [x] **Migration Prisma** : **AUCUNE**. Le périmètre est porté par un champ ajouté à l'objet JSON `CollectionConfig`, stocké dans la colonne `config Json?` existante de `MediaShareToken`. Pas de changement de `schema.prisma`.
+- [x] **Enums** : aucun nouvel enum ; on réutilise `MediaPhotoStatus` déjà importé du client généré.
+- [x] **UI** : réutilisation des composants existants de `CollectionBuilder.tsx` (mêmes primitives que le reste du formulaire) — pas de nouveau composant UI.
+
+## Approche générale
+
+Le concept « tout télécharger » existe déjà pour un événement unique via le type de token
+`MEDIA_ALL` (filtre de statut conditionnel dans `src/app/api/media/download/[token]/zip/route.ts:30-34`).
+On applique le **même patron** aux collections, mais **sans nouveau type de token** : on ajoute un
+**drapeau booléen** à `CollectionConfig` (le contenu JSON d'un token `COLLECTION`), et on remplace le
+filtre `status: "APPROVED"` codé en dur par un **helper unique** partagé entre les trois points de
+lecture. Par défaut (drapeau absent/faux), le comportement est strictement identique à aujourd'hui.
+
+## Modèle de données
+
+**Aucune migration.** Extension du type applicatif `CollectionConfig` uniquement.
+
+```ts
+// src/modules/media/services/tokens.ts (interface CollectionConfig, ~L23)
+export interface CollectionConfig {
+  scope: "photos" | "files" | "both";
+  eventIds: string[];
+  projectIds: string[];
+  includeAllPhotos?: boolean; // NOUVEAU — défaut absent = faux = photos validées uniquement
+}
+```
+
+- Champ **optionnel** → les collections déjà créées (config sans le champ) sont traitées comme
+  `false` = « validées uniquement ». **Rétrocompatibilité garantie, zéro régression.**
+- Le champ est stocké tel quel dans la colonne JSON `config` existante (`MediaShareToken.config`).
+
+## Services / logique métier
+
+Ajouter dans le module média un helper **pur** qui centralise le filtre de statut photo d'une
+collection, pour éviter la triple duplication et garantir la cohérence entre listing, ZIP et
+téléchargement unitaire :
+
+```ts
+// src/modules/media/services/tokens.ts (ou un petit fichier dédié du module)
+import type { Prisma } from "@/generated/prisma/client";
+
+/** Filtre Prisma des photos d'une collection selon son périmètre. */
+export function collectionPhotoWhere(config: CollectionConfig): Prisma.MediaPhotoWhereInput {
+  return config.includeAllPhotos ? {} : { status: "APPROVED" };
+}
+```
+
+- Exporté via `src/modules/media/index.ts`.
+- **Ne concerne que les photos.** Le filtre des visuels/fichiers (`status in ["APPROVED","FINAL_APPROVED"]`)
+  reste inchangé (hors périmètre de la spec).
+
+## API
+
+| Endpoint | Méthode | Permission | Changement |
+|---|---|---|---|
+| `/api/admin/media/collections` | POST | `media:manage` | Schéma Zod + `includeAllPhotos` dans la config ; journalisation |
+| `/api/media/collection/[token]` | GET | token COLLECTION | Filtre photos via `collectionPhotoWhere(config)` |
+| `/api/media/collection/[token]/zip` | POST | token COLLECTION | idem (remplace `status: "APPROVED"` L49) |
+| `/api/media/collection/[token]/photo/[photoId]` | GET | token COLLECTION | Autorise la photo si elle satisfait `collectionPhotoWhere(config)` (remplace le rejet `status !== "APPROVED"` L27) |
+
+Détails :
+
+1. **Création** — `src/app/api/admin/media/collections/route.ts`
+   - Étendre le schéma Zod du body d'un `includeAllPhotos: z.boolean().optional()` (défaut `false`).
+   - Le passer dans `collectionConfig` transmis à `createMediaShareToken`.
+   - Inclure `includeAllPhotos` dans les métadonnées de `logAudit` (traçabilité — critère d'acceptation).
+
+2. **Listing** — `src/app/api/media/collection/[token]/route.ts:38`
+   - Remplacer `where: { status: "APPROVED" }` par `where: collectionPhotoWhere(config)` (fusionné avec un éventuel filtre d'ids déjà présent).
+
+3. **ZIP** — `src/app/api/media/collection/[token]/zip/route.ts:49`
+   - Remplacer `status: "APPROVED"` par l'étalement de `collectionPhotoWhere(config)` dans le `where` des photos (en conservant le filtre optionnel `id: { in: body.photoIds }`).
+
+4. **Téléchargement unitaire** — `src/app/api/media/collection/[token]/photo/[photoId]/route.ts:27`
+   - Remplacer le garde-fou `if (photo.status !== "APPROVED")` par une vérification équivalente au périmètre : si `!config.includeAllPhotos && photo.status !== "APPROVED"` → refus (404/403 comme aujourd'hui).
+
+## UI / composants
+
+- **`src/app/(auth)/media/collections/CollectionBuilder.tsx`**
+  - Ajouter un **interrupteur binaire** « Photos validées uniquement » / « Toutes les photos »
+    (défaut : validées uniquement), visible uniquement quand le scope inclut les photos
+    (`scope === "photos" | "both"`).
+  - Inclure `includeAllPhotos` dans le payload POST vers `/api/admin/media/collections` (L108).
+  - Libellé explicite prévenant que « toutes les photos » diffuse aussi les photos non validées.
+- **`src/app/(auth)/media/collections/page.tsx`**
+  - Le comptage affiché par événement compte aujourd'hui les photos `APPROVED` (L20). Optionnel :
+    afficher aussi le **total** (ex. « 12 validées / 30 au total ») pour informer le créateur de ce
+    qu'implique « toutes les photos ». Purement informatif — n'affecte pas le périmètre réel.
+- **Vue publique** (`src/app/media/c/[token]/CollectionView.tsx`) : **aucune modification** — les
+  photos non validées apparaissent sans distinction (décision de la spec).
+
+## Décisions & alternatives écartées
+
+- **Choix** : drapeau `includeAllPhotos` dans `CollectionConfig` (JSON).
+  *Pourquoi* : les collections sont pilotées par leur config, pas par leur type ; pas de migration ;
+  rétrocompatible.
+- **Écarté** : créer un nouveau type de token `COLLECTION_ALL` (sur le modèle `MEDIA/MEDIA_ALL`).
+  *Raison* : dupliquerait toute la logique de collection et introduirait un enum + une migration
+  pour un simple booléen de périmètre.
+- **Choix** : un helper unique `collectionPhotoWhere` partagé par les 3 routes.
+  *Raison* : garantit que listing, ZIP et téléchargement unitaire appliquent exactement le même
+  périmètre (cohérence = critère d'acceptation) ; logique dans le module (constitution).
+- **Écarté** : réutiliser le champ `onlyApproved` (déjà utilisé par les tokens `GALLERY`).
+  *Raison* : sémantique et valeur par défaut différentes selon le type → source de confusion ; un
+  nom explicite propre aux collections est plus sûr.
+
+## Risques & points d'attention
+
+- **Rétrocompatibilité** : bien traiter `includeAllPhotos` absent comme `false` (collections
+  existantes = validées uniquement). Couvert par le champ optionnel + le helper.
+- **Cohérence des 3 routes** : le téléchargement unitaire doit refuser une photo hors périmètre même
+  si son `photoId` est fourni explicitement — utiliser le même prédicat que le listing/ZIP.
+- **Photos sans fichier S3** : certaines photos non validées peuvent avoir un `originalKey` vide
+  (cf. incident SharedArrayBuffer passé). Le ZIP les ignore déjà (try/catch autour de
+  `getS3ObjectStream`) ; le téléchargement unitaire renverra une erreur S3 gérée par `errorResponse`.
+  Comportement acceptable.
+- **Exposition externe des photos rejetées** : assumé par la spec (choix explicite du créateur,
+  journalisé). Pas de garde-fou supplémentaire demandé.
+
+## Stratégie de tests
+
+- **Unitaire (Vitest)** sur `collectionPhotoWhere` : retourne `{ status: "APPROVED" }` quand
+  `includeAllPhotos` est absent/`false`, et `{}` quand `true`. C'est le cœur du comportement.
+- **Schéma de création** : vérifier que le body accepte `includeAllPhotos` optionnel et le propage
+  dans la config du token créé.
+- Vérifier la non-régression du filtre visuels/fichiers (inchangé) via une assertion sur le helper
+  photos qui ne touche pas aux fichiers.

--- a/specs/001-collection-toutes-photos/spec.md
+++ b/specs/001-collection-toutes-photos/spec.md
@@ -1,0 +1,108 @@
+# Spec — Téléchargement de toutes les photos (même non validées) dans une collection
+
+- **Numéro** : 001
+- **Statut** : Validée
+- **Créée le** : 2026-07-03
+- **Branche suggérée** : `feat/collection-toutes-photos`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+
+## Contexte & problème
+
+Une **collection** est un lien de partage public (sans authentification) qui regroupe des
+contenus média provenant de plusieurs événements et/ou projets, pour qu'un destinataire externe
+(prestataire, responsable, partenaire) puisse les consulter et les télécharger — photo par photo
+ou en une archive ZIP.
+
+Aujourd'hui, une collection n'expose **que les photos validées**. Les photos en attente de
+validation ne sont jamais accessibles via une collection. Or il existe des situations où l'on veut
+partager **l'ensemble des photos**, indépendamment de leur statut de validation :
+
+- confier le lot brut complet à un photographe ou à un prestataire pour tri/retouche externe ;
+- archiver ou transmettre l'intégralité des prises de vue d'un événement ;
+- partager rapidement quand le circuit de validation interne n'est pas nécessaire.
+
+À noter : cette capacité « tout télécharger » existe déjà pour le partage d'un **événement unique**
+(un type de lien dédié permet de télécharger toutes les photos, validées ou non). Les **collections
+multi-sources** ne l'offrent pas encore. Cette spec vise à combler cet écart.
+
+## Utilisateurs concernés
+
+- **Créateur de la collection** (rôles disposant de la gestion média : Super Admin, Admin, et
+  membres du département Production Média habilités). C'est lui qui décide, à la création, du
+  périmètre des photos incluses.
+- **Destinataire du lien** (externe, non authentifié) : consulte et télécharge ce que le créateur
+  a choisi d'inclure. Il n'a aucun contrôle sur le périmètre.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Un créateur habilité ouvre l'outil de création de collection.
+2. Il sélectionne les événements (et/ou projets) à inclure et un intitulé.
+3. Il choisit le **périmètre des photos** via une **option binaire** : *« photos validées
+   uniquement »* (comportement actuel, par défaut) **ou** *« toutes les photos »*. L'option
+   *« toutes les photos »* inclut **l'intégralité** des photos des sources, quel que soit leur
+   statut (validées, en attente, pré-validées et rejetées) — mêmes semantics que le lien
+   « toutes photos » déjà proposé pour un événement unique.
+4. Il génère le lien de collection.
+5. Le destinataire ouvre le lien : la collection affiche les photos correspondant au périmètre
+   choisi, **sans aucune mention de leur statut de validation**, et le téléchargement (individuel
+   comme ZIP) porte exactement sur ce même périmètre.
+
+### Scénarios alternatifs / cas limites
+
+- **Périmètre par défaut** : si le créateur ne change rien, la collection reste sur *« photos
+  validées uniquement »* — le comportement historique est préservé.
+- **Collection « toutes les photos » sur un lot mixte** : la collection expose l'intégralité des
+  photos (validées, en attente, pré-validées, rejetées) dans une seule vue et une seule archive,
+  sans distinction visible.
+- **Aucune photo validée mais des photos en attente** : une collection *« validées uniquement »*
+  apparaît vide côté photos ; une collection *« toutes les photos »* les expose.
+- **Chaque collection est indépendante** : le périmètre est figé à la création et propre à ce lien.
+  Créer un autre lien avec un autre périmètre reste possible.
+- **Le périmètre ne modifie jamais le statut des photos** : inclure une photo non validée dans une
+  collection ne la valide pas et ne change rien à son statut.
+
+## Critères d'acceptation
+
+- [ ] À la création d'une collection, le créateur peut choisir entre « photos validées uniquement »
+      et « toutes les photos ».
+- [ ] Par défaut (choix non modifié), une collection n'expose que les photos validées — identique à
+      aujourd'hui.
+- [ ] Une collection créée en mode « toutes les photos » affiche **l'intégralité** des photos de ses
+      sources, quel que soit leur statut (validées, en attente, pré-validées, rejetées).
+- [ ] La vue publique ne fait apparaître **aucune** mention du statut de validation des photos.
+- [ ] Le téléchargement ZIP d'une telle collection contient exactement les photos affichées (même
+      périmètre).
+- [ ] Le téléchargement individuel d'une photo non validée est autorisé si — et seulement si — la
+      collection est en mode « toutes les photos ».
+- [ ] Une collection en mode « validées uniquement » refuse toujours l'accès aux photos non validées
+      (aucune régression).
+- [ ] Le périmètre ne s'applique **qu'aux photos** : les visuels/fichiers d'une collection conservent
+      leur comportement actuel (approuvés uniquement), quel que soit le choix.
+- [ ] Le choix du périmètre est journalisé à la création de la collection (traçabilité de qui a
+      partagé quoi).
+
+## Hors périmètre
+
+- Le comportement du partage d'un **événement unique** (lien « toutes photos » existant) n'est pas
+  modifié.
+- Le **workflow de validation** des photos (validation, rejet, pré-validation) n'est pas modifié.
+- Aucune modification du contrôle d'accès à la **création** de collections (mêmes rôles habilités
+  qu'aujourd'hui).
+- La modification du périmètre d'une collection **après** sa création n'est pas prévue (une
+  collection existante garde son périmètre ; on en recrée une au besoin).
+- Les **visuels/fichiers** d'une collection ne sont pas concernés : ils restent limités aux éléments
+  approuvés, quel que soit le périmètre choisi pour les photos.
+- Aucune **mention de statut** (badge « non validée », etc.) n'est affichée au destinataire.
+
+## Décisions arrêtées
+
+- **Option binaire** : « photos validées uniquement » (défaut, comportement actuel) **ou** « toutes
+  les photos ». On ne change jamais le périmètre d'une photo ; on choisit seulement l'un des deux
+  ensembles à partager.
+- **« Toutes les photos » = intégralité**, y compris les photos rejetées — mêmes semantics que le
+  lien « toutes photos » existant pour un événement unique.
+- **Photos uniquement** : le choix n'affecte pas les visuels/fichiers.
+- **Aucune distinction de statut** dans la vue publique du destinataire.

--- a/specs/001-collection-toutes-photos/spec.md
+++ b/specs/001-collection-toutes-photos/spec.md
@@ -1,7 +1,7 @@
 # Spec — Téléchargement de toutes les photos (même non validées) dans une collection
 
 - **Numéro** : 001
-- **Statut** : Validée
+- **Statut** : Implémentée
 - **Créée le** : 2026-07-03
 - **Branche suggérée** : `feat/collection-toutes-photos`
 

--- a/specs/001-collection-toutes-photos/tasks.md
+++ b/specs/001-collection-toutes-photos/tasks.md
@@ -1,7 +1,7 @@
 # Tâches — Téléchargement de toutes les photos (même non validées) dans une collection
 
 - **Spec** : `./spec.md` · **Plan** : `./plan.md`
-- **Statut** : À faire
+- **Statut** : Terminé
 
 > Tâches ordonnées et vérifiables. Dépendances : type/helper (module) → API création → API lecture
 > → UI → tests. Les tâches `[P]` sont parallélisables (fichiers indépendants).
@@ -9,53 +9,58 @@
 
 ## Prérequis
 
-- [ ] Branche créée : `feat/collection-toutes-photos`
-- [ ] ~~Migration Prisma~~ — **sans objet** (pas de changement de `schema.prisma`)
+- [x] Branche créée : `feat/collection-toutes-photos`
+- [x] ~~Migration Prisma~~ — **sans objet** (pas de changement de `schema.prisma`)
 
 ## Tâches
 
 ### 1. Type & logique métier (module média)
 
-- [ ] **T1** — Ajouter le champ optionnel `includeAllPhotos?: boolean` à l'interface
+- [x] **T1** — Ajouter le champ optionnel `includeAllPhotos?: boolean` à l'interface
       `CollectionConfig` *(fichier : `src/modules/media/services/tokens.ts`, ~L23)*
-- [ ] **T2** — Ajouter le helper pur `collectionPhotoWhere(config): Prisma.MediaPhotoWhereInput`
+- [x] **T2** — Ajouter le helper pur `collectionPhotoWhere(config): Prisma.MediaPhotoWhereInput`
       retournant `{}` si `includeAllPhotos`, sinon `{ status: "APPROVED" }`
       *(fichier : `src/modules/media/services/tokens.ts`)*
-- [ ] **T3** — Exporter `collectionPhotoWhere` depuis l'index du module
+- [x] **T3** — Exporter `collectionPhotoWhere` depuis l'index du module
       *(fichier : `src/modules/media/index.ts`)*
 
 ### 2. API — création de collection
 
-- [ ] **T4** — Étendre le schéma Zod du body avec `includeAllPhotos: z.boolean().optional()`,
+- [x] **T4** — Étendre le schéma Zod du body avec `includeAllPhotos: z.boolean().optional()`,
       le propager dans `collectionConfig` transmis à `createMediaShareToken`, et l'inclure dans les
       métadonnées `logAudit` *(fichier : `src/app/api/admin/media/collections/route.ts`)*
 
 ### 3. API — lecture / téléchargement (périmètre appliqué)
 
-- [ ] **T5** [P] — Listing : remplacer `where: { status: "APPROVED" }` par
+- [x] **T5** [P] — Listing : remplacer `where: { status: "APPROVED" }` par
       `collectionPhotoWhere(config)` *(fichier : `src/app/api/media/collection/[token]/route.ts`, ~L38)*
-- [ ] **T6** [P] — ZIP : remplacer `status: "APPROVED"` par l'étalement de
+- [x] **T6** [P] — ZIP : remplacer `status: "APPROVED"` par l'étalement de
       `collectionPhotoWhere(config)` (en conservant le filtre optionnel `id: { in: body.photoIds }`)
       *(fichier : `src/app/api/media/collection/[token]/zip/route.ts`, ~L49)*
-- [ ] **T7** [P] — Téléchargement unitaire : remplacer le garde-fou `photo.status !== "APPROVED"`
+- [x] **T7** [P] — Téléchargement unitaire : remplacer le garde-fou `photo.status !== "APPROVED"`
       par `!config.includeAllPhotos && photo.status !== "APPROVED"` → refus (même code d'erreur
       qu'aujourd'hui) *(fichier : `src/app/api/media/collection/[token]/photo/[photoId]/route.ts`, ~L27)*
 
 ### 4. UI
 
-- [ ] **T8** [P] — Ajouter l'interrupteur binaire « Photos validées uniquement / Toutes les photos »
+- [x] **T8** [P] — Ajouter l'interrupteur binaire « Photos validées uniquement / Toutes les photos »
       (défaut : validées ; visible si `scope` inclut les photos), inclure `includeAllPhotos` dans le
       payload POST, libellé prévenant que « toutes » diffuse aussi les photos non validées
       *(fichier : `src/app/(auth)/media/collections/CollectionBuilder.tsx`)*
-- [ ] **T9** [P] — (Optionnel) Afficher le total de photos à côté du nombre de validées par événement
+- [x] **T9** [P] — (Optionnel) Afficher le total de photos à côté du nombre de validées par événement
       (ex. « 12 validées / 30 au total ») *(fichier : `src/app/(auth)/media/collections/page.tsx`, ~L20)*
+      — Implémentée via `prisma.mediaPhoto.groupBy` (un `_count` Prisma ne peut pas porter deux
+      filtres différents sur la même relation).
 
 ### 5. Tests
 
-- [ ] **T10** — Test unitaire de `collectionPhotoWhere` : `{ status: "APPROVED" }` quand
-      `includeAllPhotos` absent/`false` ; `{}` quand `true` *(fichier : `src/modules/media/services/tokens.test.ts` ou colocalisé)*
-- [ ] **T11** — Test : le schéma/route de création accepte `includeAllPhotos` optionnel et le propage
-      dans la config du token *(fichier de test correspondant)*
+- [x] **T10** — Test unitaire de `collectionPhotoWhere` : `{ status: "APPROVED" }` quand
+      `includeAllPhotos` absent/`false` ; `{}` quand `true`
+      *(fichier : `src/modules/media/services/__tests__/tokens.test.ts`, alignée sur la convention
+      `__tests__/` du dépôt — aucun `*.test.ts` colocalisé n'existe ailleurs dans le repo)*
+- [x] **T11** — Test : le schéma/route de création accepte `includeAllPhotos` optionnel et le propage
+      dans la config du token, et journalise la valeur (`false` par défaut)
+      *(fichier : `src/app/api/admin/media/collections/__tests__/route.test.ts`)*
 
 ## Couverture des critères d'acceptation
 
@@ -73,11 +78,13 @@
 
 ## Vérification finale
 
-- [ ] `npm run typecheck`
-- [ ] `npm run lint`
-- [ ] `npm run lint:boundaries`
-- [ ] `npm run test`
-- [ ] Tous les critères d'acceptation de `spec.md` satisfaits (voir table ci-dessus)
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits (voir table ci-dessus)
 - [ ] Test manuel : créer une collection « toutes les photos », vérifier vue publique + ZIP +
       téléchargement unitaire d'une photo non validée ; puis une collection « validées » (refus)
-- [ ] PR ouverte vers la branche cible
+      *(non exécuté — pas d'environnement de recette à disposition dans cette session ; couvert par
+      les tests unitaires/route)*
+- [ ] PR ouverte vers la branche cible *(volontairement pas ouverte — revue demandée avant PR)*

--- a/specs/001-collection-toutes-photos/tasks.md
+++ b/specs/001-collection-toutes-photos/tasks.md
@@ -1,0 +1,83 @@
+# Tâches — Téléchargement de toutes les photos (même non validées) dans une collection
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : À faire
+
+> Tâches ordonnées et vérifiables. Dépendances : type/helper (module) → API création → API lecture
+> → UI → tests. Les tâches `[P]` sont parallélisables (fichiers indépendants).
+> **Aucune tâche de migration** : le périmètre est porté par le JSON `CollectionConfig` existant.
+
+## Prérequis
+
+- [ ] Branche créée : `feat/collection-toutes-photos`
+- [ ] ~~Migration Prisma~~ — **sans objet** (pas de changement de `schema.prisma`)
+
+## Tâches
+
+### 1. Type & logique métier (module média)
+
+- [ ] **T1** — Ajouter le champ optionnel `includeAllPhotos?: boolean` à l'interface
+      `CollectionConfig` *(fichier : `src/modules/media/services/tokens.ts`, ~L23)*
+- [ ] **T2** — Ajouter le helper pur `collectionPhotoWhere(config): Prisma.MediaPhotoWhereInput`
+      retournant `{}` si `includeAllPhotos`, sinon `{ status: "APPROVED" }`
+      *(fichier : `src/modules/media/services/tokens.ts`)*
+- [ ] **T3** — Exporter `collectionPhotoWhere` depuis l'index du module
+      *(fichier : `src/modules/media/index.ts`)*
+
+### 2. API — création de collection
+
+- [ ] **T4** — Étendre le schéma Zod du body avec `includeAllPhotos: z.boolean().optional()`,
+      le propager dans `collectionConfig` transmis à `createMediaShareToken`, et l'inclure dans les
+      métadonnées `logAudit` *(fichier : `src/app/api/admin/media/collections/route.ts`)*
+
+### 3. API — lecture / téléchargement (périmètre appliqué)
+
+- [ ] **T5** [P] — Listing : remplacer `where: { status: "APPROVED" }` par
+      `collectionPhotoWhere(config)` *(fichier : `src/app/api/media/collection/[token]/route.ts`, ~L38)*
+- [ ] **T6** [P] — ZIP : remplacer `status: "APPROVED"` par l'étalement de
+      `collectionPhotoWhere(config)` (en conservant le filtre optionnel `id: { in: body.photoIds }`)
+      *(fichier : `src/app/api/media/collection/[token]/zip/route.ts`, ~L49)*
+- [ ] **T7** [P] — Téléchargement unitaire : remplacer le garde-fou `photo.status !== "APPROVED"`
+      par `!config.includeAllPhotos && photo.status !== "APPROVED"` → refus (même code d'erreur
+      qu'aujourd'hui) *(fichier : `src/app/api/media/collection/[token]/photo/[photoId]/route.ts`, ~L27)*
+
+### 4. UI
+
+- [ ] **T8** [P] — Ajouter l'interrupteur binaire « Photos validées uniquement / Toutes les photos »
+      (défaut : validées ; visible si `scope` inclut les photos), inclure `includeAllPhotos` dans le
+      payload POST, libellé prévenant que « toutes » diffuse aussi les photos non validées
+      *(fichier : `src/app/(auth)/media/collections/CollectionBuilder.tsx`)*
+- [ ] **T9** [P] — (Optionnel) Afficher le total de photos à côté du nombre de validées par événement
+      (ex. « 12 validées / 30 au total ») *(fichier : `src/app/(auth)/media/collections/page.tsx`, ~L20)*
+
+### 5. Tests
+
+- [ ] **T10** — Test unitaire de `collectionPhotoWhere` : `{ status: "APPROVED" }` quand
+      `includeAllPhotos` absent/`false` ; `{}` quand `true` *(fichier : `src/modules/media/services/tokens.test.ts` ou colocalisé)*
+- [ ] **T11** — Test : le schéma/route de création accepte `includeAllPhotos` optionnel et le propage
+      dans la config du token *(fichier de test correspondant)*
+
+## Couverture des critères d'acceptation
+
+| Critère (spec) | Tâche(s) |
+|---|---|
+| Choix « validées / toutes » à la création | T1, T4, T8 |
+| Défaut = validées uniquement (pas de régression) | T2, T7, T10 |
+| Mode « toutes » = intégralité des statuts | T2, T5, T6 |
+| Aucune mention de statut côté destinataire | (aucune modif — vérif visuelle) |
+| ZIP = exactement les photos affichées | T5 + T6 (même helper) |
+| Téléchargement unitaire d'une non-validée ssi mode « toutes » | T7 |
+| Mode « validées » refuse toujours les non-validées | T2, T5, T6, T7 |
+| Photos uniquement — visuels/fichiers inchangés | T2 (helper photos seul), vérif T6 |
+| Choix journalisé à la création | T4 |
+
+## Vérification finale
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run lint:boundaries`
+- [ ] `npm run test`
+- [ ] Tous les critères d'acceptation de `spec.md` satisfaits (voir table ci-dessus)
+- [ ] Test manuel : créer une collection « toutes les photos », vérifier vue publique + ZIP +
+      téléchargement unitaire d'une photo non validée ; puis une collection « validées » (refus)
+- [ ] PR ouverte vers la branche cible

--- a/src/app/(auth)/media/collections/CollectionBuilder.tsx
+++ b/src/app/(auth)/media/collections/CollectionBuilder.tsx
@@ -7,6 +7,7 @@ type EventItem = {
   name: string;
   date: string;
   approvedPhotoCount: number;
+  totalPhotoCount: number;
 };
 
 type ProjectItem = {
@@ -32,6 +33,7 @@ export default function CollectionBuilder({
   projects: ProjectItem[];
 }) {
   const [scope, setScope]           = useState<Scope>("both");
+  const [includeAllPhotos, setIncludeAllPhotos] = useState(false);
   const [selectedEvents, setSelectedEvents] = useState<Set<string>>(new Set());
   const [selectedProjects, setSelectedProjects] = useState<Set<string>>(new Set());
   const [label, setLabel]           = useState("");
@@ -89,7 +91,7 @@ export default function CollectionBuilder({
 
   const totalPhotos = filteredEvents
     .filter((e) => selectedEvents.has(e.id))
-    .reduce((n, e) => n + e.approvedPhotoCount, 0);
+    .reduce((n, e) => n + (includeAllPhotos ? e.totalPhotoCount : e.approvedPhotoCount), 0);
   const totalFiles = projects
     .filter((p) => selectedProjects.has(p.id))
     .reduce((n, p) => n + p.approvedFileCount, 0);
@@ -115,6 +117,7 @@ export default function CollectionBuilder({
           eventIds:   showEvents   ? Array.from(selectedEvents)   : [],
           projectIds: showProjects ? Array.from(selectedProjects) : [],
           expiresInDays: expiresInDays !== "" ? expiresInDays : undefined,
+          includeAllPhotos: showEvents ? includeAllPhotos : undefined,
         }),
       });
 
@@ -156,6 +159,32 @@ export default function CollectionBuilder({
             </button>
           ))}
         </div>
+
+        {showEvents && (
+          <div className="pt-2 border-t border-gray-100 space-y-2">
+            <p className="text-xs font-medium text-gray-600">Périmètre des photos</p>
+            <div className="flex gap-2 flex-wrap">
+              {([false, true] as const).map((allPhotos) => (
+                <button
+                  key={String(allPhotos)}
+                  onClick={() => setIncludeAllPhotos(allPhotos)}
+                  className={`px-4 py-2 rounded-xl text-sm font-medium border transition-colors ${
+                    includeAllPhotos === allPhotos
+                      ? "bg-icc-violet text-white border-icc-violet"
+                      : "bg-white text-gray-600 border-gray-200 hover:border-icc-violet/40 hover:bg-icc-violet/5"
+                  }`}
+                >
+                  {allPhotos ? "Toutes les photos" : "Photos validées uniquement"}
+                </button>
+              ))}
+            </div>
+            {includeAllPhotos && (
+              <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
+                Attention : ce lien diffusera aussi les photos en attente ou non validées, sans distinction de statut.
+              </p>
+            )}
+          </div>
+        )}
       </div>
 
       {/* ── Events filter + selection ──────────────────────────────────────── */}
@@ -225,7 +254,7 @@ export default function CollectionBuilder({
                       <p className="text-xs text-gray-400">{formatDate(e.date)}</p>
                     </div>
                     <span className={`text-xs rounded-full px-2 py-0.5 shrink-0 ${e.approvedPhotoCount > 0 ? "bg-green-50 text-green-700" : "bg-gray-100 text-gray-400"}`}>
-                      {e.approvedPhotoCount} validée{e.approvedPhotoCount !== 1 ? "s" : ""}
+                      {e.approvedPhotoCount} validée{e.approvedPhotoCount !== 1 ? "s" : ""} / {e.totalPhotoCount} au total
                     </span>
                   </li>
                 ))}

--- a/src/app/(auth)/media/collections/page.tsx
+++ b/src/app/(auth)/media/collections/page.tsx
@@ -9,7 +9,7 @@ export default async function CollectionsPage() {
 
   await requireMediaManageAccess(churchId);
 
-  const [events, projects] = await Promise.all([
+  const [events, projects, totalPhotoCounts] = await Promise.all([
     prisma.mediaEvent.findMany({
       where: { churchId },
       orderBy: { date: "desc" },
@@ -30,13 +30,24 @@ export default async function CollectionsPage() {
         _count: { select: { files: { where: { status: { in: ["APPROVED", "FINAL_APPROVED"] } } } } },
       },
     }),
+    // Total toutes photos (tous statuts) par événement — pour informer le créateur du périmètre
+    // possible avec "toutes les photos" (Prisma ne permet pas deux compteurs filtrés différents
+    // sur la même relation dans un seul `_count`).
+    prisma.mediaPhoto.groupBy({
+      by: ["mediaEventId"],
+      where: { mediaEvent: { churchId } },
+      _count: { _all: true },
+    }),
   ]);
+
+  const totalPhotoByEventId = new Map(totalPhotoCounts.map((c) => [c.mediaEventId, c._count._all]));
 
   const serializedEvents = events.map((e) => ({
     id: e.id,
     name: e.name,
     date: e.date.toISOString(),
     approvedPhotoCount: e._count.photos,
+    totalPhotoCount: totalPhotoByEventId.get(e.id) ?? 0,
   }));
 
   const serializedProjects = projects.map((p) => ({

--- a/src/app/api/admin/media/collections/__tests__/route.test.ts
+++ b/src/app/api/admin/media/collections/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests — POST /api/admin/media/collections
+ *
+ * Le champ `includeAllPhotos` (option « toutes les photos ») doit être accepté par le
+ * schéma Zod, propagé tel quel dans la `collectionConfig` transmise à `createMediaShareToken`,
+ * et journalisé via `logAudit`. Par défaut (absent), le comportement reste inchangé.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createAdminSession } from "@/__mocks__/auth";
+
+const mockRequireMediaManageAccess = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireMediaManageAccess: (...args: unknown[]) => mockRequireMediaManageAccess(...args),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+const mockCreateMediaShareToken = vi.fn();
+vi.mock("@/modules/media", () => ({
+  createMediaShareToken: (...args: unknown[]) => mockCreateMediaShareToken(...args),
+}));
+
+const mockLogAudit = vi.fn();
+vi.mock("@/lib/audit", () => ({
+  logAudit: (...args: unknown[]) => mockLogAudit(...args),
+}));
+
+const { POST } = await import("../route");
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/admin/media/collections", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/admin/media/collections — includeAllPhotos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireMediaManageAccess.mockResolvedValue(createAdminSession());
+    prismaMock.mediaEvent.findMany.mockResolvedValue([{ id: "evt-1" }] as never);
+    mockCreateMediaShareToken.mockResolvedValue({
+      id: "token-1",
+      url: "http://localhost/media/c/abc",
+      label: null,
+    });
+  });
+
+  it("propage includeAllPhotos: true dans la collectionConfig du token créé", async () => {
+    const res = await POST(
+      makeRequest({
+        churchId: "church-1",
+        scope: "photos",
+        eventIds: ["evt-1"],
+        projectIds: [],
+        includeAllPhotos: true,
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockCreateMediaShareToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionConfig: expect.objectContaining({ includeAllPhotos: true }),
+      })
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ details: expect.objectContaining({ includeAllPhotos: true }) })
+    );
+  });
+
+  it("par défaut (champ absent), includeAllPhotos n'est pas forcé à true et l'audit journalise false", async () => {
+    const res = await POST(
+      makeRequest({
+        churchId: "church-1",
+        scope: "photos",
+        eventIds: ["evt-1"],
+        projectIds: [],
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockCreateMediaShareToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionConfig: expect.objectContaining({ includeAllPhotos: undefined }),
+      })
+    );
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ details: expect.objectContaining({ includeAllPhotos: false }) })
+    );
+  });
+});

--- a/src/app/api/admin/media/collections/route.ts
+++ b/src/app/api/admin/media/collections/route.ts
@@ -12,6 +12,7 @@ const createSchema = z.object({
   eventIds: z.array(z.string()).default([]),
   projectIds: z.array(z.string()).default([]),
   expiresInDays: z.number().int().positive().optional(),
+  includeAllPhotos: z.boolean().optional(),
 });
 
 export async function POST(request: Request) {
@@ -55,6 +56,7 @@ export async function POST(request: Request) {
         scope: data.scope,
         eventIds: data.eventIds,
         projectIds: data.projectIds,
+        includeAllPhotos: data.includeAllPhotos,
       },
     });
 
@@ -64,7 +66,13 @@ export async function POST(request: Request) {
       action: "CREATE",
       entityType: "MediaShareToken",
       entityId: token.id,
-      details: { type: "COLLECTION", scope: data.scope, eventIds: data.eventIds, projectIds: data.projectIds },
+      details: {
+        type: "COLLECTION",
+        scope: data.scope,
+        eventIds: data.eventIds,
+        projectIds: data.projectIds,
+        includeAllPhotos: data.includeAllPhotos ?? false,
+      },
     });
 
     return successResponse(token, 201);

--- a/src/app/api/media/collection/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/collection/[token]/photo/[photoId]/route.ts
@@ -24,7 +24,7 @@ export async function GET(
 
     if (!photo) throw new ApiError(404, "Photo introuvable");
     if (!config.eventIds.includes(photo.mediaEventId)) throw new ApiError(403, "Photo hors périmètre");
-    if (photo.status !== "APPROVED") throw new ApiError(403, "Photo non approuvée");
+    if (!config.includeAllPhotos && photo.status !== "APPROVED") throw new ApiError(403, "Photo non approuvée");
 
     const downloadUrl = await getSignedDownloadUrl(photo.originalKey, photo.filename);
     return successResponse({ id: photo.id, filename: photo.filename, downloadUrl });

--- a/src/app/api/media/collection/[token]/route.ts
+++ b/src/app/api/media/collection/[token]/route.ts
@@ -4,7 +4,7 @@
  */
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
-import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
+import { validateMediaShareToken, getSignedThumbnailUrl, collectionPhotoWhere } from "@/modules/media";
 import type { CollectionConfig } from "@/modules/media";
 
 export async function GET(
@@ -35,7 +35,7 @@ export async function GET(
         orderBy: { date: "desc" },
         include: {
           photos: {
-            where: { status: "APPROVED" },
+            where: collectionPhotoWhere(config),
             orderBy: { uploadedAt: "asc" },
             select: { id: true, filename: true, size: true, width: true, height: true, thumbnailKey: true },
           },

--- a/src/app/api/media/collection/[token]/zip/route.ts
+++ b/src/app/api/media/collection/[token]/zip/route.ts
@@ -5,7 +5,7 @@
  */
 import { prisma } from "@/lib/prisma";
 import { errorResponse, ApiError } from "@/lib/api-utils";
-import { validateMediaShareToken, getS3ObjectStream } from "@/modules/media";
+import { validateMediaShareToken, getS3ObjectStream, collectionPhotoWhere } from "@/modules/media";
 import type { CollectionConfig } from "@/modules/media";
 import archiver from "archiver";
 import { PassThrough } from "node:stream";
@@ -46,7 +46,7 @@ export async function POST(
           name: true,
           photos: {
             where: {
-              status: "APPROVED",
+              ...collectionPhotoWhere(config),
               ...(body.photoIds?.length ? { id: { in: body.photoIds } } : {}),
             },
             select: { filename: true, originalKey: true },

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -1,6 +1,6 @@
 import { defineModule } from "@/core/module-registry";
 
-export { createMediaShareToken, validateMediaShareToken, getTokenUrlPath, isTokenExpired, generateToken } from "./services/tokens";
+export { createMediaShareToken, validateMediaShareToken, getTokenUrlPath, isTokenExpired, generateToken, collectionPhotoWhere } from "./services/tokens";
 export type { CollectionConfig } from "./services/tokens";
 export { processImage, validatePhotoFile, getExtensionFromMimeType, ALLOWED_PHOTO_MIME_TYPES, MAX_PHOTO_SIZE } from "./services/image";
 export {

--- a/src/modules/media/services/__tests__/tokens.test.ts
+++ b/src/modules/media/services/__tests__/tokens.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests — collectionPhotoWhere
+ *
+ * Périmètre des photos d'une collection : « validées uniquement » (défaut) ou
+ * « toutes les photos » (tous statuts), piloté par `CollectionConfig.includeAllPhotos`.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+// `tokens.ts` importe `@/lib/prisma` au niveau module (instancie un vrai client sinon).
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+const { collectionPhotoWhere } = await import("../tokens");
+type CollectionConfig = Parameters<typeof collectionPhotoWhere>[0];
+
+const baseConfig: CollectionConfig = {
+  scope: "photos",
+  eventIds: ["evt-1"],
+  projectIds: [],
+};
+
+describe("collectionPhotoWhere", () => {
+  it("retourne { status: APPROVED } quand includeAllPhotos est absent", () => {
+    expect(collectionPhotoWhere(baseConfig)).toEqual({ status: "APPROVED" });
+  });
+
+  it("retourne { status: APPROVED } quand includeAllPhotos vaut false", () => {
+    expect(collectionPhotoWhere({ ...baseConfig, includeAllPhotos: false })).toEqual({ status: "APPROVED" });
+  });
+
+  it("retourne {} (aucun filtre) quand includeAllPhotos vaut true", () => {
+    expect(collectionPhotoWhere({ ...baseConfig, includeAllPhotos: true })).toEqual({});
+  });
+});

--- a/src/modules/media/services/tokens.ts
+++ b/src/modules/media/services/tokens.ts
@@ -24,6 +24,13 @@ export interface CollectionConfig {
   scope: "photos" | "files" | "both";
   eventIds: string[];
   projectIds: string[];
+  /** Défaut absent = faux = photos validées uniquement. */
+  includeAllPhotos?: boolean;
+}
+
+/** Filtre Prisma des photos d'une collection selon son périmètre. */
+export function collectionPhotoWhere(config: CollectionConfig): Prisma.MediaPhotoWhereInput {
+  return config.includeAllPhotos ? {} : { status: "APPROVED" };
 }
 
 interface CreateTokenOptions {


### PR DESCRIPTION
## Contexte

Une collection média (lien de partage public multi-sources) n'exposait jusqu'ici que les photos **validées**. Cette PR ajoute, à la création d'une collection, une **option binaire** : « photos validées uniquement » (défaut, comportement inchangé) ou « toutes les photos » (intégralité, tous statuts).

Conçue via le workflow spec-driven — voir `specs/001-collection-toutes-photos/` (spec, plan, tasks).

## Changements

- `CollectionConfig` : nouveau champ optionnel `includeAllPhotos` (porté par le JSON existant → **aucune migration Prisma**)
- Helper unique `collectionPhotoWhere(config)` exporté par `@/modules/media`, appliqué aux 3 points de lecture (listing, ZIP, téléchargement unitaire) pour garantir un périmètre cohérent
- Création (`POST /api/admin/media/collections`) : schéma Zod étendu + choix journalisé (`logAudit`)
- UI `CollectionBuilder` : interrupteur binaire (visible si le scope inclut les photos) + avertissement quand « toutes »
- Page collections : affichage « X validées / Y au total » par événement

## Périmètre

- Photos uniquement — les visuels/fichiers restent limités aux éléments approuvés
- Aucune mention de statut côté destinataire
- Rétrocompatible : collections existantes = « validées uniquement » par défaut

## Vérifications

- typecheck + lint + lint:boundaries : OK
- 356 tests passent (+5 : helper `collectionPhotoWhere` + propagation création)
- Reste à faire : test manuel du parcours complet sur l'environnement de recette

🤖 Generated with [Claude Code](https://claude.com/claude-code)