### PR TITLE
fix(planning): vue personnelle — filtrage statuts, gras département, zones cross-dept

### DIFF
--- a/src/app/(auth)/planning/MyPlanningView.tsx
+++ b/src/app/(auth)/planning/MyPlanningView.tsx
@@ -150,7 +150,7 @@ export default function MyPlanningView({ plannings, tasksByEvent = {} }: Props) 
             const event = p.eventDepartment.event;
             const dept = p.eventDepartment.department;
             const isPast = new Date(event.date) < new Date();
-            const tasks = tasksByEvent[event.id] ?? [];
+            const tasks = tasksByEvent[`${event.id}_${dept.id}`] ?? [];
             return (
               <div
                 key={p.id}
@@ -164,7 +164,7 @@ export default function MyPlanningView({ plannings, tasksByEvent = {} }: Props) 
                     <p className="text-xs text-gray-500 mt-0.5">
                       {formatDate(event.date)}
                       <span className="mx-1.5">·</span>
-                      {dept.name}
+                      <span className="font-semibold text-gray-700">{dept.name}</span>
                     </p>
                     {tasks.length > 0 && (
                       <div className="flex flex-wrap gap-1 mt-1.5">

--- a/src/app/(auth)/planning/page.tsx
+++ b/src/app/(auth)/planning/page.tsx
@@ -34,7 +34,10 @@ export default async function MyPlanningPage() {
 
   const [plannings, taskAssignments] = await Promise.all([
     prisma.planning.findMany({
-      where: { memberId: link.memberId },
+      where: {
+        memberId: link.memberId,
+        status: { in: ["EN_SERVICE", "EN_SERVICE_DEBRIEF"] },
+      },
       include: {
         eventDepartment: {
           include: {
@@ -47,16 +50,17 @@ export default async function MyPlanningPage() {
     }),
     prisma.taskAssignment.findMany({
       where: { memberId: link.memberId },
-      select: { eventId: true, task: { select: { name: true } } },
+      select: { eventId: true, task: { select: { name: true, departmentId: true } } },
     }),
   ]);
 
-  // Map eventId → task names
+  // Map eventId_departmentId → task names (clé composite pour éviter les croisements)
   const tasksByEvent = new Map<string, string[]>();
   for (const ta of taskAssignments) {
-    const arr = tasksByEvent.get(ta.eventId) ?? [];
+    const key = `${ta.eventId}_${ta.task.departmentId}`;
+    const arr = tasksByEvent.get(key) ?? [];
     arr.push(ta.task.name);
-    tasksByEvent.set(ta.eventId, arr);
+    tasksByEvent.set(key, arr);
   }
 
   const memberName = `${link.member.firstName} ${link.member.lastName}`;


### PR DESCRIPTION
Corrections suite aux remontées utilisateur d'Ophélie.

## Changements

**Trop de lignes** (`page.tsx`)
Ajout du filtre `status: { in: ["EN_SERVICE", "EN_SERVICE_DEBRIEF"] }` dans la requête Prisma. Les services INDISPONIBLE et les lignes sans statut n'apparaissent plus dans la vue personnelle.

**Département pas en gras** (`MyPlanningView.tsx`)
Le nom du département est maintenant dans un `<span className="font-semibold text-gray-700">` distinct de la date.

**Bug zones A/B sur mauvais département** (`page.tsx` + `MyPlanningView.tsx`)
Les tâches étaient indexées par `eventId` seul. Si un membre est assigné à deux départements pour le même événement, les tâches du premier s'affichaient sur le second. La clé est désormais composite `eventId_departmentId` côté serveur et côté rendu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)