### PR TITLE
fix(media): liens de partage fonctionnels pour les projets médias (v1.14.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.14.1] - 2026-07-18
+
+### Corrigé
+
+- **Liens de partage des projets médias** : les liens « Téléchargement (validées) », « Téléchargement (toutes) » et « Galerie » créés sur un projet média n'affichaient aucun contenu. Ces flux ne lisaient que les photos d'un événement et ignoraient les fichiers d'un projet ; ils exploitent désormais les fichiers du projet (validés `APPROVED`/`FINAL_APPROVED` pour les liens « validées »/galerie approuvée, tous les non-brouillons pour « toutes »). Les liens déjà partagés fonctionnent sans avoir à les recréer.
+
 ## [v1.14.0] - 2026-07-05
 
 ### Ajouté

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/media/download/[token]/__tests__/route.test.ts
+++ b/src/app/api/media/download/[token]/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests — GET /api/media/download/[token] doit servir les fichiers d'un projet
+ * (et pas seulement les photos d'un événement).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+const mockValidateMediaShareToken = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/modules/media", () => ({
+  validateMediaShareToken: (...args: unknown[]) => mockValidateMediaShareToken(...args),
+  getSignedThumbnailUrl: (key: string) => Promise.resolve(`signed://${key}`),
+}));
+
+const { GET } = await import("../route");
+
+const makeParams = (token: string) => Promise.resolve({ token });
+
+function projectFile(id: string, status: string) {
+  return {
+    id,
+    filename: `${id}.jpg`,
+    type: "VISUAL",
+    mimeType: "image/jpeg",
+    size: 1000,
+    status,
+    versions: [{ thumbnailKey: `thumb/${id}`, originalKey: `orig/${id}` }],
+  };
+}
+
+describe("GET /api/media/download/[token] — projet média", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("MEDIA : ne retourne que les fichiers validés du projet", async () => {
+    mockValidateMediaShareToken.mockResolvedValue({
+      id: "tok-1",
+      type: "MEDIA",
+      label: null,
+      mediaEvent: null,
+      mediaProject: {
+        id: "proj-1",
+        name: "Affiche Culte",
+        createdAt: new Date("2026-07-01"),
+        files: [
+          projectFile("f-approved", "APPROVED"),
+          projectFile("f-final", "FINAL_APPROVED"),
+          projectFile("f-review", "IN_REVIEW"),
+          projectFile("f-pending", "PENDING"),
+        ],
+      },
+    });
+
+    const res = await GET(new Request("http://localhost"), { params: makeParams("tok-1") });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.event).toMatchObject({ id: "proj-1", name: "Affiche Culte", photoCount: 2 });
+    expect(json.photos.map((p: { id: string }) => p.id)).toEqual(["f-approved", "f-final"]);
+    expect(json.photos[0].thumbnailUrl).toBe("signed://thumb/f-approved");
+    // aucune requête sur les photos d'événement
+    expect(prismaMock.mediaPhoto.findMany).not.toHaveBeenCalled();
+  });
+
+  it("MEDIA_ALL : retourne tous les fichiers non-brouillons du projet", async () => {
+    mockValidateMediaShareToken.mockResolvedValue({
+      id: "tok-2",
+      type: "MEDIA_ALL",
+      label: null,
+      mediaEvent: null,
+      mediaProject: {
+        id: "proj-1",
+        name: "Affiche Culte",
+        createdAt: new Date("2026-07-01"),
+        // l'include filtre déjà les DRAFT côté validateMediaShareToken
+        files: [
+          projectFile("f-approved", "APPROVED"),
+          projectFile("f-review", "IN_REVIEW"),
+          projectFile("f-pending", "PENDING"),
+        ],
+      },
+    });
+
+    const res = await GET(new Request("http://localhost"), { params: makeParams("tok-2") });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.event.photoCount).toBe(3);
+    expect(json.photos.map((p: { id: string }) => p.id)).toEqual([
+      "f-approved",
+      "f-review",
+      "f-pending",
+    ]);
+  });
+});

--- a/src/app/api/media/download/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/download/[token]/photo/[photoId]/route.ts
@@ -14,6 +14,43 @@ export async function GET(
     const { token, photoId } = await params;
     const shareToken = await validateMediaShareToken(token, ["MEDIA", "MEDIA_ALL"]);
 
+    // ── Projet : le "photoId" désigne un fichier du projet ──────────────────────
+    if (shareToken.mediaProjectId) {
+      const file = await prisma.mediaFile.findUnique({
+        where: { id: photoId },
+        select: {
+          id: true,
+          filename: true,
+          mediaProjectId: true,
+          status: true,
+          versions: {
+            orderBy: { versionNumber: "desc" },
+            take: 1,
+            select: { originalKey: true },
+          },
+        },
+      });
+
+      if (!file) throw new ApiError(404, "Fichier introuvable");
+      if (file.mediaProjectId !== shareToken.mediaProjectId) {
+        throw new ApiError(403, "Fichier hors périmètre");
+      }
+      if (
+        shareToken.type === "MEDIA" &&
+        !["APPROVED", "FINAL_APPROVED"].includes(file.status)
+      ) {
+        throw new ApiError(403, "Fichier non validé");
+      }
+      if (file.status === "DRAFT") throw new ApiError(403, "Fichier non validé");
+
+      const originalKey = file.versions[0]?.originalKey;
+      if (!originalKey) throw new ApiError(404, "Fichier S3 introuvable");
+
+      const downloadUrl = await getSignedDownloadUrl(originalKey, file.filename);
+      return successResponse({ id: file.id, filename: file.filename, downloadUrl });
+    }
+
+    // ── Événement : photo ───────────────────────────────────────────────────────
     const photo = await prisma.mediaPhoto.findUnique({
       where: { id: photoId },
       select: { id: true, filename: true, mediaEventId: true, originalKey: true, status: true },

--- a/src/app/api/media/download/[token]/route.ts
+++ b/src/app/api/media/download/[token]/route.ts
@@ -1,10 +1,15 @@
 /**
  * GET /api/media/download/[token]
- * Retourne les photos approuvées accessibles au téléchargement (token MEDIA).
+ * Retourne les médias accessibles au téléchargement (token MEDIA / MEDIA_ALL).
+ * - Token lié à un événement : photos (approuvées, ou toutes si MEDIA_ALL).
+ * - Token lié à un projet : fichiers validés (APPROVED/FINAL_APPROVED,
+ *   ou tous les non-brouillons si MEDIA_ALL).
  */
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse } from "@/lib/api-utils";
 import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
+
+const APPROVED_FILE_STATUSES = new Set<string>(["APPROVED", "FINAL_APPROVED"]);
 
 export async function GET(
   _request: Request,
@@ -13,34 +18,66 @@ export async function GET(
   try {
     const { token } = await params;
     const shareToken = await validateMediaShareToken(token, ["MEDIA", "MEDIA_ALL"]);
-    const event = shareToken.mediaEvent;
-
-    if (!event) return successResponse({ token: shareToken, photos: [] });
-
     const allStatuses = shareToken.type === "MEDIA_ALL";
+    const tokenInfo = { id: shareToken.id, type: shareToken.type, label: shareToken.label };
 
-    const photos = await prisma.mediaPhoto.findMany({
-      where: { mediaEventId: event.id, ...(!allStatuses && { status: "APPROVED" }) },
-      orderBy: { uploadedAt: "asc" },
-    });
+    // ── Événement (photos) ──────────────────────────────────────────────────────
+    if (shareToken.mediaEvent) {
+      const event = shareToken.mediaEvent;
 
-    const photosWithUrls = await Promise.all(
-      photos.map(async (p) => ({
-        id: p.id,
-        filename: p.filename,
-        size: p.size,
-        width: p.width,
-        height: p.height,
-        status: p.status,
-        thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
-      }))
-    );
+      const photos = await prisma.mediaPhoto.findMany({
+        where: { mediaEventId: event.id, ...(!allStatuses && { status: "APPROVED" }) },
+        orderBy: { uploadedAt: "asc" },
+      });
 
-    return successResponse({
-      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label },
-      event: { id: event.id, name: event.name, date: event.date, photoCount: photosWithUrls.length },
-      photos: photosWithUrls,
-    });
+      const photosWithUrls = await Promise.all(
+        photos.map(async (p) => ({
+          id: p.id,
+          filename: p.filename,
+          size: p.size,
+          width: p.width,
+          height: p.height,
+          status: p.status,
+          thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
+        }))
+      );
+
+      return successResponse({
+        token: tokenInfo,
+        event: { id: event.id, name: event.name, date: event.date, photoCount: photosWithUrls.length },
+        photos: photosWithUrls,
+      });
+    }
+
+    // ── Projet (fichiers validés) ───────────────────────────────────────────────
+    if (shareToken.mediaProject) {
+      const project = shareToken.mediaProject;
+      const files = project.files.filter(
+        (f) => allStatuses || APPROVED_FILE_STATUSES.has(f.status)
+      );
+
+      const filesWithUrls = await Promise.all(
+        files.map(async (f) => ({
+          id: f.id,
+          filename: f.filename,
+          size: f.size,
+          width: null,
+          height: null,
+          status: f.status,
+          thumbnailUrl: f.versions[0]?.thumbnailKey
+            ? await getSignedThumbnailUrl(f.versions[0].thumbnailKey)
+            : "",
+        }))
+      );
+
+      return successResponse({
+        token: tokenInfo,
+        event: { id: project.id, name: project.name, date: project.createdAt, photoCount: filesWithUrls.length },
+        photos: filesWithUrls,
+      });
+    }
+
+    return successResponse({ token: tokenInfo, event: null, photos: [] });
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/app/api/media/download/[token]/zip/route.ts
+++ b/src/app/api/media/download/[token]/zip/route.ts
@@ -23,42 +23,61 @@ export async function POST(
   try {
     const { token } = await params;
     const shareToken = await validateMediaShareToken(token, ["MEDIA", "MEDIA_ALL"]);
-    const event = shareToken.mediaEvent;
-    if (!event) throw new ApiError(404, "Événement introuvable");
 
     const body = bodySchema.parse(await request.json().catch(() => ({})));
     const allStatuses = shareToken.type === "MEDIA_ALL";
 
-    const where = {
-      mediaEventId: event.id,
-      ...(!allStatuses && { status: "APPROVED" as const }),
-      ...(body.photoIds?.length ? { id: { in: body.photoIds } } : {}),
-    };
+    // Résout les entrées à zipper (photos d'événement ou fichiers de projet).
+    let entries: { filename: string; originalKey: string }[] = [];
+    let zipBaseName = "medias";
 
-    const photos = await prisma.mediaPhoto.findMany({
-      where,
-      select: { id: true, filename: true, originalKey: true },
-      orderBy: { uploadedAt: "asc" },
-    });
+    if (shareToken.mediaEvent) {
+      const event = shareToken.mediaEvent;
+      const photos = await prisma.mediaPhoto.findMany({
+        where: {
+          mediaEventId: event.id,
+          ...(!allStatuses && { status: "APPROVED" as const }),
+          ...(body.photoIds?.length ? { id: { in: body.photoIds } } : {}),
+        },
+        select: { filename: true, originalKey: true },
+        orderBy: { uploadedAt: "asc" },
+      });
+      entries = photos;
+      zipBaseName = event.name;
+    } else if (shareToken.mediaProject) {
+      const project = shareToken.mediaProject;
+      const selectedIds = body.photoIds?.length ? new Set(body.photoIds) : null;
+      entries = project.files
+        .filter(
+          (f) =>
+            (allStatuses || ["APPROVED", "FINAL_APPROVED"].includes(f.status)) &&
+            (!selectedIds || selectedIds.has(f.id))
+        )
+        .map((f) => ({ filename: f.filename, originalKey: f.versions[0]?.originalKey ?? "" }))
+        .filter((e) => e.originalKey);
+      zipBaseName = project.name;
+    } else {
+      throw new ApiError(404, "Contenu introuvable");
+    }
 
-    if (photos.length === 0) throw new ApiError(404, "Aucune photo disponible");
+    if (entries.length === 0) throw new ApiError(404, "Aucun fichier disponible");
 
-    // Nom du fichier ZIP : nom événement sanitisé
-    const safeName = event.name.replace(/[^a-z0-9\-_]/gi, "_").slice(0, 60);
+    // Nom du fichier ZIP : nom événement/projet sanitisé
+    const safeName = zipBaseName.replace(/[^a-z0-9\-_]/gi, "_").slice(0, 60);
     const zipFilename = `${safeName}.zip`;
 
     const archive = archiver("zip", { zlib: { level: 1 } });
     const passthrough = new PassThrough();
     archive.pipe(passthrough);
 
-    // Ajout séquentiel des photos dans le ZIP
+    // Ajout séquentiel des médias dans le ZIP
     (async () => {
-      for (const photo of photos) {
+      for (const entry of entries) {
         try {
-          const stream = await getS3ObjectStream(photo.originalKey);
-          archive.append(stream, { name: photo.filename });
+          const stream = await getS3ObjectStream(entry.originalKey);
+          archive.append(stream, { name: entry.filename });
         } catch {
-          // Photo manquante en S3 — on skip sans planter le ZIP
+          // Objet manquant en S3 — on skip sans planter le ZIP
         }
       }
       await archive.finalize();

--- a/src/app/api/media/gallery/[token]/__tests__/route.test.ts
+++ b/src/app/api/media/gallery/[token]/__tests__/route.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests — GET /api/media/gallery/[token] doit servir les fichiers d'un projet
+ * (et pas seulement les photos d'un événement).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+const mockValidateMediaShareToken = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/modules/media", () => ({
+  validateMediaShareToken: (...args: unknown[]) => mockValidateMediaShareToken(...args),
+  getSignedThumbnailUrl: (key: string) => Promise.resolve(`signed://${key}`),
+}));
+
+const { GET } = await import("../route");
+
+const makeParams = (token: string) => Promise.resolve({ token });
+
+function projectFile(id: string, status: string) {
+  return {
+    id,
+    filename: `${id}.jpg`,
+    type: "VISUAL",
+    mimeType: "image/jpeg",
+    size: 1000,
+    status,
+    versions: [{ thumbnailKey: `thumb/${id}`, originalKey: `orig/${id}` }],
+  };
+}
+
+function projectToken(config: unknown) {
+  return {
+    id: "tok-1",
+    type: "GALLERY",
+    label: null,
+    config,
+    mediaEvent: null,
+    mediaProject: {
+      id: "proj-1",
+      name: "Affiche Culte",
+      createdAt: new Date("2026-07-01"),
+      files: [
+        projectFile("f-approved", "APPROVED"),
+        projectFile("f-final", "FINAL_APPROVED"),
+        projectFile("f-review", "IN_REVIEW"),
+      ],
+    },
+  };
+}
+
+describe("GET /api/media/gallery/[token] — projet média", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("onlyApproved : ne retourne que les fichiers validés du projet", async () => {
+    mockValidateMediaShareToken.mockResolvedValue(projectToken({ onlyApproved: true }));
+
+    const res = await GET(new Request("http://localhost"), { params: makeParams("tok-1") });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.event).toMatchObject({ id: "proj-1", name: "Affiche Culte", photoCount: 2 });
+    expect(json.photos.map((p: { id: string }) => p.id)).toEqual(["f-approved", "f-final"]);
+    expect(prismaMock.mediaPhoto.findMany).not.toHaveBeenCalled();
+  });
+
+  it("sans onlyApproved : retourne tous les fichiers non-brouillons du projet", async () => {
+    mockValidateMediaShareToken.mockResolvedValue(projectToken({ onlyApproved: false }));
+
+    const res = await GET(new Request("http://localhost"), { params: makeParams("tok-1") });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.event.photoCount).toBe(3);
+    expect(json.photos.map((p: { id: string }) => p.id)).toEqual([
+      "f-approved",
+      "f-final",
+      "f-review",
+    ]);
+  });
+});

--- a/src/app/api/media/gallery/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/gallery/[token]/photo/[photoId]/route.ts
@@ -13,6 +13,40 @@ export async function GET(
   try {
     const { token, photoId } = await params;
     const shareToken = await validateMediaShareToken(token, "GALLERY");
+    const onlyApproved = (shareToken.config as { onlyApproved?: boolean } | null)?.onlyApproved ?? false;
+
+    // ── Projet : le "photoId" désigne un fichier du projet ──────────────────────
+    if (shareToken.mediaProjectId) {
+      const file = await prisma.mediaFile.findUnique({
+        where: { id: photoId },
+        select: {
+          id: true,
+          filename: true,
+          mediaProjectId: true,
+          status: true,
+          versions: {
+            orderBy: { versionNumber: "desc" },
+            take: 1,
+            select: { originalKey: true },
+          },
+        },
+      });
+
+      if (!file) throw new ApiError(404, "Fichier introuvable");
+      if (file.mediaProjectId !== shareToken.mediaProjectId) {
+        throw new ApiError(403, "Fichier hors périmètre");
+      }
+      if (file.status === "DRAFT") throw new ApiError(403, "Ce fichier n'est pas disponible");
+      if (onlyApproved && !["APPROVED", "FINAL_APPROVED"].includes(file.status)) {
+        throw new ApiError(403, "Ce fichier n'est pas validé");
+      }
+
+      const originalKey = file.versions[0]?.originalKey;
+      if (!originalKey) throw new ApiError(404, "Fichier S3 introuvable");
+
+      const downloadUrl = await getSignedOriginalUrl(originalKey);
+      return successResponse({ id: file.id, filename: file.filename, downloadUrl });
+    }
 
     const photo = await prisma.mediaPhoto.findUnique({
       where: { id: photoId },
@@ -24,7 +58,6 @@ export async function GET(
       throw new ApiError(403, "Photo hors périmètre");
     }
 
-    const onlyApproved = (shareToken.config as { onlyApproved?: boolean } | null)?.onlyApproved ?? false;
     if (onlyApproved && photo.status !== "APPROVED") {
       throw new ApiError(403, "Cette photo n'est pas approuvée");
     }

--- a/src/app/api/media/gallery/[token]/route.ts
+++ b/src/app/api/media/gallery/[token]/route.ts
@@ -6,6 +6,8 @@ import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse } from "@/lib/api-utils";
 import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
 
+const APPROVED_FILE_STATUSES = new Set<string>(["APPROVED", "FINAL_APPROVED"]);
+
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ token: string }> }
@@ -15,39 +17,66 @@ export async function GET(
     const shareToken = await validateMediaShareToken(token, "GALLERY");
 
     const onlyApproved = (shareToken.config as { onlyApproved?: boolean } | null)?.onlyApproved ?? false;
-    const event = shareToken.mediaEvent;
+    const tokenInfo = { id: shareToken.id, type: shareToken.type, label: shareToken.label, config: shareToken.config };
 
-    if (!event) return successResponse({ token: shareToken, photos: [] });
+    // ── Événement (photos) ──────────────────────────────────────────────────────
+    if (shareToken.mediaEvent) {
+      const event = shareToken.mediaEvent;
 
-    const photos = await prisma.mediaPhoto.findMany({
-      where: {
-        mediaEventId: event.id,
-        ...(onlyApproved ? { status: "APPROVED" } : {}),
-      },
-      orderBy: { uploadedAt: "asc" },
-    });
+      const photos = await prisma.mediaPhoto.findMany({
+        where: {
+          mediaEventId: event.id,
+          ...(onlyApproved ? { status: "APPROVED" } : {}),
+        },
+        orderBy: { uploadedAt: "asc" },
+      });
 
-    const photosWithUrls = await Promise.all(
-      photos.map(async (p) => ({
-        id: p.id,
-        filename: p.filename,
-        status: p.status,
-        width: p.width,
-        height: p.height,
-        thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
-      }))
-    );
+      const photosWithUrls = await Promise.all(
+        photos.map(async (p) => ({
+          id: p.id,
+          filename: p.filename,
+          status: p.status,
+          width: p.width,
+          height: p.height,
+          thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
+        }))
+      );
 
-    return successResponse({
-      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label, config: shareToken.config },
-      event: {
-        id: event.id,
-        name: event.name,
-        date: event.date,
-        photoCount: photosWithUrls.length,
-      },
-      photos: photosWithUrls,
-    });
+      return successResponse({
+        token: tokenInfo,
+        event: { id: event.id, name: event.name, date: event.date, photoCount: photosWithUrls.length },
+        photos: photosWithUrls,
+      });
+    }
+
+    // ── Projet (fichiers) ───────────────────────────────────────────────────────
+    if (shareToken.mediaProject) {
+      const project = shareToken.mediaProject;
+      const files = project.files.filter(
+        (f) => !onlyApproved || APPROVED_FILE_STATUSES.has(f.status)
+      );
+
+      const filesWithUrls = await Promise.all(
+        files.map(async (f) => ({
+          id: f.id,
+          filename: f.filename,
+          status: f.status,
+          width: null,
+          height: null,
+          thumbnailUrl: f.versions[0]?.thumbnailKey
+            ? await getSignedThumbnailUrl(f.versions[0].thumbnailKey)
+            : "",
+        }))
+      );
+
+      return successResponse({
+        token: tokenInfo,
+        event: { id: project.id, name: project.name, date: project.createdAt, photoCount: filesWithUrls.length },
+        photos: filesWithUrls,
+      });
+    }
+
+    return successResponse({ token: tokenInfo, event: null, photos: [] });
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/modules/media/services/tokens.ts
+++ b/src/modules/media/services/tokens.ts
@@ -67,6 +67,7 @@ export async function validateMediaShareToken(
           id: true,
           name: true,
           churchId: true,
+          createdAt: true,
           shareTokens: { select: { type: true } },
           files: {
             orderBy: { createdAt: "asc" as const },


### PR DESCRIPTION
## Problème

Les liens de partage **« Téléchargement (validées) »** (`MEDIA`), **« Téléchargement (toutes) »** (`MEDIA_ALL`) et **« Galerie »** (`GALLERY`) peuvent être créés sur un **projet** média, mais n'affichaient **aucun contenu** (lien mort silencieux).

Ces routes publiques ne lisaient que `shareToken.mediaEvent` et interrogeaient la table des photos. Un projet n'a pas d'événement (`mediaEvent = null`) — son contenu vit dans `mediaProject.files`. Résultat : réponse vide → « aucune photo n'apparaît ».

## Correctif

Les routes `download` (liste, item, zip) et `gallery` (liste, item) gèrent désormais les deux cas :

- **Token lié à un événement** → photos (comportement inchangé).
- **Token lié à un projet** → fichiers, via la dernière version comme source S3 :
  - `MEDIA` / galerie `onlyApproved` → fichiers validés (`APPROVED` + `FINAL_APPROVED`)
  - `MEDIA_ALL` / galerie sans `onlyApproved` → tous les non-brouillons

**Les liens déjà partagés fonctionnent sans les recréer.**

## Détails

- `validateMediaShareToken` : ajout de `createdAt` au projet (date d'en-tête).
- Routes modifiées : `download/[token]` (+ `/photo/[photoId]`, `/zip`), `gallery/[token]` (+ `/photo/[photoId]`).
- Tests dédiés : `download` (2 cas) + `gallery` (2 cas).

## Vérifications

- `typecheck` ✅ · `lint:boundaries` ✅ · **480 tests** ✅

Release **v1.14.1** (package.json + CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)