### PR TITLE
fix(media): consolidation collection/validator — divergence route/page (v1.14.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.14.3] - 2026-07-18
+
+### Corrigé
+
+- **Consolidation préventive des liens de partage média** (suite à v1.14.1/v1.14.2) : les pages publiques « Collection » et « Validateur »/« Pré-validateur » dupliquaient elles aussi leur logique de récupération de données depuis leur route API, avec le même risque de divergence silencieuse. La logique est désormais centralisée (`resolveCollectionData`, `resolveValidatorData`) et partagée entre routes API et pages SSR.
+  - Bug latent corrigé au passage : la page « Collection » ignorait le paramètre `includeAllPhotos` d'un token (elle filtrait toujours sur les photos approuvées, contrairement à sa route API) — un lien collection configuré pour tout afficher masquait les photos non validées.
+  - La page « Validateur »/« Pré-validateur » appelait deux fois la validation du token à chaque chargement, comptabilisant deux usages au lieu d'un dans les statistiques du lien.
+
 ## [v1.14.2] - 2026-07-18
 
 ### Corrigé

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/media/collection/[token]/route.ts
+++ b/src/app/api/media/collection/[token]/route.ts
@@ -2,10 +2,8 @@
  * GET /api/media/collection/[token]
  * Retourne les contenus d'une collection multi-sources (token COLLECTION).
  */
-import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
-import { validateMediaShareToken, getSignedThumbnailUrl, collectionPhotoWhere } from "@/modules/media";
-import type { CollectionConfig } from "@/modules/media";
+import { validateMediaShareToken, resolveCollectionData } from "@/modules/media";
 
 export async function GET(
   _request: Request,
@@ -14,109 +12,13 @@ export async function GET(
   try {
     const { token } = await params;
     const shareToken = await validateMediaShareToken(token, "COLLECTION");
-    const config = shareToken.config as CollectionConfig | null;
-
-    if (!config) throw new ApiError(400, "Configuration de collection manquante");
-
-    const { scope, eventIds, projectIds } = config;
-
-    // ── Photos (scope: photos | both) ──────────────────────────────────────────
-    type PhotoGroup = {
-      eventId: string;
-      eventName: string;
-      eventDate: string;
-      photos: { id: string; filename: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }[];
-    };
-    const photoGroups: PhotoGroup[] = [];
-
-    if ((scope === "photos" || scope === "both") && eventIds.length > 0) {
-      const events = await prisma.mediaEvent.findMany({
-        where: { id: { in: eventIds } },
-        orderBy: { date: "desc" },
-        include: {
-          photos: {
-            where: collectionPhotoWhere(config),
-            orderBy: { uploadedAt: "asc" },
-            select: { id: true, filename: true, size: true, width: true, height: true, thumbnailKey: true },
-          },
-        },
-      });
-
-      for (const event of events) {
-        const photos = await Promise.all(
-          event.photos.map(async (p) => ({
-            id: p.id,
-            filename: p.filename,
-            size: p.size,
-            width: p.width,
-            height: p.height,
-            thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
-          }))
-        );
-        photoGroups.push({ eventId: event.id, eventName: event.name, eventDate: event.date.toISOString(), photos });
-      }
-    }
-
-    // ── Fichiers/Visuels (scope: files | both) ─────────────────────────────────
-    type FileGroup = {
-      projectId: string;
-      projectName: string;
-      files: { id: string; filename: string; type: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }[];
-    };
-    const fileGroups: FileGroup[] = [];
-
-    if ((scope === "files" || scope === "both") && projectIds.length > 0) {
-      const projects = await prisma.mediaProject.findMany({
-        where: { id: { in: projectIds } },
-        orderBy: { createdAt: "desc" },
-        include: {
-          files: {
-            where: { status: { in: ["APPROVED", "FINAL_APPROVED"] } },
-            orderBy: { createdAt: "asc" },
-            select: {
-              id: true,
-              filename: true,
-              type: true,
-              size: true,
-              width: true,
-              height: true,
-              versions: {
-                orderBy: { versionNumber: "desc" },
-                take: 1,
-                select: { thumbnailKey: true },
-              },
-            },
-          },
-        },
-      });
-
-      for (const project of projects) {
-        const files = await Promise.all(
-          project.files.map(async (f) => ({
-            id: f.id,
-            filename: f.filename,
-            type: f.type,
-            size: f.size,
-            width: f.width,
-            height: f.height,
-            thumbnailUrl: f.versions[0]?.thumbnailKey
-              ? await getSignedThumbnailUrl(f.versions[0].thumbnailKey)
-              : "",
-          }))
-        );
-        fileGroups.push({ projectId: project.id, projectName: project.name, files });
-      }
-    }
-
-    const totalPhotos = photoGroups.reduce((n, g) => n + g.photos.length, 0);
-    const totalFiles  = fileGroups.reduce((n, g) => n + g.files.length, 0);
+    const data = await resolveCollectionData(shareToken);
+    if (!data) throw new ApiError(400, "Configuration de collection manquante");
 
     return successResponse({
-      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label, config },
-      photoGroups,
-      fileGroups,
-      totalPhotos,
-      totalFiles,
+      ...data,
+      totalPhotos: data.photoGroups.reduce((n, g) => n + g.photos.length, 0),
+      totalFiles: data.fileGroups.reduce((n, g) => n + g.files.length, 0),
     });
   } catch (error) {
     return errorResponse(error);

--- a/src/app/api/media/validate/[token]/route.ts
+++ b/src/app/api/media/validate/[token]/route.ts
@@ -1,10 +1,10 @@
 /**
  * GET /api/media/validate/[token]
- * Retourne l'événement média et ses photos pour validation/prévalidation.
+ * Retourne l'événement ou le projet média (photos/fichiers à valider).
  * Accessible sans authentification via un token de partage VALIDATOR ou PREVALIDATOR.
  */
 import { successResponse, errorResponse } from "@/lib/api-utils";
-import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
+import { validateMediaShareToken, resolveValidatorData } from "@/modules/media";
 
 export async function GET(
   _request: Request,
@@ -13,60 +13,8 @@ export async function GET(
   try {
     const { token } = await params;
     const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
-
-    const isPrevalidator = shareToken.type === "PREVALIDATOR";
-    const event = shareToken.mediaEvent;
-
-    if (!event) {
-      return successResponse({ token: shareToken, event: null });
-    }
-
-    const hasPrevalidator = event.shareTokens.some((t) => t.type === "PREVALIDATOR");
-
-    // Filtre statuts selon le type de token
-    let statusFilter: string[];
-    if (isPrevalidator) {
-      statusFilter = ["PENDING"];
-    } else if (hasPrevalidator) {
-      statusFilter = ["PREVALIDATED", "APPROVED", "REJECTED"];
-    } else {
-      statusFilter = ["PENDING", "PREVALIDATED", "APPROVED", "REJECTED"];
-    }
-
-    const { prisma } = await import("@/lib/prisma");
-    const photos = await prisma.mediaPhoto.findMany({
-      where: {
-        mediaEventId: event.id,
-        status: { in: statusFilter as ("PENDING" | "APPROVED" | "REJECTED" | "PREVALIDATED" | "PREREJECTED")[] },
-      },
-      orderBy: { uploadedAt: "asc" },
-    });
-
-    const photosWithUrls = await Promise.all(
-      photos.map(async (p) => ({
-        ...p,
-        thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
-      }))
-    );
-
-    return successResponse({
-      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label },
-      event: {
-        id: event.id,
-        name: event.name,
-        date: event.date,
-        status: event.status,
-        isPrevalidator,
-        hasPrevalidator,
-        totalPhotos: event.photos.length,
-        approvedCount: event.photos.filter((p) => p.status === "APPROVED").length,
-        pendingCount: event.photos.filter((p) => p.status === "PENDING").length,
-        rejectedCount: event.photos.filter((p) => p.status === "REJECTED").length,
-        prevalidatedCount: event.photos.filter((p) => p.status === "PREVALIDATED").length,
-        prerejectedCount: event.photos.filter((p) => p.status === "PREREJECTED").length,
-      },
-      photos: photosWithUrls,
-    });
+    const data = await resolveValidatorData(shareToken);
+    return successResponse(data ?? { token: { id: shareToken.id, type: shareToken.type, label: shareToken.label }, event: null });
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/app/media/c/[token]/page.tsx
+++ b/src/app/media/c/[token]/page.tsx
@@ -3,115 +3,13 @@
  * Accessible via un lien COLLECTION sans authentification.
  */
 import { notFound } from "next/navigation";
-import { prisma } from "@/lib/prisma";
-import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
-import type { CollectionConfig } from "@/modules/media";
+import { validateMediaShareToken, resolveCollectionData } from "@/modules/media";
 import CollectionView from "./CollectionView";
 
 async function fetchCollectionData(token: string) {
   try {
     const shareToken = await validateMediaShareToken(token, "COLLECTION");
-    const config = shareToken.config as CollectionConfig | null;
-    if (!config) return null;
-
-    const { scope, eventIds, projectIds } = config;
-
-    type PhotoGroup = {
-      eventId: string;
-      eventName: string;
-      eventDate: string;
-      photos: { id: string; filename: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }[];
-    };
-    const photoGroups: PhotoGroup[] = [];
-
-    if ((scope === "photos" || scope === "both") && eventIds.length > 0) {
-      const events = await prisma.mediaEvent.findMany({
-        where: { id: { in: eventIds } },
-        orderBy: { date: "desc" },
-        include: {
-          photos: {
-            where: { status: "APPROVED" },
-            orderBy: { uploadedAt: "asc" },
-            select: { id: true, filename: true, size: true, width: true, height: true, thumbnailKey: true },
-          },
-        },
-      });
-
-      for (const event of events) {
-        const photos = await Promise.all(
-          event.photos.map(async (p) => ({
-            id: p.id,
-            filename: p.filename,
-            size: p.size,
-            width: p.width,
-            height: p.height,
-            thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
-          }))
-        );
-        photoGroups.push({
-          eventId: event.id,
-          eventName: event.name,
-          eventDate: event.date.toISOString(),
-          photos,
-        });
-      }
-    }
-
-    type FileGroup = {
-      projectId: string;
-      projectName: string;
-      files: { id: string; filename: string; type: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }[];
-    };
-    const fileGroups: FileGroup[] = [];
-
-    if ((scope === "files" || scope === "both") && projectIds.length > 0) {
-      const projects = await prisma.mediaProject.findMany({
-        where: { id: { in: projectIds } },
-        orderBy: { createdAt: "desc" },
-        include: {
-          files: {
-            where: { status: { in: ["APPROVED", "FINAL_APPROVED"] } },
-            orderBy: { createdAt: "asc" },
-            select: {
-              id: true,
-              filename: true,
-              type: true,
-              size: true,
-              width: true,
-              height: true,
-              versions: {
-                orderBy: { versionNumber: "desc" },
-                take: 1,
-                select: { thumbnailKey: true },
-              },
-            },
-          },
-        },
-      });
-
-      for (const project of projects) {
-        const files = await Promise.all(
-          project.files.map(async (f) => ({
-            id: f.id,
-            filename: f.filename,
-            type: f.type,
-            size: f.size,
-            width: f.width,
-            height: f.height,
-            thumbnailUrl: f.versions[0]?.thumbnailKey
-              ? await getSignedThumbnailUrl(f.versions[0].thumbnailKey)
-              : "",
-          }))
-        );
-        fileGroups.push({ projectId: project.id, projectName: project.name, files });
-      }
-    }
-
-    return {
-      token: { id: shareToken.id, label: shareToken.label, config },
-      photoGroups,
-      fileGroups,
-    };
+    return await resolveCollectionData(shareToken);
   } catch {
     return null;
   }

--- a/src/app/media/v/[token]/page.tsx
+++ b/src/app/media/v/[token]/page.tsx
@@ -3,127 +3,32 @@
  * Accessible via un lien VALIDATOR ou PREVALIDATOR sans authentification.
  */
 import { notFound } from "next/navigation";
-import { prisma } from "@/lib/prisma";
-import { validateMediaShareToken, getSignedThumbnailUrl } from "@/modules/media";
+import { validateMediaShareToken, resolveValidatorData } from "@/modules/media";
 import ValidatorView from "./ValidatorView";
 import ProjectValidatorView from "./ProjectValidatorView";
-
-async function fetchEventValidationData(token: string) {
-  try {
-    const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
-    if (!shareToken.mediaEvent) return null;
-
-    const isPrevalidator = shareToken.type === "PREVALIDATOR";
-    const event = shareToken.mediaEvent;
-    const hasPrevalidator = event.shareTokens.some((t) => t.type === "PREVALIDATOR");
-
-    let statusFilter: string[];
-    if (isPrevalidator) {
-      statusFilter = ["PENDING"];
-    } else if (hasPrevalidator) {
-      statusFilter = ["PREVALIDATED", "APPROVED", "REJECTED"];
-    } else {
-      statusFilter = ["PENDING", "PREVALIDATED", "APPROVED", "REJECTED"];
-    }
-
-    const photos = await prisma.mediaPhoto.findMany({
-      where: {
-        mediaEventId: event.id,
-        status: { in: statusFilter as ("PENDING" | "APPROVED" | "REJECTED" | "PREVALIDATED" | "PREREJECTED")[] },
-      },
-      orderBy: { uploadedAt: "asc" },
-    });
-
-    const photosWithUrls = await Promise.all(
-      photos.map(async (p) => ({ ...p, thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey) }))
-    );
-
-    return {
-      type: "event" as const,
-      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label },
-      event: {
-        id: event.id,
-        name: event.name,
-        date: event.date.toISOString(),
-        status: event.status,
-        isPrevalidator,
-        hasPrevalidator,
-        totalPhotos: event.photos.length,
-        approvedCount: event.photos.filter((p) => p.status === "APPROVED").length,
-        pendingCount: event.photos.filter((p) => p.status === "PENDING").length,
-        rejectedCount: event.photos.filter((p) => p.status === "REJECTED").length,
-        prevalidatedCount: event.photos.filter((p) => p.status === "PREVALIDATED").length,
-        prerejectedCount: event.photos.filter((p) => p.status === "PREREJECTED").length,
-      },
-      photos: photosWithUrls,
-    };
-  } catch {
-    return null;
-  }
-}
-
-async function fetchProjectValidationData(token: string) {
-  try {
-    const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
-    if (!shareToken.mediaProject) return null;
-
-    const isPrevalidator = shareToken.type === "PREVALIDATOR";
-    const project = shareToken.mediaProject;
-    const hasPrevalidator = project.shareTokens.some((t) => t.type === "PREVALIDATOR");
-
-    const filesWithUrls = await Promise.all(
-      project.files.map(async (f) => {
-        const thumbKey = f.versions[0]?.thumbnailKey;
-        let thumbnailUrl: string | null = null;
-        if (thumbKey && f.mimeType.startsWith("image/")) {
-          try { thumbnailUrl = await getSignedThumbnailUrl(thumbKey); } catch { /* pas de preview */ }
-        }
-        return {
-          id: f.id,
-          filename: f.filename,
-          type: f.type,
-          mimeType: f.mimeType,
-          size: f.size,
-          status: f.status,
-          thumbnailUrl,
-        };
-      })
-    );
-
-    return {
-      type: "project" as const,
-      token: { id: shareToken.id, type: shareToken.type, label: shareToken.label },
-      project: {
-        id: project.id,
-        name: project.name,
-        isPrevalidator,
-        hasPrevalidator,
-        totalFiles: filesWithUrls.length,
-      },
-      files: filesWithUrls,
-    };
-  } catch {
-    return null;
-  }
-}
 
 export default async function ValidatorPage({ params }: { params: Promise<{ token: string }> }) {
   const { token } = await params;
 
-  // Detect project vs event by trying each
-  const shareToken = await (async () => {
-    try { return await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]); } catch { return null; }
+  const data = await (async () => {
+    try {
+      const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
+      return await resolveValidatorData(shareToken);
+    } catch {
+      return null;
+    }
   })();
 
-  if (!shareToken) notFound();
+  if (!data) notFound();
 
-  if (shareToken!.mediaProjectId) {
-    const data = await fetchProjectValidationData(token);
-    if (!data) notFound();
+  if (data.type === "project") {
     return <ProjectValidatorView token={token} data={data} />;
   }
 
-  const data = await fetchEventValidationData(token);
-  if (!data) notFound();
-  return <ValidatorView token={token} data={{ token: data.token, event: data.event, photos: data.photos }} />;
+  return (
+    <ValidatorView
+      token={token}
+      data={{ token: data.token, event: { ...data.event, date: data.event.date.toISOString() }, photos: data.photos }}
+    />
+  );
 }

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -1,7 +1,7 @@
 import { defineModule } from "@/core/module-registry";
 
-export { createMediaShareToken, validateMediaShareToken, getTokenUrlPath, isTokenExpired, generateToken, collectionPhotoWhere, resolveDownloadData, resolveGalleryData } from "./services/tokens";
-export type { CollectionConfig, ResolvedMediaData, ResolvedGalleryData, ResolvedMediaEntry } from "./services/tokens";
+export { createMediaShareToken, validateMediaShareToken, getTokenUrlPath, isTokenExpired, generateToken, collectionPhotoWhere, resolveDownloadData, resolveGalleryData, resolveCollectionData, resolveValidatorData } from "./services/tokens";
+export type { CollectionConfig, ResolvedMediaData, ResolvedGalleryData, ResolvedMediaEntry, ResolvedCollectionData, ResolvedValidatorEventData, ResolvedValidatorProjectData } from "./services/tokens";
 export { processImage, validatePhotoFile, getExtensionFromMimeType, ALLOWED_PHOTO_MIME_TYPES, MAX_PHOTO_SIZE } from "./services/image";
 export {
   uploadFile as uploadMediaFile,

--- a/src/modules/media/services/__tests__/tokens.test.ts
+++ b/src/modules/media/services/__tests__/tokens.test.ts
@@ -19,7 +19,7 @@ vi.mock("../s3", () => ({
   getSignedThumbnailUrl: (key: string) => Promise.resolve(`signed://${key}`),
 }));
 
-const { collectionPhotoWhere, resolveDownloadData, resolveGalleryData } = await import("../tokens");
+const { collectionPhotoWhere, resolveDownloadData, resolveGalleryData, resolveCollectionData, resolveValidatorData } = await import("../tokens");
 type CollectionConfig = Parameters<typeof collectionPhotoWhere>[0];
 
 const baseConfig: CollectionConfig = {
@@ -117,5 +117,114 @@ describe("resolveGalleryData — projet média (GALLERY)", () => {
 
     expect(data.event?.photoCount).toBe(4);
     expect(data.photos.map((p) => p.id)).toEqual(["f-approved", "f-final", "f-review", "f-pending"]);
+  });
+});
+
+describe("resolveCollectionData — respecte includeAllPhotos (COLLECTION)", () => {
+  it("includeAllPhotos: true — inclut les photos non approuvées de l'événement", async () => {
+    prismaMock.mediaEvent.findMany.mockResolvedValue([
+      {
+        id: "evt-1",
+        name: "Culte",
+        date: new Date("2026-07-01"),
+        photos: [
+          { id: "p-approved", filename: "a.jpg", size: 100, width: null, height: null, thumbnailKey: "t/p-approved" },
+          { id: "p-pending", filename: "b.jpg", size: 100, width: null, height: null, thumbnailKey: "t/p-pending" },
+        ],
+      },
+    ] as never);
+
+    const data = await resolveCollectionData({
+      id: "tok-1",
+      type: "COLLECTION",
+      label: null,
+      config: { scope: "photos", eventIds: ["evt-1"], projectIds: [], includeAllPhotos: true },
+    } as never);
+
+    expect(data?.photoGroups[0].photos.map((p) => p.id)).toEqual(["p-approved", "p-pending"]);
+    expect(prismaMock.mediaEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: expect.objectContaining({ photos: expect.objectContaining({ where: {} }) }),
+      })
+    );
+  });
+
+  it("includeAllPhotos absent — filtre sur APPROVED uniquement", async () => {
+    prismaMock.mediaEvent.findMany.mockResolvedValue([]);
+
+    await resolveCollectionData({
+      id: "tok-2",
+      type: "COLLECTION",
+      label: null,
+      config: { scope: "photos", eventIds: ["evt-1"], projectIds: [] },
+    } as never);
+
+    expect(prismaMock.mediaEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: expect.objectContaining({ photos: expect.objectContaining({ where: { status: "APPROVED" } }) }),
+      })
+    );
+  });
+
+  it("config manquante : retourne null", async () => {
+    const data = await resolveCollectionData({ id: "tok-3", type: "COLLECTION", label: null, config: null } as never);
+    expect(data).toBeNull();
+  });
+});
+
+describe("resolveValidatorData — événement vs projet (VALIDATOR/PREVALIDATOR)", () => {
+  it("token lié à un projet : retourne les fichiers du projet (pas de requête mediaPhoto)", async () => {
+    const data = await resolveValidatorData({
+      id: "tok-1",
+      type: "VALIDATOR",
+      label: null,
+      mediaEvent: null,
+      mediaProject: {
+        id: "proj-1",
+        name: "Affiche Culte",
+        shareTokens: [],
+        files: [
+          { id: "f-1", filename: "a.jpg", type: "VISUAL", mimeType: "image/jpeg", size: 100, status: "PENDING", versions: [] },
+        ],
+      },
+    } as never);
+
+    expect(data?.type).toBe("project");
+    expect(prismaMock.mediaPhoto.findMany).not.toHaveBeenCalled();
+  });
+
+  it("token lié à un événement PREVALIDATOR : ne retourne que les photos PENDING", async () => {
+    prismaMock.mediaPhoto.findMany.mockResolvedValue([]);
+
+    const data = await resolveValidatorData({
+      id: "tok-2",
+      type: "PREVALIDATOR",
+      label: null,
+      mediaEvent: {
+        id: "evt-1",
+        name: "Culte",
+        date: new Date("2026-07-01"),
+        status: "ACTIVE",
+        shareTokens: [],
+        photos: [],
+      },
+      mediaProject: null,
+    } as never);
+
+    expect(data?.type).toBe("event");
+    expect(prismaMock.mediaPhoto.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ status: { in: ["PENDING"] } }) })
+    );
+  });
+
+  it("ni événement ni projet : retourne null", async () => {
+    const data = await resolveValidatorData({
+      id: "tok-3",
+      type: "VALIDATOR",
+      label: null,
+      mediaEvent: null,
+      mediaProject: null,
+    } as never);
+    expect(data).toBeNull();
   });
 });

--- a/src/modules/media/services/tokens.ts
+++ b/src/modules/media/services/tokens.ts
@@ -255,6 +255,256 @@ export async function resolveGalleryData(
   return { token: tokenInfo, event: null, photos: [] };
 }
 
+export type ResolvedCollectionData = {
+  token: { id: string; type: MediaTokenType; label: string | null; config: CollectionConfig };
+  photoGroups: {
+    eventId: string;
+    eventName: string;
+    eventDate: string;
+    photos: { id: string; filename: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }[];
+  }[];
+  fileGroups: {
+    projectId: string;
+    projectName: string;
+    files: { id: string; filename: string; type: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }[];
+  }[];
+};
+
+/**
+ * Résout le contenu d'un token COLLECTION déjà validé (photos d'événements +
+ * fichiers de projets, selon le scope configuré). Partagé entre la route API
+ * et la page SSR publique pour éviter toute divergence entre les deux.
+ */
+export async function resolveCollectionData(
+  shareToken: Awaited<ReturnType<typeof validateMediaShareToken>>
+): Promise<ResolvedCollectionData | null> {
+  const config = shareToken.config as CollectionConfig | null;
+  if (!config) return null;
+
+  const { scope, eventIds, projectIds } = config;
+  const photoGroups: ResolvedCollectionData["photoGroups"] = [];
+  const fileGroups: ResolvedCollectionData["fileGroups"] = [];
+
+  if ((scope === "photos" || scope === "both") && eventIds.length > 0) {
+    const events = await prisma.mediaEvent.findMany({
+      where: { id: { in: eventIds } },
+      orderBy: { date: "desc" },
+      include: {
+        photos: {
+          where: collectionPhotoWhere(config),
+          orderBy: { uploadedAt: "asc" },
+          select: { id: true, filename: true, size: true, width: true, height: true, thumbnailKey: true },
+        },
+      },
+    });
+
+    for (const event of events) {
+      const photos = await Promise.all(
+        event.photos.map(async (p) => ({
+          id: p.id,
+          filename: p.filename,
+          size: p.size,
+          width: p.width,
+          height: p.height,
+          thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey),
+        }))
+      );
+      photoGroups.push({ eventId: event.id, eventName: event.name, eventDate: event.date.toISOString(), photos });
+    }
+  }
+
+  if ((scope === "files" || scope === "both") && projectIds.length > 0) {
+    const projects = await prisma.mediaProject.findMany({
+      where: { id: { in: projectIds } },
+      orderBy: { createdAt: "desc" },
+      include: {
+        files: {
+          where: { status: { in: ["APPROVED", "FINAL_APPROVED"] } },
+          orderBy: { createdAt: "asc" },
+          select: {
+            id: true,
+            filename: true,
+            type: true,
+            size: true,
+            width: true,
+            height: true,
+            versions: {
+              orderBy: { versionNumber: "desc" },
+              take: 1,
+              select: { thumbnailKey: true },
+            },
+          },
+        },
+      },
+    });
+
+    for (const project of projects) {
+      const files = await Promise.all(
+        project.files.map(async (f) => ({
+          id: f.id,
+          filename: f.filename,
+          type: f.type,
+          size: f.size,
+          width: f.width,
+          height: f.height,
+          thumbnailUrl: f.versions[0]?.thumbnailKey
+            ? await getSignedThumbnailUrl(f.versions[0].thumbnailKey)
+            : "",
+        }))
+      );
+      fileGroups.push({ projectId: project.id, projectName: project.name, files });
+    }
+  }
+
+  return {
+    token: { id: shareToken.id, type: shareToken.type, label: shareToken.label, config },
+    photoGroups,
+    fileGroups,
+  };
+}
+
+export type ResolvedValidatorEventData = {
+  type: "event";
+  token: { id: string; type: MediaTokenType; label: string | null };
+  event: {
+    id: string;
+    name: string;
+    date: Date;
+    status: string;
+    isPrevalidator: boolean;
+    hasPrevalidator: boolean;
+    totalPhotos: number;
+    approvedCount: number;
+    pendingCount: number;
+    rejectedCount: number;
+    prevalidatedCount: number;
+    prerejectedCount: number;
+  };
+  photos: Array<{ id: string; filename: string; status: string; size: number; width: number | null; height: number | null; thumbnailUrl: string }>;
+};
+
+export type ResolvedValidatorProjectData = {
+  type: "project";
+  token: { id: string; type: MediaTokenType; label: string | null };
+  project: {
+    id: string;
+    name: string;
+    isPrevalidator: boolean;
+    hasPrevalidator: boolean;
+    totalFiles: number;
+  };
+  files: Array<{
+    id: string;
+    filename: string;
+    type: string;
+    mimeType: string;
+    size: number;
+    status: string;
+    thumbnailUrl: string | null;
+  }>;
+};
+
+/**
+ * Résout les données d'un token VALIDATOR/PREVALIDATOR déjà validé — événement
+ * (photos à valider) ou projet (fichiers à valider). Partagé entre la route API
+ * et la page SSR publique pour éviter toute divergence entre les deux.
+ */
+export async function resolveValidatorData(
+  shareToken: Awaited<ReturnType<typeof validateMediaShareToken>>
+): Promise<ResolvedValidatorEventData | ResolvedValidatorProjectData | null> {
+  const isPrevalidator = shareToken.type === "PREVALIDATOR";
+  const tokenInfo = { id: shareToken.id, type: shareToken.type, label: shareToken.label };
+
+  if (shareToken.mediaProject) {
+    const project = shareToken.mediaProject;
+    const hasPrevalidator = project.shareTokens.some((t) => t.type === "PREVALIDATOR");
+
+    const filesWithUrls = await Promise.all(
+      project.files.map(async (f) => {
+        const thumbKey = f.versions[0]?.thumbnailKey;
+        let thumbnailUrl: string | null = null;
+        if (thumbKey && f.mimeType.startsWith("image/")) {
+          try {
+            thumbnailUrl = await getSignedThumbnailUrl(thumbKey);
+          } catch {
+            // pas de preview
+          }
+        }
+        return {
+          id: f.id,
+          filename: f.filename,
+          type: f.type,
+          mimeType: f.mimeType,
+          size: f.size,
+          status: f.status,
+          thumbnailUrl,
+        };
+      })
+    );
+
+    return {
+      type: "project",
+      token: tokenInfo,
+      project: {
+        id: project.id,
+        name: project.name,
+        isPrevalidator,
+        hasPrevalidator,
+        totalFiles: filesWithUrls.length,
+      },
+      files: filesWithUrls,
+    };
+  }
+
+  if (shareToken.mediaEvent) {
+    const event = shareToken.mediaEvent;
+    const hasPrevalidator = event.shareTokens.some((t) => t.type === "PREVALIDATOR");
+
+    let statusFilter: string[];
+    if (isPrevalidator) {
+      statusFilter = ["PENDING"];
+    } else if (hasPrevalidator) {
+      statusFilter = ["PREVALIDATED", "APPROVED", "REJECTED"];
+    } else {
+      statusFilter = ["PENDING", "PREVALIDATED", "APPROVED", "REJECTED"];
+    }
+
+    const photos = await prisma.mediaPhoto.findMany({
+      where: {
+        mediaEventId: event.id,
+        status: { in: statusFilter as ("PENDING" | "APPROVED" | "REJECTED" | "PREVALIDATED" | "PREREJECTED")[] },
+      },
+      orderBy: { uploadedAt: "asc" },
+    });
+
+    const photosWithUrls = await Promise.all(
+      photos.map(async (p) => ({ ...p, thumbnailUrl: await getSignedThumbnailUrl(p.thumbnailKey) }))
+    );
+
+    return {
+      type: "event",
+      token: tokenInfo,
+      event: {
+        id: event.id,
+        name: event.name,
+        date: event.date,
+        status: event.status,
+        isPrevalidator,
+        hasPrevalidator,
+        totalPhotos: event.photos.length,
+        approvedCount: event.photos.filter((p) => p.status === "APPROVED").length,
+        pendingCount: event.photos.filter((p) => p.status === "PENDING").length,
+        rejectedCount: event.photos.filter((p) => p.status === "REJECTED").length,
+        prevalidatedCount: event.photos.filter((p) => p.status === "PREVALIDATED").length,
+        prerejectedCount: event.photos.filter((p) => p.status === "PREREJECTED").length,
+      },
+      photos: photosWithUrls,
+    };
+  }
+
+  return null;
+}
+
 export async function createMediaShareToken(options: CreateTokenWithTarget & { baseUrl?: string }) {
   const { type, label, expiresInDays, onlyApproved, collectionConfig, mediaEventId, mediaProjectId, baseUrl: callerBaseUrl } = options;
 


### PR DESCRIPTION
## Contexte

Suite à v1.14.1/v1.14.2 (liens de partage projet toujours vides), audit des deux autres pages publiques à token (`/media/c` Collection, `/media/v` Validator/Prevalidator) pour le même risque structurel : chaque page SSR réimplémentait sa propre copie de la requête de données au lieu de partager la logique avec sa route API — c'est exactement ce qui avait permis au bug précédent de passer inaperçu deux fois (la route était corrigée, pas la page réellement affichée).

## Bugs latents trouvés en comparant page vs route

- **Collection** : la route API respectait `config.includeAllPhotos` via `collectionPhotoWhere(config)`, mais la page hardcodait `where: { status: "APPROVED" }`. Un lien collection configuré pour « toutes les photos » masquait silencieusement les photos non validées sur la page réellement vue par l'utilisateur.
- **Validator/Prevalidator** : la page appelait `validateMediaShareToken` **deux fois** par chargement (une fois pour détecter événement vs projet, une fois dans le fetch dédié) — double incrémentation de `usageCount`, requête DB en trop.

## Correctif

Centralisation dans `resolveCollectionData` / `resolveValidatorData` (`src/modules/media/services/tokens.ts`), réutilisées par les routes API **et** les pages SSR — même remède que le fix download/gallery. Le validator ne valide plus le token qu'une seule fois.

## Vérifications

- `typecheck` ✅ · `lint:boundaries` ✅ · **487 tests** ✅ (6 nouveaux tests resolver)

Release **v1.14.3** (package.json + CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)