### PR TITLE
fix(backups): import config — churchId source dans memberUserLink

### DIFF
--- a/src/lib/config-import.ts
+++ b/src/lib/config-import.ts
@@ -354,14 +354,14 @@ async function applyLinks(
         data: {
           memberId: link.memberId,
           userId: user.id,
-          churchId: link.churchId,
+          churchId: church.id,
           validatedAt: link.validatedAt ? new Date(link.validatedAt) : null,
         },
       });
       result.created++;
     } else {
       const exists = await tx.memberUserLink.findFirst({
-        where: { memberId: link.memberId, churchId: link.churchId },
+        where: { memberId: link.memberId, churchId: church.id },
       });
       if (exists) {
         if (strategy === "UPDATE") {
@@ -378,7 +378,7 @@ async function applyLinks(
           data: {
             memberId: link.memberId,
             userId: user.id,
-            churchId: link.churchId,
+            churchId: church.id,
             validatedAt: link.validatedAt ? new Date(link.validatedAt) : null,
           },
         });


### PR DESCRIPTION
## Problème

Suite du fix #411. Même cause racine (import cross-instance, IDs différents entre instances), nouvelle manifestation :

`link.churchId` dans `applyLinks` provient du fichier d'export (ID de l'instance source). Lors d'un `memberUserLink.create()`, MariaDB rejette la FK car cet ID n'existe pas dans la cible :

```
Foreign key constraint violated on the fields: (churchId)
```

## Correctif

Remplace `link.churchId` par `church.id` dans les 3 usages de `applyLinks` (REPLACE create, findFirst, SKIP/UPDATE create). `church.id` est l'ID effectif résolu en début de transaction (par slug si l'ID source est absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)