### PR TITLE
feat(onboarding): réconciliation par email + auto-liaison STAR sur confirmation (P2)

### DIFF
--- a/specs/002-onboarding-liaison-email/tasks.md
+++ b/specs/002-onboarding-liaison-email/tasks.md
@@ -83,4 +83,80 @@ doublon (même email ou même nom dans l'église) en proposant de rattacher à l
 - [x] `npm run test`
 - [ ] Test manuel : créer une fiche avec un email/nom déjà présent → alerte + candidats ; forcer →
       création ; créer une fiche distincte → OK
+- [x] PR ouverte vers `feat/onboarding-liaison-email` (pas vers `main`) — **#400 mergée**
+
+---
+
+## Phase 2 — Réconciliation par email + auto-liaison STAR (proposition à confirmer)
+
+**Objectif** : à l'arrivée dans l'onboarding, proposer à la personne les fiches STAR **non liées**
+dont l'email correspond à son **email de compte vérifié** ; sur **confirmation**, établir le lien
+directement (rôle STAR), **sans validation admin** — le serveur vérifiant l'égalité des emails.
+
+> **Sécurité** : `assertSelfLinkAllowed` doit être infaillible (email normalisé identique, fiche non
+> liée dans l'église visée, cohérence église). Aucune attribution de rôle autre que `STAR`.
+> Sous-branche : `feat/onboarding-p2-reconciliation` (depuis `feat/onboarding-liaison-email`).
+
+### Prérequis
+
+- [x] Sous-branche créée : `feat/onboarding-p2-reconciliation`
+- [ ] ~~Migration Prisma~~ — **index `Member.email` différé** (simple optimisation ; la réconciliation
+      fonctionne sans, à l'échelle d'une personne/église). À ajouter dans une petite migration
+      dédiée quand une base de dev est disponible. **P2 reste sans migration ni changement de
+      `schema.prisma`.**
+
+### Tâches
+
+#### 1. Logique métier (helper `src/lib/onboarding.ts`)
+
+- [x] **T2** — `findUnlinkedMembersByEmail(email): Promise<CandidateMember[]>` — fiches dont l'email
+      normalisé correspond, **et qui n'ont pas de `MemberUserLink`** (non liées), avec leur église
+      (via département principal) et leur département principal. Toutes églises confondues.
+- [x] **T3** — `assertSelfLinkAllowed(sessionEmail, member, churchId)` — lève `ApiError(403)` si :
+      email de session normalisé ≠ email fiche normalisé, OU fiche déjà liée dans cette église, OU
+      la fiche n'appartient pas à `churchId`. Sinon retourne OK.
+
+#### 3. API
+
+- [x] **T4** — `GET /api/onboarding/candidates` (nouveau) : `requireAuth` ; retourne
+      `findUnlinkedMembersByEmail(session.user.email)`. Ne fuite rien d'autre que les fiches
+      correspondant à l'email du demandeur.
+- [x] **T5** — `POST /api/member-user-links/self` (nouveau) : `requireAuth` ; body Zod
+      `{ memberId, churchId }` ; charge la fiche ; `assertSelfLinkAllowed(session.user.email, member,
+      churchId)` ; transaction : crée le `MemberUserLink` (validé) + `UserChurchRole` STAR si absent ;
+      `logAudit`. **Aucune** validation admin, **aucun** rôle autre que STAR.
+
+#### 4. UI (`src/app/no-access/NoAccessClient.tsx`)
+
+- [x] **T6** — Nouvelle **première étape « réconciliation email »** : à l'entrée, appeler
+      `GET /api/onboarding/candidates`. Si résultat(s) : afficher « Cette fiche vous correspond-elle ? »
+      (nom, église, département) avec **Confirmer** → `POST /api/member-user-links/self` puis
+      rafraîchir la session / rediriger vers `/dashboard`. Bouton « Aucune de ces fiches » → bascule
+      vers le parcours par nom existant. Si aucun candidat : parcours par nom inchangé.
+
+#### 5. Tests
+
+- [x] **T7** — Unitaires (`src/lib/__tests__/onboarding.test.ts`) : `findUnlinkedMembersByEmail`
+      (match email, exclusion des fiches déjà liées, multi-église) ; `assertSelfLinkAllowed` (succès +
+      chaque refus : email différent, fiche déjà liée, mauvaise église).
+- [x] **T8** — Routes : `POST /api/member-user-links/self` (succès crée lien + rôle STAR ; refus 403
+      sur email différent / fiche liée / mauvaise église) ; `GET /api/onboarding/candidates` (renvoie
+      les fiches de l'email de session, rien d'autre).
+
+### Couverture des critères d'acceptation (P2)
+
+| Critère (spec) | Tâche(s) |
+|---|---|
+| Rapprochement d'abord par l'email vérifié, toutes églises | T2, T4, T6 |
+| Fiche proposée → confirmation → lien établi directement (sans validation admin) | T5, T6 |
+| Multi-tenant : rattachements par église sur un même compte | T2, T3, T5 |
+| Journalisation des rattachements établis | T5 |
+
+*(Index `Member.email` — optimisation différée, hors P2.)*
+
+### Vérification finale (P2)
+
+- [x] `npm run typecheck` · `npm run lint` · `npm run lint:boundaries` · `npm run test`
+- [ ] Test manuel (recette) : fiche avec email == compte → proposée → confirmée → accès STAR ;
+      email différent → refus ; fiche déjà liée → non proposée
 - [ ] PR ouverte vers `feat/onboarding-liaison-email` (pas vers `main`)

--- a/src/app/api/member-user-links/self/__tests__/route.test.ts
+++ b/src/app/api/member-user-links/self/__tests__/route.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests — P2 : auto-liaison self-service par email (POST /api/member-user-links/self)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+const mockRequireAuth = vi.fn();
+const mockRequireRateLimit = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/audit", () => ({ logAudit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/lib/rate-limit", () => ({
+  requireRateLimit: (...args: unknown[]) => mockRequireRateLimit(...args),
+  RATE_LIMIT_SENSITIVE: { windowMs: 60000, max: 10 },
+}));
+
+const { POST } = await import("../route");
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/member-user-links/self", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/member-user-links/self", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({ user: { id: "user-1", email: "alice@example.com" } });
+    mockRequireRateLimit.mockReturnValue(undefined);
+    prismaMock.$transaction.mockImplementation(
+      async (fn: (tx: typeof prismaMock) => Promise<unknown>) => fn(prismaMock)
+    );
+  });
+
+  it("crée le lien + le rôle STAR quand l'email correspond (succès)", async () => {
+    prismaMock.member.findUnique.mockResolvedValue({ id: "m1", email: "Alice@Example.com" } as never);
+    // assertSelfLinkAllowed : fiche dans l'église + pas de lien existant
+    prismaMock.memberDepartment.findFirst.mockResolvedValue({ id: "md1" } as never);
+    prismaMock.memberUserLink.findUnique.mockResolvedValue(null);
+    // transaction
+    prismaMock.memberUserLink.create.mockResolvedValue({ id: "link-1" } as never);
+    prismaMock.userChurchRole.findFirst.mockResolvedValue(null);
+    prismaMock.userChurchRole.create.mockResolvedValue({ id: "ucr-1" } as never);
+
+    const res = await POST(makeRequest({ memberId: "m1", churchId: "c1" }));
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.memberUserLink.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ memberId: "m1", userId: "user-1", churchId: "c1" }),
+      })
+    );
+    expect(prismaMock.userChurchRole.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ role: "STAR" }) })
+    );
+  });
+
+  it("n'attribue pas STAR si l'utilisateur a déjà un rôle dans l'église", async () => {
+    prismaMock.member.findUnique.mockResolvedValue({ id: "m1", email: "alice@example.com" } as never);
+    prismaMock.memberDepartment.findFirst.mockResolvedValue({ id: "md1" } as never);
+    prismaMock.memberUserLink.findUnique.mockResolvedValue(null);
+    prismaMock.memberUserLink.create.mockResolvedValue({ id: "link-1" } as never);
+    prismaMock.userChurchRole.findFirst.mockResolvedValue({ id: "existing-role" } as never);
+
+    const res = await POST(makeRequest({ memberId: "m1", churchId: "c1" }));
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.userChurchRole.create).not.toHaveBeenCalled();
+  });
+
+  it("refuse (403) si l'email du compte diffère de celui de la fiche", async () => {
+    prismaMock.member.findUnique.mockResolvedValue({ id: "m1", email: "bob@example.com" } as never);
+
+    const res = await POST(makeRequest({ memberId: "m1", churchId: "c1" }));
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.memberUserLink.create).not.toHaveBeenCalled();
+  });
+
+  it("refuse (403) si la fiche est déjà liée dans cette église", async () => {
+    prismaMock.member.findUnique.mockResolvedValue({ id: "m1", email: "alice@example.com" } as never);
+    prismaMock.memberDepartment.findFirst.mockResolvedValue({ id: "md1" } as never);
+    prismaMock.memberUserLink.findUnique.mockResolvedValue({ id: "existing-link" } as never);
+
+    const res = await POST(makeRequest({ memberId: "m1", churchId: "c1" }));
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.memberUserLink.create).not.toHaveBeenCalled();
+  });
+
+  it("refuse (403) si la fiche n'appartient pas à l'église visée", async () => {
+    prismaMock.member.findUnique.mockResolvedValue({ id: "m1", email: "alice@example.com" } as never);
+    prismaMock.memberDepartment.findFirst.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ memberId: "m1", churchId: "c1" }));
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.memberUserLink.create).not.toHaveBeenCalled();
+  });
+
+  it("retourne 404 si la fiche est introuvable", async () => {
+    prismaMock.member.findUnique.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ memberId: "unknown", churchId: "c1" }));
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/member-user-links/self/route.ts
+++ b/src/app/api/member-user-links/self/route.ts
@@ -1,0 +1,83 @@
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { logAudit } from "@/lib/audit";
+import { requireRateLimit, RATE_LIMIT_SENSITIVE } from "@/lib/rate-limit";
+import { assertSelfLinkAllowed } from "@/lib/onboarding";
+import { z } from "zod";
+
+const schema = z.object({
+  memberId: z.string(),
+  churchId: z.string(),
+});
+
+/**
+ * POST /api/member-user-links/self — auto-liaison self-service par email (P2).
+ *
+ * Sécurité : le serveur vérifie TOUJOURS l'égalité (normalisée) entre l'email du
+ * compte et l'email de la fiche, que la fiche appartient à l'église visée, et
+ * qu'elle n'est pas déjà liée (`assertSelfLinkAllowed`). Aucune validation admin.
+ * Le seul rôle jamais attribué ici est `STAR` (identité, pas élévation de privilège),
+ * et uniquement si l'utilisateur n'a encore aucun rôle dans cette église.
+ */
+export async function POST(request: Request) {
+  try {
+    const session = await requireAuth();
+    requireRateLimit(request, { prefix: `self-link:${session.user.id}`, ...RATE_LIMIT_SENSITIVE });
+
+    const { memberId, churchId } = schema.parse(await request.json());
+
+    const member = await prisma.member.findUnique({
+      where: { id: memberId },
+      select: { id: true, email: true },
+    });
+    if (!member) throw new ApiError(404, "Fiche introuvable");
+
+    await assertSelfLinkAllowed(session.user.email, member, churchId);
+
+    try {
+      const link = await prisma.$transaction(async (tx) => {
+        const created = await tx.memberUserLink.create({
+          data: {
+            memberId,
+            userId: session.user.id,
+            churchId,
+            validatedAt: new Date(),
+            validatedById: session.user.id,
+          },
+        });
+
+        // Auto-attribution du rôle STAR uniquement si aucun rôle dans cette église
+        const hasAnyRole = await tx.userChurchRole.findFirst({
+          where: { userId: session.user.id, churchId },
+        });
+        if (!hasAnyRole) {
+          await tx.userChurchRole.create({
+            data: { userId: session.user.id, churchId, role: "STAR" },
+          });
+        }
+
+        return created;
+      });
+
+      await logAudit({
+        userId: session.user.id,
+        churchId,
+        action: "CREATE",
+        entityType: "MemberUserLink",
+        entityId: link.id,
+        details: { memberId, self: true },
+      });
+
+      return successResponse(link, 201);
+    } catch (error) {
+      // Course à la contrainte d'unicité (fiche/compte déjà lié entre-temps)
+      if (error && typeof error === "object" && "code" in error && (error as { code?: string }).code === "P2002") {
+        throw new ApiError(409, "Cette fiche est déjà liée à un compte");
+      }
+      throw error;
+    }
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/onboarding/candidates/__tests__/route.test.ts
+++ b/src/app/api/onboarding/candidates/__tests__/route.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests — P2 : réconciliation par email (GET /api/onboarding/candidates)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+const mockRequireAuth = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+const { GET } = await import("../route");
+
+function memberRow(id: string, email: string | null) {
+  return {
+    id,
+    firstName: "Alice",
+    lastName: "Martin",
+    email,
+    departments: [
+      {
+        department: {
+          name: "Son",
+          ministry: { church: { id: "c1", name: "ICC Rennes" } },
+        },
+      },
+    ],
+  };
+}
+
+describe("GET /api/onboarding/candidates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({ user: { id: "user-1", email: "alice@example.com" } });
+  });
+
+  it("retourne les fiches non liées correspondant à l'email de session", async () => {
+    prismaMock.member.findMany.mockResolvedValue([
+      memberRow("m1", "Alice@Example.com"),
+      memberRow("m2", "other@example.com"),
+    ] as never);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.candidates).toHaveLength(1);
+    expect(body.candidates[0]).toMatchObject({ memberId: "m1", churchId: "c1", churchName: "ICC Rennes" });
+  });
+
+  it("ne recherche que les fiches sans lien utilisateur", async () => {
+    prismaMock.member.findMany.mockResolvedValue([] as never);
+
+    await GET();
+
+    expect(prismaMock.member.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { email: { not: null }, userLinks: { none: {} } },
+      })
+    );
+  });
+
+  it("retourne une liste vide quand le compte n'a pas d'email", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "user-1", email: null } });
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.candidates).toEqual([]);
+    expect(prismaMock.member.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/onboarding/candidates/route.ts
+++ b/src/app/api/onboarding/candidates/route.ts
@@ -1,0 +1,19 @@
+import { requireAuth } from "@/lib/auth";
+import { successResponse, errorResponse } from "@/lib/api-utils";
+import { findUnlinkedMembersByEmail } from "@/lib/onboarding";
+
+/**
+ * GET /api/onboarding/candidates — réconciliation par email (P2).
+ * Retourne les fiches STAR non liées dont l'email correspond à l'email vérifié
+ * du compte du demandeur. Ne renvoie QUE les fiches de cet email.
+ */
+export async function GET() {
+  try {
+    const session = await requireAuth();
+    const email = session.user.email;
+    const candidates = email ? await findUnlinkedMembersByEmail(email) : [];
+    return successResponse({ candidates });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/no-access/NoAccessClient.tsx
+++ b/src/app/no-access/NoAccessClient.tsx
@@ -28,7 +28,16 @@ type RequestedRole =
   | "REPORTER"
   | null;
 
-type Step = "identity" | "match" | "department" | "role" | "confirm" | "pending";
+type Candidate = {
+  memberId: string;
+  firstName: string;
+  lastName: string;
+  churchId: string;
+  churchName: string;
+  department: string;
+};
+
+type Step = "reconcile" | "identity" | "match" | "department" | "role" | "confirm" | "pending";
 
 const ROLE_LABELS: Record<NonNullable<RequestedRole>, string> = {
   DEPARTMENT_HEAD: "Responsable de département",
@@ -49,6 +58,12 @@ export default function NoAccessClient({
 }) {
   const [step, setStep] = useState<Step>("identity");
   const [churchId, setChurchId] = useState(churches[0]?.id ?? "");
+
+  // Étape 0 — réconciliation par email (P2)
+  const [bootLoading, setBootLoading] = useState(true);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [linking, setLinking] = useState(false);
+  const [linkError, setLinkError] = useState<string | null>(null);
 
   // Étape 1 — identité
   const [firstName, setFirstName] = useState("");
@@ -74,6 +89,52 @@ export default function NoAccessClient({
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Réconciliation par email au chargement de l'assistant (P2)
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/onboarding/candidates");
+        const json = await res.json();
+        const found: Candidate[] = res.ok && Array.isArray(json?.candidates) ? json.candidates : [];
+        if (cancelled) return;
+        setCandidates(found);
+        if (found.length > 0) setStep("reconcile");
+      } catch {
+        // En cas d'échec, on retombe sur le parcours par nom
+      } finally {
+        if (!cancelled) setBootLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function confirmCandidate(candidate: Candidate) {
+    setLinkError(null);
+    setLinking(true);
+    try {
+      const res = await fetch("/api/member-user-links/self", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ memberId: candidate.memberId, churchId: candidate.churchId }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Erreur lors de la liaison");
+      // Rechargement complet : la session serveur (stratégie DB) recharge les rôles
+      window.location.assign("/dashboard");
+    } catch (e) {
+      setLinkError(e instanceof Error ? e.message : "Une erreur est survenue");
+      setLinking(false);
+    }
+  }
+
+  function skipReconcile() {
+    setLinkError(null);
+    setStep("identity");
+  }
 
   // Auto-search quand prénom/nom changent (étape identity)
   useEffect(() => {
@@ -186,6 +247,62 @@ export default function NoAccessClient({
   }
 
   // ── Rendu ────────────────────────────────────────────────────────────────────
+
+  if (bootLoading) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-icc-violet border-t-transparent" />
+      </div>
+    );
+  }
+
+  // ── Étape 0 : Réconciliation par email ─────────────────────────────────────
+  if (step === "reconcile") {
+    return (
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm font-medium text-gray-700">Cette fiche vous correspond-elle ?</p>
+          <p className="mt-1 text-xs text-gray-500">
+            Une fiche enregistrée avec votre adresse email a été trouvée. Confirmez pour lier votre
+            compte directement.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          {candidates.map((c) => (
+            <div
+              key={`${c.memberId}-${c.churchId}`}
+              className="rounded-lg border-2 border-gray-200 px-4 py-3"
+            >
+              <p className="text-sm font-semibold text-gray-900">
+                {c.firstName} {c.lastName}
+              </p>
+              <p className="mt-0.5 text-xs text-gray-500">
+                {c.churchName} · {c.department}
+              </p>
+              <button
+                onClick={() => confirmCandidate(c)}
+                disabled={linking}
+                className="mt-3 w-full rounded-lg bg-icc-violet px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-icc-violet/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {linking ? "Liaison en cours..." : "Confirmer, c'est moi"}
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {linkError && <p className="text-sm text-icc-rouge">{linkError}</p>}
+
+        <button
+          onClick={skipReconcile}
+          disabled={linking}
+          className="text-sm text-gray-400 transition-colors hover:text-gray-600 disabled:opacity-50"
+        >
+          Aucune de ces fiches ne me correspond →
+        </button>
+      </div>
+    );
+  }
 
   if (step === "pending") {
     return (

--- a/src/lib/__tests__/onboarding.test.ts
+++ b/src/lib/__tests__/onboarding.test.ts
@@ -5,7 +5,42 @@ vi.mock("@/lib/prisma", () => ({
   prisma: prismaMock,
 }));
 
-const { normalizeName, normalizeEmail, findDuplicateCandidates } = await import("../onboarding");
+const {
+  normalizeName,
+  normalizeEmail,
+  findDuplicateCandidates,
+  findUnlinkedMembersByEmail,
+  assertSelfLinkAllowed,
+} = await import("../onboarding");
+
+// Fabrique une fiche telle que renvoyée par findMany (avec département principal)
+function memberRow(over: {
+  id: string;
+  email: string | null;
+  churchId?: string;
+  churchName?: string;
+  department?: string;
+  noPrimary?: boolean;
+}) {
+  return {
+    id: over.id,
+    firstName: "Jean",
+    lastName: "Dupont",
+    email: over.email,
+    departments: over.noPrimary
+      ? []
+      : [
+          {
+            department: {
+              name: over.department ?? "Choristes",
+              ministry: {
+                church: { id: over.churchId ?? "church-1", name: over.churchName ?? "ICC Rennes" },
+              },
+            },
+          },
+        ],
+  };
+}
 
 describe("normalizeName", () => {
   it("lowercases and strips accents", () => {
@@ -87,5 +122,102 @@ describe("findDuplicateCandidates", () => {
     });
 
     expect(result).toHaveLength(0);
+  });
+});
+
+describe("findUnlinkedMembersByEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("matches on normalized email and returns church + primary department", async () => {
+    prismaMock.member.findMany.mockResolvedValue([
+      memberRow({ id: "m1", email: "Alice@Example.com", churchId: "c1", churchName: "ICC Rennes", department: "Son" }),
+      memberRow({ id: "m2", email: "bob@example.com", churchId: "c1" }),
+    ] as never);
+
+    const result = await findUnlinkedMembersByEmail("  alice@example.com ");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      memberId: "m1",
+      churchId: "c1",
+      churchName: "ICC Rennes",
+      department: "Son",
+    });
+  });
+
+  it("only queries members without any user link", async () => {
+    prismaMock.member.findMany.mockResolvedValue([] as never);
+
+    await findUnlinkedMembersByEmail("alice@example.com");
+
+    expect(prismaMock.member.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { email: { not: null }, userLinks: { none: {} } },
+      })
+    );
+  });
+
+  it("returns candidates across multiple churches", async () => {
+    prismaMock.member.findMany.mockResolvedValue([
+      memberRow({ id: "m1", email: "alice@example.com", churchId: "c1", churchName: "Rennes" }),
+      memberRow({ id: "m2", email: "alice@example.com", churchId: "c2", churchName: "Brest" }),
+    ] as never);
+
+    const result = await findUnlinkedMembersByEmail("alice@example.com");
+
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.churchId).sort()).toEqual(["c1", "c2"]);
+  });
+
+  it("skips members without a primary department", async () => {
+    prismaMock.member.findMany.mockResolvedValue([
+      memberRow({ id: "m1", email: "alice@example.com", noPrimary: true }),
+    ] as never);
+
+    const result = await findUnlinkedMembersByEmail("alice@example.com");
+
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("assertSelfLinkAllowed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.memberDepartment.findFirst.mockResolvedValue({ id: "md1" } as never);
+    prismaMock.memberUserLink.findUnique.mockResolvedValue(null);
+  });
+
+  it("resolves when email matches, church is correct and no existing link", async () => {
+    await expect(
+      assertSelfLinkAllowed("Alice@Example.com", { id: "m1", email: "alice@example.com" }, "c1")
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects when session email is absent", async () => {
+    await expect(
+      assertSelfLinkAllowed(null, { id: "m1", email: "alice@example.com" }, "c1")
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("rejects when emails differ", async () => {
+    await expect(
+      assertSelfLinkAllowed("other@example.com", { id: "m1", email: "alice@example.com" }, "c1")
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("rejects when the member is not in the target church", async () => {
+    prismaMock.memberDepartment.findFirst.mockResolvedValue(null);
+    await expect(
+      assertSelfLinkAllowed("alice@example.com", { id: "m1", email: "alice@example.com" }, "c1")
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("rejects when the member is already linked", async () => {
+    prismaMock.memberUserLink.findUnique.mockResolvedValue({ id: "link-1" } as never);
+    await expect(
+      assertSelfLinkAllowed("alice@example.com", { id: "m1", email: "alice@example.com" }, "c1")
+    ).rejects.toMatchObject({ statusCode: 403 });
   });
 });

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma";
+import { ApiError } from "@/lib/api-utils";
 
 /**
  * Normalise un nom (minuscules, accents retirés) pour une comparaison insensible
@@ -52,4 +53,102 @@ export async function findDuplicateCandidates(
     const nameMatch = normalizeName(`${member.firstName} ${member.lastName}`) === normalizedName;
     return emailMatch || nameMatch;
   });
+}
+
+export type CandidateMember = {
+  memberId: string;
+  firstName: string;
+  lastName: string;
+  churchId: string;
+  churchName: string;
+  department: string;
+};
+
+/**
+ * Réconciliation par email (onboarding self-service, P2) : recherche les fiches
+ * membres **non liées** (aucun `MemberUserLink`) dont l'email normalisé correspond
+ * à `email`, toutes églises confondues. L'église et le département sont déterminés
+ * par le **département principal** (`isPrimary`) de la fiche. Les fiches sans email,
+ * déjà liées, ou sans département principal sont exclues.
+ */
+export async function findUnlinkedMembersByEmail(email: string): Promise<CandidateMember[]> {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) return [];
+
+  const members = await prisma.member.findMany({
+    where: { email: { not: null }, userLinks: { none: {} } },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+      departments: {
+        where: { isPrimary: true },
+        select: {
+          department: {
+            select: {
+              name: true,
+              ministry: { select: { church: { select: { id: true, name: true } } } },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const candidates: CandidateMember[] = [];
+  for (const member of members) {
+    if (!member.email || normalizeEmail(member.email) !== normalizedEmail) continue;
+    const primary = member.departments[0];
+    if (!primary) continue;
+    candidates.push({
+      memberId: member.id,
+      firstName: member.firstName,
+      lastName: member.lastName,
+      churchId: primary.department.ministry.church.id,
+      churchName: primary.department.ministry.church.name,
+      department: primary.department.name,
+    });
+  }
+  return candidates;
+}
+
+/**
+ * Garde-fou serveur de l'auto-liaison self-service (P2). Lève `ApiError(403)` si
+ * l'auto-liaison n'est PAS autorisée :
+ *  - email de session absent, ou différent (normalisé) de l'email de la fiche ;
+ *  - fiche déjà liée à un compte dans cette église ;
+ *  - fiche n'appartenant pas à `churchId` (pas de département principal dans cette église).
+ * Ne retourne rien si l'opération est autorisée. Les vérifications dépendantes de
+ * l'état (appartenance église, lien existant) interrogent Prisma → testable via mock.
+ */
+export async function assertSelfLinkAllowed(
+  sessionEmail: string | null | undefined,
+  member: { id: string; email: string | null },
+  churchId: string
+): Promise<void> {
+  if (!sessionEmail) {
+    throw new ApiError(403, "Aucun email de compte vérifié");
+  }
+  if (!member.email || normalizeEmail(sessionEmail) !== normalizeEmail(member.email)) {
+    throw new ApiError(403, "L'email de votre compte ne correspond pas à cette fiche");
+  }
+
+  // La fiche appartient-elle bien à l'église visée (via son département principal) ?
+  const inChurch = await prisma.memberDepartment.findFirst({
+    where: { memberId: member.id, isPrimary: true, department: { ministry: { churchId } } },
+    select: { id: true },
+  });
+  if (!inChurch) {
+    throw new ApiError(403, "Cette fiche n'appartient pas à cette église");
+  }
+
+  // La fiche est-elle déjà liée dans cette église ?
+  const existingLink = await prisma.memberUserLink.findUnique({
+    where: { memberId_churchId: { memberId: member.id, churchId } },
+    select: { id: true },
+  });
+  if (existingLink) {
+    throw new ApiError(403, "Cette fiche est déjà liée à un compte");
+  }
 }


### PR DESCRIPTION
Phase 2 de la refonte de l'onboarding (spec `specs/002-onboarding-liaison-email/`).

## Objectif
À l'arrivée dans l'onboarding, proposer à la personne les fiches STAR non liées dont l'email correspond à son email de compte vérifié ; sur confirmation, établir le lien directement (rôle STAR), sans validation admin — le serveur vérifiant l'égalité des emails.

## Changements
- `src/lib/onboarding.ts` : `findUnlinkedMembersByEmail` (fiches non liées par email, toutes églises, via département principal) + `assertSelfLinkAllowed` (garde-fou serveur)
- `GET /api/onboarding/candidates` : fiches correspondant à l'email de session
- `POST /api/member-user-links/self` : auto-liaison self-service — `requireAuth` + rate-limit sensible + `assertSelfLinkAllowed` (égalité email normalisée, fiche non liée, cohérence église) → lien validé + rôle STAR si aucun rôle ; jamais de validation admin ni de rôle autre que STAR ; conflit d'unicité → 409
- UI `NoAccessClient` : nouvelle étape « réconciliation email » (proposition → confirmation → /dashboard), repli « aucune de ces fiches » vers le parcours par nom

## Sécurité
Auto-liaison gardée côté serveur : email de session normalisé == email fiche, fiche non déjà liée dans l'église, appartenance à l'église vérifiée. Rôle STAR uniquement.

## Périmètre
Aucune migration (index `Member.email` différé). `displayName` inchangé.

## Vérifications
- typecheck + lint + lint:boundaries : OK
- 385 tests passent (+18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)