### PR TITLE
chore: release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.10.0] - 2026-07-03
+
+### Ajouté
+
+- **Collections média — option « toutes les photos »** (#398)
+  - À la création d'une collection, choix binaire : « photos validées uniquement » (défaut, comportement inchangé) ou « toutes les photos » (intégralité, tous statuts)
+  - Photos uniquement (les visuels/fichiers restent limités aux éléments approuvés) ; aucune mention de statut côté destinataire ; choix journalisé
+  - Rétrocompatible : les collections existantes restent en « validées uniquement »
+- **Environnement de recette (staging)** (#397)
+  - Workflow GitHub Actions `Deploy Staging` à déclenchement manuel (`workflow_dispatch`) vers une VM dédiée
+  - Guide `docs/staging.md` (provisionnement, Environment GitHub `staging`, garde-fous)
+- **Workflow spec-driven development** (#396)
+  - Slash commands `/specify`, `/plan`, `/tasks`, `/implement` + `specs/constitution.md` et templates
+
 ## [v1.9.2] - 2026-07-01
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Résumé

- **Collections média — option « toutes les photos »** (#398) : choix binaire à la création d'une collection entre « photos validées uniquement » (défaut) et « toutes les photos » (tous statuts), rétrocompatible.
- **Environnement de recette (staging)** (#397) : workflow GitHub Actions `Deploy Staging` à déclenchement manuel vers une VM dédiée + guide `docs/staging.md`.
- **Workflow spec-driven development** (#396) : slash commands `/specify`, `/plan`, `/tasks`, `/implement` + `specs/constitution.md` et templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)