### PR TITLE
feat(jobs): profils de recherche d'emploi — flux candidat

### DIFF
--- a/prisma/migrations/20260704000000_add_job_seeker_profiles/migration.sql
+++ b/prisma/migrations/20260704000000_add_job_seeker_profiles/migration.sql
@@ -1,0 +1,29 @@
+-- Add wantSeekers flag to job notification subscriptions
+ALTER TABLE `job_notification_subscriptions` ADD COLUMN `wantSeekers` BOOLEAN NOT NULL DEFAULT false;
+
+-- Create job_seekers table
+CREATE TABLE `job_seekers` (
+    `id` VARCHAR(191) NOT NULL,
+    `title` VARCHAR(200) NOT NULL,
+    `wantEmploi` BOOLEAN NOT NULL DEFAULT false,
+    `wantStage` BOOLEAN NOT NULL DEFAULT false,
+    `wantAlternance` BOOLEAN NOT NULL DEFAULT false,
+    `sector` VARCHAR(150) NULL,
+    `location` VARCHAR(150) NULL,
+    `remote` BOOLEAN NOT NULL DEFAULT false,
+    `availableFrom` DATETIME(3) NULL,
+    `description` LONGTEXT NOT NULL,
+    `contactEmail` VARCHAR(150) NULL,
+    `contactUrl` VARCHAR(500) NULL,
+    `status` ENUM('ACTIVE', 'FOUND', 'ARCHIVED') NOT NULL DEFAULT 'ACTIVE',
+    `authorId` VARCHAR(191) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    INDEX `job_seekers_status_idx`(`status`),
+    INDEX `job_seekers_authorId_idx`(`authorId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- Add foreign key constraint
+ALTER TABLE `job_seekers` ADD CONSTRAINT `job_seekers_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,6 +169,7 @@ model User {
   financialAttachmentsUploaded FinancialAttachment[] @relation("AccountingAttachmentsUploaded")
   // Module emploi
   jobOffers                    JobOffer[]
+  jobSeekers                   JobSeeker[]
   jobNotificationSubscription  JobNotificationSubscription?
   // (relation superviseur église déplacée vers PastoralProfile)
 
@@ -1483,7 +1484,7 @@ model JobOffer {
   @@map("job_offers")
 }
 
-/// Préférences de notifications pour les offres d'emploi.
+/// Préférences de notifications pour les offres d'emploi et profils de recherche.
 model JobNotificationSubscription {
   id             String  @id @default(cuid())
   userId         String  @unique
@@ -1492,9 +1493,41 @@ model JobNotificationSubscription {
   wantEmploi     Boolean @default(true)
   wantStage      Boolean @default(true)
   wantAlternance Boolean @default(true)
+  wantSeekers    Boolean @default(false)
   user           User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("job_notification_subscriptions")
+}
+
+enum JobSeekerStatus {
+  ACTIVE
+  FOUND
+  ARCHIVED
+}
+
+/// Profil de recherche d'emploi publié par un utilisateur.
+model JobSeeker {
+  id             String          @id @default(cuid())
+  title          String          @db.VarChar(200)
+  wantEmploi     Boolean         @default(false)
+  wantStage      Boolean         @default(false)
+  wantAlternance Boolean         @default(false)
+  sector         String?         @db.VarChar(150)
+  location       String?         @db.VarChar(150)
+  remote         Boolean         @default(false)
+  availableFrom  DateTime?
+  description    String          @db.Text
+  contactEmail   String?         @db.VarChar(150)
+  contactUrl     String?         @db.VarChar(500)
+  status         JobSeekerStatus @default(ACTIVE)
+  authorId       String
+  author         User            @relation(fields: [authorId], references: [id])
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+
+  @@index([status])
+  @@index([authorId])
+  @@map("job_seekers")
 }
 
 /// Association berger/co-berger à une famille (référentiel externe).

--- a/specs/003-emploi-profils-recherche/plan.md
+++ b/specs/003-emploi-profils-recherche/plan.md
@@ -1,0 +1,299 @@
+# Plan technique — Profils de recherche d'emploi
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Brouillon
+- **Mis à jour le** : 2026-07-04
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+---
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : aucun import interne dans `src/app/` — le module `jobs` n'expose que son index (`@/modules/jobs`). Aucune logique métier complexe → pas de service dédié nécessaire, CRUD direct dans les route handlers (comme `JobOffer` existant).
+- [x] **Sécurité** : toutes les routes API protégées par `requireAuth()` ou `requirePermission()`. Pas de `churchId` (aligné sur `JobOffer` existant — module cross-tenant voulu).
+- [x] **Permissions** via `rolePermissions` (`@/lib/registry`) — nouvelle permission `jobs:seek` ajoutée au module.
+- [x] **Validation** Zod sur toutes les mutations (POST, PATCH).
+- [x] **Migration** Prisma prévue (`prisma migrate dev`) — ajout modèle `JobSeeker` + champ `wantSeekers` sur `JobNotificationSubscription`.
+- [x] **Enums** importés depuis `@/generated/prisma/client`.
+- [x] **UI** : réutilisation des composants existants (`src/components/ui/`). Aucun nouveau composant UI générique nécessaire.
+
+---
+
+## Approche générale
+
+On étend le module emploi existant en miroir de `JobOffer` : même périmètre cross-tenant, mêmes patterns API (CRUD + notify), même structure de pages. La page `/jobs` adopte un layout à deux onglets pilotés par `searchParams` (SSR-friendly). Un nouveau modèle `JobSeeker` est ajouté au schéma sans perturber l'existant. La permission `jobs:seek` est introduite pour séparer sémantiquement "publier une offre" de "publier son profil de recherche".
+
+---
+
+## Modèle de données
+
+### Nouveaux enums
+
+```prisma
+enum JobSeekerStatus {
+  ACTIVE
+  FOUND
+  ARCHIVED
+}
+```
+
+- `ACTIVE` : en recherche, visible dans la liste publique
+- `FOUND` : a trouvé — fermé par l'auteur, visible uniquement par lui et les admins
+- `ARCHIVED` : archivé par un admin/secrétaire (modération)
+
+### Nouveau modèle `JobSeeker`
+
+```prisma
+/// Profil de recherche d'emploi publié par un utilisateur.
+model JobSeeker {
+  id              String          @id @default(cuid())
+  title           String          @db.VarChar(200)
+  wantEmploi      Boolean         @default(false)
+  wantStage       Boolean         @default(false)
+  wantAlternance  Boolean         @default(false)
+  sector          String?         @db.VarChar(150)
+  location        String?         @db.VarChar(150)
+  remote          Boolean         @default(false)
+  availableFrom   DateTime?
+  description     String          @db.Text
+  contactEmail    String?         @db.VarChar(150)
+  contactUrl      String?         @db.VarChar(500)
+  status          JobSeekerStatus @default(ACTIVE)
+  authorId        String
+  author          User            @relation(fields: [authorId], references: [id])
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+
+  @@index([status])
+  @@index([authorId])
+  @@map("job_seekers")
+}
+```
+
+### Modification `JobNotificationSubscription`
+
+```prisma
+model JobNotificationSubscription {
+  // … champs existants …
+  wantSeekers    Boolean @default(false)   // ← nouveau champ
+}
+```
+
+### Relation `User`
+
+```prisma
+model User {
+  // … relations existantes …
+  jobSeekers  JobSeeker[]
+}
+```
+
+### Migration
+
+Une migration Prisma créée avec `prisma migrate dev --name add_job_seeker_profiles`.
+
+---
+
+## API
+
+| Endpoint | Méthode | Permission | Corps Zod | Sortie |
+|---|---|---|---|---|
+| `GET /api/jobs/seekers` | GET | `requireAuth()` | `?type=EMPLOI\|STAGE\|ALTERNANCE` (query) | `JobSeeker[]` (ACTIVE uniquement) |
+| `POST /api/jobs/seekers` | POST | `requirePermission("jobs:seek")` | `createSeekerSchema` | `JobSeeker` (201) |
+| `GET /api/jobs/seekers/[id]` | GET | `requireAuth()` | — | `JobSeeker` (FOUND/ARCHIVED accessibles auteur + admin) |
+| `PATCH /api/jobs/seekers/[id]` | PATCH | `requireAuth()` | `patchSeekerSchema` | `JobSeeker` |
+| `DELETE /api/jobs/seekers/[id]` | DELETE | `requireAuth()` | — | `{ success: true }` |
+| `PUT /api/jobs/subscription` | PUT | `requireAuth()` | ajouter `wantSeekers: z.boolean().optional()` | `JobNotificationSubscription` |
+
+### Schémas Zod
+
+```typescript
+const createSeekerSchema = z.object({
+  title:         z.string().min(1).max(200),
+  wantEmploi:    z.boolean().default(false),
+  wantStage:     z.boolean().default(false),
+  wantAlternance: z.boolean().default(false),
+  sector:        z.string().max(150).optional().nullable(),
+  location:      z.string().max(150).optional().nullable(),
+  remote:        z.boolean().default(false),
+  availableFrom: z.string().datetime().optional().nullable(),
+  description:   z.string().min(1),
+  contactEmail:  z.string().email().max(150).optional().nullable(),
+  contactUrl:    z.string().url().max(500).optional().nullable(),
+});
+// Contrainte : au moins un wantEmploi || wantStage || wantAlternance = true (refine)
+
+const patchSeekerSchema = createSeekerSchema.partial().extend({
+  status: z.enum(["ACTIVE", "FOUND", "ARCHIVED"]).optional(),
+});
+// Logique d'autorisation dans le handler : seul l'auteur peut passer à FOUND ;
+// seul admin/secrétaire peut passer à ARCHIVED.
+```
+
+### Règles d'autorisation dans les handlers
+
+**PATCH** :
+- Auteur : peut modifier tous les champs sauf `status: ARCHIVED` (réservé admin)
+- Admin/secrétaire (`jobs:manage`) : peut modifier tout, peut passer à `ARCHIVED`
+- Tiers : 403
+
+**DELETE** :
+- Auteur : peut supprimer si `status: ACTIVE` ou `FOUND`
+- Admin/secrétaire (`jobs:manage`) : peut toujours supprimer
+- Tiers : 403
+
+---
+
+## Services / logique métier
+
+Pas de service dédié dans `src/modules/jobs/services/` — la logique est simple (CRUD + notification fire-and-forget). Pattern identique à `JobOffer`.
+
+### Notifications à la création (fire-and-forget)
+
+Fonction `notifySeekerSubscribers(seeker)` dans `src/app/api/jobs/seekers/route.ts` :
+
+```typescript
+// Filtre les abonnés avec wantSeekers: true
+// Pour chaque abonné : notification in-app (type "JOB_SEEKER") et email si sub.email
+// Notification in-app : title "Nouveau profil en recherche", link "/jobs/seekers/{id}"
+```
+
+Le type de notification `"JOB_SEEKER"` est ajouté à l'enum `NotificationType` dans le schéma Prisma.
+
+---
+
+## UI / composants
+
+### Structure des fichiers
+
+```
+src/app/(auth)/jobs/
+├── page.tsx                        ← refonte : layout deux onglets (searchParams ?tab=)
+├── JobsListClient.tsx              ← inchangé
+├── SeekersListClient.tsx           ← NOUVEAU : liste profils + filtre type
+├── new/
+│   ├── page.tsx                    ← inchangé (offres)
+│   └── JobFormClient.tsx           ← inchangé
+├── [id]/
+│   ├── page.tsx                    ← inchangé
+│   └── JobDetailClient.tsx         ← inchangé
+└── seekers/
+    ├── new/
+    │   ├── page.tsx                ← NOUVEAU : server component, précharge email session
+    │   └── SeekerFormClient.tsx    ← NOUVEAU : formulaire création/édition
+    └── [id]/
+        ├── page.tsx                ← NOUVEAU : server component
+        ├── SeekerDetailClient.tsx  ← NOUVEAU : vue détail + actions
+        └── edit/
+            └── page.tsx            ← NOUVEAU : server component, charge le profil
+
+src/app/(auth)/admin/jobs/
+├── page.tsx                        ← ajouter onglet "Profils de recherche"
+└── AdminJobsClient.tsx             ← ajouter section seekers (tab)
+
+src/app/api/jobs/
+├── seekers/
+│   ├── route.ts                    ← NOUVEAU : GET + POST
+│   └── [id]/
+│       └── route.ts                ← NOUVEAU : GET + PATCH + DELETE
+└── subscription/
+    └── route.ts                    ← modifier : ajouter wantSeekers au schéma Zod
+```
+
+### Page `/jobs` — refonte des onglets
+
+La page serveur lit `searchParams.tab` (`"offers"` par défaut | `"seekers"`). Elle charge les données du tab actif et passe le rendu au bon client component. Un composant client léger `JobsTabBar` gère la navigation entre onglets via `useRouter` + `useSearchParams`.
+
+Le CTA principal ("Publier une offre" / "Publier mon profil") change selon le tab actif.
+
+### `SeekersListClient`
+
+- Filtre par type (boutons toggles, plusieurs sélectionnables)
+- Tri : plus récent en premier
+- Carte profil : nom de l'auteur (ou "Anonyme"), titre, types souhaités (badges colorés), localisation + télétravail, date de dispo, extrait description (line-clamp-2)
+- Badge "Mon profil" si `authorId === currentUserId`
+- État vide avec CTA "Publier mon profil → /jobs/seekers/new"
+
+### `SeekerFormClient`
+
+- Champs : titre (obligatoire), types de contrat (checkboxes, au moins 1 requis), secteur, localisation, télétravail (toggle), date de disponibilité, description (obligatoire), email de contact, lien externe
+- Email pré-rempli depuis la session (passé en props par la page serveur)
+- Réutilise le style des inputs de `JobFormClient` (cohérence visuelle)
+
+### `SeekerDetailClient`
+
+- Vue complète du profil
+- Actions auteur : "Modifier" → edit, "J'ai trouvé !" → PATCH status: FOUND, "Supprimer" → DELETE
+- Actions admin/secrétaire (canManage) : "Archiver" → PATCH status: ARCHIVED, "Supprimer" → DELETE
+- Profil FOUND : bannière "Ce profil est clôturé (emploi trouvé)" + masquage de l'action "J'ai trouvé"
+- Profil ARCHIVED : bannière "Ce profil a été archivé par un modérateur"
+
+### Paramètre `tab` et navigation
+
+```
+/jobs            → tab "Offres" (défaut)
+/jobs?tab=seekers → tab "En recherche"
+```
+
+Lien "Publier mon profil" depuis l'onglet seekers → `/jobs/seekers/new`
+Après création d'un profil → redirect vers `/jobs/seekers/{id}`
+
+---
+
+## Module `jobs` — ajout permission
+
+```typescript
+// src/modules/jobs/index.ts
+permissions: {
+  "jobs:view":   [...tous les rôles...],
+  "jobs:post":   [...tous les rôles...],
+  "jobs:seek":   [...tous les rôles...],   // ← nouveau
+  "jobs:manage": ["SUPER_ADMIN", "ADMIN", "SECRETARY"],
+},
+```
+
+`jobs:seek` regroupe les mêmes rôles que `jobs:post` mais garde une sémantique distincte pour une éventuelle différenciation future.
+
+---
+
+## Décisions & alternatives écartées
+
+- **Trois booleans `wantEmploi/wantStage/wantAlternance` vs. tableau JSON ou table de jonction** : choix des booleans — cohérence avec `JobNotificationSubscription`, simplicité des requêtes de filtrage, pas de support natif des tableaux en MariaDB. Un tableau JSON aurait rendu les index impossibles.
+
+- **Cross-tenant (pas de `churchId`) vs. scoped par église** : choix cross-tenant — aligné sur `JobOffer`. Le module emploi est volontairement un espace commun à toute la plateforme, pas limité à une église.
+
+- **Statut `FOUND` vs. simple suppression quand "j'ai trouvé"** : choix du statut — conserve l'historique consultable par l'auteur, évite la perte de données involontaire, permet des statistiques futures.
+
+- **`searchParams` (SSR) vs. état client pour les onglets** : choix `searchParams` — le tab est partageable par URL (`/jobs?tab=seekers`), SEO-friendly, compatible avec le rendu serveur initial de la liste.
+
+- **`/jobs/seekers/[id]` vs. `/jobs/[id]?type=seeker`** : URLs distinctes — modèles différents, pas de pollution du handler existant `JobOffer`.
+
+- **Service dédié dans `src/modules/jobs/services/`** : écarté — la logique est du CRUD pur sans invariant métier complexe. Ajouter un service serait de la sur-ingénierie.
+
+---
+
+## Risques & points d'attention
+
+- **`NotificationType` enum** : ajouter `JOB_SEEKER` nécessite une migration. Vérifier qu'aucun autre code ne fait de switch exhaustif sur cet enum sans cas par défaut.
+- **Email pré-rempli** : la session Next.js expose `session.user.email` — le passer en props côté serveur, ne pas le lire côté client.
+- **Filtrage multi-type** : le filtre "Emploi + Stage" sélectionnés simultanément doit utiliser un `OR` Prisma (`{ OR: [{ wantEmploi: true }, { wantStage: true }] }`).
+- **Admin `/admin/jobs`** : la page admin doit couvrir les deux entités. L'onglet seekers liste tous les profils (ACTIVE + FOUND + ARCHIVED).
+
+---
+
+## Stratégie de tests
+
+Tests Vitest dans `src/app/api/jobs/__tests__/` (fichier dédié `seekers.test.ts`) :
+
+| Cas | Type |
+|---|---|
+| POST `/api/jobs/seekers` — sans auth → 401 | Unitaire API |
+| POST `/api/jobs/seekers` — body invalide (sans type de contrat) → 400 | Unitaire API |
+| POST `/api/jobs/seekers` — succès → 201 + profil retourné | Unitaire API |
+| GET `/api/jobs/seekers` — filtre par type → seuls les profils ACTIVE + type matching | Unitaire API |
+| PATCH `/api/jobs/seekers/[id]` — auteur passe à FOUND → 200 | Unitaire API |
+| PATCH `/api/jobs/seekers/[id]` — auteur tente ARCHIVED → 403 | Unitaire API |
+| PATCH `/api/jobs/seekers/[id]` — tiers → 403 | Unitaire API |
+| DELETE `/api/jobs/seekers/[id]` — auteur → 200 | Unitaire API |
+| DELETE `/api/jobs/seekers/[id]` — tiers → 403 | Unitaire API |

--- a/specs/003-emploi-profils-recherche/spec.md
+++ b/specs/003-emploi-profils-recherche/spec.md
@@ -1,0 +1,96 @@
+# Spec — Profils de recherche d'emploi
+
+- **Numéro** : 003
+- **Statut** : Implémentée
+- **Créée le** : 2026-07-04
+- **Branche suggérée** : `feat/emploi-profils-recherche`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+---
+
+## Contexte & problème
+
+Le module emploi de Koinonia est aujourd'hui un panneau d'affichage **à sens unique** : des membres de la communauté publient des offres, d'autres peuvent postuler par email ou lien externe. Le flux inversé — un membre qui cherche un emploi et souhaite se faire connaître de la communauté — n'existe pas.
+
+Résultat : les membres en recherche active ne peuvent pas signaler leur disponibilité. Les membres qui recrutent (ou connaissent une opportunité) n'ont aucun moyen de savoir qui est ouvert à de nouvelles opportunités. Le réseau d'entraide professionnelle reste inexploité.
+
+---
+
+## Utilisateurs concernés
+
+| Rôle | Ce qu'il peut faire |
+|---|---|
+| **Tout utilisateur authentifié** (tous rôles) | Créer, modifier, clôturer ses propres profils de recherche ; consulter tous les profils actifs de la communauté |
+| **Super Admin / Admin / Secrétaire** | En plus : archiver ou supprimer n'importe quel profil (modération) |
+
+Un même utilisateur peut avoir **plusieurs profils actifs simultanément** (ex : cherche un CDI en informatique ET une alternance en comptabilité).
+
+---
+
+## Comportement attendu
+
+### Scénario principal — publier un profil de recherche
+
+1. Un membre connecté accède à la section Emploi.
+2. Il voit deux onglets : **Offres** (liste existante) et **En recherche** (nouveau).
+3. Depuis l'onglet "En recherche", il clique sur "Publier mon profil".
+4. Il remplit un formulaire : titre du profil, type(s) de contrat souhaité(s) (emploi, stage, alternance — sélection multiple), secteur / domaine d'activité, localisation souhaitée, ouverture au télétravail, date de disponibilité, présentation libre, email de contact, lien externe (LinkedIn, portfolio…).
+5. Il publie. Son profil apparaît dans l'onglet "En recherche", visible par tous les membres connectés.
+6. Les membres abonnés aux notifications emploi qui ont activé l'option "nouvelles recherches" reçoivent une notification in-app.
+
+### Scénario — mettre à jour ou clôturer un profil
+
+1. L'auteur retrouve son profil (via l'onglet ou via sa propre liste).
+2. Il peut modifier n'importe quel champ tant que le profil est actif.
+3. Quand il a trouvé un emploi, il clôture le profil ("J'ai trouvé !"). Le profil passe en statut **Trouvé** et disparaît de la liste publique, mais reste consultable par son auteur et les admins.
+
+### Scénario — consulter les profils
+
+1. Un membre ouvre l'onglet "En recherche".
+2. Il voit les profils actifs, triés du plus récent au plus ancien.
+3. Il peut filtrer par type de contrat (emploi / stage / alternance).
+4. Il clique sur un profil pour voir le détail complet : présentation, disponibilité, contact.
+
+### Scénarios alternatifs / cas limites
+
+- **Si l'utilisateur n'a pas de profil actif**, l'onglet "En recherche" affiche un état vide avec le CTA "Publier mon profil".
+- **Si un profil dépasse une durée de 6 mois sans modification**, il reste visible mais peut faire l'objet d'une relance (hors périmètre V1).
+- **Quand un admin supprime un profil**, l'auteur n'en est pas notifié en V1.
+- **Un utilisateur peut publier plusieurs profils actifs** ; ils apparaissent chacun comme une carte distincte dans la liste (avec un indicateur "Ma publication").
+- **Si aucune date de disponibilité n'est renseignée**, le profil s'affiche sans mention de disponibilité (champ facultatif).
+- **Le contact email est pré-rempli** avec l'email du compte, mais l'utilisateur peut le remplacer ou le vider.
+
+---
+
+## Critères d'acceptation
+
+- [ ] Un utilisateur connecté peut créer un profil de recherche avec au minimum un titre et un type de contrat.
+- [ ] Un utilisateur peut créer plusieurs profils actifs simultanément.
+- [ ] Les profils actifs sont visibles dans l'onglet "En recherche" par tous les membres connectés.
+- [ ] L'auteur peut modifier son profil tant qu'il est actif.
+- [ ] L'auteur peut clôturer son profil ("J'ai trouvé") ; le profil disparaît alors de la liste publique.
+- [ ] Un admin/secrétaire peut supprimer n'importe quel profil.
+- [ ] La liste peut être filtrée par type de contrat (emploi / stage / alternance).
+- [ ] Les membres abonnés aux notifications emploi avec l'option "nouvelles recherches" reçoivent une notification in-app à chaque nouveau profil publié.
+- [ ] La page `/jobs` présente bien deux onglets distincts sans régression sur l'onglet "Offres" existant.
+- [ ] Un utilisateur non connecté ne peut pas accéder aux profils (comportement inchangé du module).
+
+---
+
+## Hors périmètre
+
+- Relance automatique des profils inactifs depuis plus de 6 mois.
+- Mise en relation directe via messagerie interne.
+- Système de matching offres ↔ profils.
+- Visibilité restreinte (profil visible uniquement par admins).
+- Import / export des profils.
+- Modération par email (notification à l'auteur en cas de suppression).
+- Abonnements par secteur d'activité (les notifications couvrent uniquement le type de contrat en V1).
+
+---
+
+## Questions ouvertes
+
+- Aucune — les décisions structurantes ont été tranchées en amont.

--- a/specs/003-emploi-profils-recherche/tasks.md
+++ b/specs/003-emploi-profils-recherche/tasks.md
@@ -1,0 +1,97 @@
+# Tâches — Profils de recherche d'emploi
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : À faire
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : migration → module → API → UI → tests. Les tâches `[P]` sont parallélisables.
+
+---
+
+## Prérequis
+
+- [ ] Branche créée : `feat/emploi-profils-recherche`
+
+---
+
+## Tâches
+
+### 1. Données & migration
+
+- [ ] **T1** — Ajouter l'enum `JobSeekerStatus` (`ACTIVE`, `FOUND`, `ARCHIVED`) et le modèle `JobSeeker` au schéma Prisma ; ajouter la relation `jobSeekers JobSeeker[]` sur `User` ; ajouter `wantSeekers Boolean @default(false)` sur `JobNotificationSubscription` ; ajouter `JOB_SEEKER` à l'enum `NotificationType`.
+  *(fichier : `prisma/schema.prisma`)*
+
+- [ ] **T2** — Générer la migration Prisma : `npm run db:migrate -- --name add_job_seeker_profiles` puis vérifier le fichier SQL généré.
+  *(fichier : `prisma/migrations/…/migration.sql`)*
+
+- [ ] **T3** — Régénérer le client Prisma : `npx prisma generate` et vérifier que `JobSeeker`, `JobSeekerStatus` sont bien exportés depuis `@/generated/prisma/client`.
+  *(fichier : `src/generated/prisma/`)*
+
+### 2. Module
+
+- [ ] **T4** — Ajouter la permission `jobs:seek` dans le module emploi, avec les mêmes rôles que `jobs:post`.
+  *(fichier : `src/modules/jobs/index.ts`)*
+
+### 3. API
+
+- [ ] **T5** — Créer `GET /api/jobs/seekers` (liste les profils `ACTIVE`, filtre optionnel `?type=EMPLOI|STAGE|ALTERNANCE` via OR sur les booleans, tri `createdAt desc`) et `POST /api/jobs/seekers` (requirePermission `jobs:seek`, validation `createSeekerSchema` Zod avec refine au moins un type de contrat, création + fire-and-forget `notifySeekerSubscribers`).
+  *(fichier : `src/app/api/jobs/seekers/route.ts`)*
+
+- [ ] **T6** — Créer `GET /api/jobs/seekers/[id]` (requireAuth, profil FOUND/ARCHIVED visible uniquement par auteur ou jobs:manage), `PATCH /api/jobs/seekers/[id]` (patchSeekerSchema, règles auteur vs admin décrites dans le plan), `DELETE /api/jobs/seekers/[id]` (auteur ou jobs:manage).
+  *(fichier : `src/app/api/jobs/seekers/[id]/route.ts`)*
+
+- [ ] **T7** — Modifier `PUT /api/jobs/subscription` : ajouter `wantSeekers: z.boolean().optional()` au `subSchema` Zod existant.
+  *(fichier : `src/app/api/jobs/subscription/route.ts`)*
+
+### 4. UI — pages et composants
+
+> Les tâches T8 à T13 sont parallélisables entre elles une fois T5–T7 terminées.
+
+- [ ] **T8** [P] — Créer `SeekersListClient.tsx` : liste des profils ACTIVE avec filtre multi-type (toggles boutons, OR combiné), tri chronologique, carte profil (auteur, titre, badges types, localisation, télétravail, dispo, extrait description, badge "Mon profil"), état vide avec CTA "Publier mon profil".
+  *(fichier : `src/app/(auth)/jobs/SeekersListClient.tsx`)*
+
+- [ ] **T9** [P] — Créer `SeekerFormClient.tsx` : formulaire création/édition (titre obligatoire, checkboxes types de contrat — au moins un requis côté client, secteur, localisation, toggle télétravail, date de dispo, description obligatoire, email pré-rempli via props, lien externe), submit POST ou PATCH selon mode, redirect vers `/jobs/seekers/{id}`.
+  *(fichier : `src/app/(auth)/jobs/seekers/new/SeekerFormClient.tsx`)*
+
+- [ ] **T10** [P] — Créer `SeekerDetailClient.tsx` : vue détail complète, actions auteur (Modifier, J'ai trouvé, Supprimer), actions admin/secrétaire (Archiver, Supprimer), bannières statut FOUND/ARCHIVED.
+  *(fichier : `src/app/(auth)/jobs/seekers/[id]/SeekerDetailClient.tsx`)*
+
+- [ ] **T11** [P] — Créer les pages serveur pour les profils de recherche :
+  - `/jobs/seekers/new/page.tsx` : auth guard, précharge l'email session en props pour `SeekerFormClient`
+  - `/jobs/seekers/[id]/page.tsx` : auth guard, charge le profil, passe `canManage` et `isAuthor`
+  - `/jobs/seekers/[id]/edit/page.tsx` : auth guard, vérifie que l'utilisateur est auteur, précharge le profil pour `SeekerFormClient`
+  *(fichiers : `src/app/(auth)/jobs/seekers/*/page.tsx`)*
+
+- [ ] **T12** [P] — Refondre `src/app/(auth)/jobs/page.tsx` : lire `searchParams.tab` (`"offers"` par défaut | `"seekers"`), charger les données du tab actif côté serveur, rendre un composant client léger `JobsTabBar` pour la navigation entre onglets, adapter le CTA principal selon le tab.
+  *(fichiers : `src/app/(auth)/jobs/page.tsx`, `src/app/(auth)/jobs/JobsTabBar.tsx`)*
+
+- [ ] **T13** [P] — Étendre la page d'administration des offres : ajouter un onglet "Profils de recherche" dans `AdminJobsClient.tsx` listant tous les profils (ACTIVE + FOUND + ARCHIVED) avec actions Archiver/Republier/Supprimer ; mettre à jour `admin/jobs/page.tsx` pour charger les seekers.
+  *(fichiers : `src/app/(auth)/admin/jobs/page.tsx`, `src/app/(auth)/admin/jobs/AdminJobsClient.tsx`)*
+
+- [ ] **T14** — Ajouter le toggle `wantSeekers` dans l'interface de gestion des abonnements aux notifications emploi (là où `wantEmploi/wantStage/wantAlternance` sont déjà exposés).
+  *(fichier : à localiser via grep sur `wantEmploi` dans les composants UI)*
+
+### 5. Tests
+
+- [ ] **T15** — Créer `seekers.test.ts` couvrant : POST sans auth → 401 ; POST body invalide (aucun type de contrat) → 400 ; POST succès → 201 ; GET filtre par type → profils ACTIVE matching ; PATCH auteur → FOUND 200 ; PATCH auteur tente ARCHIVED → 403 ; PATCH tiers → 403 ; DELETE auteur → 200 ; DELETE tiers → 403.
+  *(fichier : `src/app/api/jobs/__tests__/seekers.test.ts`)*
+
+---
+
+## Vérification finale
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run lint:boundaries`
+- [ ] `npm run test`
+- [ ] **CA1** — Un utilisateur connecté peut créer un profil avec au minimum titre + 1 type de contrat *(T5, T9)*
+- [ ] **CA2** — Un utilisateur peut avoir plusieurs profils actifs simultanément *(T5, T8)*
+- [ ] **CA3** — Les profils actifs sont visibles par tous les membres connectés *(T5, T8, T12)*
+- [ ] **CA4** — L'auteur peut modifier son profil tant qu'il est actif *(T6, T10, T11)*
+- [ ] **CA5** — L'auteur peut clôturer son profil ("J'ai trouvé") ; il disparaît de la liste publique *(T6, T10)*
+- [ ] **CA6** — Un admin/secrétaire peut supprimer n'importe quel profil *(T6, T10, T13)*
+- [ ] **CA7** — La liste peut être filtrée par type de contrat *(T5, T8)*
+- [ ] **CA8** — Les abonnés avec `wantSeekers` reçoivent une notification in-app à chaque nouveau profil *(T5, T7)*
+- [ ] **CA9** — La page `/jobs` présente deux onglets sans régression sur "Offres" *(T12)*
+- [ ] **CA10** — Un utilisateur non connecté ne peut pas accéder aux profils *(T5, T6)*
+- [ ] PR ouverte vers `main`

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -57,6 +57,7 @@ export const prismaMock = {
   welcomeDutyAssignment: createModelMock(),
   // Module emploi
   jobOffer: createModelMock(),
+  jobSeeker: createModelMock(),
   jobNotificationSubscription: createModelMock(),
   $transaction: vi.fn((fn: (tx: typeof prismaMock) => Promise<unknown>) =>
     fn(prismaMock)

--- a/src/app/(auth)/admin/jobs/AdminJobsClient.tsx
+++ b/src/app/(auth)/admin/jobs/AdminJobsClient.tsx
@@ -17,6 +17,19 @@ interface Job {
   author: { id: string; name: string | null; displayName: string | null; image: string | null };
 }
 
+interface Seeker {
+  id: string;
+  title: string;
+  wantEmploi: boolean;
+  wantStage: boolean;
+  wantAlternance: boolean;
+  sector: string | null;
+  location: string | null;
+  status: "ACTIVE" | "FOUND" | "ARCHIVED";
+  createdAt: string;
+  author: { id: string; name: string | null; displayName: string | null; image: string | null };
+}
+
 const TYPE_LABELS: Record<JobType, string> = {
   EMPLOI:     "Emploi",
   STAGE:      "Stage",
@@ -29,7 +42,63 @@ const TYPE_COLORS: Record<JobType, string> = {
   ALTERNANCE: "bg-icc-jaune/20 text-amber-700",
 };
 
-export default function AdminJobsClient({ jobs }: { jobs: Job[] }) {
+const SEEKER_STATUS_LABELS: Record<Seeker["status"], string> = {
+  ACTIVE:   "En recherche",
+  FOUND:    "A trouvé",
+  ARCHIVED: "Archivé",
+};
+
+const SEEKER_STATUS_COLORS: Record<Seeker["status"], string> = {
+  ACTIVE:   "bg-green-100 text-green-700",
+  FOUND:    "bg-blue-100 text-blue-700",
+  ARCHIVED: "bg-gray-100 text-gray-500",
+};
+
+export default function AdminJobsClient({
+  jobs,
+  seekers,
+}: {
+  jobs: Job[];
+  seekers: Seeker[];
+}) {
+  const [mainTab, setMainTab] = useState<"offers" | "seekers">("offers");
+
+  return (
+    <div>
+      {/* Onglets principaux */}
+      <div className="flex gap-1 mb-6 border-b border-gray-200">
+        <button
+          onClick={() => setMainTab("offers")}
+          className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+            mainTab === "offers"
+              ? "border-icc-violet text-icc-violet"
+              : "border-transparent text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          Offres <span className="ml-1 text-xs text-gray-400">({jobs.length})</span>
+        </button>
+        <button
+          onClick={() => setMainTab("seekers")}
+          className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+            mainTab === "seekers"
+              ? "border-icc-violet text-icc-violet"
+              : "border-transparent text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          Profils de recherche <span className="ml-1 text-xs text-gray-400">({seekers.length})</span>
+        </button>
+      </div>
+
+      {mainTab === "offers" ? (
+        <OffersPanel jobs={jobs} />
+      ) : (
+        <SeekersPanel seekers={seekers} />
+      )}
+    </div>
+  );
+}
+
+function OffersPanel({ jobs }: { jobs: Job[] }) {
   const router = useRouter();
   const [filter, setFilter] = useState<"ALL" | "PUBLISHED" | "ARCHIVED">("ALL");
   const [loading, setLoading] = useState<string | null>(null);
@@ -68,11 +137,10 @@ export default function AdminJobsClient({ jobs }: { jobs: Job[] }) {
 
   return (
     <div>
-      {/* Filter tabs */}
       <div className="flex gap-1 mb-6 border-b border-gray-200">
         {([
-          { key: "ALL",       label: "Tout",    count: jobs.length },
-          { key: "PUBLISHED", label: "Publiées",count: publishedCount },
+          { key: "ALL",       label: "Tout",     count: jobs.length },
+          { key: "PUBLISHED", label: "Publiées", count: publishedCount },
           { key: "ARCHIVED",  label: "Archivées",count: archivedCount },
         ] as const).map(({ key, label, count }) => (
           <button
@@ -94,9 +162,9 @@ export default function AdminJobsClient({ jobs }: { jobs: Job[] }) {
       ) : (
         <div className="space-y-3">
           {filtered.map((job) => {
-            const author      = job.author.displayName ?? job.author.name ?? "Inconnu";
-            const deadline    = job.deadline ? new Date(job.deadline) : null;
-            const isArchived  = job.status === "ARCHIVED";
+            const author     = job.author.displayName ?? job.author.name ?? "Inconnu";
+            const deadline   = job.deadline ? new Date(job.deadline) : null;
+            const isArchived = job.status === "ARCHIVED";
 
             return (
               <div
@@ -134,6 +202,125 @@ export default function AdminJobsClient({ jobs }: { jobs: Job[] }) {
                     className="px-3 py-1.5 text-xs font-semibold border-2 border-icc-rouge/30 text-icc-rouge rounded-lg hover:bg-icc-rouge/5 disabled:opacity-50 transition-colors"
                   >
                     {loading === job.id ? "…" : "Supprimer"}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SeekersPanel({ seekers }: { seekers: Seeker[] }) {
+  const router = useRouter();
+  const [filter, setFilter] = useState<"ALL" | "ACTIVE" | "FOUND" | "ARCHIVED">("ALL");
+  const [loading, setLoading] = useState<string | null>(null);
+
+  const filtered = seekers.filter((s) => filter === "ALL" || s.status === filter);
+
+  async function toggleArchive(seeker: Seeker) {
+    setLoading(seeker.id);
+    try {
+      const newStatus = seeker.status === "ARCHIVED" ? "ACTIVE" : "ARCHIVED";
+      const res = await fetch(`/api/jobs/seekers/${seeker.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur"); return; }
+      router.refresh();
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm("Supprimer définitivement ce profil ?")) return;
+    setLoading(id);
+    try {
+      const res = await fetch(`/api/jobs/seekers/${id}`, { method: "DELETE" });
+      if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur"); return; }
+      router.refresh();
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex gap-1 mb-6 border-b border-gray-200">
+        {([
+          { key: "ALL",      label: "Tout",        count: seekers.length },
+          { key: "ACTIVE",   label: "En recherche",count: seekers.filter((s) => s.status === "ACTIVE").length },
+          { key: "FOUND",    label: "A trouvé",    count: seekers.filter((s) => s.status === "FOUND").length },
+          { key: "ARCHIVED", label: "Archivés",    count: seekers.filter((s) => s.status === "ARCHIVED").length },
+        ] as const).map(({ key, label, count }) => (
+          <button
+            key={key}
+            onClick={() => setFilter(key)}
+            className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              filter === key
+                ? "border-icc-violet text-icc-violet"
+                : "border-transparent text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            {label} <span className="ml-1 text-xs text-gray-400">({count})</span>
+          </button>
+        ))}
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="text-center text-gray-400 py-12">Aucun profil.</p>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map((seeker) => {
+            const author     = seeker.author.displayName ?? seeker.author.name ?? "Inconnu";
+            const isArchived = seeker.status === "ARCHIVED";
+
+            const contractTypes = [
+              seeker.wantEmploi     && "Emploi",
+              seeker.wantStage      && "Stage",
+              seeker.wantAlternance && "Alternance",
+            ].filter(Boolean).join(", ");
+
+            return (
+              <div
+                key={seeker.id}
+                className={`bg-white rounded-lg border-2 p-4 flex items-center gap-4 ${isArchived ? "border-gray-100 opacity-60" : "border-gray-200"}`}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap mb-0.5">
+                    <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${SEEKER_STATUS_COLORS[seeker.status]}`}>
+                      {SEEKER_STATUS_LABELS[seeker.status]}
+                    </span>
+                  </div>
+                  <Link href={`/jobs/seekers/${seeker.id}`} className="font-semibold text-gray-900 hover:text-icc-violet text-sm">
+                    {seeker.title}
+                  </Link>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    {author}
+                    {contractTypes && ` — ${contractTypes}`}
+                    {seeker.location && ` — ${seeker.location}`}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  {seeker.status !== "FOUND" && (
+                    <button
+                      onClick={() => toggleArchive(seeker)}
+                      disabled={loading === seeker.id}
+                      className="px-3 py-1.5 text-xs font-semibold border-2 border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors"
+                    >
+                      {loading === seeker.id ? "…" : isArchived ? "Republier" : "Archiver"}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => handleDelete(seeker.id)}
+                    disabled={loading === seeker.id}
+                    className="px-3 py-1.5 text-xs font-semibold border-2 border-icc-rouge/30 text-icc-rouge rounded-lg hover:bg-icc-rouge/5 disabled:opacity-50 transition-colors"
+                  >
+                    {loading === seeker.id ? "…" : "Supprimer"}
                   </button>
                 </div>
               </div>

--- a/src/app/(auth)/admin/jobs/page.tsx
+++ b/src/app/(auth)/admin/jobs/page.tsx
@@ -12,23 +12,39 @@ export default async function AdminJobsPage() {
   const permissions = new Set(userRoles.flatMap((r) => rolePermissions[r] ?? []));
   if (!session.user.isSuperAdmin && !permissions.has("jobs:manage")) redirect("/jobs");
 
-  const jobs = await prisma.jobOffer.findMany({
-    include: {
-      author: { select: { id: true, name: true, displayName: true, image: true } },
-    },
-    orderBy: { createdAt: "desc" },
-  });
+  const [jobs, seekers] = await Promise.all([
+    prisma.jobOffer.findMany({
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.jobSeeker.findMany({
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
 
   return (
     <div className="max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold text-gray-900 mb-2">Modération — Emploi</h1>
-      <p className="text-sm text-gray-500 mb-6">Gérez les offres publiées par les membres de la communauté.</p>
-      <AdminJobsClient jobs={jobs.map((j) => ({
-        ...j,
-        deadline:  j.deadline  ? j.deadline.toISOString()  : null,
-        createdAt: j.createdAt.toISOString(),
-        updatedAt: j.updatedAt.toISOString(),
-      }))} />
+      <p className="text-sm text-gray-500 mb-6">Gérez les offres et les profils de recherche de la communauté.</p>
+      <AdminJobsClient
+        jobs={jobs.map((j) => ({
+          ...j,
+          deadline:  j.deadline  ? j.deadline.toISOString()  : null,
+          createdAt: j.createdAt.toISOString(),
+          updatedAt: j.updatedAt.toISOString(),
+        }))}
+        seekers={seekers.map((s) => ({
+          ...s,
+          availableFrom: s.availableFrom ? s.availableFrom.toISOString() : null,
+          createdAt:     s.createdAt.toISOString(),
+          updatedAt:     s.updatedAt.toISOString(),
+        }))}
+      />
     </div>
   );
 }

--- a/src/app/(auth)/jobs/JobsTabBar.tsx
+++ b/src/app/(auth)/jobs/JobsTabBar.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+export default function JobsTabBar({
+  offersCount,
+  seekersCount,
+}: {
+  offersCount: number;
+  seekersCount: number;
+}) {
+  const router       = useRouter();
+  const searchParams = useSearchParams();
+  const activeTab    = searchParams.get("tab") ?? "offers";
+
+  function switchTab(tab: string) {
+    router.push(`/jobs${tab === "offers" ? "" : "?tab=" + tab}`);
+  }
+
+  return (
+    <div className="flex gap-1 mb-6 border-b border-gray-200">
+      <button
+        onClick={() => switchTab("offers")}
+        className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+          activeTab === "offers"
+            ? "border-icc-violet text-icc-violet"
+            : "border-transparent text-gray-500 hover:text-gray-700"
+        }`}
+      >
+        Offres <span className="ml-1.5 text-xs text-gray-400">({offersCount})</span>
+      </button>
+      <button
+        onClick={() => switchTab("seekers")}
+        className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+          activeTab === "seekers"
+            ? "border-icc-violet text-icc-violet"
+            : "border-transparent text-gray-500 hover:text-gray-700"
+        }`}
+      >
+        En recherche <span className="ml-1.5 text-xs text-gray-400">({seekersCount})</span>
+      </button>
+    </div>
+  );
+}

--- a/src/app/(auth)/jobs/SeekersListClient.tsx
+++ b/src/app/(auth)/jobs/SeekersListClient.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+type ContractType = "EMPLOI" | "STAGE" | "ALTERNANCE";
+
+interface Seeker {
+  id: string;
+  title: string;
+  wantEmploi: boolean;
+  wantStage: boolean;
+  wantAlternance: boolean;
+  sector: string | null;
+  location: string | null;
+  remote: boolean;
+  availableFrom: string | null;
+  description: string;
+  status: string;
+  createdAt: string;
+  author: { id: string; name: string | null; displayName: string | null; image: string | null };
+}
+
+const TYPE_LABELS: Record<ContractType, string> = {
+  EMPLOI:     "Emploi",
+  STAGE:      "Stage",
+  ALTERNANCE: "Alternance",
+};
+
+const TYPE_COLORS: Record<ContractType, string> = {
+  EMPLOI:     "bg-icc-violet/10 text-icc-violet",
+  STAGE:      "bg-icc-bleu/10 text-icc-bleu",
+  ALTERNANCE: "bg-icc-jaune/20 text-amber-700",
+};
+
+export default function SeekersListClient({
+  seekers,
+  currentUserId,
+}: {
+  seekers: Seeker[];
+  currentUserId: string;
+}) {
+  const [activeFilters, setActiveFilters] = useState<Set<ContractType>>(new Set());
+
+  function toggleFilter(type: ContractType) {
+    setActiveFilters((prev) => {
+      const next = new Set(prev);
+      next.has(type) ? next.delete(type) : next.add(type);
+      return next;
+    });
+  }
+
+  const filtered =
+    activeFilters.size === 0
+      ? seekers
+      : seekers.filter((s) =>
+          (activeFilters.has("EMPLOI")     && s.wantEmploi)     ||
+          (activeFilters.has("STAGE")      && s.wantStage)      ||
+          (activeFilters.has("ALTERNANCE") && s.wantAlternance)
+        );
+
+  return (
+    <div>
+      {/* Filtres */}
+      <div className="flex gap-2 mb-6 flex-wrap">
+        {(["EMPLOI", "STAGE", "ALTERNANCE"] as const).map((type) => (
+          <button
+            key={type}
+            onClick={() => toggleFilter(type)}
+            className={`px-3 py-1.5 text-xs font-semibold rounded-full border-2 transition-colors ${
+              activeFilters.has(type)
+                ? TYPE_COLORS[type] + " border-current"
+                : "border-gray-200 text-gray-500 hover:border-gray-300"
+            }`}
+          >
+            {TYPE_LABELS[type]}
+          </button>
+        ))}
+        {activeFilters.size > 0 && (
+          <button
+            onClick={() => setActiveFilters(new Set())}
+            className="px-3 py-1.5 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            Effacer
+          </button>
+        )}
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-16 text-gray-400">
+          <p className="text-lg font-medium">
+            {seekers.length === 0 ? "Aucun profil de recherche pour le moment" : "Aucun profil ne correspond au filtre"}
+          </p>
+          {seekers.length === 0 && (
+            <>
+              <p className="text-sm mt-1">Soyez le premier à publier votre recherche !</p>
+              <Link
+                href="/jobs/seekers/new"
+                className="inline-block mt-4 px-4 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 transition-colors"
+              >
+                Publier mon profil
+              </Link>
+            </>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {filtered.map((seeker) => (
+            <SeekerCard
+              key={seeker.id}
+              seeker={seeker}
+              isOwn={seeker.author.id === currentUserId}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SeekerCard({ seeker, isOwn }: { seeker: Seeker; isOwn: boolean }) {
+  const createdDate     = new Date(seeker.createdAt);
+  const availableDate   = seeker.availableFrom ? new Date(seeker.availableFrom) : null;
+  const authorName      = seeker.author.displayName ?? seeker.author.name ?? "Anonyme";
+
+  const contractBadges = (
+    [
+      seeker.wantEmploi     && "EMPLOI",
+      seeker.wantStage      && "STAGE",
+      seeker.wantAlternance && "ALTERNANCE",
+    ] as (ContractType | false)[]
+  ).filter(Boolean) as ContractType[];
+
+  return (
+    <Link
+      href={`/jobs/seekers/${seeker.id}`}
+      className="block bg-white rounded-lg border-2 border-gray-100 p-5 hover:border-icc-violet/30 hover:shadow-sm transition-all"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
+            {contractBadges.map((type) => (
+              <span key={type} className={`inline-block text-xs font-semibold px-2.5 py-0.5 rounded-full ${TYPE_COLORS[type]}`}>
+                {TYPE_LABELS[type]}
+              </span>
+            ))}
+            {isOwn && (
+              <span className="text-xs text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">Mon profil</span>
+            )}
+          </div>
+          <h3 className="font-semibold text-gray-900 text-base leading-snug">{seeker.title}</h3>
+          <p className="text-sm text-gray-600 mt-0.5">{authorName}</p>
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 mt-1">
+            {seeker.location && (
+              <p className="text-xs text-gray-400">{seeker.location}{seeker.remote ? " · télétravail" : ""}</p>
+            )}
+            {!seeker.location && seeker.remote && (
+              <p className="text-xs text-gray-400">Télétravail</p>
+            )}
+            {seeker.sector && (
+              <p className="text-xs text-gray-400">{seeker.sector}</p>
+            )}
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          <p className="text-xs text-gray-400">
+            {createdDate.toLocaleDateString("fr-FR", { day: "numeric", month: "short" })}
+          </p>
+          {availableDate && (
+            <p className="text-xs text-gray-400 mt-0.5">
+              Dispo le {availableDate.toLocaleDateString("fr-FR", { day: "numeric", month: "short" })}
+            </p>
+          )}
+        </div>
+      </div>
+      <p className="text-sm text-gray-500 mt-2 line-clamp-2">{seeker.description}</p>
+    </Link>
+  );
+}

--- a/src/app/(auth)/jobs/page.tsx
+++ b/src/app/(auth)/jobs/page.tsx
@@ -2,29 +2,54 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import Link from "next/link";
+import { Suspense } from "react";
 import JobsListClient from "./JobsListClient";
+import SeekersListClient from "./SeekersListClient";
+import JobsTabBar from "./JobsTabBar";
 
-export default async function JobsPage() {
+export default async function JobsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
   const session = await auth();
   if (!session?.user) redirect("/");
 
+  const { tab } = await searchParams;
+  const activeTab = tab === "seekers" ? "seekers" : "offers";
+
   const now = new Date();
 
-  const jobs = await prisma.jobOffer.findMany({
-    where: {
-      status: "PUBLISHED",
-      OR: [{ deadline: null }, { deadline: { gte: now } }],
-    },
-    include: {
-      author: { select: { id: true, name: true, displayName: true, image: true } },
-    },
-    orderBy: { createdAt: "desc" },
-  });
+  const [jobs, seekers] = await Promise.all([
+    prisma.jobOffer.findMany({
+      where: {
+        status: "PUBLISHED",
+        OR: [{ deadline: null }, { deadline: { gte: now } }],
+      },
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.jobSeeker.findMany({
+      where: { status: "ACTIVE" },
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
 
-  const serialized = jobs.map((j) => ({
+  const serializedJobs = jobs.map((j) => ({
     ...j,
     deadline:  j.deadline  ? j.deadline.toISOString()  : null,
     createdAt: j.createdAt.toISOString(),
+  }));
+
+  const serializedSeekers = seekers.map((s) => ({
+    ...s,
+    availableFrom: s.availableFrom ? s.availableFrom.toISOString() : null,
+    createdAt:     s.createdAt.toISOString(),
   }));
 
   return (
@@ -32,17 +57,45 @@ export default async function JobsPage() {
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Emploi</h1>
-          <p className="text-sm text-gray-500 mt-1">Offres d&apos;emploi, stages et alternances de la communauté</p>
+          <p className="text-sm text-gray-500 mt-1">
+            {activeTab === "offers"
+              ? "Offres d’emploi, stages et alternances de la communauté"
+              : "Membres de la communauté en recherche d’emploi"}
+          </p>
         </div>
-        <Link
-          href="/jobs/new"
-          className="px-4 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 transition-colors"
-        >
-          Publier une offre
-        </Link>
+        {activeTab === "offers" ? (
+          <Link
+            href="/jobs/new"
+            className="px-4 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 transition-colors"
+          >
+            Publier une offre
+          </Link>
+        ) : (
+          <Link
+            href="/jobs/seekers/new"
+            className="px-4 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 transition-colors"
+          >
+            Publier mon profil
+          </Link>
+        )}
       </div>
 
-      <JobsListClient jobs={serialized} currentUserId={session.user.id!} nowMs={now.getTime()} />
+      <Suspense>
+        <JobsTabBar offersCount={serializedJobs.length} seekersCount={serializedSeekers.length} />
+      </Suspense>
+
+      {activeTab === "offers" ? (
+        <JobsListClient
+          jobs={serializedJobs}
+          currentUserId={session.user.id!}
+          nowMs={now.getTime()}
+        />
+      ) : (
+        <SeekersListClient
+          seekers={serializedSeekers}
+          currentUserId={session.user.id!}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/(auth)/jobs/seekers/[id]/SeekerDetailClient.tsx
+++ b/src/app/(auth)/jobs/seekers/[id]/SeekerDetailClient.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+type ContractType = "EMPLOI" | "STAGE" | "ALTERNANCE";
+
+interface Seeker {
+  id: string;
+  title: string;
+  wantEmploi: boolean;
+  wantStage: boolean;
+  wantAlternance: boolean;
+  sector: string | null;
+  location: string | null;
+  remote: boolean;
+  availableFrom: string | null;
+  description: string;
+  contactEmail: string | null;
+  contactUrl: string | null;
+  status: "ACTIVE" | "FOUND" | "ARCHIVED";
+  createdAt: string;
+  author: { id: string; name: string | null; displayName: string | null; image: string | null };
+}
+
+const TYPE_LABELS: Record<ContractType, string> = {
+  EMPLOI:     "Emploi",
+  STAGE:      "Stage",
+  ALTERNANCE: "Alternance",
+};
+
+const TYPE_COLORS: Record<ContractType, string> = {
+  EMPLOI:     "bg-icc-violet/10 text-icc-violet",
+  STAGE:      "bg-icc-bleu/10 text-icc-bleu",
+  ALTERNANCE: "bg-icc-jaune/20 text-amber-700",
+};
+
+export default function SeekerDetailClient({
+  seeker,
+  canManage,
+  isAuthor,
+}: {
+  seeker: Seeker;
+  canManage: boolean;
+  isAuthor: boolean;
+}) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const isFound    = seeker.status === "FOUND";
+  const isArchived = seeker.status === "ARCHIVED";
+
+  const contractBadges = (
+    [
+      seeker.wantEmploi     && "EMPLOI",
+      seeker.wantStage      && "STAGE",
+      seeker.wantAlternance && "ALTERNANCE",
+    ] as (ContractType | false)[]
+  ).filter(Boolean) as ContractType[];
+
+  async function markFound() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/jobs/seekers/${seeker.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "FOUND" }),
+      });
+      if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur"); return; }
+      router.refresh();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function toggleArchive() {
+    setLoading(true);
+    try {
+      const newStatus = isArchived ? "ACTIVE" : "ARCHIVED";
+      const res = await fetch(`/api/jobs/seekers/${seeker.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur"); return; }
+      router.refresh();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm("Supprimer définitivement ce profil ?")) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/jobs/seekers/${seeker.id}`, { method: "DELETE" });
+      if (!res.ok) { const d = await res.json(); alert(d.error || "Erreur"); return; }
+      router.push("/jobs?tab=seekers");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const authorName   = seeker.author.displayName ?? seeker.author.name ?? "Anonyme";
+  const createdDate  = new Date(seeker.createdAt);
+  const availableDate = seeker.availableFrom ? new Date(seeker.availableFrom) : null;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-4">
+        <Link href="/jobs?tab=seekers" className="text-sm text-gray-400 hover:text-gray-600">
+          ← Tous les profils
+        </Link>
+      </div>
+
+      <div className="bg-white rounded-lg border-2 border-gray-200 p-6">
+        {isFound && (
+          <div className="mb-4 px-4 py-3 bg-green-50 text-green-700 text-sm rounded-lg border border-green-200">
+            Ce profil est clôturé — emploi trouvé ! 🎉
+          </div>
+        )}
+        {isArchived && (
+          <div className="mb-4 px-4 py-2 bg-gray-100 text-gray-500 text-sm rounded-lg">
+            Ce profil a été archivé par un modérateur.
+          </div>
+        )}
+
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <div>
+            <div className="flex flex-wrap gap-2 mb-2">
+              {contractBadges.map((type) => (
+                <span key={type} className={`inline-block text-xs font-semibold px-2.5 py-0.5 rounded-full ${TYPE_COLORS[type]}`}>
+                  {TYPE_LABELS[type]}
+                </span>
+              ))}
+            </div>
+            <h1 className="text-xl font-bold text-gray-900">{seeker.title}</h1>
+            <p className="text-gray-600 mt-0.5">{authorName}</p>
+          </div>
+
+          {(canManage || isAuthor) && (
+            <div className="flex flex-wrap gap-2 shrink-0">
+              {isAuthor && !isFound && !isArchived && (
+                <Link
+                  href={`/jobs/seekers/${seeker.id}/edit`}
+                  className="px-3 py-1.5 text-xs font-semibold border-2 border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+                >
+                  Modifier
+                </Link>
+              )}
+              {isAuthor && !isFound && !isArchived && (
+                <button
+                  onClick={markFound}
+                  disabled={loading}
+                  className="px-3 py-1.5 text-xs font-semibold border-2 border-green-300 text-green-700 rounded-lg hover:bg-green-50 disabled:opacity-50 transition-colors"
+                >
+                  {loading ? "…" : "J'ai trouvé ! 🎉"}
+                </button>
+              )}
+              {canManage && (
+                <button
+                  onClick={toggleArchive}
+                  disabled={loading}
+                  className="px-3 py-1.5 text-xs font-semibold border-2 border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors"
+                >
+                  {loading ? "…" : isArchived ? "Republier" : "Archiver"}
+                </button>
+              )}
+              {(canManage || isAuthor) && (
+                <button
+                  onClick={handleDelete}
+                  disabled={loading}
+                  className="px-3 py-1.5 text-xs font-semibold border-2 border-icc-rouge/30 text-icc-rouge rounded-lg hover:bg-icc-rouge/5 disabled:opacity-50 transition-colors"
+                >
+                  {loading ? "…" : "Supprimer"}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Métadonnées */}
+        <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-500 mb-5 py-3 border-y border-gray-100">
+          {seeker.sector && (
+            <span>Secteur : <strong className="text-gray-700">{seeker.sector}</strong></span>
+          )}
+          {seeker.location && (
+            <span>
+              Localisation : <strong className="text-gray-700">{seeker.location}{seeker.remote ? " · télétravail" : ""}</strong>
+            </span>
+          )}
+          {!seeker.location && seeker.remote && (
+            <span><strong className="text-gray-700">Télétravail</strong></span>
+          )}
+          {availableDate && (
+            <span>
+              Disponible le : <strong className="text-gray-700">{availableDate.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}</strong>
+            </span>
+          )}
+          <span>
+            Publié par <strong className="text-gray-700">{authorName}</strong> le {createdDate.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}
+          </span>
+        </div>
+
+        {/* Description */}
+        <div className="prose prose-sm max-w-none">
+          <p className="text-gray-700 whitespace-pre-wrap">{seeker.description}</p>
+        </div>
+
+        {/* Contact */}
+        {(seeker.contactEmail || seeker.contactUrl) && (
+          <div className="mt-6 pt-5 border-t border-gray-100">
+            <p className="text-sm font-semibold text-gray-700 mb-3">Contact</p>
+            <div className="flex flex-wrap gap-3">
+              {seeker.contactEmail && (
+                <a
+                  href={`mailto:${seeker.contactEmail}`}
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 transition-colors"
+                >
+                  Envoyer un email →
+                </a>
+              )}
+              {seeker.contactUrl && (
+                <a
+                  href={seeker.contactUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 px-4 py-2 border-2 border-icc-violet text-icc-violet text-sm font-semibold rounded-lg hover:bg-icc-violet/5 transition-colors"
+                >
+                  Voir le profil ↗
+                </a>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/jobs/seekers/[id]/edit/page.tsx
+++ b/src/app/(auth)/jobs/seekers/[id]/edit/page.tsx
@@ -1,0 +1,50 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import SeekerFormClient from "../../new/SeekerFormClient";
+
+export default async function EditSeekerPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/");
+
+  const { id } = await params;
+
+  const seeker = await prisma.jobSeeker.findUnique({ where: { id } });
+
+  if (!seeker) notFound();
+  if (seeker.authorId !== session.user.id) redirect(`/jobs/seekers/${id}`);
+  if (seeker.status !== "ACTIVE") redirect(`/jobs/seekers/${id}`);
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center gap-2 mb-4">
+        <Link href={`/jobs/seekers/${id}`} className="text-sm text-gray-400 hover:text-gray-600">
+          ← Retour
+        </Link>
+      </div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Modifier le profil</h1>
+      <SeekerFormClient
+        initial={{
+          id:             seeker.id,
+          title:          seeker.title,
+          wantEmploi:     seeker.wantEmploi,
+          wantStage:      seeker.wantStage,
+          wantAlternance: seeker.wantAlternance,
+          sector:         seeker.sector,
+          location:       seeker.location,
+          remote:         seeker.remote,
+          availableFrom:  seeker.availableFrom ? seeker.availableFrom.toISOString() : null,
+          description:    seeker.description,
+          contactEmail:   seeker.contactEmail,
+          contactUrl:     seeker.contactUrl,
+        }}
+        defaultEmail={session.user.email ?? null}
+      />
+    </div>
+  );
+}

--- a/src/app/(auth)/jobs/seekers/[id]/page.tsx
+++ b/src/app/(auth)/jobs/seekers/[id]/page.tsx
@@ -1,0 +1,46 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect, notFound } from "next/navigation";
+import { rolePermissions } from "@/lib/registry";
+import SeekerDetailClient from "./SeekerDetailClient";
+
+export default async function SeekerDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await auth();
+  if (!session?.user) redirect("/");
+
+  const { id } = await params;
+
+  const seeker = await prisma.jobSeeker.findUnique({
+    where: { id },
+    include: {
+      author: { select: { id: true, name: true, displayName: true, image: true } },
+    },
+  });
+
+  if (!seeker) notFound();
+
+  const userRoles   = session.user.churchRoles.map((r) => r.role);
+  const permissions = new Set(userRoles.flatMap((r) => rolePermissions[r] ?? []));
+  const canManage   = session.user.isSuperAdmin || permissions.has("jobs:manage");
+  const isAuthor    = seeker.authorId === session.user.id;
+
+  if (seeker.status !== "ACTIVE" && !isAuthor && !canManage) notFound();
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <SeekerDetailClient
+        seeker={{
+          ...seeker,
+          availableFrom: seeker.availableFrom ? seeker.availableFrom.toISOString() : null,
+          createdAt:     seeker.createdAt.toISOString(),
+        }}
+        canManage={canManage}
+        isAuthor={isAuthor}
+      />
+    </div>
+  );
+}

--- a/src/app/(auth)/jobs/seekers/new/SeekerFormClient.tsx
+++ b/src/app/(auth)/jobs/seekers/new/SeekerFormClient.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface SeekerInitial {
+  id: string;
+  title: string;
+  wantEmploi: boolean;
+  wantStage: boolean;
+  wantAlternance: boolean;
+  sector: string | null;
+  location: string | null;
+  remote: boolean;
+  availableFrom: string | null;
+  description: string;
+  contactEmail: string | null;
+  contactUrl: string | null;
+}
+
+export default function SeekerFormClient({
+  initial,
+  defaultEmail,
+}: {
+  initial?: SeekerInitial;
+  defaultEmail?: string | null;
+}) {
+  const router = useRouter();
+  const isEdit = !!initial;
+
+  const [title,          setTitle]          = useState(initial?.title          ?? "");
+  const [wantEmploi,     setWantEmploi]     = useState(initial?.wantEmploi     ?? false);
+  const [wantStage,      setWantStage]      = useState(initial?.wantStage      ?? false);
+  const [wantAlternance, setWantAlternance] = useState(initial?.wantAlternance ?? false);
+  const [sector,         setSector]         = useState(initial?.sector         ?? "");
+  const [location,       setLocation]       = useState(initial?.location       ?? "");
+  const [remote,         setRemote]         = useState(initial?.remote         ?? false);
+  const [availableFrom,  setAvailableFrom]  = useState(
+    initial?.availableFrom ? new Date(initial.availableFrom).toISOString().slice(0, 10) : ""
+  );
+  const [description,    setDescription]    = useState(initial?.description    ?? "");
+  const [contactEmail,   setContactEmail]   = useState(initial?.contactEmail   ?? defaultEmail ?? "");
+  const [contactUrl,     setContactUrl]     = useState(initial?.contactUrl     ?? "");
+  const [saving,         setSaving]         = useState(false);
+  const [error,          setError]          = useState<string | null>(null);
+
+  const noContractSelected = !wantEmploi && !wantStage && !wantAlternance;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (noContractSelected) {
+      setError("Sélectionnez au moins un type de contrat.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+
+    const body = {
+      title:          title.trim(),
+      wantEmploi,
+      wantStage,
+      wantAlternance,
+      sector:         sector.trim()       || null,
+      location:       location.trim()     || null,
+      remote,
+      availableFrom:  availableFrom ? new Date(availableFrom).toISOString() : null,
+      description:    description.trim(),
+      contactEmail:   contactEmail.trim() || null,
+      contactUrl:     contactUrl.trim()   || null,
+    };
+
+    try {
+      const url    = isEdit ? `/api/jobs/seekers/${initial!.id}` : "/api/jobs/seekers";
+      const method = isEdit ? "PATCH" : "POST";
+      const res    = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error || "Erreur lors de la publication"); return; }
+      router.push(`/jobs/seekers/${data.id}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-white rounded-lg border-2 border-gray-200 p-6 space-y-5">
+      {error && (
+        <div className="bg-icc-rouge/10 text-icc-rouge text-sm px-4 py-3 rounded-lg">{error}</div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="col-span-2">
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">
+            Titre de la recherche *
+          </label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+            maxLength={200}
+            placeholder="Ex: Développeur React en recherche de CDI"
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+
+        <div className="col-span-2">
+          <label className="block text-sm font-semibold text-gray-700 mb-2">
+            Type(s) de contrat recherché(s) *
+          </label>
+          <div className="flex gap-4 flex-wrap">
+            {[
+              { label: "Emploi (CDI/CDD)", key: "wantEmploi",     value: wantEmploi,     set: setWantEmploi },
+              { label: "Stage",            key: "wantStage",      value: wantStage,      set: setWantStage },
+              { label: "Alternance",       key: "wantAlternance", value: wantAlternance, set: setWantAlternance },
+            ].map(({ label, key, value, set }) => (
+              <label key={key} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={value}
+                  onChange={(e) => set(e.target.checked)}
+                  className="w-4 h-4 rounded border-2 border-gray-300 accent-icc-violet"
+                />
+                <span className="text-sm text-gray-700">{label}</span>
+              </label>
+            ))}
+          </div>
+          {noContractSelected && (
+            <p className="text-xs text-icc-rouge mt-1">Sélectionnez au moins un type de contrat.</p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Secteur / Domaine</label>
+          <input
+            type="text"
+            value={sector}
+            onChange={(e) => setSector(e.target.value)}
+            maxLength={150}
+            placeholder="Ex: Informatique, Finance, RH..."
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Localisation souhaitée</label>
+          <input
+            type="text"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            maxLength={150}
+            placeholder="Ville, région..."
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <input
+            type="checkbox"
+            id="remote"
+            checked={remote}
+            onChange={(e) => setRemote(e.target.checked)}
+            className="w-4 h-4 rounded border-2 border-gray-300 accent-icc-violet"
+          />
+          <label htmlFor="remote" className="text-sm font-semibold text-gray-700 cursor-pointer">
+            Ouvert au télétravail
+          </label>
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Disponible à partir du</label>
+          <input
+            type="date"
+            value={availableFrom}
+            onChange={(e) => setAvailableFrom(e.target.value)}
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+
+        <div className="col-span-2">
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Présentation *</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            required
+            rows={6}
+            placeholder="Présentez votre profil, vos compétences, vos expériences et ce que vous recherchez..."
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet resize-y"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">Email de contact</label>
+          <input
+            type="email"
+            value={contactEmail}
+            onChange={(e) => setContactEmail(e.target.value)}
+            placeholder="votre@email.fr"
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1.5">LinkedIn / Portfolio</label>
+          <input
+            type="url"
+            value={contactUrl}
+            onChange={(e) => setContactUrl(e.target.value)}
+            placeholder="https://linkedin.com/in/..."
+            className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-icc-violet/40 focus:border-icc-violet"
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={saving}
+          className="px-5 py-2 bg-icc-violet text-white text-sm font-semibold rounded-lg hover:bg-icc-violet/90 disabled:opacity-50 transition-colors"
+        >
+          {saving ? "Publication…" : isEdit ? "Enregistrer" : "Publier mon profil"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="px-5 py-2 border-2 border-gray-200 text-gray-700 text-sm font-semibold rounded-lg hover:bg-gray-50 transition-colors"
+        >
+          Annuler
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(auth)/jobs/seekers/new/page.tsx
+++ b/src/app/(auth)/jobs/seekers/new/page.tsx
@@ -1,0 +1,22 @@
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import SeekerFormClient from "./SeekerFormClient";
+
+export default async function NewSeekerPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/");
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center gap-2 mb-4">
+        <Link href="/jobs?tab=seekers" className="text-sm text-gray-400 hover:text-gray-600">
+          ← Retour
+        </Link>
+      </div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-1">Publier mon profil de recherche</h1>
+      <p className="text-sm text-gray-500 mb-6">Faites-vous connaître de la communauté pour trouver votre prochain emploi.</p>
+      <SeekerFormClient defaultEmail={session.user.email ?? null} />
+    </div>
+  );
+}

--- a/src/app/(auth)/profile/JobSubscriptionClient.tsx
+++ b/src/app/(auth)/profile/JobSubscriptionClient.tsx
@@ -9,6 +9,7 @@ interface Subscription {
   wantEmploi: boolean;
   wantStage: boolean;
   wantAlternance: boolean;
+  wantSeekers: boolean;
 }
 
 export default function JobSubscriptionClient() {
@@ -57,7 +58,7 @@ export default function JobSubscriptionClient() {
   return (
     <div className="bg-white rounded-lg border-2 border-gray-200 p-6 mb-6">
       <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-1">Notifications — Emploi</h2>
-      <p className="text-xs text-gray-400 mb-5">Recevez une notification quand une nouvelle offre est publiée.</p>
+      <p className="text-xs text-gray-400 mb-5">Recevez une notification quand une offre ou un profil de recherche est publié.</p>
 
       {/* Channels */}
       <div className="space-y-3 mb-5">
@@ -96,6 +97,7 @@ export default function JobSubscriptionClient() {
           { key: "wantEmploi",     label: "Emploi" },
           { key: "wantStage",      label: "Stage" },
           { key: "wantAlternance", label: "Alternance" },
+          { key: "wantSeekers",    label: "Profils en recherche" },
         ] as const).map(({ key, label }) => (
           <label
             key={key}

--- a/src/app/api/jobs/__tests__/seekers.test.ts
+++ b/src/app/api/jobs/__tests__/seekers.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createAdminSession } from "@/__mocks__/auth";
+
+const mockRequireAuth       = vi.fn();
+const mockRequirePermission = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  requireAuth:       (...args: unknown[]) => mockRequireAuth(...args),
+  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+// ─── /api/jobs/seekers ──────────────────────────────────────────────────────
+
+const { GET: getSeekers, POST: postSeeker } = await import("../seekers/route");
+
+const baseSeeker = {
+  id: "s1", title: "Dev React cherche CDI",
+  wantEmploi: true, wantStage: false, wantAlternance: false,
+  sector: "Informatique", location: "Paris", remote: false,
+  availableFrom: null, description: "5 ans d'expérience React",
+  contactEmail: "dev@example.com", contactUrl: null,
+  status: "ACTIVE", authorId: "user-admin",
+  createdAt: new Date(), updatedAt: new Date(),
+  author: { id: "user-admin", name: "Alice", displayName: null, image: null },
+};
+
+describe("GET /api/jobs/seekers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+  });
+
+  it("returns active seekers", async () => {
+    prismaMock.jobSeeker.findMany.mockResolvedValue([baseSeeker] as never);
+
+    const res = await getSeekers(new Request("http://localhost/api/jobs/seekers"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].title).toBe("Dev React cherche CDI");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireAuth.mockRejectedValue(new Error("UNAUTHORIZED"));
+    const res = await getSeekers(new Request("http://localhost/api/jobs/seekers"));
+    expect(res.status).toBe(401);
+  });
+
+  it("filters by type — only wantEmploi seekers", async () => {
+    prismaMock.jobSeeker.findMany.mockResolvedValue([baseSeeker] as never);
+
+    const res = await getSeekers(new Request("http://localhost/api/jobs/seekers?type=EMPLOI"));
+    expect(res.status).toBe(200);
+    expect(prismaMock.jobSeeker.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ wantEmploi: true }),
+      })
+    );
+  });
+});
+
+describe("POST /api/jobs/seekers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequirePermission.mockResolvedValue(createAdminSession());
+    prismaMock.jobNotificationSubscription.findMany.mockResolvedValue([]);
+  });
+
+  it("creates a seeker profile", async () => {
+    prismaMock.jobSeeker.create.mockResolvedValue(baseSeeker as never);
+
+    const req = new Request("http://localhost/api/jobs/seekers", {
+      method: "POST",
+      body: JSON.stringify({
+        title: "Dev React cherche CDI",
+        wantEmploi: true,
+        description: "5 ans d'expérience React",
+      }),
+    });
+    const res = await postSeeker(req);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.title).toBe("Dev React cherche CDI");
+  });
+
+  it("returns 400 when no contract type selected", async () => {
+    const req = new Request("http://localhost/api/jobs/seekers", {
+      method: "POST",
+      body: JSON.stringify({
+        title: "Cherche emploi",
+        wantEmploi: false,
+        wantStage: false,
+        wantAlternance: false,
+        description: "Présentation",
+      }),
+    });
+    const res = await postSeeker(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequirePermission.mockRejectedValue(new Error("UNAUTHORIZED"));
+    const req = new Request("http://localhost/api/jobs/seekers", {
+      method: "POST",
+      body: JSON.stringify({ title: "Dev", wantEmploi: true, description: "Desc" }),
+    });
+    const res = await postSeeker(req);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── /api/jobs/seekers/[id] ─────────────────────────────────────────────────
+
+const { PATCH: patchSeeker, DELETE: deleteSeeker } = await import("../seekers/[id]/route");
+
+describe("PATCH /api/jobs/seekers/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows author to set status FOUND", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "author-1", isSuperAdmin: false, churchRoles: [{ role: "STAR" }] } });
+    prismaMock.jobSeeker.findUnique.mockResolvedValue({ id: "s1", authorId: "author-1", status: "ACTIVE" } as never);
+    prismaMock.jobSeeker.update.mockResolvedValue({ ...baseSeeker, status: "FOUND", author: {} } as never);
+
+    const req = new Request("http://localhost/api/jobs/seekers/s1", {
+      method: "PATCH",
+      body: JSON.stringify({ status: "FOUND" }),
+    });
+    const res = await patchSeeker(req, { params: Promise.resolve({ id: "s1" }) });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 when author tries to set status ARCHIVED", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "author-1", isSuperAdmin: false, churchRoles: [{ role: "STAR" }] } });
+    prismaMock.jobSeeker.findUnique.mockResolvedValue({ id: "s1", authorId: "author-1", status: "ACTIVE" } as never);
+
+    const req = new Request("http://localhost/api/jobs/seekers/s1", {
+      method: "PATCH",
+      body: JSON.stringify({ status: "ARCHIVED" }),
+    });
+    const res = await patchSeeker(req, { params: Promise.resolve({ id: "s1" }) });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 for third-party user", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "other-user", isSuperAdmin: false, churchRoles: [{ role: "STAR" }] } });
+    prismaMock.jobSeeker.findUnique.mockResolvedValue({ id: "s1", authorId: "author-1", status: "ACTIVE" } as never);
+
+    const req = new Request("http://localhost/api/jobs/seekers/s1", {
+      method: "PATCH",
+      body: JSON.stringify({ title: "Nouveau titre" }),
+    });
+    const res = await patchSeeker(req, { params: Promise.resolve({ id: "s1" }) });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows admin to archive", async () => {
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+    prismaMock.jobSeeker.findUnique.mockResolvedValue({ id: "s1", authorId: "author-1", status: "ACTIVE" } as never);
+    prismaMock.jobSeeker.update.mockResolvedValue({ ...baseSeeker, status: "ARCHIVED", author: {} } as never);
+
+    const req = new Request("http://localhost/api/jobs/seekers/s1", {
+      method: "PATCH",
+      body: JSON.stringify({ status: "ARCHIVED" }),
+    });
+    const res = await patchSeeker(req, { params: Promise.resolve({ id: "s1" }) });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("DELETE /api/jobs/seekers/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows author to delete", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "author-1", isSuperAdmin: false, churchRoles: [{ role: "STAR" }] } });
+    prismaMock.jobSeeker.findUnique.mockResolvedValue({ id: "s1", authorId: "author-1" } as never);
+    prismaMock.jobSeeker.delete.mockResolvedValue({} as never);
+
+    const res = await deleteSeeker(
+      new Request("http://localhost/api/jobs/seekers/s1", { method: "DELETE" }),
+      { params: Promise.resolve({ id: "s1" }) }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 403 for third-party user", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "other-user", isSuperAdmin: false, churchRoles: [{ role: "STAR" }] } });
+    prismaMock.jobSeeker.findUnique.mockResolvedValue({ id: "s1", authorId: "author-1" } as never);
+
+    const res = await deleteSeeker(
+      new Request("http://localhost/api/jobs/seekers/s1", { method: "DELETE" }),
+      { params: Promise.resolve({ id: "s1" }) }
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/jobs/seekers/[id]/route.ts
+++ b/src/app/api/jobs/seekers/[id]/route.ts
@@ -1,0 +1,137 @@
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { z } from "zod";
+
+const patchSeekerSchema = z
+  .object({
+    title:          z.string().min(1).max(200).optional(),
+    wantEmploi:     z.boolean().optional(),
+    wantStage:      z.boolean().optional(),
+    wantAlternance: z.boolean().optional(),
+    sector:         z.string().max(150).nullable().optional(),
+    location:       z.string().max(150).nullable().optional(),
+    remote:         z.boolean().optional(),
+    availableFrom:  z.string().datetime().nullable().optional(),
+    description:    z.string().min(1).optional(),
+    contactEmail:   z.string().email().max(150).nullable().optional(),
+    contactUrl:     z.string().url().max(500).nullable().optional(),
+    status:         z.enum(["ACTIVE", "FOUND", "ARCHIVED"]).optional(),
+  });
+
+function canManageJobs(session: { user: { isSuperAdmin: boolean; churchRoles?: { role: string }[] } }) {
+  return (
+    session.user.isSuperAdmin ||
+    session.user.churchRoles?.some((r) =>
+      ["SUPER_ADMIN", "ADMIN", "SECRETARY"].includes(r.role)
+    )
+  );
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await requireAuth();
+    const { id } = await params;
+
+    const seeker = await prisma.jobSeeker.findUnique({
+      where: { id },
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+    });
+
+    if (!seeker) throw new ApiError(404, "Profil introuvable");
+
+    const isAuthor  = seeker.authorId === session.user.id;
+    const canManage = canManageJobs(session);
+
+    if (seeker.status !== "ACTIVE" && !isAuthor && !canManage) {
+      throw new ApiError(404, "Profil introuvable");
+    }
+
+    return successResponse(seeker);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await requireAuth();
+    const { id } = await params;
+
+    const seeker = await prisma.jobSeeker.findUnique({
+      where: { id },
+      select: { id: true, authorId: true, status: true },
+    });
+
+    if (!seeker) throw new ApiError(404, "Profil introuvable");
+
+    const isAuthor  = seeker.authorId === session.user.id;
+    const canManage = canManageJobs(session);
+
+    if (!isAuthor && !canManage) throw new ApiError(403, "Accès refusé");
+
+    const data = patchSeekerSchema.parse(await request.json());
+
+    // Seul un admin/secrétaire peut archiver
+    if (data.status === "ARCHIVED" && !canManage) {
+      throw new ApiError(403, "Seul un modérateur peut archiver un profil");
+    }
+    // Seul l'auteur peut passer à FOUND (ou admin)
+    if (data.status === "FOUND" && !isAuthor && !canManage) {
+      throw new ApiError(403, "Accès refusé");
+    }
+
+    const updated = await prisma.jobSeeker.update({
+      where: { id },
+      data: {
+        ...data,
+        ...(data.availableFrom !== undefined
+          ? { availableFrom: data.availableFrom ? new Date(data.availableFrom) : null }
+          : {}),
+      },
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+    });
+
+    return successResponse(updated);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await requireAuth();
+    const { id } = await params;
+
+    const seeker = await prisma.jobSeeker.findUnique({
+      where: { id },
+      select: { id: true, authorId: true },
+    });
+
+    if (!seeker) throw new ApiError(404, "Profil introuvable");
+
+    const isAuthor  = seeker.authorId === session.user.id;
+    const canManage = canManageJobs(session);
+
+    if (!isAuthor && !canManage) throw new ApiError(403, "Accès refusé");
+
+    await prisma.jobSeeker.delete({ where: { id } });
+
+    return successResponse({ success: true });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/jobs/seekers/route.ts
+++ b/src/app/api/jobs/seekers/route.ts
@@ -1,0 +1,109 @@
+import { prisma } from "@/lib/prisma";
+import { requireAuth, requirePermission } from "@/lib/auth";
+import { successResponse, errorResponse } from "@/lib/api-utils";
+import { z } from "zod";
+
+const createSeekerSchema = z
+  .object({
+    title:          z.string().min(1).max(200),
+    wantEmploi:     z.boolean().default(false),
+    wantStage:      z.boolean().default(false),
+    wantAlternance: z.boolean().default(false),
+    sector:         z.string().max(150).optional().nullable(),
+    location:       z.string().max(150).optional().nullable(),
+    remote:         z.boolean().default(false),
+    availableFrom:  z.string().datetime().optional().nullable(),
+    description:    z.string().min(1),
+    contactEmail:   z.string().email().max(150).optional().nullable(),
+    contactUrl:     z.string().url().max(500).optional().nullable(),
+  })
+  .refine((d) => d.wantEmploi || d.wantStage || d.wantAlternance, {
+    message: "Au moins un type de contrat doit être sélectionné",
+  });
+
+export async function GET(request: Request) {
+  try {
+    await requireAuth();
+
+    const { searchParams } = new URL(request.url);
+    const type = searchParams.get("type") as "EMPLOI" | "STAGE" | "ALTERNANCE" | null;
+
+    const typeFilter =
+      type === "EMPLOI"
+        ? { wantEmploi: true }
+        : type === "STAGE"
+          ? { wantStage: true }
+          : type === "ALTERNANCE"
+            ? { wantAlternance: true }
+            : undefined;
+
+    const seekers = await prisma.jobSeeker.findMany({
+      where: {
+        status: "ACTIVE",
+        ...(typeFilter ?? {}),
+      },
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return successResponse(seekers);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await requirePermission("jobs:seek");
+    const body = await request.json();
+    const data = createSeekerSchema.parse(body);
+
+    const seeker = await prisma.jobSeeker.create({
+      data: {
+        ...data,
+        availableFrom: data.availableFrom ? new Date(data.availableFrom) : null,
+        authorId: session.user.id!,
+      },
+      include: {
+        author: { select: { id: true, name: true, displayName: true, image: true } },
+      },
+    });
+
+    void notifySeekerSubscribers(seeker).catch(() => null);
+
+    return successResponse(seeker, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+async function notifySeekerSubscribers(seeker: {
+  id: string;
+  title: string;
+  author: { name: string | null; displayName: string | null };
+}) {
+  const subs = await prisma.jobNotificationSubscription.findMany({
+    where: { wantSeekers: true },
+    select: { userId: true, inApp: true, email: true },
+  });
+
+  const authorName = seeker.author.displayName ?? seeker.author.name ?? "Quelqu'un";
+
+  await Promise.allSettled(
+    subs.map(async (sub) => {
+      if (sub.inApp) {
+        await prisma.notification.create({
+          data: {
+            userId:  sub.userId,
+            type:    "JOB_SEEKER",
+            title:   "Nouveau profil en recherche",
+            message: `${authorName} cherche un emploi : « ${seeker.title} »`,
+            link:    `/jobs/seekers/${seeker.id}`,
+          },
+        });
+      }
+    })
+  );
+}

--- a/src/app/api/jobs/subscription/route.ts
+++ b/src/app/api/jobs/subscription/route.ts
@@ -25,6 +25,7 @@ const subSchema = z.object({
   wantEmploi:     z.boolean().optional(),
   wantStage:      z.boolean().optional(),
   wantAlternance: z.boolean().optional(),
+  wantSeekers:    z.boolean().optional(),
 });
 
 export async function PUT(request: Request) {

--- a/src/modules/jobs/index.ts
+++ b/src/modules/jobs/index.ts
@@ -5,6 +5,7 @@ import { defineModule } from "@/core/module-registry";
  *
  * Périmètre :
  *   - Offres d'emploi, de stage et d'alternance
+ *   - Profils de recherche d'emploi (flux candidat)
  *   - Abonnements aux notifications par type
  *   - Modération (archivage) par les admins et secrétaires
  *
@@ -18,6 +19,7 @@ export const jobsModule = defineModule({
   permissions: {
     "jobs:view":   ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD", "DISCIPLE_MAKER", "REPORTER", "STAR", "AGENDA_QUALIFIER", "ACCOUNTANT"],
     "jobs:post":   ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD", "DISCIPLE_MAKER", "REPORTER", "STAR", "AGENDA_QUALIFIER", "ACCOUNTANT"],
+    "jobs:seek":   ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD", "DISCIPLE_MAKER", "REPORTER", "STAR", "AGENDA_QUALIFIER", "ACCOUNTANT"],
     "jobs:manage": ["SUPER_ADMIN", "ADMIN", "SECRETARY"],
   },
 });


### PR DESCRIPTION
## Résumé

- Ajoute le flux "En recherche" au module emploi : les membres peuvent publier leur profil de recherche et se rendre visibles de la communauté
- Page `/jobs` refondre avec deux onglets **Offres** / **En recherche** (via `searchParams?tab=`)
- Nouveau modèle `JobSeeker` avec statuts `ACTIVE` / `FOUND` / `ARCHIVED`
- Notifications in-app pour les abonnés ayant activé `wantSeekers`

## Périmètre

- **Schéma** : nouveau modèle `JobSeeker`, champ `wantSeekers` sur `JobNotificationSubscription`, migration Prisma
- **Module** : nouvelle permission `jobs:seek` (tous rôles)
- **API** : `GET/POST /api/jobs/seekers`, `GET/PATCH/DELETE /api/jobs/seekers/[id]`, mise à jour `/api/jobs/subscription`
- **UI** : pages `/jobs/seekers/new`, `/[id]`, `/[id]/edit`, onglet modération dans `/admin/jobs`, toggle `wantSeekers` dans les préférences profil
- **Tests** : 25 tests unitaires, 10 critères d'acceptation couverts

## Spec

`specs/003-emploi-profils-recherche/`

## Plan de test

- [ ] Créer un profil de recherche depuis `/jobs?tab=seekers` → CTA "Publier mon profil"
- [ ] Vérifier qu'un profil sans type de contrat est refusé (validation côté client + API)
- [ ] Créer deux profils simultanés avec le même compte
- [ ] Clôturer un profil ("J'ai trouvé") → disparaît de la liste publique
- [ ] En tant qu'admin : archiver et supprimer un profil depuis `/admin/jobs`
- [ ] Activer `wantSeekers` dans le profil → vérifier la notification in-app à la création d'un profil

🤖 Generated with [Claude Code](https://claude.com/claude-code)