### PR TITLE
fix(members): gestion des STAR multi-départements par les responsables scoped

### DIFF
--- a/src/app/(auth)/admin/members/MembersClient.tsx
+++ b/src/app/(auth)/admin/members/MembersClient.tsx
@@ -143,9 +143,20 @@ export default function MembersClient({ initialMembers, departments, readOnly = 
     setFirstName(m.firstName);
     setLastName(m.lastName);
     setEmail(m.email ?? "");
-    const primaryId = m.primaryDepartment?.id ?? m.allDepartments[0]?.id ?? departments[0]?.id ?? "";
+    // `departments` = départements gérables par l'utilisateur (scopé côté serveur).
+    // Si le principal réel du STAR est hors périmètre, on retombe sur un département géré
+    // pour le sélecteur ; le serveur préserve de toute façon le vrai principal hors scope.
+    const manageableIds = new Set(departments.map((d) => d.id));
+    const actualPrimary = m.primaryDepartment?.id ?? m.allDepartments[0]?.id;
+    const primaryId =
+      actualPrimary && manageableIds.has(actualPrimary)
+        ? actualPrimary
+        : m.allDepartments.find((d) => manageableIds.has(d.id))?.id ?? departments[0]?.id ?? "";
     setDepartmentId(primaryId);
-    setAdditionalDeptIds(m.allDepartments.filter((d) => !d.isPrimary).map((d) => d.id));
+    // Ne pré-cocher que les départements gérés ; les affiliations hors périmètre restent intactes
+    setAdditionalDeptIds(
+      m.allDepartments.filter((d) => d.id !== primaryId && manageableIds.has(d.id)).map((d) => d.id)
+    );
     setError("");
     setDuplicateCandidates(null);
     setModalOpen(true);

--- a/src/app/api/members/[memberId]/__tests__/security.test.ts
+++ b/src/app/api/members/[memberId]/__tests__/security.test.ts
@@ -23,6 +23,11 @@ describe("PUT /api/members/[memberId] — cross-tenant isolation", () => {
   });
 
   it("rejects update with cross-church departmentId", async () => {
+    // Existing member in church-1
+    prismaMock.member.findUnique.mockResolvedValue({
+      id: "m-1",
+      departments: [{ departmentId: "dept-1", isPrimary: true }],
+    });
     // Target department belongs to church-2
     prismaMock.department.findMany.mockResolvedValue([{
       id: "dept-other",

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -46,70 +46,102 @@ export async function PUT(
     const body = await request.json();
     const { departmentId, additionalDepartmentIds = [], ...memberData } = updateSchema.parse(body);
 
-    if (scopedDeptIds) {
-      const existing = await prisma.member.findUnique({
-        where: { id: memberId },
-        include: { departments: { where: { isPrimary: true }, select: { departmentId: true } } },
-      });
+    // Charger le membre avec toutes ses affiliations actuelles
+    const existing = await prisma.member.findUnique({
+      where: { id: memberId },
+      include: { departments: { select: { departmentId: true, isPrimary: true } } },
+    });
+    if (!existing) throw new ApiError(404, "STAR introuvable");
 
-      if (!existing) throw new ApiError(404, "STAR introuvable");
+    // Périmètre géré : null = accès global (admin), sinon ensemble des départements de l'utilisateur
+    const manageable = scopedDeptIds ? new Set(scopedDeptIds) : null;
 
-      const primaryDeptId = existing.departments[0]?.departmentId;
-      if (!primaryDeptId || !scopedDeptIds.includes(primaryDeptId)) {
-        throw new ApiError(403, "Ce STAR est hors de votre périmètre");
-      }
-
-      if (!scopedDeptIds.includes(departmentId)) {
-        throw new ApiError(403, "Département cible non autorisé");
-      }
+    // Un utilisateur scoped doit partager au moins un département avec le STAR
+    if (manageable && !existing.departments.some((d) => manageable.has(d.departmentId))) {
+      throw new ApiError(403, "Ce STAR est hors de votre périmètre");
     }
 
-    // Valider que tous les départements appartiennent à la même église
-    const allDeptIds = [departmentId, ...additionalDepartmentIds.filter((id) => id !== departmentId)];
+    // Départements soumis (principal + secondaires), dédupliqués
+    const submittedIds = Array.from(new Set([departmentId, ...additionalDepartmentIds]));
+
+    // Valider que tous les départements soumis appartiennent à la même église
     const depts = await prisma.department.findMany({
-      where: { id: { in: allDeptIds } },
+      where: { id: { in: submittedIds } },
       include: { ministry: { select: { churchId: true } } },
     });
-    if (depts.length !== allDeptIds.length || depts.some((d) => d.ministry.churchId !== churchId)) {
+    if (depts.length !== submittedIds.length || depts.some((d) => d.ministry.churchId !== churchId)) {
       throw new ApiError(403, "Tous les départements doivent appartenir à la même église");
     }
+
+    // Un utilisateur scoped n'agit que sur SES départements ; les affiliations
+    // hors périmètre (y compris un département principal hors scope) sont préservées.
+    const preserved = manageable
+      ? existing.departments.filter((d) => !manageable.has(d.departmentId))
+      : [];
+    const submittedManageable = manageable
+      ? submittedIds.filter((id) => manageable.has(id))
+      : submittedIds;
+
+    const finalIds = Array.from(
+      new Set([...preserved.map((d) => d.departmentId), ...submittedManageable])
+    );
+
+    // Déterminer le département principal
+    let primaryId: string;
+    if (manageable) {
+      const preservedPrimary = preserved.find((d) => d.isPrimary)?.departmentId;
+      // Si le principal est hors périmètre, on le conserve intact ;
+      // sinon l'utilisateur choisit le principal parmi ses départements.
+      primaryId =
+        preservedPrimary ??
+        (manageable.has(departmentId) ? departmentId : submittedManageable[0]);
+    } else {
+      primaryId = departmentId;
+    }
+
+    // Départements réellement retirés (uniquement dans le périmètre géré)
+    const finalSet = new Set(finalIds);
+    const removedIds = existing.departments
+      .map((d) => d.departmentId)
+      .filter((id) => !finalSet.has(id));
 
     const member = await prisma.$transaction(async (tx) => {
       // Mettre à jour les champs scalaires
       await tx.member.update({ where: { id: memberId }, data: memberData });
 
-      // Reconstruire les affiliations départementales
-      // 1. Retirer les affiliations qui ne sont plus dans la liste
-      await tx.memberDepartment.deleteMany({
-        where: { memberId, departmentId: { notIn: allDeptIds } },
-      });
+      if (removedIds.length > 0) {
+        // 1. Retirer les affiliations retirées
+        await tx.memberDepartment.deleteMany({
+          where: { memberId, departmentId: { in: removedIds } },
+        });
 
-      // Supprimer les affectations planning et tâches futures dans les départements retirés
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      await tx.planning.deleteMany({
-        where: {
-          memberId,
-          eventDepartment: {
-            departmentId: { notIn: allDeptIds },
-            event: { date: { gte: today } },
+        // Supprimer les affectations planning et tâches futures dans les départements retirés
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        await tx.planning.deleteMany({
+          where: {
+            memberId,
+            eventDepartment: {
+              departmentId: { in: removedIds },
+              event: { date: { gte: today } },
+            },
           },
-        },
-      });
-      await tx.taskAssignment.deleteMany({
-        where: {
-          memberId,
-          event: { date: { gte: today } },
-          task: { departmentId: { notIn: allDeptIds } },
-        },
-      });
+        });
+        await tx.taskAssignment.deleteMany({
+          where: {
+            memberId,
+            event: { date: { gte: today } },
+            task: { departmentId: { in: removedIds } },
+          },
+        });
+      }
 
-      // 2. Upsert chaque département avec le bon flag isPrimary
-      for (const deptId of allDeptIds) {
+      // 2. Upsert chaque département final avec le bon flag isPrimary
+      for (const deptId of finalIds) {
         await tx.memberDepartment.upsert({
           where: { memberId_departmentId: { memberId, departmentId: deptId } },
-          update: { isPrimary: deptId === departmentId },
-          create: { memberId, departmentId: deptId, isPrimary: deptId === departmentId },
+          update: { isPrimary: deptId === primaryId },
+          create: { memberId, departmentId: deptId, isPrimary: deptId === primaryId },
         });
       }
 
@@ -136,14 +168,24 @@ export async function DELETE(
 
     const member = await prisma.member.findUnique({
       where: { id: memberId },
-      include: { departments: { where: { isPrimary: true }, select: { departmentId: true } } },
+      include: { departments: { select: { departmentId: true } } },
     });
 
     if (!member) throw new ApiError(404, "STAR introuvable");
 
-    const primaryDeptId = member.departments[0]?.departmentId;
-    if (scopedDeptIds && (!primaryDeptId || !scopedDeptIds.includes(primaryDeptId))) {
-      throw new ApiError(403, "Ce STAR est hors de votre périmètre");
+    // Supprimer un STAR efface toutes ses affiliations : un utilisateur scoped
+    // ne peut le faire que si le STAR appartient exclusivement à ses départements.
+    if (scopedDeptIds) {
+      const manageable = new Set(scopedDeptIds);
+      const fullyInScope =
+        member.departments.length > 0 &&
+        member.departments.every((d) => manageable.has(d.departmentId));
+      if (!fullyInScope) {
+        throw new ApiError(
+          403,
+          "Ce STAR appartient à des départements hors de votre périmètre. Retirez-le de votre département plutôt que de le supprimer."
+        );
+      }
     }
 
     // Delete dependent records before member to avoid FK constraint errors

--- a/src/app/api/members/__tests__/member-scope.test.ts
+++ b/src/app/api/members/__tests__/member-scope.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createAdminSession, createDepartmentHeadSession } from "@/__mocks__/auth";
+
+// Mock auth + audit before importing the route handlers
+const mockRequireChurchPermission = vi.fn();
+const mockResolveChurchId = vi.fn().mockResolvedValue("church-1");
+vi.mock("@/lib/auth", () => ({
+  requireChurchPermission: (...args: unknown[]) => mockRequireChurchPermission(...args),
+  resolveChurchId: (...args: unknown[]) => mockResolveChurchId(...args),
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/audit", () => ({ logAudit: vi.fn() }));
+
+const { PUT, DELETE } = await import("../[memberId]/route");
+
+function putRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/members/member-1", {
+    method: "PUT",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// department.findMany renvoie les départements validés (tous dans church-1)
+function mockDeptValidation(ids: string[]) {
+  prismaMock.department.findMany.mockResolvedValue(
+    ids.map((id) => ({ id, ministry: { churchId: "church-1" } }))
+  );
+}
+
+describe("PUT /api/members/[memberId] — périmètre multi-départements", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveChurchId.mockResolvedValue("church-1");
+    prismaMock.member.update.mockResolvedValue({});
+    prismaMock.memberDepartment.upsert.mockResolvedValue({});
+    prismaMock.memberDepartment.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.planning.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.taskAssignment.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.member.findUnique.mockResolvedValue({ id: "member-1", departments: [] });
+  });
+
+  it("laisse un responsable gérer un STAR dont le département principal est hors de son périmètre", async () => {
+    // Responsable du dept-A ; le STAR a pour principal dept-B (hors scope) + dept-A (dans scope)
+    mockRequireChurchPermission.mockResolvedValue(
+      createDepartmentHeadSession([{ id: "dept-A", name: "A" }])
+    );
+    prismaMock.member.findUnique
+      .mockResolvedValueOnce({
+        id: "member-1",
+        departments: [
+          { departmentId: "dept-B", isPrimary: true },
+          { departmentId: "dept-A", isPrimary: false },
+        ],
+      })
+      .mockResolvedValueOnce({ id: "member-1", departments: [] });
+    mockDeptValidation(["dept-A"]);
+
+    const res = await PUT(putRequest({ firstName: "Jean", lastName: "Dupont", departmentId: "dept-A" }), {
+      params: Promise.resolve({ memberId: "member-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    // Le principal hors scope (dept-B) est préservé comme principal
+    expect(prismaMock.memberDepartment.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { memberId_departmentId: { memberId: "member-1", departmentId: "dept-B" } },
+        update: { isPrimary: true },
+      })
+    );
+    expect(prismaMock.memberDepartment.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { memberId_departmentId: { memberId: "member-1", departmentId: "dept-A" } },
+        update: { isPrimary: false },
+      })
+    );
+    // Rien n'est retiré
+    expect(prismaMock.memberDepartment.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("désaffecte le STAR d'un département géré sans toucher aux affiliations hors périmètre", async () => {
+    // Responsable de dept-A et dept-C ; STAR dans dept-A (principal), dept-C (géré) et dept-B (hors scope)
+    mockRequireChurchPermission.mockResolvedValue(
+      createDepartmentHeadSession([
+        { id: "dept-A", name: "A" },
+        { id: "dept-C", name: "C" },
+      ])
+    );
+    prismaMock.member.findUnique
+      .mockResolvedValueOnce({
+        id: "member-1",
+        departments: [
+          { departmentId: "dept-A", isPrimary: true },
+          { departmentId: "dept-C", isPrimary: false },
+          { departmentId: "dept-B", isPrimary: false },
+        ],
+      })
+      .mockResolvedValueOnce({ id: "member-1", departments: [] });
+    mockDeptValidation(["dept-A"]);
+
+    // L'utilisateur retire dept-C (ne soumet que dept-A)
+    const res = await PUT(putRequest({ firstName: "Jean", lastName: "Dupont", departmentId: "dept-A" }), {
+      params: Promise.resolve({ memberId: "member-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    // Seul dept-C est retiré ; dept-B (hors périmètre) est préservé
+    expect(prismaMock.memberDepartment.deleteMany).toHaveBeenCalledWith({
+      where: { memberId: "member-1", departmentId: { in: ["dept-C"] } },
+    });
+  });
+
+  it("reconstruit toutes les affiliations pour un admin (accès global)", async () => {
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    prismaMock.member.findUnique
+      .mockResolvedValueOnce({
+        id: "member-1",
+        departments: [
+          { departmentId: "dept-1", isPrimary: true },
+          { departmentId: "dept-2", isPrimary: false },
+        ],
+      })
+      .mockResolvedValueOnce({ id: "member-1", departments: [] });
+    mockDeptValidation(["dept-2", "dept-3"]);
+
+    const res = await PUT(
+      putRequest({ firstName: "Jean", lastName: "Dupont", departmentId: "dept-2", additionalDepartmentIds: ["dept-3"] }),
+      { params: Promise.resolve({ memberId: "member-1" }) }
+    );
+
+    expect(res.status).toBe(200);
+    // dept-1 (non soumis) est retiré ; dept-2 devient principal
+    expect(prismaMock.memberDepartment.deleteMany).toHaveBeenCalledWith({
+      where: { memberId: "member-1", departmentId: { in: ["dept-1"] } },
+    });
+    expect(prismaMock.memberDepartment.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { memberId_departmentId: { memberId: "member-1", departmentId: "dept-2" } },
+        update: { isPrimary: true },
+      })
+    );
+  });
+});
+
+describe("DELETE /api/members/[memberId] — périmètre multi-départements", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveChurchId.mockResolvedValue("church-1");
+  });
+
+  it("refuse la suppression d'un STAR partagé avec un département hors périmètre", async () => {
+    mockRequireChurchPermission.mockResolvedValue(
+      createDepartmentHeadSession([{ id: "dept-A", name: "A" }])
+    );
+    prismaMock.member.findUnique.mockResolvedValue({
+      id: "member-1",
+      departments: [{ departmentId: "dept-A" }, { departmentId: "dept-B" }],
+    });
+
+    const res = await DELETE(new Request("http://localhost/api/members/member-1", { method: "DELETE" }), {
+      params: Promise.resolve({ memberId: "member-1" }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.member.delete).not.toHaveBeenCalled();
+  });
+
+  it("autorise la suppression d'un STAR entièrement dans le périmètre", async () => {
+    mockRequireChurchPermission.mockResolvedValue(
+      createDepartmentHeadSession([{ id: "dept-A", name: "A" }])
+    );
+    prismaMock.member.findUnique.mockResolvedValue({
+      id: "member-1",
+      departments: [{ departmentId: "dept-A" }],
+    });
+    prismaMock.planning.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.taskAssignment.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.discipleshipAttendance.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.memberUserLink.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.memberLinkRequest.updateMany.mockResolvedValue({ count: 0 });
+    prismaMock.discipleship.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.member.delete.mockResolvedValue({ id: "member-1" });
+
+    const res = await DELETE(new Request("http://localhost/api/members/member-1", { method: "DELETE" }), {
+      params: Promise.resolve({ memberId: "member-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.member.delete).toHaveBeenCalledWith({ where: { id: "member-1" } });
+  });
+});

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -99,21 +99,32 @@ export async function PATCH(request: Request) {
       : Array.from(new Set(churchRoles.flatMap((r) => r.departments.map((d) => d.department.id))));
 
     if (scopedDeptIds) {
+      const manageable = new Set(scopedDeptIds);
       const members = await prisma.member.findMany({
         where: { id: { in: ids } },
-        include: { departments: { where: { isPrimary: true }, select: { departmentId: true } } },
+        include: { departments: { select: { departmentId: true } } },
       });
 
-      const allInScope = members.every((m) => {
-        const primaryDeptId = m.departments[0]?.departmentId;
-        return primaryDeptId ? scopedDeptIds.includes(primaryDeptId) : false;
-      });
-      if (!allInScope) {
-        throw new ApiError(403, "Certains STAR sont hors de votre périmètre");
-      }
-
-      if (action === "update" && data?.primaryDepartmentId && !scopedDeptIds.includes(data.primaryDepartmentId)) {
-        throw new ApiError(403, "Département cible non autorisé");
+      if (action === "delete") {
+        // Supprimer efface toutes les affiliations : réservé aux STAR exclusivement dans le périmètre
+        const allFullyInScope = members.every(
+          (m) => m.departments.length > 0 && m.departments.every((d) => manageable.has(d.departmentId))
+        );
+        if (!allFullyInScope) {
+          throw new ApiError(
+            403,
+            "Certains STAR appartiennent à des départements hors de votre périmètre et ne peuvent pas être supprimés"
+          );
+        }
+      } else {
+        // Modifier : autorisé dès qu'au moins un département est partagé avec l'utilisateur
+        const allShareScope = members.every((m) => m.departments.some((d) => manageable.has(d.departmentId)));
+        if (!allShareScope) {
+          throw new ApiError(403, "Certains STAR sont hors de votre périmètre");
+        }
+        if (data?.primaryDepartmentId && !manageable.has(data.primaryDepartmentId)) {
+          throw new ApiError(403, "Département cible non autorisé");
+        }
       }
     }
 


### PR DESCRIPTION
Corrige les erreurs 403 remontées par les responsables de département et ministres lors de l'affectation/désaffectation de STAR partagés entre plusieurs départements.

## Cause racine

Incohérence de périmètre entre **la liste** des STAR (affichée dès qu'un STAR partage ≥1 département avec l'utilisateur) et **le contrôle à l'écriture** (qui exigeait que le département **principal** du STAR soit dans le périmètre). Un STAR dont le principal appartient à un autre département apparaissait dans la liste mais toute édition renvoyait `403 "Ce STAR est hors de votre périmètre"`.

Bug jumeau : la reconstruction complète des affiliations (`deleteMany notIn`) pouvait retirer des départements hors périmètre non gérés par l'utilisateur.

## Règle appliquée

Un responsable/ministre peut gérer un STAR dès qu'il partage **au moins un département** avec lui. Il n'agit que sur **ses** départements ; les autres affiliations (dont un principal hors périmètre) restent intactes.

## Changements

- **`PUT /api/members/[id]`** : contrôle de périmètre = « ≥1 département partagé ». Réconciliation limitée aux départements gérés ; préservation des affiliations et du principal hors périmètre.
- **`DELETE /api/members/[id]`** et **`PATCH` bulk delete** : suppression réservée aux STAR **entièrement** dans le périmètre (supprimer efface toutes les affiliations). Message explicite invitant à retirer le STAR du département plutôt qu'à le supprimer.
- **`PATCH` bulk update** : autorisé dès ≥1 département partagé.
- **UI `MembersClient`** : le sélecteur « principal » retombe sur un département géré si le vrai principal est hors périmètre ; seuls les départements gérés sont pré-cochés.

## Tests

- Nouveau `member-scope.test.ts` (5 cas) : gestion d'un STAR au principal hors scope, désaffectation sans toucher au hors-périmètre, reconstruction complète pour un admin, refus/autorisation de suppression selon le périmètre.
- `security.test.ts` (cross-église) ajusté au nouvel ordre de chargement.
- Suite complète : 449 tests OK, typecheck / lint / lint:boundaries OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)