### PR TITLE
feat(star): recentrage nav STAR + agenda hebdomadaire des événements

### DIFF
--- a/specs/006-star-navigation-evenements/plan.md
+++ b/specs/006-star-navigation-evenements/plan.md
@@ -1,0 +1,109 @@
+# Plan technique — Recentrage de l'espace STAR & agenda hebdomadaire
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Validé
+- **Mis à jour le** : 2026-07-05
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : la nouvelle page importe `@/lib/prisma`, `@/lib/auth`, `@/lib/registry` — aucun chemin interne de module.
+- [x] **Sécurité** : nouvelle page protégée par `requireChurchPermission("planning:view")` ; périmètre requests re-gaté sur `members:view` ; multi-tenant `churchId` respecté partout.
+- [x] **Permissions** via `rolePermissions` (`@/lib/registry`) — réutilisation de `members:view`, aucune nouvelle permission.
+- [x] **Validation** Zod : aucune nouvelle mutation → rien à valider (la vue hebdo est en lecture seule, les gardes modifiées ne changent pas les corps de requête).
+- [x] **Migration** Prisma : aucun changement de schéma.
+- [x] **Enums** depuis `@/generated/prisma/client` : non nécessaire (aucun enum manipulé).
+- [x] **UI** : réutilisation du style de cartes de `MyPlanningView` et des composants `src/components/ui/`.
+
+## Approche générale
+
+Deux axes indépendants :
+
+1. **Recentrage d'accès** (navigation + gardes de routes) : masquer « Mes demandes » et « Réservation de salles » pour le STAR « pur », en re-gatant le périmètre requests/annonces sur une permission de gestion et en conditionnant le lien MRBS.
+2. **Nouvelle vue hebdomadaire** : une page **Server Component** en lecture seule listant les événements de l'église pour une semaine, avec navigation semaine précédente/suivante via un paramètre d'URL. **Aucun** nouvel endpoint, **aucun** schéma, **aucune** permission créée.
+
+## Modèle de données
+
+**[Aucun changement]**
+
+> Note : le modèle `Event` ne possède **pas de champ lieu**. La vue hebdomadaire affiche donc **intitulé, date, horaire (extrait de `date`) et type**. Les occurrences récurrentes sont supposées matérialisées en lignes `Event` distinctes (une par date) ; une requête par plage de dates suffit — à confirmer à l'implémentation.
+
+## API
+
+**Aucun nouvel endpoint.** La vue hebdomadaire interroge Prisma directement côté serveur (comme `/planning`).
+
+Re-gatage des routes existantes du périmètre « Mes demandes » (`planning:view` → `members:view`) pour réserver la section aux profils de gestion (Super Admin, Admin, Secrétaire, Ministre, Responsable de département) :
+
+| Route / page | Avant | Après |
+|---|---|---|
+| Page `/requests`, `/requests/new`, `/requests/[id]/edit` | `planning:view` | `members:view` |
+| `GET`/`POST` `/api/requests` | `planning:view` | `members:view` |
+| `GET`/`PATCH` `/api/requests/[id]` (côté demandeur) | `planning:view` | `members:view` |
+| `GET`/`POST` `/api/announcements` | `planning:view` | `members:view` |
+| `GET`/`PATCH` `/api/announcements/[id]` (côté demandeur) | `planning:view` | `members:view` |
+| Traitement : `/api/requests` `PATCH` (`planning:edit`), `/api/requests/[id]` (`events:manage`) | inchangé | inchangé |
+
+> Vérifié : `GET /api/announcements` renvoie les annonces **soumises par l'utilisateur** (sauf managers) — c'est la liste « mes demandes », pas un mur public ; la fermer aux STAR est cohérent. **Action** : auditer exhaustivement tous les points `planning:view` du périmètre requests/announcements pour n'en oublier aucun.
+
+## Services / logique métier
+
+- Petits **helpers de dates purs** (testables), placés dans `src/lib/` :
+  - `weekBounds(ref: Date): { start: Date; end: Date }` — lundi 00:00 → dimanche 23:59:59 de la semaine de `ref`.
+  - `shiftWeek(mondayISO: string, delta: -1 | 1): string` — semaine précédente/suivante.
+- La requête événements (church + plage) vit dans la page Server Component (pattern `/planning/page.tsx`), pas dans un module (logique de vue, non métier).
+
+## UI / composants
+
+- **Nouvelle page** `/(auth)/planning/events/page.tsx` (Server Component) :
+  - `requireChurchPermission("planning:view", churchId)` ; `churchId` via `getCurrentChurchId(session)`.
+  - `const { week } = await searchParams` (pattern Next 16 déjà utilisé) ; `week` = ISO du lundi cible, absent = semaine courante.
+  - `prisma.event.findMany({ where: { churchId, date: { gte: start, lte: end } }, orderBy: { date: "asc" }, select: { id, title, type, date } })`.
+  - Rendu : en-tête de semaine + liste de cartes (réemploi du style `MyPlanningView`), état vide explicite, liens **précédent/suivant** (`?week=<lundi>`) en `<Link>` — **navigation serveur, aucun composant client requis**.
+- **Navigation** (`src/app/(auth)/layout.tsx` + `Sidebar.tsx` + `BottomNav.tsx`) :
+  - « Mes demandes » : condition `planning:view` → **`members:view`**.
+  - « Réservation de salles » (`mrbsUrl`) : masqué si l'utilisateur est **STAR-only** (rôles de l'église courante ⊆ `{STAR}`, hors super admin/pastoral) ; conservé pour tous les autres rôles.
+  - Nouvelle entrée **« Événements »** → `/planning/events`, affichée si `planning:view && !events:view` (correspond exactement au rôle STAR ; les gestionnaires gardent leur section Événements existante, pas de doublon).
+  - Répercuter l'entrée « Événements » et le masquage dans `BottomNav` de façon cohérente.
+
+### Cohabitation des deux entrées « Événements » (pas d'overlap)
+
+Les deux entrées branchent sur `events:view` en opposition, donc **mutuellement exclusives** — aucun utilisateur ne voit les deux :
+
+| Entrée | Condition | Destination |
+|---|---|---|
+| « Événements » existante (Liste/Calendrier) | `events:view` | `/events` |
+| « Événements » STAR (hebdo) | `planning:view && !events:view` | `/planning/events` |
+
+- `planning:view && !events:view` = **exactement le rôle STAR** (tout autre rôle avec `planning:view` — Ministre, Resp. dépt, Secrétaire, Admin — a aussi `events:view`).
+- **Multi-rôles (ex. Responsable de département + STAR)** : les permissions sont l'**union** des rôles ; `events:view` (du rôle de gestion) est présent → l'utilisateur voit l'entrée existante (Liste/Calendrier, sur-ensemble incluant déjà l'agenda de la semaine) et **pas** l'entrée hebdo. Résolution automatique, sans condition spéciale.
+
+### Correction BottomNav (bug latent)
+
+Aujourd'hui `BottomNav.tsx:114` affiche « Événements » → `/events` **sans condition** : un STAR sur mobile voit une entrée pointant vers une page interdite (`events:view`). **Action** : rendre la destination conditionnelle — `/events` si `events:view`, sinon `/planning/events` — ce qui répare ce comportement au passage. Le label « Événements » reste unique et cohérent puisqu'un utilisateur donné n'a qu'une seule des deux cibles.
+
+## Décisions & alternatives écartées
+
+- **Choix** : réutiliser `members:view` pour gater le périmètre « Mes demandes » — *Pourquoi* : son ensemble de rôles est **exactement** les 5 profils de gestion visés, zéro nouvelle permission.
+  **Écarté** : créer `requests:view` — *Raison* : sur-ingénierie (impacterait la map dépréciée `permissions.ts`, les tests de parité et la table des permissions de `CLAUDE.md`) pour un gain sémantique marginal.
+- **Choix** : page Server Component + navigation par `searchParams (?week=)` — *Pourquoi* : pas d'endpoint ni de JS client, requête bornée à une semaine (légère).
+  **Écarté** : charger tous les événements puis filtrer côté client (comme `MyPlanningView` pour les mois) — *Raison* : volumétrie non bornée en navigation multi-semaines.
+- **Choix** : entrée « Événements » conditionnée par `planning:view && !events:view` — *Pourquoi* : cible pile le STAR, évite un doublon avec la section des gestionnaires.
+- **Choix** : MRBS masqué pour STAR-only — *Pourquoi* : décision produit « uniquement pour les STAR » (conservé pour Reporter, FD, Comptable, etc.).
+  **Écarté** : gater MRBS par `members:view` — *Raison* : retirerait aussi le lien à Reporter/FD/Comptable, non demandé.
+- **Résolution des `[À CLARIFIER]`** : semaine **lundi→dimanche** ; **pas de lieu** (champ inexistant) ; navigation **illimitée**.
+
+## Risques & points d'attention
+
+- **Exhaustivité du re-gatage** requests/annonces : ne laisser aucun point `planning:view` ouvert qui permettrait à un STAR d'atteindre la section en accès direct.
+- **Tests existants** requests/annonces utilisant une session STAR (`planning:view`) : à mettre à jour vers `members:view`.
+- **Détection STAR-only** (MRBS) : bien gérer multi-rôles, super admin et profils pastoraux.
+- **Deux points de navigation** (Sidebar + BottomNav) à garder synchronisés.
+- **Récurrences** : confirmer que les occurrences sont des lignes `Event` distinctes (sinon, expansion à prévoir — hors périmètre a priori).
+
+## Stratégie de tests
+
+- **Helpers de dates** (`weekBounds`, `shiftWeek`) : tests unitaires purs (bornes lundi/dimanche, passage de mois/année, précédent/suivant).
+- **Gardes requests/annonces** : un STAR (`planning:view`, sans `members:view`) reçoit **403** sur `GET`/`POST` `/api/requests` et `/api/announcements` ; un profil de gestion (`members:view`) passe. Mise à jour des tests de sécurité existants + ajout du cas STAR interdit.
+- **Vue hebdomadaire** : test de la fonction de calcul de plage + du filtre de requête (church + plage) extrait en fonction pure ; vérification que le filtre `churchId` est toujours présent (non-fuite multi-tenant).
+- Suite complète verte : `typecheck && lint && lint:boundaries && test`.

--- a/specs/006-star-navigation-evenements/spec.md
+++ b/specs/006-star-navigation-evenements/spec.md
@@ -1,0 +1,86 @@
+# Spec — Recentrage de l'espace STAR & agenda hebdomadaire
+
+- **Numéro** : 006
+- **Statut** : Implémentée
+- **Créée le** : 2026-07-05
+- **Branche suggérée** : `feat/star-navigation-evenements`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+L'espace d'un STAR présente aujourd'hui deux éléments qui ne le concernent pas :
+
+- **« Mes demandes »** : le point d'entrée du workflow de demandes (annonces, visuels, réseaux sociaux). Ce parcours est destiné aux profils qui portent l'organisation d'un service — responsables de département, ministres, secrétariat, administration — pas au simple serviteur.
+- **« Réservation de salles »** : un outil d'organisateur (réserver un espace pour une réunion/activité), sans usage pour un STAR sans responsabilité.
+
+Leur présence encombre la navigation du STAR et prête à confusion sur ce qu'on attend réellement de lui.
+
+À l'inverse, un STAR n'a aujourd'hui **aucune visibilité** sur les événements de l'église : il ne voit que ses propres services dans « Mon planning ». Il ne sait pas ce qui se passe dans l'église cette semaine (cultes, réunions, activités), ce qui nuit à son engagement et à sa capacité à s'organiser.
+
+On veut donc **recentrer l'espace STAR** : retirer ce qui ne le concerne pas, et lui offrir un **aperçu hebdomadaire des événements de l'église**.
+
+## Utilisateurs concernés
+
+- **STAR (sans rôle de gestion)** — principal concerné :
+  - ne voit plus « Mes demandes » ni « Réservation de salles » ;
+  - dispose d'une nouvelle entrée « Événements » donnant l'agenda hebdomadaire de l'église.
+- **Utilisateur cumulant STAR + un rôle de gestion** (ex. STAR aussi Responsable de département) :
+  - conserve « Mes demandes » et « Réservation de salles » au titre de son rôle de gestion ;
+  - bénéficie aussi de la nouvelle entrée « Événements ».
+- **Admin, Super Admin, Secrétaire, Ministre, Responsable de département** :
+  - « Mes demandes » et « Réservation de salles » restent inchangés pour eux.
+- **Faiseur de Disciples, Reporter** : non impactés (ils ne voyaient déjà pas « Mes demandes »).
+
+> Règle directrice : la visibilité de « Mes demandes » et « Réservation de salles » dépend de la détention d'un **rôle de gestion** (Admin, Super Admin, Secrétaire, Ministre, Responsable de département), et non du fait d'être STAR. Un STAR « pur » les perd ; un multi-rôles les garde.
+
+## Comportement attendu
+
+### Scénario principal — un STAR consulte l'agenda de la semaine
+
+1. Un STAR se connecte à Koinonia.
+2. Sa navigation ne présente **plus** « Mes demandes » ni « Réservation de salles ».
+3. Il voit une **nouvelle entrée « Événements »**.
+4. En l'ouvrant, il voit la liste des **événements de l'église de la semaine en cours**, triés chronologiquement, que le STAR y serve ou non.
+5. Chaque événement affiche au minimum : son **intitulé**, sa **date**, son **horaire** et son **type**.
+6. Il peut naviguer vers la **semaine précédente** et la **semaine suivante** ; l'intitulé de la semaine affichée est clairement indiqué.
+
+### Scénarios alternatifs / cas limites
+
+- **Si la semaine affichée ne contient aucun événement**, un état vide explicite est présenté (« Aucun événement cette semaine »).
+- **Quand un utilisateur cumule STAR et un rôle de gestion**, « Mes demandes » et « Réservation de salles » restent visibles, et « Événements » s'ajoute.
+- **Quand un STAR revient sur la page**, la semaine en cours est affichée par défaut (le point de départ est toujours « aujourd'hui »).
+- **Les événements de l'église uniquement** sont listés : la vue est strictement multi-tenant (jamais d'événement d'une autre église).
+- **Un STAR n'a aucune action d'écriture** sur ces événements : consultation seule.
+
+## Critères d'acceptation
+
+- [ ] Un STAR sans rôle de gestion ne voit plus l'entrée « Mes demandes ».
+- [ ] Un STAR sans rôle de gestion ne voit plus l'entrée « Réservation de salles ».
+- [ ] Les rôles Admin, Super Admin, Secrétaire, Ministre et Responsable de département continuent de voir « Mes demandes ».
+- [ ] « Réservation de salles » reste visible pour les rôles de gestion (non-STAR).
+- [ ] Un utilisateur cumulant STAR + rôle de gestion continue de voir « Mes demandes » et « Réservation de salles ».
+- [ ] Un STAR voit une entrée de navigation « Événements ».
+- [ ] Par défaut, « Événements » affiche les événements de l'église de la **semaine en cours**.
+- [ ] La liste montre **tous** les événements de l'église pour la semaine, indépendamment du service du STAR.
+- [ ] Le STAR peut naviguer vers la semaine précédente puis vers la semaine suivante, et l'intitulé de la semaine se met à jour.
+- [ ] Une semaine sans événement affiche un état vide explicite.
+- [ ] Chaque événement affiche au minimum intitulé, date, horaire et type.
+- [ ] Un STAR ne peut ni créer, ni modifier, ni supprimer un événement depuis cette vue.
+- [ ] Aucun événement d'une autre église n'apparaît.
+
+## Hors périmètre
+
+- Aucune création/édition/suppression d'événement par les STAR (lecture seule).
+- Pas d'indicateur « je suis en service » sur les événements de la semaine (option retenue : tous les événements, sans surlignage du service — « Mon planning » reste la vue des services).
+- Pas de modification des permissions des autres rôles sur « Mes demandes » et « Réservation de salles » au-delà du masquage pour le STAR « pur ».
+- Pas de refonte de « Mon planning » : les services du STAR restent où ils sont.
+- Pas d'accès à la vue calendrier complète, aux annonces, ni au détail éditable d'un événement.
+- Pas de suppression globale de « Réservation de salles » (conservée pour les rôles de gestion).
+
+## Questions ouvertes
+
+- **[À CLARIFIER : définition de la semaine]** — semaine du lundi au dimanche (usage FR) supposée par défaut. À confirmer si un autre découpage est attendu.
+- **[À CLARIFIER : informations par événement]** — au-delà d'intitulé / date / horaire / type, faut-il afficher le **lieu** et/ou une indication de durée ? Défaut supposé : afficher le lieu s'il est renseigné.
+- **[À CLARIFIER : bornes de navigation]** — la navigation entre semaines est-elle illimitée (passé et futur) ou bornée ? Défaut supposé : illimitée.

--- a/specs/006-star-navigation-evenements/tasks.md
+++ b/specs/006-star-navigation-evenements/tasks.md
@@ -1,0 +1,70 @@
+# Tâches — Recentrage de l'espace STAR & agenda hebdomadaire
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : Fait
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : migration → services → API → UI → tests. Les tâches `[P]` sont parallélisables.
+
+## Prérequis
+
+- [x] Branche créée : `feat/star-navigation-evenements`
+- [x] Aucune migration Prisma (pas de changement de schéma)
+
+## Tâches
+
+### 1. Helpers (lib)
+
+- [x] **T1** [P] — Créer les helpers de dates purs : `weekBounds(ref: Date): { start: Date; end: Date }` (lundi 00:00:00 → dimanche 23:59:59) et `shiftWeek(mondayISO: string, delta: -1 | 1): string`. *(fichier : `src/lib/week.ts`)*
+
+### 2. API & gardes — réserver « Mes demandes » aux profils de gestion (`planning:view` → `members:view`)
+
+> Auditer **tous** les points `planning:view` du périmètre requests/annonces côté demandeur ; ne laisser aucune porte ouverte. Laisser inchangés les points de traitement (`planning:edit`, `events:manage`).
+
+- [x] **T2** [P] — Re-gater l'API requests : `GET`/`POST` `/api/requests` et `GET`/`PATCH` côté demandeur de `/api/requests/[id]` (`planning:view` → `members:view`). Conserver `planning:edit` (traitement) et `events:manage`. *(fichiers : `src/app/api/requests/route.ts`, `src/app/api/requests/[id]/route.ts`)*
+- [x] **T3** [P] — Re-gater l'API annonces : `GET`/`POST` `/api/announcements` et les points demandeur de `/api/announcements/[id]` (`planning:view` → `members:view`). *(fichiers : `src/app/api/announcements/route.ts`, `src/app/api/announcements/[id]/route.ts`)*
+- [x] **T4** [P] — Re-gater les pages du périmètre : `/requests`, `/requests/new`, `/requests/[id]/edit` (`planning:view` → `members:view`). *(fichiers : `src/app/(auth)/requests/page.tsx`, `src/app/(auth)/requests/new/page.tsx`, `src/app/(auth)/requests/[id]/edit/page.tsx`)*
+
+### 3. UI — nouvelle vue hebdomadaire des événements (STAR)
+
+- [x] **T5** — Créer la page Server Component `/planning/events` : garde `requireChurchPermission("planning:view", churchId)` (`churchId` via `getCurrentChurchId`), lecture de `const { week } = await searchParams`, calcul de plage via `weekBounds`/`shiftWeek` (T1), requête `prisma.event.findMany({ where: { churchId, date: { gte, lte } }, orderBy: { date: "asc" }, select: { id, title, type, date } })`. Rendu : en-tête de semaine, liste de cartes (réemploi du style `MyPlanningView` : intitulé, date, horaire, type), état vide explicite, liens **précédent/suivant** en `<Link href="?week=…">`. Aucune action d'écriture. *(fichier : `src/app/(auth)/planning/events/page.tsx`)*
+
+### 4. UI — navigation
+
+- [x] **T6** — `layout.tsx` : (a) gater « Mes demandes » sur `members:view` au lieu de `planning:view` ; (b) masquer `mrbsUrl` si l'utilisateur est **STAR-only** (rôles de l'église courante ⊆ `{STAR}`, hors super admin/pastoral) ; (c) calculer un flag « entrée Événements STAR » = `planning:view && !events:view` et le passer aux composants de nav. *(fichier : `src/app/(auth)/layout.tsx`)*
+- [x] **T7** — `Sidebar.tsx` : afficher la nouvelle entrée « Événements » → `/planning/events` quand le flag STAR est vrai ; ne pas l'afficher pour les détenteurs de `events:view` (qui gardent la section Liste/Calendrier). *(fichier : `src/components/Sidebar.tsx`)*
+- [x] **T8** — `BottomNav.tsx` : rendre la destination de « Événements » conditionnelle — `/events` si `events:view`, sinon `/planning/events` — (corrige le lien actuel pointant vers une page interdite pour les STAR). *(fichier : `src/components/BottomNav.tsx`)*
+
+### 5. Tests (Vitest)
+
+- [x] **T9** [P] — Tests unitaires des helpers `weekBounds`/`shiftWeek` : bornes lundi/dimanche, passage de mois et d'année, semaine précédente/suivante. *(fichier : `src/lib/__tests__/week.test.ts`)*
+- [x] **T10** [P] — Gardes requests/annonces : un STAR (`planning:view`, sans `members:view`) reçoit **403** sur `GET`/`POST` `/api/requests` et `/api/announcements` ; un profil de gestion (`members:view`) passe. Mettre à jour les tests de sécurité existants utilisant une session STAR + ajouter le cas STAR interdit. *(fichiers : `src/app/api/announcements/__tests__/security.test.ts`, tests requests le cas échéant)*
+- [x] **T11** [P] — Vue hebdomadaire : test de la construction du filtre de requête (présence systématique de `churchId` → non-fuite multi-tenant, plage de dates cohérente). Extraire au besoin une petite fonction pure `buildWeekEventsQuery(churchId, ref)`. *(fichier : `src/app/(auth)/planning/events/__tests__/*.test.ts` ou `src/lib/__tests__/week.test.ts`)*
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits (voir couverture ci-dessous)
+- [x] Mettre le statut de `spec.md` à « Implémentée »
+- [ ] PR ouverte vers `main`
+
+## Couverture des critères d'acceptation
+
+| Critère (spec) | Tâche(s) |
+|---|---|
+| STAR ne voit plus « Mes demandes » | T4, T6 |
+| STAR ne voit plus « Réservation de salles » | T6 |
+| Rôles de gestion gardent « Mes demandes » | T2–T4, T6, T10 |
+| « Réservation de salles » conservée pour la gestion | T6 |
+| Multi-rôles STAR + gestion garde les deux | T6 (STAR-only), T10 |
+| STAR voit une entrée « Événements » | T6, T7, T8 |
+| Défaut = semaine en cours | T5 |
+| Tous les événements de l'église pour la semaine | T5 |
+| Navigation semaine précédente/suivante | T1, T5, T9 |
+| Semaine sans événement → état vide | T5 |
+| Événement : intitulé, date, horaire, type | T5 |
+| STAR ne peut ni créer/modifier/supprimer | T5 (lecture seule, garde `planning:view`) |
+| Aucun événement d'une autre église | T5, T11 |

--- a/src/__mocks__/auth.ts
+++ b/src/__mocks__/auth.ts
@@ -129,6 +129,21 @@ export function createAgendaQualifierSession(churchId = "church-1"): Session {
   });
 }
 
+export function createStarSession(churchId = "church-1"): Session {
+  return createSession({
+    churchRoles: [
+      {
+        id: "role-1",
+        churchId,
+        role: "STAR",
+        ministryId: null,
+        church: { id: churchId, name: "Test Church", slug: "test-church" },
+        departments: [],
+      },
+    ],
+  });
+}
+
 export function createProtocoleMemberSession(
   protocoleDeptId: string,
   churchId = "church-1"

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -128,7 +128,7 @@ export default async function AuthLayout({
     userPermissions.add("pastoral:view");
     userPermissions.add("events:view");
     userPermissions.add("discipleship:view");
-    userPermissions.add("planning:view"); // permet "Mes demandes"
+    userPermissions.add("planning:view");
   }
   const visibleConfigLinks = configLinksDef
     .filter((link) => {
@@ -140,7 +140,7 @@ export default async function AuthLayout({
   // ── Section "Demandes" (workflow requêtes) ──────────────────────────────────
   const requestLinks: { href: string; label: string }[] = [];
 
-  if (userPermissions.has("planning:view")) {
+  if (userPermissions.has("members:view")) {
     requestLinks.push({ href: "/requests", label: "Mes demandes" });
   }
 
@@ -335,8 +335,17 @@ export default async function AuthLayout({
     </footer>
   );
 
-  // ── Module MRBS (optionnel) ───────────────────────────────────────────────
-  const mrbsUrl = registry.has("mrbs") ? (process.env.MRBS_URL ?? null) : null;
+  // STAR "pur" : uniquement des rôles STAR dans l'église courante (hors super admin / pastoral)
+  const churchRolesInCurrentChurch = churchRoles.filter((r) => r.churchId === currentChurchId);
+  const isStarOnly =
+    !session.user.isSuperAdmin &&
+    !isPastoral &&
+    churchRolesInCurrentChurch.length > 0 &&
+    churchRolesInCurrentChurch.every((r) => r.role === "STAR");
+
+  // ── Module MRBS (optionnel) — masqué pour le STAR "pur" ──────────────────
+  const mrbsUrl =
+    registry.has("mrbs") && !isStarOnly ? (process.env.MRBS_URL ?? null) : null;
   const mrbsAdminLink =
     registry.has("mrbs") && userPermissions.has("mrbs:manage")
       ? "/admin/mrbs-links"
@@ -353,6 +362,9 @@ export default async function AuthLayout({
   const hasPlanningAccess = userPermissions.has("planning:view");
   const hasMembersAccess = userPermissions.has("members:view");
   const hasReports = userPermissions.has("reports:view");
+  // Entrée "Événements" hebdomadaire (STAR) — mutuellement exclusive avec la
+  // section Événements existante (Liste/Calendrier), réservée à events:view.
+  const showStarEvents = hasPlanningAccess && !hasEventsAccess;
 
   // "Mon planning" — visible pour tout utilisateur lié à un STAR dans l'église courante
   const memberLink = currentChurchId
@@ -388,6 +400,7 @@ export default async function AuthLayout({
       hasMembersAccess={hasMembersAccess}
       hasReports={hasReports}
       hasMyPlanning={hasMyPlanning}
+      showStarEvents={showStarEvents}
       userRole={currentRole as "SUPER_ADMIN" | "ADMIN" | "SECRETARY" | "MINISTER" | "DEPARTMENT_HEAD" | "DISCIPLE_MAKER" | "REPORTER" | "STAR" | "ACCOUNTANT"}
       headerColor={churchPrimaryColor}
       header={headerContent}

--- a/src/app/(auth)/planning/events/page.tsx
+++ b/src/app/(auth)/planning/events/page.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+import { requireAuth, getCurrentChurchId, requireChurchPermission } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { weekBounds, shiftWeek, currentWeekMonday, buildWeekEventsQuery } from "@/lib/week";
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function formatDate(date: Date) {
+  return date.toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+function formatTime(date: Date) {
+  return date.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatWeekLabel(start: Date, end: Date) {
+  const sameMonth = start.getMonth() === end.getMonth() && start.getFullYear() === end.getFullYear();
+  const startLabel = start.toLocaleDateString("fr-FR", { day: "numeric", month: sameMonth ? undefined : "long" });
+  const endLabel = end.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" });
+  return `Semaine du ${startLabel} au ${endLabel}`;
+}
+
+export default async function StarWeeklyEventsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ week?: string }>;
+}) {
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("planning:view", churchId);
+
+  const { week } = await searchParams;
+  const mondayISO = week && ISO_DATE_RE.test(week) ? week : currentWeekMonday();
+  const [y, m, d] = mondayISO.split("-").map(Number);
+  const ref = new Date(y, m - 1, d);
+
+  const { start, end } = weekBounds(ref);
+  const query = buildWeekEventsQuery(churchId, ref);
+  const events = await prisma.event.findMany(query);
+
+  const prevWeek = shiftWeek(mondayISO, -1);
+  const nextWeek = shiftWeek(mondayISO, 1);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Événements</h1>
+        <p className="text-sm text-gray-500 mt-1">Agenda hebdomadaire de l&apos;église</p>
+      </div>
+
+      {/* Navigation semaine */}
+      <div className="flex items-center justify-between mb-6">
+        <Link
+          href={`/planning/events?week=${prevWeek}`}
+          className="p-2 rounded-lg border-2 border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors"
+          aria-label="Semaine précédente"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </Link>
+        <h2 className="text-base font-semibold text-gray-800 capitalize">
+          {formatWeekLabel(start, end)}
+        </h2>
+        <Link
+          href={`/planning/events?week=${nextWeek}`}
+          className="p-2 rounded-lg border-2 border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors"
+          aria-label="Semaine suivante"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </Link>
+      </div>
+
+      {events.length === 0 ? (
+        <div className="text-center py-12 text-gray-400 border-2 border-gray-200 border-dashed rounded-lg">
+          <p className="text-lg">Aucun événement cette semaine.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {events.map((event) => (
+            <div
+              key={event.id}
+              className="bg-white rounded-lg border-2 border-gray-200 px-4 py-3"
+            >
+              <p className="font-medium text-gray-900">{event.title}</p>
+              <p className="text-xs text-gray-500 mt-0.5 capitalize">
+                {formatDate(event.date)}
+                <span className="mx-1.5">·</span>
+                {formatTime(event.date)}
+                <span className="mx-1.5">·</span>
+                <span className="font-semibold text-gray-700">{event.type}</span>
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(auth)/requests/[id]/edit/page.tsx
+++ b/src/app/(auth)/requests/[id]/edit/page.tsx
@@ -14,7 +14,7 @@ export default async function EditRequestPage({ params }: Props) {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
-  await requireChurchPermission("planning:view", churchId);
+  await requireChurchPermission("members:view", churchId);
 
   // Fetch the request with its announcement relation
   const request = await prisma.request.findUnique({

--- a/src/app/(auth)/requests/new/page.tsx
+++ b/src/app/(auth)/requests/new/page.tsx
@@ -7,7 +7,7 @@ export default async function NewRequestPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
-  await requireChurchPermission("planning:view", churchId);
+  await requireChurchPermission("members:view", churchId);
 
   const churchPermissions = new Set(
     session.user.churchRoles

--- a/src/app/(auth)/requests/page.tsx
+++ b/src/app/(auth)/requests/page.tsx
@@ -8,7 +8,7 @@ export default async function MyRequestsPage() {
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
-  await requireChurchPermission("planning:view", churchId);
+  await requireChurchPermission("members:view", churchId);
 
   // All requests submitted by the user (both announcement-linked and standalone)
   const requests = await prisma.request.findMany({

--- a/src/app/api/announcements/[id]/route.ts
+++ b/src/app/api/announcements/[id]/route.ts
@@ -33,7 +33,7 @@ export async function GET(
     });
     if (!minimal) throw new ApiError(404, "Annonce introuvable");
 
-    const session = await requireChurchPermission("planning:view", minimal.churchId);
+    const session = await requireChurchPermission("members:view", minimal.churchId);
 
     const userPermissions = new Set(
       session.user.churchRoles
@@ -94,7 +94,7 @@ export async function PATCH(
     });
     if (!announcement) throw new ApiError(404, "Annonce introuvable");
 
-    const session = await requireChurchPermission("planning:view", announcement.churchId);
+    const session = await requireChurchPermission("members:view", announcement.churchId);
 
     const userPermissions = new Set(
       session.user.churchRoles
@@ -183,7 +183,7 @@ export async function DELETE(
     });
     if (!announcement) throw new ApiError(404, "Annonce introuvable");
 
-    const session = await requireChurchPermission("planning:view", announcement.churchId);
+    const session = await requireChurchPermission("members:view", announcement.churchId);
 
     const userPermissions = new Set(
       session.user.churchRoles

--- a/src/app/api/announcements/__tests__/security.test.ts
+++ b/src/app/api/announcements/__tests__/security.test.ts
@@ -26,8 +26,32 @@ vi.mock("@/lib/department-functions", () => ({
   },
 }));
 
-const { POST } = await import("../route");
+const { GET, POST } = await import("../route");
 const { PATCH } = await import("../../announcements/[id]/route");
+
+describe("GET /api/announcements — authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequirePermission.mockResolvedValue(createAdminSession());
+    prismaMock.announcement.findMany.mockResolvedValue([]);
+  });
+
+  it("gates the list on members:view (not planning:view)", async () => {
+    const request = new Request("http://localhost/api/announcements?churchId=church-1");
+    await GET(request);
+
+    expect(mockRequirePermission).toHaveBeenCalledWith("members:view", "church-1");
+  });
+
+  it("returns 403 (FORBIDDEN) for a STAR without members:view", async () => {
+    mockRequirePermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const request = new Request("http://localhost/api/announcements?churchId=church-1");
+    const res = await GET(request);
+
+    expect(res.status).toBe(403);
+  });
+});
 
 const basePostBody = {
   churchId: "church-1",
@@ -114,6 +138,28 @@ describe("POST /api/announcements — cross-tenant validation", () => {
     const res = await POST(request);
 
     expect(res.status).toBe(401);
+  });
+
+  it("gates creation on members:view (not planning:view)", async () => {
+    const request = new Request("http://localhost/api/announcements", {
+      method: "POST",
+      body: JSON.stringify(basePostBody),
+    });
+    await POST(request);
+
+    expect(mockRequirePermission).toHaveBeenCalledWith("members:view", "church-1");
+  });
+
+  it("returns 403 (FORBIDDEN) for a STAR without members:view", async () => {
+    mockRequirePermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const request = new Request("http://localhost/api/announcements", {
+      method: "POST",
+      body: JSON.stringify(basePostBody),
+    });
+    const res = await POST(request);
+
+    expect(res.status).toBe(403);
   });
 });
 

--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: Request) {
     const churchId = searchParams.get("churchId");
     if (!churchId) throw new ApiError(400, "churchId requis");
 
-    const session = await requireChurchPermission("planning:view", churchId);
+    const session = await requireChurchPermission("members:view", churchId);
 
     const userPermissions = new Set(
       session.user.churchRoles
@@ -99,7 +99,7 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
     const data = createSchema.parse(body);
-    const session = await requireChurchPermission("planning:view", data.churchId);
+    const session = await requireChurchPermission("members:view", data.churchId);
     requireRateLimit(request, { prefix: `mut:${session.user.id}`, ...RATE_LIMIT_MUTATION });
 
     // Validate departmentId belongs to churchId

--- a/src/app/api/requests/[id]/route.ts
+++ b/src/app/api/requests/[id]/route.ts
@@ -43,7 +43,7 @@ export async function GET(
     });
     if (!minimal) throw new ApiError(404, "Demande introuvable");
 
-    const session = await requireChurchPermission("planning:view", minimal.churchId);
+    const session = await requireChurchPermission("members:view", minimal.churchId);
 
     const userPermissions = new Set(
       session.user.churchRoles
@@ -128,7 +128,7 @@ export async function PATCH(
     });
     if (!existing) throw new ApiError(404, "Demande introuvable");
 
-    const session = await requireChurchPermission("planning:view", existing.churchId);
+    const session = await requireChurchPermission("members:view", existing.churchId);
 
     const userPermissions = new Set(
       session.user.churchRoles

--- a/src/app/api/requests/__tests__/security.test.ts
+++ b/src/app/api/requests/__tests__/security.test.ts
@@ -17,13 +17,67 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 vi.mock("@/lib/request-executor", () => ({ executeRequest: vi.fn() }));
 
-const { POST } = await import("../route");
+const { GET, POST } = await import("../route");
 const { PATCH } = await import("../../requests/[id]/route");
+
+describe("GET /api/requests — authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequirePermission.mockResolvedValue(createAdminSession());
+    prismaMock.request.findMany.mockResolvedValue([]);
+  });
+
+  it("gates the list on members:view (not planning:view)", async () => {
+    const request = new Request("http://localhost/api/requests?churchId=church-1");
+    await GET(request);
+
+    expect(mockRequirePermission).toHaveBeenCalledWith("members:view", "church-1");
+  });
+
+  it("returns 403 (FORBIDDEN) for a STAR without members:view", async () => {
+    mockRequirePermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const request = new Request("http://localhost/api/requests?churchId=church-1");
+    const res = await GET(request);
+
+    expect(res.status).toBe(403);
+  });
+});
 
 describe("POST /api/requests — validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequirePermission.mockResolvedValue(createAdminSession());
+  });
+
+  it("gates VISUEL creation on members:view (not planning:view)", async () => {
+    const request = new Request("http://localhost/api/requests", {
+      method: "POST",
+      body: JSON.stringify({
+        churchId: "church-1",
+        type: "VISUEL",
+        title: "Test visuel",
+      }),
+    });
+    await POST(request);
+
+    expect(mockRequirePermission).toHaveBeenCalledWith("members:view", "church-1");
+  });
+
+  it("returns 403 (FORBIDDEN) for a STAR without members:view", async () => {
+    mockRequirePermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const request = new Request("http://localhost/api/requests", {
+      method: "POST",
+      body: JSON.stringify({
+        churchId: "church-1",
+        type: "VISUEL",
+        title: "Test visuel",
+      }),
+    });
+    const res = await POST(request);
+
+    expect(res.status).toBe(403);
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -97,6 +151,31 @@ describe("PATCH /api/requests/[id] — authorization", () => {
     const res = await PATCH(request, { params: Promise.resolve({ id: "req-1" }) });
 
     expect(res.status).toBe(401);
+  });
+
+  it("gates PATCH on members:view (not planning:view)", async () => {
+    prismaMock.request.findUnique.mockResolvedValue(existingRequest);
+
+    const request = new Request("http://localhost/api/requests/req-1", {
+      method: "PATCH",
+      body: JSON.stringify({ status: "EN_COURS" }),
+    });
+    await PATCH(request, { params: Promise.resolve({ id: "req-1" }) });
+
+    expect(mockRequirePermission).toHaveBeenCalledWith("members:view", "church-1");
+  });
+
+  it("returns 403 (FORBIDDEN) for a STAR without members:view", async () => {
+    prismaMock.request.findUnique.mockResolvedValue(existingRequest);
+    mockRequirePermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const request = new Request("http://localhost/api/requests/req-1", {
+      method: "PATCH",
+      body: JSON.stringify({ status: "EN_COURS" }),
+    });
+    const res = await PATCH(request, { params: Promise.resolve({ id: "req-1" }) });
+
+    expect(res.status).toBe(403);
   });
 
   it("returns 404 when request doesn't exist", async () => {

--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -44,7 +44,7 @@ export async function GET(request: Request) {
     const submittedByMe = searchParams.get("submittedByMe");
 
     if (!churchId) throw new ApiError(400, "churchId requis");
-    const session = await requireChurchPermission("planning:view", churchId);
+    const session = await requireChurchPermission("members:view", churchId);
 
     const churchPermissions = new Set(
       session.user.churchRoles
@@ -119,7 +119,7 @@ export async function POST(request: Request) {
 
 async function createVisuel(_request: Request, body: unknown) {
   const data = createVisuelSchema.parse(body);
-  const session = await requireChurchPermission("planning:view", data.churchId);
+  const session = await requireChurchPermission("members:view", data.churchId);
 
   // Validate cross-tenant references
   if (data.departmentId) {

--- a/src/components/AuthLayoutShell.tsx
+++ b/src/components/AuthLayoutShell.tsx
@@ -36,6 +36,7 @@ interface AuthLayoutShellProps {
   hasMembersAccess: boolean;
   hasReports: boolean;
   hasMyPlanning?: boolean;
+  showStarEvents?: boolean;
   hasAccounting?: boolean;
   hasJobs?: boolean;
   hasJobsManage?: boolean;
@@ -73,6 +74,7 @@ export default function AuthLayoutShell({
   hasMembersAccess,
   hasReports,
   hasMyPlanning = false,
+  showStarEvents = false,
   hasAccounting = false,
   hasJobs = false,
   hasJobsManage = false,
@@ -139,6 +141,7 @@ export default function AuthLayoutShell({
             hasMembersAccess={hasMembersAccess}
             hasReports={hasReports}
             hasMyPlanning={hasMyPlanning}
+            showStarEvents={showStarEvents}
             hasAccounting={hasAccounting}
             hasJobs={hasJobs}
             hasJobsManage={hasJobsManage}
@@ -165,6 +168,7 @@ export default function AuthLayoutShell({
           hasMembersAccess={hasMembersAccess}
           hasReports={hasReports}
           hasMyPlanning={hasMyPlanning}
+          showStarEvents={showStarEvents}
           hasAccounting={hasAccounting}
           hasJobs={hasJobs}
           hasJobsManage={hasJobsManage}
@@ -186,6 +190,7 @@ export default function AuthLayoutShell({
       <BottomNav
         hasMembersAccess={hasMembersAccess}
         hasMyPlanning={hasMyPlanning}
+        showStarEvents={showStarEvents}
         isPastoral={isPastoral}
         onMenuOpen={() => setSidebarOpen(true)}
       />

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 interface BottomNavProps {
   hasMembersAccess?: boolean;
   hasMyPlanning?: boolean;
+  showStarEvents?: boolean;
   isPastoral?: boolean;
   onMenuOpen?: () => void;
 }
@@ -56,6 +57,7 @@ function IconMembers({ className }: { className?: string }) {
 
 export default function BottomNav({
   hasMyPlanning = false,
+  showStarEvents = false,
   isPastoral = false,
   onMenuOpen,
 }: BottomNavProps) {
@@ -112,9 +114,9 @@ export default function BottomNav({
       icon: <IconPerson className="w-5 h-5" />,
     },
     {
-      href: "/events",
+      href: showStarEvents ? "/planning/events" : "/events",
       label: "Événements",
-      matchPrefix: "/events",
+      matchPrefix: showStarEvents ? "/planning/events" : "/events",
       icon: <IconCalendar className="w-5 h-5" />,
     },
   ].filter(Boolean) as { href: string; label: string; matchPrefix: string; icon: React.ReactNode }[];

--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -23,6 +23,7 @@ interface MobileNavSheetProps {
   hasMembersAccess?: boolean;
   hasReports?: boolean;
   hasMyPlanning?: boolean;
+  showStarEvents?: boolean;
   hasAccounting?: boolean;
   hasJobs?: boolean;
   hasJobsManage?: boolean;
@@ -247,6 +248,7 @@ export default function MobileNavSheet({
   hasMembersAccess = false,
   hasReports = false,
   hasMyPlanning = false,
+  showStarEvents = false,
   hasAccounting = false,
   hasJobs = false,
   hasJobsManage = false,
@@ -398,6 +400,15 @@ export default function MobileNavSheet({
             icon={<IconMyPlanning className="w-5 h-5" />}
             href="/planning"
             isActive={pathname === "/planning"}
+            onClose={onClose}
+          />
+        )}
+        {showStarEvents && (
+          <RootRow
+            label="Événements"
+            icon={<IconCalendar className="w-5 h-5" />}
+            href="/planning/events"
+            isActive={pathname.startsWith("/planning/events")}
             onClose={onClose}
           />
         )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,6 +21,7 @@ interface SidebarProps {
   hasMembersAccess?: boolean;
   hasReports?: boolean;
   hasMyPlanning?: boolean;
+  showStarEvents?: boolean;
   hasAccounting?: boolean;
   hasJobs?: boolean;
   hasJobsManage?: boolean;
@@ -322,6 +323,7 @@ export default function Sidebar({
   hasMembersAccess = false,
   hasReports = false,
   hasMyPlanning = false,
+  showStarEvents = false,
   hasAccounting = false,
   hasJobs = false,
   hasJobsManage = false,
@@ -335,6 +337,7 @@ export default function Sidebar({
   // ── Active detection ────────────────────────────────────
   const isDashboardActive = pathname === "/dashboard";
   const isMyPlanningActive = pathname === "/planning";
+  const isStarEventsActive = pathname.startsWith("/planning/events");
   const isEventsActive =
     pathname.startsWith("/events") ||
     pathname.startsWith("/admin/events") ||
@@ -510,6 +513,22 @@ export default function Sidebar({
         >
           <IconMyPlanning className="w-4 h-4" />
           Mon planning
+        </Link>
+      )}
+
+      {/* Événements (STAR uniquement — vue hebdomadaire en lecture seule) */}
+      {showStarEvents && (
+        <Link
+          href="/planning/events"
+          onClick={onClose}
+          className={`flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm font-semibold tracking-wide transition-colors ${
+            isStarEventsActive
+              ? "bg-icc-violet-light text-icc-violet"
+              : "text-gray-600 hover:bg-gray-50"
+          }`}
+        >
+          <IconCalendar className="w-4 h-4" />
+          Événements
         </Link>
       )}
 

--- a/src/lib/__tests__/auth-security.test.ts
+++ b/src/lib/__tests__/auth-security.test.ts
@@ -4,6 +4,8 @@ import {
   createAdminSession,
   createSuperAdminSession,
   createDepartmentHeadSession,
+  createStarSession,
+  createSecretarySession,
 } from "@/__mocks__/auth";
 
 // Mock auth() to return a configurable session
@@ -101,6 +103,28 @@ describe("requireChurchPermission", () => {
     await expect(
       requireChurchPermission("events:view", "church-1")
     ).rejects.toThrow("UNAUTHORIZED");
+  });
+
+  // Feature 006 — recentrage de l'espace STAR : le périmètre "Mes demandes"
+  // (requests/announcements) est réservé aux profils de gestion via members:view.
+  it("STAR keeps planning:view (Mon planning) but loses members:view (Mes demandes)", async () => {
+    mockAuth.mockResolvedValue(createStarSession("church-1"));
+
+    await expect(
+      requireChurchPermission("planning:view", "church-1")
+    ).resolves.toBeDefined();
+
+    await expect(
+      requireChurchPermission("members:view", "church-1")
+    ).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("a management profile (Secretary) has members:view and can access the requests scope", async () => {
+    mockAuth.mockResolvedValue(createSecretarySession("church-1"));
+
+    await expect(
+      requireChurchPermission("members:view", "church-1")
+    ).resolves.toBeDefined();
   });
 });
 

--- a/src/lib/__tests__/week.test.ts
+++ b/src/lib/__tests__/week.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { weekBounds, shiftWeek, currentWeekMonday, buildWeekEventsQuery } from "../week";
+
+describe("weekBounds", () => {
+  it("returns Monday 00:00:00.000 to Sunday 23:59:59.999 for a mid-week date", () => {
+    // Wednesday 8 July 2026
+    const { start, end } = weekBounds(new Date(2026, 6, 8, 15, 30));
+    expect(start.getFullYear()).toBe(2026);
+    expect(start.getMonth()).toBe(6); // July
+    expect(start.getDate()).toBe(6); // Monday 6 July 2026
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getSeconds()).toBe(0);
+    expect(start.getMilliseconds()).toBe(0);
+
+    expect(end.getFullYear()).toBe(2026);
+    expect(end.getMonth()).toBe(6);
+    expect(end.getDate()).toBe(12); // Sunday 12 July 2026
+    expect(end.getHours()).toBe(23);
+    expect(end.getMinutes()).toBe(59);
+    expect(end.getSeconds()).toBe(59);
+    expect(end.getMilliseconds()).toBe(999);
+  });
+
+  it("returns the same week when ref is a Monday", () => {
+    const { start, end } = weekBounds(new Date(2026, 6, 6));
+    expect(start.getDate()).toBe(6);
+    expect(end.getDate()).toBe(12);
+  });
+
+  it("returns the same week when ref is a Sunday", () => {
+    const { start, end } = weekBounds(new Date(2026, 6, 12));
+    expect(start.getDate()).toBe(6);
+    expect(end.getDate()).toBe(12);
+  });
+
+  it("handles a month boundary crossing", () => {
+    // Wednesday 29 July 2026 → week spans July/August
+    const { start, end } = weekBounds(new Date(2026, 6, 29));
+    expect(start.getMonth()).toBe(6); // July
+    expect(start.getDate()).toBe(27);
+    expect(end.getMonth()).toBe(7); // August
+    expect(end.getDate()).toBe(2);
+  });
+
+  it("handles a year boundary crossing", () => {
+    // Wednesday 30 December 2026 → week spans into January 2027
+    const { start, end } = weekBounds(new Date(2026, 11, 30));
+    expect(start.getFullYear()).toBe(2026);
+    expect(start.getMonth()).toBe(11);
+    expect(start.getDate()).toBe(28);
+    expect(end.getFullYear()).toBe(2027);
+    expect(end.getMonth()).toBe(0);
+    expect(end.getDate()).toBe(3);
+  });
+});
+
+describe("shiftWeek", () => {
+  it("returns the previous Monday", () => {
+    expect(shiftWeek("2026-07-06", -1)).toBe("2026-06-29");
+  });
+
+  it("returns the next Monday", () => {
+    expect(shiftWeek("2026-07-06", 1)).toBe("2026-07-13");
+  });
+
+  it("handles a year change forward", () => {
+    expect(shiftWeek("2026-12-28", 1)).toBe("2027-01-04");
+  });
+
+  it("handles a year change backward", () => {
+    expect(shiftWeek("2027-01-04", -1)).toBe("2026-12-28");
+  });
+});
+
+describe("currentWeekMonday", () => {
+  it("returns the ISO date of the Monday of the reference week", () => {
+    expect(currentWeekMonday(new Date(2026, 6, 8))).toBe("2026-07-06");
+  });
+});
+
+describe("buildWeekEventsQuery", () => {
+  it("always scopes the query to the given churchId", () => {
+    const query = buildWeekEventsQuery("church-1", new Date(2026, 6, 8));
+    expect(query.where.churchId).toBe("church-1");
+  });
+
+  it("never leaks another church's events (churchId is always present, not optional)", () => {
+    const query = buildWeekEventsQuery("church-2", new Date(2026, 6, 8));
+    expect(query.where).toHaveProperty("churchId", "church-2");
+    expect(Object.keys(query.where)).toContain("churchId");
+  });
+
+  it("scopes the date range to the week of the reference date", () => {
+    const ref = new Date(2026, 6, 8);
+    const query = buildWeekEventsQuery("church-1", ref);
+    const { start, end } = weekBounds(ref);
+    expect(query.where.date.gte).toEqual(start);
+    expect(query.where.date.lte).toEqual(end);
+    expect(query.where.date.gte.getTime()).toBeLessThan(query.where.date.lte.getTime());
+  });
+
+  it("orders results chronologically and selects the minimal fields", () => {
+    const query = buildWeekEventsQuery("church-1", new Date(2026, 6, 8));
+    expect(query.orderBy).toEqual({ date: "asc" });
+    expect(query.select).toEqual({ id: true, title: true, type: true, date: true });
+  });
+});

--- a/src/lib/week.ts
+++ b/src/lib/week.ts
@@ -1,0 +1,72 @@
+/**
+ * Helpers de dates purs pour la vue hebdomadaire des événements (STAR).
+ * Semaine française : lundi 00:00:00.000 → dimanche 23:59:59.999.
+ */
+
+/**
+ * Calcule les bornes (lundi 00:00 → dimanche 23:59:59.999) de la semaine
+ * contenant la date `ref`. Fonctionne en heure locale, robuste aux
+ * changements de mois/année.
+ */
+export function weekBounds(ref: Date): { start: Date; end: Date } {
+  const d = new Date(ref.getFullYear(), ref.getMonth(), ref.getDate());
+  const day = d.getDay(); // 0 = dimanche, 1 = lundi, ..., 6 = samedi
+  const diffToMonday = day === 0 ? -6 : 1 - day;
+
+  const start = new Date(d);
+  start.setDate(d.getDate() + diffToMonday);
+  start.setHours(0, 0, 0, 0);
+
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  end.setHours(23, 59, 59, 999);
+
+  return { start, end };
+}
+
+function toISODate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Renvoie l'ISO (yyyy-mm-dd) du lundi de la semaine précédente (`delta = -1`)
+ * ou suivante (`delta = 1`) par rapport au lundi `mondayISO`.
+ */
+export function shiftWeek(mondayISO: string, delta: -1 | 1): string {
+  const [year, month, day] = mondayISO.split("-").map(Number);
+  const d = new Date(year, month - 1, day);
+  d.setDate(d.getDate() + delta * 7);
+  return toISODate(d);
+}
+
+/** Renvoie l'ISO (yyyy-mm-dd) du lundi de la semaine contenant `ref`. */
+export function currentWeekMonday(ref: Date = new Date()): string {
+  const { start } = weekBounds(ref);
+  return toISODate(start);
+}
+
+/**
+ * Construit les paramètres d'une requête Prisma `event.findMany` bornée à
+ * l'église `churchId` et à la semaine contenant `ref`. Extrait en fonction
+ * pure pour être testable indépendamment de Prisma (non-fuite multi-tenant,
+ * cohérence de la plage de dates).
+ */
+export function buildWeekEventsQuery(churchId: string, ref: Date) {
+  const { start, end } = weekBounds(ref);
+  return {
+    where: {
+      churchId,
+      date: { gte: start, lte: end },
+    },
+    orderBy: { date: "asc" as const },
+    select: {
+      id: true,
+      title: true,
+      type: true,
+      date: true,
+    } as const,
+  };
+}


### PR DESCRIPTION
Implémente la spec **006** (`specs/006-star-navigation-evenements/`).

## Objectif

Recentrer l'espace du STAR « pur » et lui offrir un aperçu hebdomadaire des événements de l'église.

## Changements

- **« Mes demandes » réservé aux profils de gestion** : gardes des pages et API requests/annonces (côté demandeur) passées de `planning:view` → `members:view` (ensemble exact des 5 rôles de gestion : Super Admin, Admin, Secrétaire, Ministre, Responsable de département). Points de traitement (`planning:edit`, `events:manage`) inchangés.
- **« Réservation de salles » masquée pour le STAR-only** (conservée pour tous les autres rôles).
- **Nouvelle vue lecture seule `/planning/events`** : événements de l'église de la semaine, navigation semaine précédente/suivante. Server Component, `?week=`, aucun endpoint ni schéma. Entrée « Événements » affichée si `planning:view && !events:view` (= rôle STAR), mutuellement exclusive avec la section Événements des gestionnaires.
- **Correctif au passage** : le lien BottomNav « Événements » pointait vers `/events` (interdit au STAR) → destination désormais conditionnelle.
- Helpers de dates purs (`weekBounds`, `shiftWeek`, `buildWeekEventsQuery`) + tests.

## Note

Le profil **pastoral-only** perd « Mes demandes » (cohérent avec la règle « rôle de gestion »). Pour le lui conserver, il faudrait ajouter `members:view` à `PASTORAL_READ_PERMISSIONS` — non fait ici.

## Vérifications

`typecheck` / `lint` / `lint:boundaries` / `test` (475) verts. 13 critères d'acceptation couverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)