### PR TITLE
feat(members): capture email + garde-fou anti-doublon à la création (onboarding P1)

### DIFF
--- a/specs/002-onboarding-liaison-email/tasks.md
+++ b/specs/002-onboarding-liaison-email/tasks.md
@@ -1,7 +1,7 @@
 # Tâches — Refonte onboarding (liaison par email)
 
 - **Spec** : `./spec.md` · **Plan** : `./plan.md`
-- **Statut** : P1 à faire
+- **Statut** : P1 terminée
 
 > Feature livrée en plusieurs phases (voir `plan.md`). Ce fichier décrit **la Phase 1 uniquement** ;
 > les tâches P2 (réconciliation + auto-liaison) et P3 (parcours self-service) seront ajoutées quand
@@ -21,14 +21,14 @@ doublon (même email ou même nom dans l'église) en proposant de rattacher à l
 
 ### Prérequis
 
-- [ ] Sous-branche créée : `feat/onboarding-p1-email-dedup` (depuis `feat/onboarding-liaison-email`)
+- [x] Sous-branche créée : `feat/onboarding-p1-email-dedup` (depuis `feat/onboarding-liaison-email`)
 - [ ] ~~Migration Prisma~~ — **sans objet** en P1
 
 ### Tâches
 
 #### 1. Logique métier (helper)
 
-- [ ] **T1** — Créer `src/lib/onboarding.ts` avec :
+- [x] **T1** — Créer `src/lib/onboarding.ts` avec :
   - `normalizeName(s: string): string` (minuscules, accents retirés — aligné sur la normalisation de
     `src/app/api/members/search/route.ts`)
   - `normalizeEmail(email: string): string`
@@ -39,30 +39,30 @@ doublon (même email ou même nom dans l'église) en proposant de rattacher à l
 
 #### 2. API — création membre
 
-- [ ] **T2** — `src/app/api/members/route.ts` (POST) :
+- [x] **T2** — `src/app/api/members/route.ts` (POST) :
   - Étendre `createSchema` avec `email: z.string().email().optional()` (et `phone` si pertinent).
   - Ajouter un flag `confirmDuplicate: z.boolean().optional()` au body.
   - Avant création : appeler `findDuplicateCandidates`. Si des candidats existent **et** que
     `confirmDuplicate !== true` → renvoyer **409** avec `{ duplicates: [...] }` (ne pas créer).
   - Sinon créer la fiche (email persisté).
-- [ ] **T3** — `src/app/api/member-link-requests/[id]/route.ts` (PATCH, approbation « nouveau STAR »)
+- [x] **T3** — `src/app/api/member-link-requests/[id]/route.ts` (PATCH, approbation « nouveau STAR »)
   : avant la création d'une fiche à l'approbation, appliquer le même garde-fou
   `findDuplicateCandidates` → si doublon, signaler à l'admin les candidats (permettre le
   rattachement à l'existante plutôt que la création). Comportement `displayName` **inchangé**.
 
 #### 3. UI
 
-- [ ] **T4** — Formulaire de création de membre (`src/app/(auth)/admin/members/…`) : ajouter le champ
+- [x] **T4** — Formulaire de création de membre (`src/app/(auth)/admin/members/…`) : ajouter le champ
   **email** (fortement incité, non bloquant). Gérer la réponse **409** : afficher les fiches
   candidates (« Ces fiches existent déjà — rattacher ou créer quand même ? ») ; bouton « créer quand
   même » renvoie la requête avec `confirmDuplicate: true`.
 
 #### 4. Tests
 
-- [ ] **T5** — Unitaire `src/lib/__tests__/onboarding.test.ts` : `normalizeName`/`normalizeEmail` ;
+- [x] **T5** — Unitaire `src/lib/__tests__/onboarding.test.ts` : `normalizeName`/`normalizeEmail` ;
   `findDuplicateCandidates` (match email exact, match nom normalisé accent-insensible, scoping
   église correct, aucun faux positif hors église).
-- [ ] **T6** — Route `POST /api/members` : création avec email OK ; garde-fou → **409 + duplicates**
+- [x] **T6** — Route `POST /api/members` : création avec email OK ; garde-fou → **409 + duplicates**
   quand doublon et pas de confirmation ; création forcée avec `confirmDuplicate: true`.
 
 ### Couverture des critères d'acceptation (P1)
@@ -77,10 +77,10 @@ doublon (même email ou même nom dans l'église) en proposant de rattacher à l
 
 ### Vérification finale (P1)
 
-- [ ] `npm run typecheck`
-- [ ] `npm run lint`
-- [ ] `npm run lint:boundaries`
-- [ ] `npm run test`
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
 - [ ] Test manuel : créer une fiche avec un email/nom déjà présent → alerte + candidats ; forcer →
       création ; créer une fiche distincte → OK
 - [ ] PR ouverte vers `feat/onboarding-liaison-email` (pas vers `main`)

--- a/src/app/(auth)/admin/members/MembersClient.tsx
+++ b/src/app/(auth)/admin/members/MembersClient.tsx
@@ -20,11 +20,14 @@ interface Member {
   id: string;
   firstName: string;
   lastName: string;
+  email?: string | null;
   churchId: string;
   primaryDepartment: { id: string; name: string; ministry: { id: string; name: string } } | null;
   allDepartments: DeptRef[];
   userLink: { userId: string; userName: string | null; userEmail: string } | null;
 }
+
+type DuplicateCandidate = { id: string; firstName: string; lastName: string; email: string | null };
 
 interface Props {
   initialMembers: Member[];
@@ -41,10 +44,12 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
   const [editing, setEditing] = useState<Member | null>(null);
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
   const [departmentId, setDepartmentId] = useState(departments[0]?.id || "");
   const [additionalDeptIds, setAdditionalDeptIds] = useState<string[]>([]);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [duplicateCandidates, setDuplicateCandidates] = useState<DuplicateCandidate[] | null>(null);
   const [filterDept, setFilterDept] = useState(() => {
     if (typeof window !== "undefined") return localStorage.getItem(LS_FILTER_DEPT) ?? "";
     return "";
@@ -125,9 +130,11 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
     setEditing(null);
     setFirstName("");
     setLastName("");
+    setEmail("");
     setDepartmentId(departments[0]?.id || "");
     setAdditionalDeptIds([]);
     setError("");
+    setDuplicateCandidates(null);
     setModalOpen(true);
   }
 
@@ -135,15 +142,21 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
     setEditing(m);
     setFirstName(m.firstName);
     setLastName(m.lastName);
+    setEmail(m.email ?? "");
     const primaryId = m.primaryDepartment?.id ?? m.allDepartments[0]?.id ?? departments[0]?.id ?? "";
     setDepartmentId(primaryId);
     setAdditionalDeptIds(m.allDepartments.filter((d) => !d.isPrimary).map((d) => d.id));
     setError("");
+    setDuplicateCandidates(null);
     setModalOpen(true);
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    await submitMember(false);
+  }
+
+  async function submitMember(confirmDuplicate: boolean) {
     setLoading(true);
     setError("");
 
@@ -157,10 +170,18 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
         body: JSON.stringify({
           firstName,
           lastName,
+          email: email || undefined,
           departmentId,
           additionalDepartmentIds: additionalDeptIds.filter((id) => id !== departmentId),
+          ...(confirmDuplicate ? { confirmDuplicate: true } : {}),
         }),
       });
+
+      if (res.status === 409) {
+        const data = await res.json();
+        setDuplicateCandidates(data.duplicates ?? []);
+        return;
+      }
 
       if (!res.ok) {
         const data = await res.json();
@@ -176,6 +197,7 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
         setMembers((prev) => [...prev, normalizedMember]);
       }
 
+      setDuplicateCandidates(null);
       setModalOpen(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Erreur");
@@ -188,6 +210,7 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
     id: string;
     firstName: string;
     lastName: string;
+    email?: string | null;
     departments?: { isPrimary: boolean; department: { id: string; name: string; ministry: { id: string; name: string; churchId?: string } } }[];
     userLink?: { userId: string; userName?: string | null; userEmail?: string; user?: { name: string | null; email: string } } | null;
     churchId?: string;
@@ -198,6 +221,7 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
       id: raw.id,
       firstName: raw.firstName,
       lastName: raw.lastName,
+      email: raw.email ?? null,
       churchId: raw.churchId ?? primaryDept?.department.ministry.churchId ?? "",
       primaryDepartment: primaryDept
         ? { id: primaryDept.department.id, name: primaryDept.department.name, ministry: primaryDept.department.ministry }
@@ -534,6 +558,13 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
             onChange={(e) => setLastName(e.target.value)}
             required
           />
+          <Input
+            label="Email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Fortement recommandé — fiabilise le rattachement du compte"
+          />
           <Select
             label="Département principal"
             value={departmentId}
@@ -567,6 +598,43 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
                 ))}
             </div>
           </div>
+          {duplicateCandidates && duplicateCandidates.length > 0 && (
+            <div className="rounded-lg border-2 border-icc-jaune bg-icc-jaune/10 p-3 space-y-2">
+              <p className="text-sm font-medium text-gray-800">
+                Ces fiches existent déjà dans l&apos;église — rattacher ou créer quand même ?
+              </p>
+              <ul className="space-y-1">
+                {duplicateCandidates.map((d) => (
+                  <li key={d.id} className="text-sm text-gray-700 flex items-center justify-between gap-2">
+                    <span>
+                      {d.lastName} {d.firstName}
+                      {d.email && <span className="text-gray-400 ml-1 text-xs">{d.email}</span>}
+                    </span>
+                    <button
+                      type="button"
+                      className="text-xs text-icc-violet hover:underline whitespace-nowrap"
+                      onClick={() => {
+                        setModalOpen(false);
+                        setDuplicateCandidates(null);
+                        setSearch(`${d.firstName} ${d.lastName}`);
+                      }}
+                    >
+                      Voir la fiche
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={loading}
+                onClick={() => submitMember(true)}
+              >
+                Créer quand même
+              </Button>
+            </div>
+          )}
           {error && <p className="text-sm text-red-600">{error}</p>}
           <div className="flex justify-end gap-2">
             <Button variant="secondary" type="button" onClick={() => setModalOpen(false)}>

--- a/src/app/api/member-link-requests/[id]/route.ts
+++ b/src/app/api/member-link-requests/[id]/route.ts
@@ -3,12 +3,14 @@ import { requireChurchPermission, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { Role } from "@/generated/prisma/client";
+import { findDuplicateCandidates } from "@/lib/onboarding";
 import { z } from "zod";
 
 const schema = z.object({
   action: z.enum(["approve", "reject", "reconsider"]),
   rejectReason: z.string().optional(),
   departmentId: z.string().optional(), // override admin si besoin
+  confirmDuplicate: z.boolean().optional(),
 });
 
 export async function PATCH(
@@ -22,7 +24,7 @@ export async function PATCH(
     const session = await requireChurchPermission("members:manage", churchId);
 
     const body = await request.json();
-    const { action, rejectReason, departmentId: adminDeptOverride } = schema.parse(body);
+    const { action, rejectReason, departmentId: adminDeptOverride, confirmDuplicate } = schema.parse(body);
 
     const linkRequest = await prisma.memberLinkRequest.findUnique({
       where: { id },
@@ -30,6 +32,7 @@ export async function PATCH(
         member: true,
         department: true,
         ministry: true,
+        user: true,
       },
     });
     if (!linkRequest) throw new ApiError(404, "Demande introuvable");
@@ -92,6 +95,18 @@ export async function PATCH(
 
     if (isNewStar && !isNoStarRole && !effectiveDeptId) {
       throw new ApiError(400, "Le département est requis pour créer un STAR");
+    }
+
+    // ── Garde-fou anti-doublon avant création d'une nouvelle fiche ─────────────
+    if (isNewStar && !isNoStarRole && !confirmDuplicate) {
+      const duplicates = await findDuplicateCandidates(linkRequest.churchId, {
+        email: linkRequest.user.email,
+        firstName: linkRequest.firstName!,
+        lastName: linkRequest.lastName!,
+      });
+      if (duplicates.length > 0) {
+        return successResponse({ duplicates }, 409);
+      }
     }
 
     await prisma.$transaction(async (tx) => {

--- a/src/app/api/members/__tests__/route.test.ts
+++ b/src/app/api/members/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createAdminSession } from "@/__mocks__/auth";
+
+// Mock auth before importing route handlers
+const mockRequireChurchPermission = vi.fn();
+const mockResolveChurchId = vi.fn().mockResolvedValue("church-1");
+vi.mock("@/lib/auth", () => ({
+  requireChurchPermission: (...args: unknown[]) => mockRequireChurchPermission(...args),
+  resolveChurchId: (...args: unknown[]) => mockResolveChurchId(...args),
+}));
+
+// Mock prisma
+vi.mock("@/lib/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+// Import handlers after mocks
+const { POST } = await import("../route");
+
+describe("POST /api/members", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockResolveChurchId.mockResolvedValue("church-1");
+    prismaMock.member.findMany.mockResolvedValue([]);
+  });
+
+  it("creates a member with email when no duplicate exists", async () => {
+    prismaMock.member.create.mockResolvedValue({
+      id: "member-new",
+      firstName: "Jean",
+      lastName: "Dupont",
+      email: "jean.dupont@example.com",
+      departments: [],
+    });
+
+    const request = new Request("http://localhost/api/members", {
+      method: "POST",
+      body: JSON.stringify({
+        firstName: "Jean",
+        lastName: "Dupont",
+        email: "jean.dupont@example.com",
+        departmentId: "dept-1",
+      }),
+    });
+    const res = await POST(request);
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.email).toBe("jean.dupont@example.com");
+    expect(prismaMock.member.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ email: "jean.dupont@example.com" }),
+      })
+    );
+  });
+
+  it("returns 409 with duplicates when email already exists in the church", async () => {
+    prismaMock.member.findMany.mockResolvedValue([
+      { id: "member-existing", firstName: "Jean", lastName: "Dupont", email: "jean.dupont@example.com" },
+    ]);
+
+    const request = new Request("http://localhost/api/members", {
+      method: "POST",
+      body: JSON.stringify({
+        firstName: "Jean",
+        lastName: "Dupont",
+        email: "jean.dupont@example.com",
+        departmentId: "dept-1",
+      }),
+    });
+    const res = await POST(request);
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.duplicates).toHaveLength(1);
+    expect(body.duplicates[0].id).toBe("member-existing");
+    expect(prismaMock.member.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 with duplicates when the normalized name already exists", async () => {
+    prismaMock.member.findMany.mockResolvedValue([
+      { id: "member-existing", firstName: "Jérémie", lastName: "Dupont", email: null },
+    ]);
+
+    const request = new Request("http://localhost/api/members", {
+      method: "POST",
+      body: JSON.stringify({
+        firstName: "Jeremie",
+        lastName: "dupont",
+        departmentId: "dept-1",
+      }),
+    });
+    const res = await POST(request);
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.duplicates).toHaveLength(1);
+  });
+
+  it("creates the member despite a duplicate when confirmDuplicate is true", async () => {
+    prismaMock.member.findMany.mockResolvedValue([
+      { id: "member-existing", firstName: "Jean", lastName: "Dupont", email: "jean.dupont@example.com" },
+    ]);
+    prismaMock.member.create.mockResolvedValue({
+      id: "member-new",
+      firstName: "Jean",
+      lastName: "Dupont",
+      email: "jean.dupont@example.com",
+      departments: [],
+    });
+
+    const request = new Request("http://localhost/api/members", {
+      method: "POST",
+      body: JSON.stringify({
+        firstName: "Jean",
+        lastName: "Dupont",
+        email: "jean.dupont@example.com",
+        departmentId: "dept-1",
+        confirmDuplicate: true,
+      }),
+    });
+    const res = await POST(request);
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.member.create).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -3,6 +3,7 @@ import { requireChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { logAudit } from "@/lib/audit";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
+import { findDuplicateCandidates } from "@/lib/onboarding";
 import { z } from "zod";
 
 // Helper : inclure les départements d'un membre (principal en premier)
@@ -182,14 +183,16 @@ export async function PATCH(request: Request) {
 const createSchema = z.object({
   firstName: z.string().min(1, "Le prénom est requis"),
   lastName: z.string().min(1, "Le nom est requis"),
+  email: z.string().email("Email invalide").optional(),
   departmentId: z.string().min(1, "Le département principal est requis"),
   additionalDepartmentIds: z.array(z.string()).optional(),
+  confirmDuplicate: z.boolean().optional(),
 });
 
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { departmentId, additionalDepartmentIds = [], ...memberData } = createSchema.parse(body);
+    const { departmentId, additionalDepartmentIds = [], confirmDuplicate, ...memberData } = createSchema.parse(body);
 
     // Résoudre l'église du département cible
     const { resolveChurchId } = await import("@/lib/auth");
@@ -219,6 +222,17 @@ export async function POST(request: Request) {
       const wrongChurch = depts.some((d) => d.ministry.churchId !== deptChurchId);
       if (wrongChurch || depts.length !== allDeptIds.length) {
         throw new ApiError(400, "Tous les départements doivent appartenir à la même église");
+      }
+    }
+
+    if (!confirmDuplicate) {
+      const duplicates = await findDuplicateCandidates(deptChurchId, {
+        email: memberData.email,
+        firstName: memberData.firstName,
+        lastName: memberData.lastName,
+      });
+      if (duplicates.length > 0) {
+        return successResponse({ duplicates }, 409);
       }
     }
 

--- a/src/lib/__tests__/onboarding.test.ts
+++ b/src/lib/__tests__/onboarding.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+const { normalizeName, normalizeEmail, findDuplicateCandidates } = await import("../onboarding");
+
+describe("normalizeName", () => {
+  it("lowercases and strips accents", () => {
+    expect(normalizeName("Jérémie Dupont")).toBe("jeremie dupont");
+  });
+
+  it("collapses extra whitespace", () => {
+    expect(normalizeName("  Jean   Dupont  ")).toBe("jean dupont");
+  });
+});
+
+describe("normalizeEmail", () => {
+  it("lowercases and trims", () => {
+    expect(normalizeEmail("  Jean.Dupont@Example.com ")).toBe("jean.dupont@example.com");
+  });
+});
+
+describe("findDuplicateCandidates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("matches on exact normalized email", async () => {
+    prismaMock.member.findMany.mockResolvedValue([
+      { id: "m1", firstName: "Alice", lastName: "Martin", email: "Alice.Martin@Example.com" },
+      { id: "m2", firstName: "Bob", lastName: "Smith", email: "bob@example.com" },
+    ]);
+
+    const result = await findDuplicateCandidates("church-1", {
+      email: "alice.martin@example.com",
+      firstName: "Alicia",
+      lastName: "Martine",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("m1");
+  });
+
+  it("matches on accent-insensitive normalized name", async () => {
+    prismaMock.member.findMany.mockResolvedValue([
+      { id: "m1", firstName: "Jérémie", lastName: "Dupont", email: null },
+    ]);
+
+    const result = await findDuplicateCandidates("church-1", {
+      email: undefined,
+      firstName: "Jeremie",
+      lastName: "dupont",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("m1");
+  });
+
+  it("scopes the search to the given church", async () => {
+    prismaMock.member.findMany.mockResolvedValue([]);
+
+    await findDuplicateCandidates("church-1", {
+      email: "test@example.com",
+      firstName: "Jean",
+      lastName: "Dupont",
+    });
+
+    expect(prismaMock.member.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { departments: { some: { department: { ministry: { churchId: "church-1" } } } } },
+      })
+    );
+  });
+
+  it("returns no false positive when neither email nor name matches", async () => {
+    prismaMock.member.findMany.mockResolvedValue([
+      { id: "m1", firstName: "Alice", lastName: "Martin", email: "alice@example.com" },
+    ]);
+
+    const result = await findDuplicateCandidates("church-1", {
+      email: "someone.else@example.com",
+      firstName: "Someone",
+      lastName: "Else",
+    });
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,55 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Normalise un nom (minuscules, accents retirés) pour une comparaison insensible
+ * à la casse et aux accents. Alignée sur la normalisation de
+ * src/app/api/members/search/route.ts.
+ */
+export function normalizeName(s: string): string {
+  return s
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+/**
+ * Normalise un email (minuscules, espaces retirés) pour une comparaison exacte.
+ */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export type DuplicateCandidate = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+};
+
+/**
+ * Recherche les fiches membres déjà présentes dans l'église (churchId) qui
+ * pourraient correspondre à `input` — même email (comparaison normalisée,
+ * quand un email est fourni) ou même nom normalisé. Utilisé comme garde-fou
+ * anti-doublon avant la création d'une nouvelle fiche membre.
+ */
+export async function findDuplicateCandidates(
+  churchId: string,
+  input: { email?: string | null; firstName: string; lastName: string }
+): Promise<DuplicateCandidate[]> {
+  const members = await prisma.member.findMany({
+    where: { departments: { some: { department: { ministry: { churchId } } } } },
+    select: { id: true, firstName: true, lastName: true, email: true },
+  });
+
+  const normalizedEmail = input.email ? normalizeEmail(input.email) : null;
+  const normalizedName = normalizeName(`${input.firstName} ${input.lastName}`);
+
+  return members.filter((member) => {
+    const emailMatch =
+      normalizedEmail !== null && member.email !== null && normalizeEmail(member.email) === normalizedEmail;
+    const nameMatch = normalizeName(`${member.firstName} ${member.lastName}`) === normalizedName;
+    return emailMatch || nameMatch;
+  });
+}


### PR DESCRIPTION
Phase 1 de la refonte de l'onboarding (spec `specs/002-onboarding-liaison-email/`).

## Objectif
Capturer l'email à la création d'une fiche membre et prévenir les doublons (même email ou même nom dans l'église) à la source.

## Changements
- `src/lib/onboarding.ts` : `normalizeName`, `normalizeEmail`, `findDuplicateCandidates` (scope par église via `departments → department → ministry → churchId`, match email normalisé OU nom normalisé)
- `POST /api/members` : champ `email` (optionnel, incité) + garde-fou → **409 + `duplicates`** si doublon non confirmé ; `confirmDuplicate: true` pour forcer
- `PATCH /api/member-link-requests/[id]` : même garde-fou avant la création d'une fiche à l'approbation « nouveau STAR » (signal email = compte du demandeur) ; `displayName` inchangé
- UI `MembersClient` : champ email + alerte listant les candidats (« Voir la fiche » / « Créer quand même »)

## Périmètre
Aucune migration Prisma (`Member.email` existe déjà). Le `displayName` par église est hors périmètre (dette traitée séparément). Réconciliation email + parcours self-service refondu = phases P2/P3.

## Vérifications
- typecheck + lint + lint:boundaries : OK
- 367 tests passent (+11 : helper `findDuplicateCandidates` + routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)