### PR TITLE
fix(pastoral): rétablir l'accès pastoral à « Mes demandes »

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -129,6 +129,7 @@ export default async function AuthLayout({
     userPermissions.add("events:view");
     userPermissions.add("discipleship:view");
     userPermissions.add("planning:view");
+    userPermissions.add("members:view"); // accès lecture membres + section "Mes demandes"
   }
   const visibleConfigLinks = configLinksDef
     .filter((link) => {

--- a/src/lib/__tests__/auth-security.test.ts
+++ b/src/lib/__tests__/auth-security.test.ts
@@ -6,6 +6,7 @@ import {
   createDepartmentHeadSession,
   createStarSession,
   createSecretarySession,
+  createSession,
 } from "@/__mocks__/auth";
 
 // Mock auth() to return a configurable session
@@ -125,6 +126,22 @@ describe("requireChurchPermission", () => {
     await expect(
       requireChurchPermission("members:view", "church-1")
     ).resolves.toBeDefined();
+  });
+
+  // Un profil pastoral (sans rôle classique) conserve l'accès à "Mes demandes"
+  // via members:view accordé par PASTORAL_READ_PERMISSIONS, mais pas l'écriture.
+  it("a pastoral-only profile is granted members:view (Mes demandes) but not members:manage", async () => {
+    mockAuth.mockResolvedValue(
+      createSession({ churchRoles: [], pastoralChurchIds: ["church-1"] })
+    );
+
+    await expect(
+      requireChurchPermission("members:view", "church-1")
+    ).resolves.toBeDefined();
+
+    await expect(
+      requireChurchPermission("members:manage", "church-1")
+    ).rejects.toThrow("FORBIDDEN");
   });
 });
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -364,6 +364,7 @@ const PASTORAL_READ_PERMISSIONS = new Set([
   "events:view",
   "discipleship:view",
   "planning:view",
+  "members:view", // accès en lecture aux membres + section "Mes demandes"
   "accounting:stats",
 ]);
 


### PR DESCRIPTION
Suite du recentrage STAR (#418, spec 006) : le périmètre « Mes demandes » a été gardé par `members:view`, ce qui excluait les **profils pastoraux** (non listés dans `PASTORAL_READ_PERMISSIONS`). Un pastoral-only voyait donc « Mes demandes » disparaître.

## Correctif

- `members:view` ajouté à `PASTORAL_READ_PERMISSIONS` (`src/lib/auth.ts`) → un profil pastoral, même sans rôle classique, accède au périmètre requests/annonces (garde).
- `members:view` ajouté au set de permissions du `layout` pour les pastoraux → « Mes demandes » réapparaît en vue classique (nav cohérente avec la garde).

## Effet de bord assumé

Les profils pastoraux gagnent l'accès **en lecture** aux membres (`members:view`), cohérent avec leur rôle d'oversight (ils disposent déjà de `/pastoral/members`). L'**écriture** (`members:manage`) reste refusée.

## Tests

Nouveau cas : un profil pastoral-only obtient `members:view` mais pas `members:manage`. Suite complète verte (476 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)