### PR TITLE
chore: release v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.13.1] - 2026-07-04
+
+### Corrigé
+
+- **Import config — conflit de slug cross-instance** (#411) : lors d'un import cross-instance (ex. prod → recette), `church.create()` échouait avec `Unique constraint on churches_slug_key` si la church existait avec le même slug mais un ID différent. L'import recherche maintenant par slug en fallback et utilise l'ID effectif de la cible pour toute la transaction.
+- **Import config — FK violation sur `memberUserLink`** (#412) : `link.churchId` (ID de l'instance source) était utilisé dans `memberUserLink.create/findFirst`, provoquant `Foreign key constraint violated on churchId`. Remplacé par `church.id` (ID effectif résolu en début de transaction).
+
 ## [v1.13.0] - 2026-07-04
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Bump version `1.13.0` → `1.13.1`.

## Fixes inclus

- **#411** — Import config : conflit de slug cross-instance (`churches_slug_key`)
- **#412** — Import config : FK violation sur `memberUserLink.churchId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)