### PR TITLE
feat(planning): gestion des absences des STAR

### DIFF
--- a/prisma/migrations/20260725220324_add_absences/migration.sql
+++ b/prisma/migrations/20260725220324_add_absences/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE `absences` (
+    `id` VARCHAR(191) NOT NULL,
+    `memberId` VARCHAR(191) NOT NULL,
+    `churchId` VARCHAR(191) NOT NULL,
+    `startDate` DATETIME(3) NOT NULL,
+    `endDate` DATETIME(3) NOT NULL,
+    `reason` TEXT NULL,
+    `status` ENUM('ACTIVE', 'CANCELLED') NOT NULL DEFAULT 'ACTIVE',
+    `createdById` VARCHAR(191) NOT NULL,
+    `cancelledById` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+    `cancelledAt` DATETIME(3) NULL,
+
+    INDEX `absences_churchId_startDate_endDate_idx`(`churchId`, `startDate`, `endDate`),
+    INDEX `absences_memberId_status_idx`(`memberId`, `status`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `absences` ADD CONSTRAINT `absences_memberId_fkey` FOREIGN KEY (`memberId`) REFERENCES `members`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `absences` ADD CONSTRAINT `absences_churchId_fkey` FOREIGN KEY (`churchId`) REFERENCES `churches`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `absences` ADD CONSTRAINT `absences_createdById_fkey` FOREIGN KEY (`createdById`) REFERENCES `users`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `absences` ADD CONSTRAINT `absences_cancelledById_fkey` FOREIGN KEY (`cancelledById`) REFERENCES `users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,36 +52,37 @@ model VerificationToken {
 // ─── Domain models ─────────────────────────────────────────────────
 
 model Church {
-  id                       String              @id @default(cuid())
-  name                     String
-  slug                     String              @unique
-  secretariatEmail         String?
-  accountingEmail          String?
-  primaryColor             String  @default("#5E17EB")
-  reminderLastSentAt       DateTime?
-  planningDigestLastSentAt DateTime?
-  createdAt                DateTime            @default(now())
-  updatedAt                DateTime            @updatedAt
-  users                    UserChurchRole[]
-  ministries               Ministry[]
-  events                   Event[]
-  auditLogs                AuditLog[]
-  announcements            Announcement[]
-  requests                 Request[]
-  memberUserLinks          MemberUserLink[]
-  memberLinkRequests       MemberLinkRequest[]
-  discipleships            Discipleship[]
-  eventReports             EventReport[]
+  id                        String                     @id @default(cuid())
+  name                      String
+  slug                      String                     @unique
+  secretariatEmail          String?
+  accountingEmail           String?
+  primaryColor              String                     @default("#5E17EB")
+  reminderLastSentAt        DateTime?
+  planningDigestLastSentAt  DateTime?
+  createdAt                 DateTime                   @default(now())
+  updatedAt                 DateTime                   @updatedAt
+  users                     UserChurchRole[]
+  ministries                Ministry[]
+  events                    Event[]
+  auditLogs                 AuditLog[]
+  announcements             Announcement[]
+  requests                  Request[]
+  memberUserLinks           MemberUserLink[]
+  memberLinkRequests        MemberLinkRequest[]
+  discipleships             Discipleship[]
+  eventReports              EventReport[]
+  absences                  Absence[]
   // Module media
-  mediaEvents              MediaEvent[]
-  mediaProjects            MediaProject[]
-  mediaSettings            MediaSettings?
+  mediaEvents               MediaEvent[]
+  mediaProjects             MediaProject[]
+  mediaSettings             MediaSettings?
   // Module mrbs (optionnel)
-  mrbsUserLinks            MrbsUserLink[]
+  mrbsUserLinks             MrbsUserLink[]
   // Module agenda
-  pastoralProfiles         PastoralProfile[]    @relation("ChurchPastoralProfiles")
-  appointmentRequests      AppointmentRequest[]
-  agendaEntries            AgendaEntry[]
+  pastoralProfiles          PastoralProfile[]          @relation("ChurchPastoralProfiles")
+  appointmentRequests       AppointmentRequest[]
+  agendaEntries             AgendaEntry[]
   // Module intégration familles
   familyIntegrationRequests FamilyIntegrationRequest[]
   familyLeaderAssignments   FamilyLeaderAssignment[]
@@ -94,10 +95,10 @@ model Church {
   welcomeDutyFamilies       WelcomeDutyFamily[]
   welcomeDutyAssignments    WelcomeDutyAssignment[]
   // Module pastoral
-  responsibleProfileId      String?  @unique
+  responsibleProfileId      String?                    @unique
   supervisorProfileId       String?
-  responsible               PastoralProfile?     @relation("ChurchResponsibleProfile", fields: [responsibleProfileId], references: [id])
-  supervisor                PastoralProfile?     @relation("ChurchSupervisorProfile", fields: [supervisorProfileId], references: [id])
+  responsible               PastoralProfile?           @relation("ChurchResponsibleProfile", fields: [responsibleProfileId], references: [id])
+  supervisor                PastoralProfile?           @relation("ChurchSupervisorProfile", fields: [supervisorProfileId], references: [id])
 
   @@map("churches")
 }
@@ -116,63 +117,65 @@ enum Role {
 }
 
 model User {
-  id                      String              @id @default(cuid())
-  email                   String              @unique
-  name                    String?
-  displayName             String?
-  image                   String?
-  emailVerified           DateTime?
-  isSuperAdmin            Boolean             @default(false)
-  hasSeenTour             Boolean             @default(false)
-  createdAt               DateTime            @default(now())
-  updatedAt               DateTime            @updatedAt
-  churchRoles             UserChurchRole[]
-  accounts                Account[]
-  sessions                Session[]
-  auditLogs               AuditLog[]
-  notifications           Notification[]
-  submittedAnnouncements  Announcement[]      @relation("AnnouncementSubmittedBy")
-  submittedRequests       Request[]           @relation("RequestSubmittedBy")
-  reviewedRequests        Request[]           @relation("RequestReviewedBy")
-  memberLinks             MemberUserLink[]    @relation("UserMemberLink")
-  validatedLinks          MemberUserLink[]    @relation("LinkValidator")
-  memberLinkRequests      MemberLinkRequest[] @relation("LinkRequester")
-  reviewedLinkRequests    MemberLinkRequest[] @relation("LinkRequestReviewer")
-  eventReports            EventReport[]       @relation("ReportAuthor")
-  departmentNotices       DepartmentNotice[]
+  id                                String                       @id @default(cuid())
+  email                             String                       @unique
+  name                              String?
+  displayName                       String?
+  image                             String?
+  emailVerified                     DateTime?
+  isSuperAdmin                      Boolean                      @default(false)
+  hasSeenTour                       Boolean                      @default(false)
+  createdAt                         DateTime                     @default(now())
+  updatedAt                         DateTime                     @updatedAt
+  churchRoles                       UserChurchRole[]
+  accounts                          Account[]
+  sessions                          Session[]
+  auditLogs                         AuditLog[]
+  notifications                     Notification[]
+  submittedAnnouncements            Announcement[]               @relation("AnnouncementSubmittedBy")
+  submittedRequests                 Request[]                    @relation("RequestSubmittedBy")
+  reviewedRequests                  Request[]                    @relation("RequestReviewedBy")
+  memberLinks                       MemberUserLink[]             @relation("UserMemberLink")
+  validatedLinks                    MemberUserLink[]             @relation("LinkValidator")
+  absencesCreated                   Absence[]                    @relation("AbsenceCreatedBy")
+  absencesCancelled                 Absence[]                    @relation("AbsenceCancelledBy")
+  memberLinkRequests                MemberLinkRequest[]          @relation("LinkRequester")
+  reviewedLinkRequests              MemberLinkRequest[]          @relation("LinkRequestReviewer")
+  eventReports                      EventReport[]                @relation("ReportAuthor")
+  departmentNotices                 DepartmentNotice[]
   // Module media
-  mediaEventsCreated      MediaEvent[]        @relation("MediaEventCreator")
-  mediaProjectsCreated    MediaProject[]      @relation("MediaProjectCreator")
-  mediaFileVersions       MediaFileVersion[]  @relation("MediaFileVersionCreator")
-  mediaComments           MediaComment[]      @relation("MediaCommentAuthor")
+  mediaEventsCreated                MediaEvent[]                 @relation("MediaEventCreator")
+  mediaProjectsCreated              MediaProject[]               @relation("MediaProjectCreator")
+  mediaFileVersions                 MediaFileVersion[]           @relation("MediaFileVersionCreator")
+  mediaComments                     MediaComment[]               @relation("MediaCommentAuthor")
   // Module mrbs (optionnel)
-  mrbsUserLinks           MrbsUserLink[]      @relation("MrbsLinkedUser")
-  mrbsUserLinksCreated    MrbsUserLink[]      @relation("MrbsLinkCreator")
+  mrbsUserLinks                     MrbsUserLink[]               @relation("MrbsLinkedUser")
+  mrbsUserLinksCreated              MrbsUserLink[]               @relation("MrbsLinkCreator")
   // Module agenda
-  pastoralProfiles        PastoralProfile[]   @relation("UserPastoralProfile")
-  appointmentsMade        AppointmentRequest[] @relation("AppointmentRequester")
-  qualifiedRequests       AppointmentRequest[] @relation("AppointmentQualifier")
-  scheduledRequests       AppointmentRequest[] @relation("AppointmentScheduler")
-  updatedRequests         AppointmentRequest[] @relation("AppointmentUpdater")
-  agendaEntriesCreated    AgendaEntry[]        @relation("AgendaEntryCreator")
-  agendaEntriesUpdated    AgendaEntry[]        @relation("AgendaEntryUpdater")
+  pastoralProfiles                  PastoralProfile[]            @relation("UserPastoralProfile")
+  appointmentsMade                  AppointmentRequest[]         @relation("AppointmentRequester")
+  qualifiedRequests                 AppointmentRequest[]         @relation("AppointmentQualifier")
+  scheduledRequests                 AppointmentRequest[]         @relation("AppointmentScheduler")
+  updatedRequests                   AppointmentRequest[]         @relation("AppointmentUpdater")
+  agendaEntriesCreated              AgendaEntry[]                @relation("AgendaEntryCreator")
+  agendaEntriesUpdated              AgendaEntry[]                @relation("AgendaEntryUpdater")
   // Module intégration familles
-  familyLeaderAssignments FamilyLeaderAssignment[]
-  familyIntegrationRequestsAssigned FamilyIntegrationRequest[] @relation("IntegrationAssignedBerger")
-  msdpFollowUpsAssigned             MsdpFollowUp[]             @relation("MsdpAssignedConseiller")
-  personJourneysCreated             PersonJourney[]            @relation("PersonJourneyCreator")
+  familyLeaderAssignments           FamilyLeaderAssignment[]
+  familyIntegrationRequestsAssigned FamilyIntegrationRequest[]   @relation("IntegrationAssignedBerger")
+  msdpFollowUpsAssigned             MsdpFollowUp[]               @relation("MsdpAssignedConseiller")
+  personJourneysCreated             PersonJourney[]              @relation("PersonJourneyCreator")
   // Module comptabilité
-  financialSeriesSubmitted  FinancialSeries[]    @relation("FinancialSeriesSubmitter")
-  financialRequestsSubmitted FinancialRequest[]  @relation("FinancialRequestSubmitter")
-  financialRequestsProcessed   FinancialRequest[]   @relation("FinancialRequestProcessor")
-  financialPaymentsReleased    FinancialPayment[]   @relation("FinancialPaymentReleaser")
-  financialAttachmentsUploaded FinancialAttachment[] @relation("AccountingAttachmentsUploaded")
+  financialSeriesSubmitted          FinancialSeries[]            @relation("FinancialSeriesSubmitter")
+  financialRequestsSubmitted        FinancialRequest[]           @relation("FinancialRequestSubmitter")
+  financialRequestsProcessed        FinancialRequest[]           @relation("FinancialRequestProcessor")
+  financialPaymentsReleased         FinancialPayment[]           @relation("FinancialPaymentReleaser")
+  financialAttachmentsUploaded      FinancialAttachment[]        @relation("AccountingAttachmentsUploaded")
   // Module emploi
-  jobOffers                    JobOffer[]
-  jobSeekers                   JobSeeker[]
-  jobNotificationSubscription  JobNotificationSubscription?
-  freelanceMissions            FreelanceMission[]
-  freelanceProfiles            FreelanceProfile[]
+  jobOffers                         JobOffer[]
+  jobSeekers                        JobSeeker[]
+  jobNotificationSubscription       JobNotificationSubscription?
+  freelanceMissions                 FreelanceMission[]
+  freelanceProfiles                 FreelanceProfile[]
   // (relation superviseur église déplacée vers PastoralProfile)
 
   @@map("users")
@@ -206,39 +209,39 @@ model UserDepartment {
 }
 
 model Ministry {
-  id              String           @id @default(cuid())
-  name            String
-  churchId        String
-  isSystem        Boolean          @default(false)
-  church          Church           @relation(fields: [churchId], references: [id])
-  departments     Department[]
-  userRoles       UserChurchRole[]
-  createdAt       DateTime         @default(now())
-  announcements   Announcement[]      @relation("AnnouncementMinistry")
-  requests        Request[]           @relation("RequestMinistry")
-  linkRequests    MemberLinkRequest[] @relation("LinkRequestMinistry")
+  id            String              @id @default(cuid())
+  name          String
+  churchId      String
+  isSystem      Boolean             @default(false)
+  church        Church              @relation(fields: [churchId], references: [id])
+  departments   Department[]
+  userRoles     UserChurchRole[]
+  createdAt     DateTime            @default(now())
+  announcements Announcement[]      @relation("AnnouncementMinistry")
+  requests      Request[]           @relation("RequestMinistry")
+  linkRequests  MemberLinkRequest[] @relation("LinkRequestMinistry")
 
   @@map("ministries")
 }
 
 model Department {
-  id                String             @id @default(cuid())
+  id                String               @id @default(cuid())
   name              String
   ministryId        String
-  isSystem          Boolean            @default(false)
+  isSystem          Boolean              @default(false)
   function          String?
-  ministry          Ministry           @relation(fields: [ministryId], references: [id])
+  ministry          Ministry             @relation(fields: [ministryId], references: [id])
   memberDepts       MemberDepartment[]
   eventDepts        EventDepartment[]
   userDepts         UserDepartment[]
   tasks             Task[]
-  createdAt         DateTime           @default(now())
-  announcements     Announcement[]      @relation("AnnouncementDepartment")
-  submittedRequests Request[]           @relation("RequestDepartment")
-  assignedRequests  Request[]           @relation("RequestAssigned")
+  createdAt         DateTime             @default(now())
+  announcements     Announcement[]       @relation("AnnouncementDepartment")
+  submittedRequests Request[]            @relation("RequestDepartment")
+  assignedRequests  Request[]            @relation("RequestAssigned")
   reportSections    EventReportSection[]
   notices           DepartmentNotice[]
-  linkRequests      MemberLinkRequest[] @relation("LinkRequestDept")
+  linkRequests      MemberLinkRequest[]  @relation("LinkRequestDept")
   financialSeries   FinancialSeries[]
   financialRequests FinancialRequest[]
 
@@ -259,24 +262,26 @@ model Member {
   linkRequests    MemberLinkRequest[]
 
   // Discipolat (un seul enregistrement actif par église grâce au @@unique du modèle)
-  discipleships       Discipleship[] @relation("DiscipleOf")
-  disciplesMade       Discipleship[] @relation("DiscipleMakerOf")
-  firstDisciples      Discipleship[] @relation("FirstDiscipleMaker")
-  attendances         DiscipleshipAttendance[]
+  discipleships  Discipleship[]           @relation("DiscipleOf")
+  disciplesMade  Discipleship[]           @relation("DiscipleMakerOf")
+  firstDisciples Discipleship[]           @relation("FirstDiscipleMaker")
+  attendances    DiscipleshipAttendance[]
 
   // Module intégration familles
   familyIntegrationRequests FamilyIntegrationRequest[] @relation("IntegrationMemberLink")
+
+  absences Absence[]
 
   @@map("members")
 }
 
 model MemberDepartment {
-  id           String     @id @default(cuid())
+  id           String  @id @default(cuid())
   memberId     String
   departmentId String
-  isPrimary    Boolean    @default(false)
+  isPrimary    Boolean @default(false)
 
-  member     Member     @relation(fields: [memberId],     references: [id], onDelete: Cascade)
+  member     Member     @relation(fields: [memberId], references: [id], onDelete: Cascade)
   department Department @relation(fields: [departmentId], references: [id])
 
   @@unique([memberId, departmentId])
@@ -291,10 +296,10 @@ model MemberUserLink {
   validatedAt   DateTime?
   validatedById String?
 
-  member      Member  @relation(fields: [memberId],      references: [id], onDelete: Cascade)
-  user        User    @relation("UserMemberLink",        fields: [userId],  references: [id])
-  church      Church  @relation(fields: [churchId],      references: [id])
-  validatedBy User?   @relation("LinkValidator",         fields: [validatedById], references: [id])
+  member      Member @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  user        User   @relation("UserMemberLink", fields: [userId], references: [id])
+  church      Church @relation(fields: [churchId], references: [id])
+  validatedBy User?  @relation("LinkValidator", fields: [validatedById], references: [id])
 
   @@unique([memberId, churchId])
   @@unique([userId, churchId])
@@ -320,17 +325,17 @@ model MemberLinkRequest {
   // Champs onboarding enrichi
   departmentId  String?
   ministryId    String?
-  requestedRole String?                 // DEPARTMENT_HEAD | DEPUTY | MINISTER | DISCIPLE_MAKER | REPORTER | null
+  requestedRole String? // DEPARTMENT_HEAD | DEPUTY | MINISTER | DISCIPLE_MAKER | REPORTER | null
   notes         String?                 @db.Text
   createdAt     DateTime                @default(now())
   reviewedAt    DateTime?
   reviewedById  String?
 
-  user       User        @relation("LinkRequester",       fields: [userId],       references: [id])
-  member     Member?     @relation(fields: [memberId],    references: [id])
-  church     Church      @relation(fields: [churchId],    references: [id])
-  department Department? @relation("LinkRequestDept",     fields: [departmentId], references: [id])
-  ministry   Ministry?   @relation("LinkRequestMinistry", fields: [ministryId],   references: [id])
+  user       User        @relation("LinkRequester", fields: [userId], references: [id])
+  member     Member?     @relation(fields: [memberId], references: [id])
+  church     Church      @relation(fields: [churchId], references: [id])
+  department Department? @relation("LinkRequestDept", fields: [departmentId], references: [id])
+  ministry   Ministry?   @relation("LinkRequestMinistry", fields: [ministryId], references: [id])
   reviewedBy User?       @relation("LinkRequestReviewer", fields: [reviewedById], references: [id])
 
   @@map("member_link_requests")
@@ -342,14 +347,14 @@ model Discipleship {
   id              String   @id @default(cuid())
   discipleId      String
   discipleMakerId String
-  firstMakerId    String   // premier FD — ne change jamais, sert pour la lignée
+  firstMakerId    String // premier FD — ne change jamais, sert pour la lignée
   churchId        String
   startedAt       DateTime @default(now())
 
-  disciple      Member @relation("DiscipleOf",        fields: [discipleId],      references: [id])
-  discipleMaker Member @relation("DiscipleMakerOf",   fields: [discipleMakerId], references: [id])
-  firstMaker    Member @relation("FirstDiscipleMaker", fields: [firstMakerId],    references: [id])
-  church        Church @relation(fields: [churchId],  references: [id])
+  disciple      Member @relation("DiscipleOf", fields: [discipleId], references: [id])
+  discipleMaker Member @relation("DiscipleMakerOf", fields: [discipleMakerId], references: [id])
+  firstMaker    Member @relation("FirstDiscipleMaker", fields: [firstMakerId], references: [id])
+  church        Church @relation(fields: [churchId], references: [id])
 
   @@unique([discipleId, churchId]) // un seul FD courant par disciple par église
   @@map("discipleships")
@@ -362,41 +367,41 @@ model DiscipleshipAttendance {
   present  Boolean @default(true)
 
   member Member @relation(fields: [memberId], references: [id])
-  event  Event  @relation(fields: [eventId],  references: [id])
+  event  Event  @relation(fields: [eventId], references: [id])
 
   @@unique([memberId, eventId])
   @@map("discipleship_attendances")
 }
 
 model Event {
-  id                 String              @id @default(cuid())
-  title              String
-  type               String
-  date               DateTime
-  churchId           String
-  church             Church              @relation(fields: [churchId], references: [id])
-  eventDepts         EventDepartment[]
-  taskAssignments    TaskAssignment[]
-  planningDeadline   DateTime?
-  recurrenceRule     String?
-  seriesId           String?
-  isRecurrenceParent Boolean             @default(false)
-  allowAnnouncements Boolean             @default(false)
-  createdAt          DateTime            @default(now())
-  announcementTargets        AnnouncementEvent[]
-  trackedForDiscipleship     Boolean                  @default(false)
-  reportEnabled              Boolean                  @default(false)
-  statsEnabled               Boolean                  @default(false)
-  welcomeDutyEnabled         Boolean                  @default(false)
-  discipleshipAttendances    DiscipleshipAttendance[]
-  report                     EventReport?
-  departmentNotices          DepartmentNotice[]
+  id                      String                     @id @default(cuid())
+  title                   String
+  type                    String
+  date                    DateTime
+  churchId                String
+  church                  Church                     @relation(fields: [churchId], references: [id])
+  eventDepts              EventDepartment[]
+  taskAssignments         TaskAssignment[]
+  planningDeadline        DateTime?
+  recurrenceRule          String?
+  seriesId                String?
+  isRecurrenceParent      Boolean                    @default(false)
+  allowAnnouncements      Boolean                    @default(false)
+  createdAt               DateTime                   @default(now())
+  announcementTargets     AnnouncementEvent[]
+  trackedForDiscipleship  Boolean                    @default(false)
+  reportEnabled           Boolean                    @default(false)
+  statsEnabled            Boolean                    @default(false)
+  welcomeDutyEnabled      Boolean                    @default(false)
+  discipleshipAttendances DiscipleshipAttendance[]
+  report                  EventReport?
+  departmentNotices       DepartmentNotice[]
   // Module media : galeries photos liées à cet événement planning
-  mediaEvents                MediaEvent[]
+  mediaEvents             MediaEvent[]
   // Module intégration : culte où l'appel au salut a été fait
-  integrationRequests        FamilyIntegrationRequest[]
+  integrationRequests     FamilyIntegrationRequest[]
   // Module service d'accueil
-  welcomeDutyAssignments     WelcomeDutyAssignment[]
+  welcomeDutyAssignments  WelcomeDutyAssignment[]
 
   @@map("events")
 }
@@ -413,9 +418,9 @@ model EventReport {
   updatedAt    DateTime @updatedAt
   authorId     String?
 
-  event    Event                @relation(fields: [eventId],   references: [id])
-  church   Church               @relation(fields: [churchId],  references: [id])
-  author   User?                @relation("ReportAuthor", fields: [authorId],  references: [id])
+  event    Event                @relation(fields: [eventId], references: [id])
+  church   Church               @relation(fields: [churchId], references: [id])
+  author   User?                @relation("ReportAuthor", fields: [authorId], references: [id])
   sections EventReportSection[]
 
   @@map("event_reports")
@@ -430,7 +435,7 @@ model EventReportSection {
   stats        Json?
   notes        String? @db.Text
 
-  report     EventReport @relation(fields: [reportId],     references: [id], onDelete: Cascade)
+  report     EventReport @relation(fields: [reportId], references: [id], onDelete: Cascade)
   department Department? @relation(fields: [departmentId], references: [id])
 
   @@map("event_report_sections")
@@ -468,6 +473,35 @@ model Planning {
   @@map("plannings")
 }
 
+enum AbsenceStatus {
+  ACTIVE
+  CANCELLED
+}
+
+model Absence {
+  id            String        @id @default(cuid())
+  memberId      String
+  churchId      String
+  startDate     DateTime
+  endDate       DateTime
+  reason        String?       @db.Text
+  status        AbsenceStatus @default(ACTIVE)
+  createdById   String
+  cancelledById String?
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+  cancelledAt   DateTime?
+
+  member      Member @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  church      Church @relation(fields: [churchId], references: [id])
+  createdBy   User   @relation("AbsenceCreatedBy", fields: [createdById], references: [id])
+  cancelledBy User?  @relation("AbsenceCancelledBy", fields: [cancelledById], references: [id])
+
+  @@index([churchId, startDate, endDate])
+  @@index([memberId, status])
+  @@map("absences")
+}
+
 model Task {
   id           String           @id @default(cuid())
   departmentId String
@@ -499,8 +533,8 @@ model AuditLog {
   id         String   @id @default(cuid())
   userId     String
   churchId   String?
-  action     String   // CREATE, UPDATE, DELETE
-  entityType String   // Event, Planning, Member, etc.
+  action     String // CREATE, UPDATE, DELETE
+  entityType String // Event, Planning, Member, etc.
   entityId   String
   details    Json?
   createdAt  DateTime @default(now())
@@ -515,7 +549,7 @@ model AuditLog {
 model Notification {
   id        String   @id @default(cuid())
   userId    String
-  type      String   // PLANNING_REMINDER, PLANNING_UPDATED, etc.
+  type      String // PLANNING_REMINDER, PLANNING_UPDATED, etc.
   title     String
   message   String   @db.Text
   read      Boolean  @default(false)
@@ -530,17 +564,17 @@ model Notification {
 // ─── Notices de service ────────────────────────────────────────────
 
 model DepartmentNotice {
-  id           String     @id @default(cuid())
+  id           String   @id @default(cuid())
   departmentId String
   eventId      String
-  content      String     @db.Text
+  content      String   @db.Text
   authorId     String
-  createdAt    DateTime   @default(now())
-  updatedAt    DateTime   @updatedAt
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  department   Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
-  event        Event      @relation(fields: [eventId],      references: [id], onDelete: Cascade)
-  author       User       @relation(fields: [authorId],     references: [id])
+  department Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+  event      Event      @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  author     User       @relation(fields: [authorId], references: [id])
 
   @@unique([departmentId, eventId])
   @@index([eventId])
@@ -557,28 +591,28 @@ enum AnnouncementStatus {
 }
 
 model Announcement {
-  id              String             @id @default(cuid())
-  churchId        String
-  submittedById   String
-  departmentId    String?
-  ministryId      String?
-  title           String
-  content         String             @db.Text
-  eventDate       DateTime?
-  isSaveTheDate   Boolean            @default(false)
-  isUrgent        Boolean            @default(false)
-  channelInterne  Boolean            @default(false)
-  channelExterne  Boolean            @default(false)
-  status          AnnouncementStatus @default(EN_ATTENTE)
-  submittedAt     DateTime           @default(now())
-  updatedAt       DateTime           @updatedAt
+  id             String             @id @default(cuid())
+  churchId       String
+  submittedById  String
+  departmentId   String?
+  ministryId     String?
+  title          String
+  content        String             @db.Text
+  eventDate      DateTime?
+  isSaveTheDate  Boolean            @default(false)
+  isUrgent       Boolean            @default(false)
+  channelInterne Boolean            @default(false)
+  channelExterne Boolean            @default(false)
+  status         AnnouncementStatus @default(EN_ATTENTE)
+  submittedAt    DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
 
-  church          Church             @relation(fields: [churchId], references: [id])
-  submittedBy     User               @relation("AnnouncementSubmittedBy", fields: [submittedById], references: [id])
-  department      Department?        @relation("AnnouncementDepartment", fields: [departmentId], references: [id])
-  ministry        Ministry?          @relation("AnnouncementMinistry", fields: [ministryId], references: [id])
-  targetEvents    AnnouncementEvent[]
-  requests        Request[]
+  church       Church              @relation(fields: [churchId], references: [id])
+  submittedBy  User                @relation("AnnouncementSubmittedBy", fields: [submittedById], references: [id])
+  department   Department?         @relation("AnnouncementDepartment", fields: [departmentId], references: [id])
+  ministry     Ministry?           @relation("AnnouncementMinistry", fields: [ministryId], references: [id])
+  targetEvents AnnouncementEvent[]
+  requests     Request[]
 
   @@index([churchId, status])
   @@map("announcements")
@@ -639,15 +673,15 @@ model Request {
   submittedAt     DateTime      @default(now())
   updatedAt       DateTime      @updatedAt
 
-  church          Church        @relation(fields: [churchId], references: [id])
-  submittedBy     User          @relation("RequestSubmittedBy", fields: [submittedById], references: [id])
-  department      Department?   @relation("RequestDepartment", fields: [departmentId], references: [id])
-  ministry        Ministry?     @relation("RequestMinistry", fields: [ministryId], references: [id])
-  assignedDept    Department?   @relation("RequestAssigned", fields: [assignedDeptId], references: [id])
-  announcement    Announcement? @relation(fields: [announcementId], references: [id])
-  parentRequest   Request?      @relation("RequestChildren", fields: [parentRequestId], references: [id])
-  childRequests   Request[]     @relation("RequestChildren")
-  reviewedBy      User?         @relation("RequestReviewedBy", fields: [reviewedById], references: [id])
+  church        Church        @relation(fields: [churchId], references: [id])
+  submittedBy   User          @relation("RequestSubmittedBy", fields: [submittedById], references: [id])
+  department    Department?   @relation("RequestDepartment", fields: [departmentId], references: [id])
+  ministry      Ministry?     @relation("RequestMinistry", fields: [ministryId], references: [id])
+  assignedDept  Department?   @relation("RequestAssigned", fields: [assignedDeptId], references: [id])
+  announcement  Announcement? @relation(fields: [announcementId], references: [id])
+  parentRequest Request?      @relation("RequestChildren", fields: [parentRequestId], references: [id])
+  childRequests Request[]     @relation("RequestChildren")
+  reviewedBy    User?         @relation("RequestReviewedBy", fields: [reviewedById], references: [id])
 
   @@index([churchId, type, status])
   @@index([assignedDeptId, status])
@@ -662,7 +696,7 @@ model Request {
 /// Utilisée quand le username MRBS n'est pas l'email Koinonia (ex : "jdupont" → jean.dupont@mail.com).
 model MrbsUserLink {
   id           String   @id @default(cuid())
-  mrbsUsername String   @unique               // mrbs_users.name dans la BDD MRBS
+  mrbsUsername String   @unique // mrbs_users.name dans la BDD MRBS
   userId       String
   churchId     String
   linkedAt     DateTime @default(now())
@@ -682,50 +716,50 @@ model MrbsUserLink {
 // ============================================================================
 
 enum MediaEventStatus {
-  DRAFT          // En cours d'upload
+  DRAFT // En cours d'upload
   PENDING_REVIEW // En attente de validation
-  REVIEWED       // Validation terminée
-  ARCHIVED       // Archivé
+  REVIEWED // Validation terminée
+  ARCHIVED // Archivé
 }
 
 enum MediaPhotoStatus {
-  PENDING      // En attente de validation
-  APPROVED     // Validée
-  REJECTED     // Rejetée
+  PENDING // En attente de validation
+  APPROVED // Validée
+  REJECTED // Rejetée
   PREVALIDATED // Pré-validée (filtrée par le prévalidateur)
-  PREREJECTED  // Écartée par le prévalidateur
+  PREREJECTED // Écartée par le prévalidateur
 }
 
 enum MediaFileType {
-  PHOTO  // Images événements
+  PHOTO // Images événements
   VISUAL // Visuels (PNG, SVG, PDF)
-  VIDEO  // Vidéos (MP4, MOV)
+  VIDEO // Vidéos (MP4, MOV)
 }
 
 enum MediaFileStatus {
-  PENDING            // Photos: en attente
-  APPROVED           // Photos: validée
-  REJECTED           // Rejetée (photos et médias)
-  PREVALIDATED       // Photos: pré-validée
-  PREREJECTED        // Photos: écartée
-  DRAFT              // Médias: brouillon
-  IN_REVIEW          // Médias: en révision
+  PENDING // Photos: en attente
+  APPROVED // Photos: validée
+  REJECTED // Rejetée (photos et médias)
+  PREVALIDATED // Photos: pré-validée
+  PREREJECTED // Photos: écartée
+  DRAFT // Médias: brouillon
+  IN_REVIEW // Médias: en révision
   REVISION_REQUESTED // Médias: révision demandée
-  FINAL_APPROVED     // Médias: approuvé définitivement
+  FINAL_APPROVED // Médias: approuvé définitivement
 }
 
 enum MediaCommentType {
-  GENERAL  // Commentaire général
+  GENERAL // Commentaire général
   TIMECODE // Commentaire avec timecode (vidéos)
 }
 
 enum MediaTokenType {
-  VALIDATOR    // Accès validation (lecture + modification status)
-  MEDIA        // Accès téléchargement (photos approuvées uniquement)
-  MEDIA_ALL    // Accès téléchargement (toutes photos, validées ou non)
+  VALIDATOR // Accès validation (lecture + modification status)
+  MEDIA // Accès téléchargement (photos approuvées uniquement)
+  MEDIA_ALL // Accès téléchargement (toutes photos, validées ou non)
   PREVALIDATOR // Accès prévalidation (filtrage avant validation finale)
-  GALLERY      // Accès galerie (téléchargement photo par photo)
-  COLLECTION   // Collection multi-sources (plusieurs événements/projets)
+  GALLERY // Accès galerie (téléchargement photo par photo)
+  COLLECTION // Collection multi-sources (plusieurs événements/projets)
 }
 
 enum MediaJobStatus {
@@ -749,8 +783,8 @@ model MediaEvent {
   planningEvent   Event?  @relation(fields: [planningEventId], references: [id], onDelete: SetNull)
 
   // Multi-tenant
-  churchId    String
-  church      Church @relation(fields: [churchId], references: [id])
+  churchId String
+  church   Church @relation(fields: [churchId], references: [id])
 
   // Créateur (utilisateur Koinonia)
   createdById String
@@ -777,8 +811,8 @@ model MediaProject {
   name        String  @db.VarChar(255)
   description String? @db.Text
 
-  churchId    String
-  church      Church @relation(fields: [churchId], references: [id])
+  churchId String
+  church   Church @relation(fields: [churchId], references: [id])
 
   createdById String
   createdBy   User   @relation("MediaProjectCreator", fields: [createdById], references: [id])
@@ -796,11 +830,11 @@ model MediaProject {
 
 /// Photo associée à un événement média.
 model MediaPhoto {
-  id           String           @id @default(cuid())
-  filename     String           @db.VarChar(255)
-  originalKey  String           @db.VarChar(512)
-  thumbnailKey String           @db.VarChar(512)
-  mimeType     String           @db.VarChar(100)
+  id           String @id @default(cuid())
+  filename     String @db.VarChar(255)
+  originalKey  String @db.VarChar(512)
+  thumbnailKey String @db.VarChar(512)
+  mimeType     String @db.VarChar(100)
   size         Int
   width        Int?
   height       Int?
@@ -830,7 +864,7 @@ model MediaFile {
   size     Int
   width    Int?
   height   Int?
-  duration Int?            // Durée en secondes (vidéos)
+  duration Int? // Durée en secondes (vidéos)
 
   scheduledDeletionAt DateTime?
 
@@ -856,10 +890,10 @@ model MediaFile {
 
 /// Version d'un fichier média.
 model MediaFileVersion {
-  id            String @id @default(cuid())
-  versionNumber Int    @default(1)
-  originalKey   String @db.VarChar(512)
-  thumbnailKey  String @db.VarChar(512)
+  id            String  @id @default(cuid())
+  versionNumber Int     @default(1)
+  originalKey   String  @db.VarChar(512)
+  thumbnailKey  String  @db.VarChar(512)
   notes         String? @db.Text
 
   mediaFileId String
@@ -952,13 +986,13 @@ model MediaZipJob {
 
 /// Paramètres du module média par église (logo, favicon, rétention).
 model MediaSettings {
-  id              String   @id @default(cuid())
-  churchId        String   @unique
-  logoKey         String?  @db.VarChar(512)
-  faviconKey      String?  @db.VarChar(512)
-  logoFilename    String?  @db.VarChar(255)
-  faviconFilename String?  @db.VarChar(255)
-  retentionDays   Int      @default(30)
+  id              String  @id @default(cuid())
+  churchId        String  @unique
+  logoKey         String? @db.VarChar(512)
+  faviconKey      String? @db.VarChar(512)
+  logoFilename    String? @db.VarChar(255)
+  faviconFilename String? @db.VarChar(255)
+  retentionDays   Int     @default(30)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -997,12 +1031,12 @@ model PastoralProfile {
   userId    String?
   createdAt DateTime     @default(now())
 
-  church               Church               @relation("ChurchPastoralProfiles", fields: [churchId], references: [id])
-  user                 User?                @relation("UserPastoralProfile", fields: [userId], references: [id])
-  entries              AgendaEntry[]
-  requests             AppointmentRequest[]
-  responsibleForChurch Church?              @relation("ChurchResponsibleProfile")
-  supervisorForChurches Church[]            @relation("ChurchSupervisorProfile")
+  church                Church               @relation("ChurchPastoralProfiles", fields: [churchId], references: [id])
+  user                  User?                @relation("UserPastoralProfile", fields: [userId], references: [id])
+  entries               AgendaEntry[]
+  requests              AppointmentRequest[]
+  responsibleForChurch  Church?              @relation("ChurchResponsibleProfile")
+  supervisorForChurches Church[]             @relation("ChurchSupervisorProfile")
 
   @@map("pastoral_profiles")
 }
@@ -1030,13 +1064,13 @@ model AppointmentRequest {
   createdAt         DateTime                 @default(now())
   updatedAt         DateTime                 @updatedAt
 
-  church      Church           @relation(fields: [churchId], references: [id])
-  user        User?            @relation("AppointmentRequester", fields: [userId], references: [id])
-  assignedTo  PastoralProfile? @relation(fields: [assignedToId], references: [id])
-  qualifiedBy User?            @relation("AppointmentQualifier", fields: [qualifiedById], references: [id])
-  scheduledBy User?            @relation("AppointmentScheduler", fields: [scheduledById], references: [id])
-  updatedBy   User?            @relation("AppointmentUpdater", fields: [updatedById], references: [id])
-  agendaEntry AgendaEntry?
+  church                   Church                    @relation(fields: [churchId], references: [id])
+  user                     User?                     @relation("AppointmentRequester", fields: [userId], references: [id])
+  assignedTo               PastoralProfile?          @relation(fields: [assignedToId], references: [id])
+  qualifiedBy              User?                     @relation("AppointmentQualifier", fields: [qualifiedById], references: [id])
+  scheduledBy              User?                     @relation("AppointmentScheduler", fields: [scheduledById], references: [id])
+  updatedBy                User?                     @relation("AppointmentUpdater", fields: [updatedById], references: [id])
+  agendaEntry              AgendaEntry?
   familyIntegrationRequest FamilyIntegrationRequest? @relation("IntegrationAppointment")
 
   @@index([churchId, status, createdAt])
@@ -1073,25 +1107,25 @@ model AgendaEntry {
 // ─── Module Intégration Familles ─────────────────────────────────────────────
 
 enum FamilyIntegrationStatus {
-  SUBMITTED       // Demande soumise
-  ASSIGNED        // Famille affectée (auto ou manuelle)
-  CONTACTED       // Berger a pris contact
-  WHATSAPP_ADDED  // Ajouté au groupe WhatsApp
-  INTEGRATED      // Intégration terminée (clôturé)
-  ABANDONED       // Abandonné
+  SUBMITTED // Demande soumise
+  ASSIGNED // Famille affectée (auto ou manuelle)
+  CONTACTED // Berger a pris contact
+  WHATSAPP_ADDED // Ajouté au groupe WhatsApp
+  INTEGRATED // Intégration terminée (clôturé)
+  ABANDONED // Abandonné
 }
 
 enum FamilyAgeRange {
-  YOUTH        // Moins de 18 ans → Famille d'impact jeunes
-  YOUNG_ADULT  // 18–30 ans
-  ADULT        // 30–60 ans
-  SENIOR       // 60 ans et plus
+  YOUTH // Moins de 18 ans → Famille d'impact jeunes
+  YOUNG_ADULT // 18–30 ans
+  ADULT // 30–60 ans
+  SENIOR // 60 ans et plus
 }
 
 enum FamilyChurchStatus {
-  VISITOR   // Visiteur
-  REGULAR   // Membre régulier
-  ENGAGED   // Membre engagé
+  VISITOR // Visiteur
+  REGULAR // Membre régulier
+  ENGAGED // Membre engagé
 }
 
 enum FamilyLeaderRole {
@@ -1105,15 +1139,15 @@ model FamilyIntegrationRequest {
   churchId String
 
   // Informations personnelles
-  firstName  String  @db.VarChar(100)
-  lastName   String  @db.VarChar(100)
-  email      String? @db.VarChar(255)
-  phone      String? @db.VarChar(30)
-  address    String? @db.VarChar(500)
-  city       String? @db.VarChar(100)
-  lat        Float?
-  lng        Float?
-  ageRange   FamilyAgeRange
+  firstName    String             @db.VarChar(100)
+  lastName     String             @db.VarChar(100)
+  email        String?            @db.VarChar(255)
+  phone        String?            @db.VarChar(30)
+  address      String?            @db.VarChar(500)
+  city         String?            @db.VarChar(100)
+  lat          Float?
+  lng          Float?
+  ageRange     FamilyAgeRange
   churchStatus FamilyChurchStatus @default(VISITOR)
 
   // Lien optionnel vers un membre Koinonia existant
@@ -1125,32 +1159,32 @@ model FamilyIntegrationRequest {
 
   // Événement (culte) lié — pour corrélation avec les comptes rendus
   eventId String?
-  event   Event? @relation(fields: [eventId], references: [id], onDelete: SetNull)
+  event   Event?  @relation(fields: [eventId], references: [id], onDelete: SetNull)
 
   // Demande de soin pastoral
-  pastoralCareRequested  Boolean  @default(false)
-  appointmentRequestId   String?  @unique
-  appointmentRequest     AppointmentRequest? @relation("IntegrationAppointment", fields: [appointmentRequestId], references: [id], onDelete: SetNull)
+  pastoralCareRequested Boolean             @default(false)
+  appointmentRequestId  String?             @unique
+  appointmentRequest    AppointmentRequest? @relation("IntegrationAppointment", fields: [appointmentRequestId], references: [id], onDelete: SetNull)
 
   // Affectation famille (référentiel externe familles.iccrennes.fr)
-  suggestedFamilyId   Int?     // Suggestion auto via point-in-polygon
-  suggestedFamilyName String?  @db.VarChar(100)
-  assignedFamilyId    Int?     // Famille confirmée
-  assignedFamilyName  String?  @db.VarChar(100)
+  suggestedFamilyId   Int? // Suggestion auto via point-in-polygon
+  suggestedFamilyName String? @db.VarChar(100)
+  assignedFamilyId    Int? // Famille confirmée
+  assignedFamilyName  String? @db.VarChar(100)
 
   // Berger assigné (notifié à l'affectation)
   assignedBergerId String?
   assignedBerger   User?   @relation("IntegrationAssignedBerger", fields: [assignedBergerId], references: [id], onDelete: SetNull)
 
   // Statut et timestamps de workflow
-  status           FamilyIntegrationStatus @default(SUBMITTED)
-  submittedAt      DateTime  @default(now())
-  assignedAt       DateTime?
-  contactedAt      DateTime?
-  whatsappAddedAt  DateTime?
-  integratedAt     DateTime?
-  abandonedAt      DateTime?
-  abandonReason    String?   @db.VarChar(500)
+  status          FamilyIntegrationStatus @default(SUBMITTED)
+  submittedAt     DateTime                @default(now())
+  assignedAt      DateTime?
+  contactedAt     DateTime?
+  whatsappAddedAt DateTime?
+  integratedAt    DateTime?
+  abandonedAt     DateTime?
+  abandonReason   String?                 @db.VarChar(500)
 
   // Notes internes (équipe intégration)
   notes String? @db.Text
@@ -1179,11 +1213,11 @@ model FamilyIntegrationRequest {
 }
 
 enum MsdpStatus {
-  SUBMITTED     // Appel reçu, en attente d'assignation
-  ASSIGNED      // Conseiller MSDP assigné
-  CONTACTED     // Premier contact établi
-  IN_FORMATION  // Intégré à la formation nouveaux convertis (PCNC)
-  COMPLETED     // Suivi terminé
+  SUBMITTED // Appel reçu, en attente d'assignation
+  ASSIGNED // Conseiller MSDP assigné
+  CONTACTED // Premier contact établi
+  IN_FORMATION // Intégré à la formation nouveaux convertis (PCNC)
+  COMPLETED // Suivi terminé
   ABANDONED
 }
 
@@ -1202,7 +1236,7 @@ model MsdpFollowUp {
 
   // Conseiller MSDP assigné (membre du département MSDP)
   assignedConseillerMsdpId String?
-  assignedConseillerMsdp   User? @relation("MsdpAssignedConseiller", fields: [assignedConseillerMsdpId], references: [id], onDelete: SetNull)
+  assignedConseillerMsdp   User?   @relation("MsdpAssignedConseiller", fields: [assignedConseillerMsdpId], references: [id], onDelete: SetNull)
 
   // Timestamps pour KPIs délais
   assignedAt    DateTime?
@@ -1277,21 +1311,21 @@ model PersonJourney {
 // ─── Module Comptabilité ──────────────────────────────────────────────────────
 
 enum FinancialRequestType {
-  EXPENSE_REPORT  // Note de frais — dépense déjà effectuée
-  BUDGET_ADVANCE  // Avance de budget — dépense à venir
+  EXPENSE_REPORT // Note de frais — dépense déjà effectuée
+  BUDGET_ADVANCE // Avance de budget — dépense à venir
 }
 
 enum FinancialRequestStatus {
-  SUBMITTED   // Soumise, en attente de traitement
-  PROCESSING  // En cours de traitement par la compta
-  APPROVED    // Validée, plan de paiement défini
-  REJECTED    // Rejetée (motif obligatoire)
-  CANCELLED   // Annulée par le demandeur (seulement si SUBMITTED)
+  SUBMITTED // Soumise, en attente de traitement
+  PROCESSING // En cours de traitement par la compta
+  APPROVED // Validée, plan de paiement défini
+  REJECTED // Rejetée (motif obligatoire)
+  CANCELLED // Annulée par le demandeur (seulement si SUBMITTED)
 }
 
 enum FinancialPriority {
-  URGENT  // Délai de traitement engagé par la compta
-  NORMAL  // Traitée dans les meilleurs délais
+  URGENT // Délai de traitement engagé par la compta
+  NORMAL // Traitée dans les meilleurs délais
 }
 
 enum RecurrenceUnit {
@@ -1308,23 +1342,23 @@ enum SeriesStatus {
 /// Série de demandes récurrentes (avances de budget uniquement).
 /// Chaque occurrence est un FinancialRequest indépendant lié à cette série.
 model FinancialSeries {
-  id                 String         @id @default(cuid())
+  id                 String               @id @default(cuid())
   churchId           String
   departmentId       String
   submittedById      String
   type               FinancialRequestType
-  label              String         @db.VarChar(200)
-  description        String?        @db.Text
-  amount             Decimal        @db.Decimal(10, 2)
+  label              String               @db.VarChar(200)
+  description        String?              @db.Text
+  amount             Decimal              @db.Decimal(10, 2)
   recurrenceEvery    Int
   recurrenceUnit     RecurrenceUnit
-  status             SeriesStatus   @default(ACTIVE)
+  status             SeriesStatus         @default(ACTIVE)
   nextOccurrenceDate DateTime
 
-  church       Church      @relation(fields: [churchId], references: [id])
-  department   Department  @relation(fields: [departmentId], references: [id])
-  submittedBy  User        @relation("FinancialSeriesSubmitter", fields: [submittedById], references: [id])
-  requests     FinancialRequest[]
+  church      Church             @relation(fields: [churchId], references: [id])
+  department  Department         @relation(fields: [departmentId], references: [id])
+  submittedBy User               @relation("FinancialSeriesSubmitter", fields: [submittedById], references: [id])
+  requests    FinancialRequest[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1338,11 +1372,11 @@ model FinancialSeries {
 model FinancialRequest {
   id               String                 @id @default(cuid())
   churchId         String
-  departmentId     String?                // null = note de frais personnelle (sans département)
+  departmentId     String? // null = note de frais personnelle (sans département)
   submittedById    String
-  seriesId         String?                // null si demande one-shot
-  occurrenceNumber Int?                   // rang dans la série
-  correctionOfId   String?                // référence à la demande rejetée corrigée
+  seriesId         String? // null si demande one-shot
+  occurrenceNumber Int? // rang dans la série
+  correctionOfId   String? // référence à la demande rejetée corrigée
   type             FinancialRequestType
   label            String                 @db.VarChar(200)
   description      String?                @db.Text
@@ -1354,13 +1388,13 @@ model FinancialRequest {
   processedById    String?
   processedAt      DateTime?
 
-  church       Church            @relation(fields: [churchId], references: [id])
-  department   Department?       @relation(fields: [departmentId], references: [id])
-  submittedBy  User              @relation("FinancialRequestSubmitter", fields: [submittedById], references: [id])
-  processedBy  User?             @relation("FinancialRequestProcessor", fields: [processedById], references: [id])
-  series       FinancialSeries?  @relation(fields: [seriesId], references: [id])
-  correctionOf FinancialRequest? @relation("RequestCorrections", fields: [correctionOfId], references: [id])
-  corrections  FinancialRequest[] @relation("RequestCorrections")
+  church       Church                @relation(fields: [churchId], references: [id])
+  department   Department?           @relation(fields: [departmentId], references: [id])
+  submittedBy  User                  @relation("FinancialRequestSubmitter", fields: [submittedById], references: [id])
+  processedBy  User?                 @relation("FinancialRequestProcessor", fields: [processedById], references: [id])
+  series       FinancialSeries?      @relation(fields: [seriesId], references: [id])
+  correctionOf FinancialRequest?     @relation("RequestCorrections", fields: [correctionOfId], references: [id])
+  corrections  FinancialRequest[]    @relation("RequestCorrections")
   attachments  FinancialAttachment[]
   payments     FinancialPayment[]
 
@@ -1376,17 +1410,17 @@ model FinancialRequest {
 
 /// Pièce jointe d'une demande financière (photo de reçu, PDF devis…).
 model FinancialAttachment {
-  id          String            @id @default(cuid())
-  requestId   String?
+  id           String  @id @default(cuid())
+  requestId    String?
   uploadedById String?
-  s3Key       String            @db.VarChar(512)
-  filename    String            @db.VarChar(255)
-  mimeType    String            @db.VarChar(100)
-  size        Int
+  s3Key        String  @db.VarChar(512)
+  filename     String  @db.VarChar(255)
+  mimeType     String  @db.VarChar(100)
+  size         Int
 
-  request      FinancialRequest? @relation(fields: [requestId], references: [id], onDelete: Cascade)
-  uploadedBy   User?             @relation("AccountingAttachmentsUploaded", fields: [uploadedById], references: [id])
-  uploadedAt   DateTime          @default(now())
+  request    FinancialRequest? @relation(fields: [requestId], references: [id], onDelete: Cascade)
+  uploadedBy User?             @relation("AccountingAttachmentsUploaded", fields: [uploadedById], references: [id])
+  uploadedAt DateTime          @default(now())
 
   @@index([requestId])
   @@map("financial_attachments")
@@ -1395,14 +1429,14 @@ model FinancialAttachment {
 /// Tranche de paiement d'une demande validée.
 /// La compta crée 1..N tranches lors de la validation, puis confirme chaque remise.
 model FinancialPayment {
-  id            String    @id @default(cuid())
-  requestId     String
-  amount        Decimal   @db.Decimal(10, 2)
-  scheduledDate DateTime
-  releasedAt     DateTime?   // null = pas encore versé
-  releasedAmount Decimal?    @db.Decimal(10, 2)  // montant effectivement remis (peut être < amount)
-  releasedById   String?     // comptable ayant confirmé la remise
-  note           String?     @db.VarChar(500)
+  id             String    @id @default(cuid())
+  requestId      String
+  amount         Decimal   @db.Decimal(10, 2)
+  scheduledDate  DateTime
+  releasedAt     DateTime? // null = pas encore versé
+  releasedAmount Decimal?  @db.Decimal(10, 2) // montant effectivement remis (peut être < amount)
+  releasedById   String? // comptable ayant confirmé la remise
+  note           String?   @db.VarChar(500)
 
   request    FinancialRequest @relation(fields: [requestId], references: [id], onDelete: Cascade)
   releasedBy User?            @relation("FinancialPaymentReleaser", fields: [releasedById], references: [id])
@@ -1419,7 +1453,7 @@ model FinancialPayment {
 model WelcomeDutyFamily {
   id         String   @id @default(cuid())
   churchId   String
-  familyId   Int              // ID dans familles.iccrennes.fr
+  familyId   Int // ID dans familles.iccrennes.fr
   familyName String   @db.VarChar(100)
   active     Boolean  @default(true)
   createdAt  DateTime @default(now())
@@ -1488,17 +1522,17 @@ model JobOffer {
 
 /// Préférences de notifications pour les offres d'emploi et profils de recherche.
 model JobNotificationSubscription {
-  id             String  @id @default(cuid())
-  userId         String  @unique
-  inApp          Boolean @default(true)
-  email          Boolean @default(false)
-  wantEmploi     Boolean @default(true)
-  wantStage      Boolean @default(true)
-  wantAlternance Boolean @default(true)
-  wantSeekers              Boolean @default(false)
-  wantFreelanceMissions    Boolean @default(false)
-  wantFreelanceProfiles    Boolean @default(false)
-  user                     User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                    String  @id @default(cuid())
+  userId                String  @unique
+  inApp                 Boolean @default(true)
+  email                 Boolean @default(false)
+  wantEmploi            Boolean @default(true)
+  wantStage             Boolean @default(true)
+  wantAlternance        Boolean @default(true)
+  wantSeekers           Boolean @default(false)
+  wantFreelanceMissions Boolean @default(false)
+  wantFreelanceProfiles Boolean @default(false)
+  user                  User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("job_notification_subscriptions")
 }
@@ -1607,7 +1641,7 @@ model FamilyLeaderAssignment {
   id         String           @id @default(cuid())
   churchId   String
   userId     String
-  familyId   Int              // ID dans familles.iccrennes.fr
+  familyId   Int // ID dans familles.iccrennes.fr
   familyName String           @db.VarChar(100)
   role       FamilyLeaderRole
 

--- a/specs/007-gestion-absences-star/plan.md
+++ b/specs/007-gestion-absences-star/plan.md
@@ -1,7 +1,7 @@
 # Plan technique — Gestion des absences des STAR
 
 - **Spec associée** : `./spec.md`
-- **Statut** : Brouillon
+- **Statut** : Validé
 - **Mis à jour le** : 2026-07-25
 
 > Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.

--- a/specs/007-gestion-absences-star/plan.md
+++ b/specs/007-gestion-absences-star/plan.md
@@ -1,0 +1,275 @@
+# Plan technique — Gestion des absences des STAR
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Brouillon
+- **Mis à jour le** : 2026-07-25
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : tout vit dans `src/modules/planning` (sous-domaine) — aucun nouvel
+      import cross-module ; `src/app/` importe uniquement `@/modules/planning` (index public).
+- [x] **Sécurité** : chaque route protégée par `requireAuth()` (self-service) ou
+      `requireChurchPermission("absences:manage"/"absences:view", churchId)` ; `churchId` toujours
+      dérivé côté serveur (jamais accepté tel quel sans vérification de cohérence membre/église).
+- [x] **Permissions** via `rolePermissions` (`@/lib/registry`), déclarées dans le manifeste
+      `planningModule`.
+- [x] **Validation** Zod sur `POST /api/absences` et `PATCH /api/absences/[id]`.
+- [x] **Migration** Prisma prévue (nouveau modèle `Absence` + enum `AbsenceStatus`).
+- [x] **Enums** : `AbsenceStatus` importé depuis `@/generated/prisma/client`.
+- [x] **UI** : réutilise `DataTable`, `Modal`, `Button`, `Input`, `Select` de `src/components/ui/` ;
+      badge ad hoc dans `PlanningGrid.tsx` (pas de nouveau composant générique nécessaire).
+
+## Approche générale
+
+Le module `absences` est un **sous-domaine de `planning`** (pas de module autonome — décision
+prise à la spec) : nouveau modèle Prisma `Absence`, service
+`src/modules/planning/services/absence.service.ts`, routes `src/app/api/absences/`.
+
+Le service gère dans une seule transaction : écriture de l'absence, calcul des conflits (jointure
+`Planning`/`EventDepartment`/`Event`, jamais stocké), création des notifications, puis émission
+d'un événement sur `planningBus` (pour cohérence avec le reste du module et une éventuelle
+consommation cross-module future — aucun abonnement n'est requis aujourd'hui).
+
+Le badge de conflit dans `PlanningGrid` est obtenu en enrichissant la réponse de la route
+existante `GET /api/events/[eventId]/departments/[deptId]/planning` d'un champ calculé par
+membre — pas de nouvelle requête dédiée côté client.
+
+La déclaration « pour soi-même » (STAR) n'exige aucune permission : elle repose sur une
+vérification d'appartenance via `MemberUserLink` (même pattern que `POST
+/api/member-user-links/self`). La déclaration « pour un tiers » (Resp. département / Ministre)
+exige `absences:manage` + une vérification de périmètre départemental
+(`getUserDepartmentScope`).
+
+## Modèle de données
+
+```prisma
+enum AbsenceStatus {
+  ACTIVE
+  CANCELLED
+}
+
+model Absence {
+  id            String        @id @default(cuid())
+  memberId      String
+  churchId      String
+  startDate     DateTime
+  endDate       DateTime
+  reason        String?       @db.Text
+  status        AbsenceStatus @default(ACTIVE)
+  createdById   String
+  cancelledById String?
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+  cancelledAt   DateTime?
+
+  member        Member @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  church        Church @relation(fields: [churchId], references: [id])
+  createdBy     User   @relation("AbsenceCreatedBy", fields: [createdById], references: [id])
+  cancelledBy   User?  @relation("AbsenceCancelledBy", fields: [cancelledById], references: [id])
+
+  @@index([churchId, startDate, endDate])
+  @@index([memberId, status])
+  @@map("absences")
+}
+```
+
+Ajouts de relations inverses :
+- `Member.absences Absence[]`
+- `Church.absences Absence[]`
+- `User.absencesCreated Absence[] @relation("AbsenceCreatedBy")`
+- `User.absencesCancelled Absence[] @relation("AbsenceCancelledBy")`
+
+`churchId` est redondant avec le rattachement du membre (comme sur `MemberUserLink`) — dénormalisé
+volontairement pour permettre un scope multi-tenant direct sans jointure, et vérifié à l'écriture
+(le `churchId` du membre doit correspondre au `churchId` transmis, sinon `ApiError(403)`).
+
+Aucun champ ni table pour les conflits : ils sont recalculés à chaque lecture par jointure
+`Planning → EventDepartment → Event`, filtrée sur `memberId`, `status IN (EN_SERVICE,
+EN_SERVICE_DEBRIEF)` et `event.date BETWEEN startDate AND endDate`.
+
+Migration : `npm run db:migrate` (nom suggéré `add_absences`).
+
+## API
+
+| Endpoint | Méthode | Permission | Entrée | Sortie |
+|---|---|---|---|---|
+| `/api/absences` | GET | `requireAuth()` + scope (voir note) | query : `churchId` (requis), `scope` (`self`\|`all`), `ministryId?`, `departmentId?`, `role?` | `{ absences: Array<{ id, member, startDate, endDate, reason, status, createdBy, hasConflict, conflicts: [{eventId,title,date,departmentId}] }> }` |
+| `/api/absences` | POST | self (ownership) ou `absences:manage` scoped | `{ churchId, memberId, startDate, endDate, reason? }` | `201 { id, ...absence }` |
+| `/api/absences/[id]` | PATCH | créateur, membre lui-même, resp/ministre scopé, ou global manager | `{ action: "cancel" }` | `{ id, status: "CANCELLED" }` |
+
+Note sur `GET` : `scope=self` retourne uniquement les absences des fiches STAR liées au compte
+appelant (aucune permission requise au-delà de `requireAuth`) ; `scope=all` exige
+`requireChurchPermission("absences:view", churchId)` et applique `getUserDepartmentScope` (un
+Resp. département/Ministre scoped ne voit que les absences des membres de ses départements ; les
+rôles globaux — Secrétaire/Admin/Super Admin — voient tout, cohérent avec `members:view`).
+
+Schéma Zod (`POST`) :
+```ts
+z.object({
+  churchId: z.string().min(1),
+  memberId: z.string().min(1),
+  startDate: z.string().datetime(),
+  endDate: z.string().datetime(),
+  reason: z.string().max(500).optional(),
+}).refine((d) => new Date(d.endDate) >= new Date(d.startDate), {
+  message: "endDate doit être postérieure ou égale à startDate",
+})
+```
+
+Enrichissement de route existante :
+
+| Endpoint | Changement |
+|---|---|
+| `GET /api/events/[eventId]/departments/[deptId]/planning` | Ajoute par membre un champ `activeAbsence: { startDate, endDate } \| null`, calculé par une requête `Absence` (`status: ACTIVE`, période chevauchant `event.date`) — permet le badge dans `PlanningGrid` avant toute affectation. |
+
+## Services / logique métier
+
+`src/modules/planning/services/absence.service.ts` :
+
+- `declareAbsence(params): Promise<Absence>`
+  - Résout le membre (`memberId`), vérifie qu'il appartient bien à `churchId`.
+  - Vérifie l'autorisation : soit `createdById` a un `MemberUserLink` vers ce `memberId`/`churchId`
+    (self), soit le périmètre départemental du `createdById` (via `getUserDepartmentScope`)
+    intersecte les départements du membre.
+  - Transaction : crée l'`Absence`, calcule les conflits (jointure décrite ci-dessus), résout la
+    liste des responsables à notifier (tous les Resp. département + Ministres des départements du
+    membre — via `MemberDepartment → Department → UserDepartment`/`UserChurchRole.ministryId`),
+    crée les notifications (`ABSENCE_DECLARED` pour tous les responsables ; `ABSENCE_CONFLICT`
+    supplémentaire pour le STAR + les responsables des départements en conflit, un seul envoi même
+    si plusieurs événements en conflit).
+  - Émet `planning:absence:declared` sur `planningBus`.
+
+- `cancelAbsence(absenceId, cancelledById): Promise<Absence>`
+  - Vérifie l'autorisation (créateur, membre lui-même via `MemberUserLink`, resp/ministre scopé,
+    ou global manager).
+  - Transaction : passe `status = CANCELLED`, `cancelledAt`, `cancelledById`.
+  - Renvoie la liste des destinataires initialement notifiés (déclaration + conflit) et crée une
+    notification `ABSENCE_CANCELLED` pour chacun.
+  - Émet `planning:absence:cancelled`.
+
+- `findAbsenceConflicts(memberId, churchId, startDate, endDate)` — fonction pure de requête,
+  réutilisée par `declareAbsence`, par `GET /api/absences` (calcul de `hasConflict`) et par
+  l'enrichissement de la route planning existante.
+
+- `resolveResponsibleUserIds(memberId, churchId)` — retourne l'ensemble dédupliqué des
+  utilisateurs Resp. département + Ministre couvrant tous les départements du membre.
+
+Nouveaux événements dans `PlanningEvents` (`src/modules/planning/events.ts`) :
+
+```ts
+"planning:absence:declared": {
+  absenceId: string;
+  churchId: string;
+  memberId: string;
+  startDate: string;
+  endDate: string;
+  createdById: string;
+  hasConflict: boolean;
+};
+"planning:absence:cancelled": {
+  absenceId: string;
+  churchId: string;
+  memberId: string;
+  cancelledById: string;
+  hadConflict: boolean;
+};
+```
+
+Aucun abonnement cross-module requis aujourd'hui (pas de handler dans `registry.ts`) — ces
+événements sont émis par cohérence avec le reste du module et pour permettre une extension future
+(ex. discipolat, reporting) sans modifier le service.
+
+Permissions ajoutées au manifeste `planningModule` (`src/modules/planning/index.ts`) :
+
+```ts
+"absences:view":   ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD"],
+"absences:manage": ["SUPER_ADMIN", "ADMIN", "MINISTER", "DEPARTMENT_HEAD"],
+```
+
+La déclaration/annulation « pour soi-même » ne passe par aucune de ces permissions — uniquement
+par la vérification d'appartenance (`MemberUserLink`), comme le self-link d'onboarding.
+
+## UI / composants
+
+- **Page** `src/app/(auth)/absences/page.tsx` (Server Component) : résout `churchId` courant
+  (`getCurrentChurchId`), charge les absences « self » (fiches liées à l'utilisateur) et, si
+  `absences:view` est présent, les absences transverses scopées ; passe le tout à un composant
+  client.
+- **Composant client** `AbsencesClient.tsx` (`"use client"`) :
+  - Section « Mes absences » (toujours visible) : liste + formulaire de déclaration (`Modal` +
+    `Input` dates + champ motif optionnel) + bouton annuler par ligne.
+  - Section « Vue d'ensemble » (visible seulement si `absences:view`) : `DataTable` avec colonnes
+    Membre / Département / Ministère / Période / Motif / Déclaré par / Conflit (badge), filtres
+    ministère/département/rôle du déclarant en en-tête. Si `absences:manage`, une action
+    « Déclarer pour un STAR » scoped à son périmètre + bouton annuler sur les lignes de son
+    périmètre.
+- **Navigation** : nouvelle entrée « Absences » dans `Sidebar.tsx`, visible à tout utilisateur
+  authentifié (comme « Mes demandes ») — la page adapte son contenu selon les permissions, pas la
+  visibilité du lien.
+- **`PlanningGrid.tsx`** : badge (icône + tooltip, ex. « Absence déclarée du JJ/MM au JJ/MM ») sur
+  la ligne d'un membre dont `activeAbsence` est non-null pour la date de l'événement affiché —
+  affiché même si aucun statut n'est encore renseigné.
+
+## Décisions & alternatives écartées
+
+- **Choix** : sous-domaine de `planning` plutôt que module autonome — *Pourquoi* : couplage fort
+  avec `Member`/`Planning`/`Event`, déjà possédés par `planning` ; évite une dépendance
+  inter-module pour un besoin cœur du domaine planning (décidé avec l'utilisateur).
+- **Choix** : conflits calculés à la volée, jamais persistés — *Pourquoi* : élimine tout risque de
+  désynchronisation avec l'état réel du planning (déjà justifié à la conception, avant
+  d'abandonner le statut `CONFIRMED`).
+- **Choix** : notification uniquement, aucune bascule automatique de `Planning.status` —
+  *Pourquoi* : imposé par la spec (Hors périmètre) ; le responsable garde l'arbitrage.
+- **Écarté** : ajouter `absences:declare` comme permission dédiée pour l'auto-déclaration —
+  *Raison* : inutile, l'auto-déclaration est une question d'appartenance (ownership), pas de rôle ;
+  ajouter une permission créerait une distinction artificielle avec le pattern self-link existant.
+- **Écarté** : notifier via abonnement `planningBus.on(...)` dans `registry.ts` plutôt que directement
+  dans le service — *Raison* : la notification est un effet intra-module immédiat et testable ;
+  le bus reste réservé à l'extensibilité cross-module, cohérent avec `deleteEvents` qui fait son
+  nettoyage directement et émet l'événement seulement pour les autres modules.
+- **Écarté** : endpoint séparé pour les conflits (`GET /api/absences/[id]/conflicts`) — *Raison* :
+  surcoût d'aller-retour réseau côté UI sans bénéfice ; le calcul est inclus directement dans la
+  réponse de liste et dans l'enrichissement de la route planning existante.
+
+## Risques & points d'attention
+
+- **Performance de `findAbsenceConflicts`** : jointure `Planning`/`EventDepartment`/`Event` par
+  église pour chaque déclaration et pour l'enrichissement de la grille planning — volumétrie
+  attendue faible (nombre d'événements par église par an), mais à surveiller si le nombre
+  d'absences actives par membre croît fortement ; index `@@index([memberId, status])` et
+  `@@index([churchId, startDate, endDate])` couvrent les accès prévus.
+- **Notification multi-départements** : `resolveResponsibleUserIds` doit dédupliquer strictement
+  (un même utilisateur Resp. département de deux départements du STAR, ou à la fois Resp. et
+  Ministre, ne doit recevoir qu'une seule notification par événement).
+- **Cohérence multi-église** : toute requête doit filtrer `churchId` explicitement à chaque étape
+  (résolution du membre, calcul des responsables, calcul des conflits) — ne jamais déduire le
+  périmètre uniquement de `memberId`, car rien n'empêche structurellement (au niveau du schéma)
+  qu'un `memberId` invalide pour l'église transmise soit fourni par erreur côté client ; toujours
+  vérifier `member.departments[].department.ministry.churchId === churchId` avant tout accès.
+- **Annulation par un tiers hors périmètre** : bien vérifier que ni un autre STAR, ni un
+  responsable d'un département non lié au membre, ne puisse annuler une absence — tester
+  explicitement le cas 403.
+
+## Stratégie de tests
+
+Tests unitaires (Vitest) dans `src/modules/planning/services/absence.service.test.ts` :
+
+- `declareAbsence` crée l'absence et retourne `hasConflict: false` quand aucun chevauchement.
+- `declareAbsence` détecte un conflit avec un `Planning.status = EN_SERVICE` chevauchant la
+  période, et pas avec `INDISPONIBLE`/`REMPLACANT`/`null`.
+- `declareAbsence` notifie tous les responsables de tous les départements du membre (cas
+  multi-départements), sans doublon pour un utilisateur cumulant plusieurs rôles.
+- `declareAbsence` refuse (403) une déclaration par un tiers hors périmètre (STAR pour un autre
+  STAR, Resp. département hors du département du membre).
+- `declareAbsence` refuse une incohérence membre/église (`churchId` transmis ≠ église du membre).
+- `cancelAbsence` notifie les responsables initialement notifiés, y compris en cas de conflit
+  préalable ; refuse l'annulation par un utilisateur hors périmètre.
+- Tests de scope multi-église : un utilisateur avec fiche STAR en église A et rôle responsable en
+  église B ne reçoit aucune notification et ne voit aucune absence de l'église A dans le contexte
+  de l'église B (et réciproquement).
+
+Tests d'intégration légers sur les routes (`GET`/`POST`/`PATCH /api/absences`) pour vérifier les
+codes de statut (401/403/404/201/200) selon les combinaisons rôle/périmètre déjà couvertes côté
+service — pas de duplication exhaustive de la logique métier au niveau route.

--- a/specs/007-gestion-absences-star/spec.md
+++ b/specs/007-gestion-absences-star/spec.md
@@ -1,7 +1,7 @@
 # Spec — Gestion des absences des STAR
 
 - **Numéro** : 007
-- **Statut** : Validée
+- **Statut** : Implémentée
 - **Créée le** : 2026-07-25
 - **Branche suggérée** : `feat/gestion-absences-star`
 

--- a/specs/007-gestion-absences-star/spec.md
+++ b/specs/007-gestion-absences-star/spec.md
@@ -1,0 +1,153 @@
+# Spec — Gestion des absences des STAR
+
+- **Numéro** : 007
+- **Statut** : Validée
+- **Créée le** : 2026-07-25
+- **Branche suggérée** : `feat/gestion-absences-star`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+Aujourd'hui, un STAR qui sait à l'avance qu'il sera absent (voyage, maladie prévue, obligation
+personnelle, etc.) n'a aucun moyen formel de le signaler dans l'application. Il doit prévenir son
+responsable oralement ou par un canal externe (message, appel), sans garantie que l'information
+remonte à temps ni qu'elle soit prise en compte au moment de construire le planning.
+
+Conséquence : un STAR peut se retrouver affecté « en service » sur un événement alors qu'il a déjà
+prévenu de son indisponibilité, ou l'inverse — un responsable découvre une absence au dernier
+moment sans avoir eu le temps de trouver un remplaçant.
+
+Cette fonctionnalité introduit une déclaration formelle et centralisée des absences prévues,
+visible par les responsables concernés, et confrontée automatiquement au planning existant pour
+signaler les situations qui nécessitent un arbitrage humain.
+
+## Utilisateurs concernés
+
+- **STAR** : déclare ses propres absences prévues, peut les annuler si ses plans changent, est
+  notifié si l'une de ses absences chevauche un service où il est déjà prévu.
+- **Resp. département** : déclare/annule une absence pour un STAR de son département, est notifié
+  des absences déclarées dans son département (avec ou sans conflit), consulte la vue transverse
+  filtrée sur son périmètre.
+- **Ministre** : mêmes droits que Resp. département, mais à l'échelle de son ministère (tous les
+  départements qu'il supervise).
+- **Secrétaire** : consulte la vue transverse de toutes les absences de l'église (lecture seule),
+  ne déclare/n'annule pas d'absence pour un tiers.
+- **Admin / Super Admin** : consulte la vue transverse de toutes les absences de l'église.
+
+Rôles non concernés par cette feature : Faiseur de Disciples, Reporter.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Un STAR se rend sur l'espace où il peut déclarer une absence.
+2. Il indique une période (date de début, date de fin) et peut ajouter un motif facultatif.
+3. Il valide : l'absence est immédiatement active, sans étape d'approbation préalable.
+4. Le(s) responsable(s) de son périmètre (resp. de département, ministre) reçoivent une
+   notification les informant de cette absence.
+5. Si aucune partie de la période déclarée ne chevauche un service où le STAR est déjà prévu « en
+   service », rien de plus ne se produit : l'absence est simplement visible dans la vue transverse
+   et sur le planning.
+6. Si une partie de la période chevauche un ou plusieurs services où le STAR est déjà prévu « en
+   service » : le STAR et le(s) responsable(s) concernés reçoivent une notification spécifique
+   signalant le conflit, et ce conflit est visible directement sur le planning à l'endroit concerné.
+   Aucune modification automatique de l'affectation n'a lieu — c'est au responsable d'arbitrer
+   (retirer le STAR, trouver un remplaçant, etc.).
+
+### Scénarios alternatifs / cas limites
+
+- **Si** le STAR change d'avis avant le début de la période, **alors** il peut annuler son
+  absence ; les responsables qui avaient été notifiés de la déclaration initiale (et, le cas
+  échéant, du conflit) reçoivent alors une notification les informant de l'annulation.
+- **Si** un responsable déclare une absence au nom d'un STAR de son périmètre, **alors** le STAR
+  concerné doit pouvoir la consulter et l'annuler lui-même comme s'il l'avait saisie.
+- **Quand** un responsable planifie un STAR « en service » sur un événement qui tombe dans une
+  période où ce STAR a déjà une absence active, le système doit signaler visuellement la
+  situation au moment de la planification (avant même que l'affectation soit enregistrée), pas
+  seulement après coup.
+- **Si** deux responsables différents (resp. de département et ministre) supervisent le même
+  STAR, **alors** les deux sont notifiés d'une déclaration ou d'un conflit le concernant.
+- **Quand** un STAR change de département ou quitte un département en cours de période
+  d'absence, le système continue de rattacher l'absence à sa fiche STAR, pas au département —
+  le responsable notifié est celui du/des départements auxquels le STAR est rattaché **au moment
+  de la déclaration**.
+- **Si** un STAR est rattaché à plusieurs départements (et donc potentiellement plusieurs
+  ministères), **alors** tous les responsables de tous ces départements/ministères sont notifiés
+  de la déclaration — pas seulement ceux du département où un conflit est détecté — car
+  l'absence peut avoir un impact sur n'importe lequel des services où le STAR est engagé.
+- **Si** une période d'absence chevauche un événement pour lequel le STAR n'a aucune affectation
+  planning (ni en service, ni indisponible, ni remplaçant), **alors** il n'y a pas de conflit à
+  signaler — seule l'existence de l'absence est visible.
+- **Si** une personne possède une fiche STAR dans l'église A et un rôle (responsable, ministre...)
+  dans l'église B, **alors** une absence déclarée pour sa fiche STAR de l'église A n'est visible,
+  notifiée ou comptabilisée que dans le périmètre de l'église A — aucune fuite d'information vers
+  l'église B, même s'il s'agit du même compte utilisateur.
+- **Si** une personne possède une fiche STAR distincte dans plusieurs églises, **alors** elle
+  déclare une absence séparément pour chaque fiche, dans le contexte de l'église concernée — il
+  n'existe pas de déclaration unique valable pour toutes ses églises à la fois.
+- **Quand** un responsable ou un STAR travaille dans le contexte d'une église donnée (celle
+  actuellement sélectionnée dans l'application), toute déclaration, notification ou consultation
+  d'absence ne concerne que cette église.
+
+## Critères d'acceptation
+
+- [ ] Un STAR peut déclarer une absence (période + motif optionnel) pour lui-même.
+- [ ] Un Resp. département ou un Ministre peut déclarer une absence pour un STAR de son périmètre.
+- [ ] Une absence déclarée est immédiatement visible, sans étape de validation préalable.
+- [ ] À la déclaration, les responsables du périmètre du STAR (resp. département + ministre)
+      reçoivent une notification.
+- [ ] Si la période d'absence chevauche un service où le STAR est déjà « en service », le STAR et
+      les responsables concernés reçoivent une notification de conflit distincte.
+- [ ] Un conflit entre une absence et une affectation planning est visible directement dans la vue
+      de planification, sans action manuelle supplémentaire.
+- [ ] Le STAR ou son responsable/ministre de périmètre peut annuler une absence active à tout
+      moment.
+- [ ] Une absence annulée n'apparaît plus comme active dans le planning ni dans les notifications
+      de conflit futures.
+- [ ] L'annulation d'une absence notifie systématiquement les responsables qui avaient été
+      notifiés de la déclaration initiale (et du conflit, le cas échéant).
+- [ ] Si un STAR est rattaché à plusieurs départements/ministères, la déclaration d'une absence
+      notifie l'ensemble des responsables de tous ces départements/ministères, pas uniquement
+      ceux du département en conflit.
+- [ ] Une vue transverse liste toutes les absences, avec filtres par ministère, par département et
+      par rôle du déclarant.
+- [ ] La vue transverse respecte le même périmètre de visibilité que la consultation des membres :
+      un Ministre ne voit que son ministère, un Resp. département que ses départements, le
+      Secrétariat et l'Admin/Super Admin voient toute l'église.
+- [ ] Le Secrétariat peut consulter la vue transverse mais ne peut pas déclarer ou annuler une
+      absence pour un tiers.
+- [ ] Un STAR ne peut ni déclarer ni annuler une absence pour un autre STAR.
+- [ ] Une absence est toujours rattachée à une seule église : celle de la fiche STAR concernée.
+- [ ] Une personne ayant une fiche STAR dans une église et un rôle de responsable dans une autre
+      église ne voit, ni ne reçoit de notification, concernant une absence en dehors de l'église
+      où cette absence a été déclarée.
+- [ ] La vue transverse ne montre jamais les absences de plusieurs églises simultanément ; elle
+      suit l'église actuellement sélectionnée par l'utilisateur, comme les autres vues de
+      l'application.
+
+## Hors périmètre
+
+- Aucune bascule automatique du statut d'un STAR sur le planning (ex. passage automatique à
+  « indisponible ») suite à la déclaration d'une absence — l'arbitrage reste toujours manuel.
+- Aucun workflow d'approbation/validation de l'absence par un tiers avant qu'elle soit effective.
+- Aucune gestion de quota, de solde ou de décompte d'absences (pas de logique de type congés).
+- Aucune récurrence d'absence (ex. « tous les premiers dimanches du mois ») — chaque absence est
+  une période ponctuelle avec une date de début et une date de fin.
+- Le Secrétariat ne peut pas déclarer d'absence au nom d'un STAR (peut uniquement consulter).
+- Aucune notification vers des rôles hors périmètre du STAR (Faiseur de Disciples, Reporter, ou
+  responsables d'autres départements/ministères non liés au STAR).
+- Aucune vue agrégée ou consolidée des absences à travers plusieurs églises, même pour un
+  Super Admin supervisant plusieurs églises — la consultation reste toujours limitée à une église
+  à la fois.
+
+## Questions ouvertes
+
+Aucune question bloquante restante — tous les points ont été tranchés :
+
+- Notification à l'annulation : systématique, vers les responsables notifiés à la déclaration.
+- Portée de la notification (STAR multi-départements) : tous les responsables de tous les
+  départements/ministères du STAR, pas uniquement ceux en conflit.
+- Impact multi-église : absence toujours rattachée à une seule église, aucune fuite ni vue
+  agrégée cross-église.

--- a/specs/007-gestion-absences-star/tasks.md
+++ b/specs/007-gestion-absences-star/tasks.md
@@ -1,0 +1,105 @@
+# Tâches — Gestion des absences des STAR
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : Terminé
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : migration → services → API → UI → tests. Les tâches `[P]` sont parallélisables.
+
+## Prérequis
+
+- [x] Branche créée : `feat/gestion-absences-star`
+- [x] Migration Prisma générée (T2)
+
+## Tâches
+
+### 1. Données & migration
+
+- [x] **T1** — Ajouter l'enum `AbsenceStatus` (`ACTIVE`/`CANCELLED`), le modèle `Absence` et les
+      relations inverses (`Member.absences`, `Church.absences`, `User.absencesCreated`,
+      `User.absencesCancelled`) *(fichier : `prisma/schema.prisma`)*
+- [x] **T2** — Générer et vérifier la migration (`npm run db:migrate` — nom `add_absences`) ;
+      contrôler le SQL généré *(fichier : `prisma/migrations/…`)*
+
+### 2. Logique métier (services)
+
+- [x] **T3** — Implémenter `findAbsenceConflicts(memberId, churchId, startDate, endDate)` :
+      jointure `Planning → EventDepartment → Event`, filtrée sur `status IN (EN_SERVICE,
+      EN_SERVICE_DEBRIEF)` et chevauchement de dates *(fichier :
+      `src/modules/planning/services/absence.service.ts`)*
+- [x] **T4** — Implémenter `resolveResponsibleUserIds(memberId, churchId)` : union dédupliquée des
+      Resp. département + Ministres couvrant tous les départements du membre *(même fichier que T3)*
+- [x] **T5** — Implémenter `declareAbsence(params)` : vérification membre/église, autorisation
+      (self via `MemberUserLink` ou périmètre départemental via `getUserDepartmentScope`),
+      transaction (création `Absence`, calcul conflits via T3, notifications `ABSENCE_DECLARED` +
+      `ABSENCE_CONFLICT` via T4), émission `planning:absence:declared` *(même fichier que T3)*
+- [x] **T6** — Implémenter `cancelAbsence(absenceId, cancelledById)` : vérification autorisation
+      (créateur, membre lui-même, resp/ministre scopé, ou manager global), transaction (statut
+      `CANCELLED`, notification `ABSENCE_CANCELLED` aux destinataires initiaux), émission
+      `planning:absence:cancelled` *(même fichier que T3)*
+- [x] **T7** [P] — Ajouter les types `planning:absence:declared` et `planning:absence:cancelled`
+      à `PlanningEvents` *(fichier : `src/modules/planning/events.ts`)*
+- [x] **T8** [P] — Ajouter les permissions `absences:view` (`SUPER_ADMIN`, `ADMIN`, `SECRETARY`,
+      `MINISTER`, `DEPARTMENT_HEAD`) et `absences:manage` (`SUPER_ADMIN`, `ADMIN`, `MINISTER`,
+      `DEPARTMENT_HEAD`) au manifeste, et exporter `declareAbsence`, `cancelAbsence`,
+      `findAbsenceConflicts` depuis l'index public *(fichier : `src/modules/planning/index.ts`)*
+
+### 3. API (route handlers)
+
+- [x] **T9** — `GET /api/absences` : query `churchId` (requis), `scope` (`self`\|`all`),
+      `ministryId?`, `departmentId?`, `role?` ; `scope=self` via `requireAuth()` uniquement ;
+      `scope=all` via `requireChurchPermission("absences:view", churchId)` +
+      `getUserDepartmentScope` ; réponse enrichie de `hasConflict`/`conflicts` par absence (via T3)
+      *(fichier : `src/app/api/absences/route.ts`)*
+- [x] **T10** — `POST /api/absences` : validation Zod (`churchId`, `memberId`, `startDate`,
+      `endDate`, `reason?`, `endDate >= startDate`), appel `declareAbsence` (T5), `201`
+      *(même fichier que T9)*
+- [x] **T11** [P] — `PATCH /api/absences/[id]` : action `cancel` uniquement, appel `cancelAbsence`
+      (T6), `404` si absence introuvable, `403` si hors périmètre *(fichier :
+      `src/app/api/absences/[id]/route.ts`)*
+- [x] **T12** [P] — Enrichir la réponse de `GET` avec `activeAbsence: { startDate, endDate } | null`
+      par membre (requête `Absence` `status: ACTIVE` chevauchant `event.date`) *(fichier :
+      `src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts`)*
+
+### 4. UI
+
+- [x] **T13** — Page serveur : résout `churchId` courant (`getCurrentChurchId`), charge les
+      absences « self » + (si `absences:view`) la vue transverse scopée, passe les données au
+      composant client *(fichier : `src/app/(auth)/absences/page.tsx`)*
+- [x] **T14** — Composant client : section « Mes absences » (liste + formulaire déclaration via
+      `Modal`/`Input`/`Button` + annulation), section « Vue d'ensemble » avec `DataTable` et
+      filtres ministère/département/rôle (visible si `absences:view`), action « Déclarer pour un
+      STAR » scopée (si `absences:manage`) *(fichier :
+      `src/app/(auth)/absences/AbsencesClient.tsx`)*
+- [x] **T15** [P] — Ajouter l'entrée de navigation « Absences » (`/absences`), visible à tout
+      utilisateur authentifié comme « Mes demandes » *(fichier : `src/components/Sidebar.tsx`)*
+- [x] **T16** [P] — Ajouter un badge visuel (icône + tooltip période) sur la ligne d'un membre
+      dont `activeAbsence` (T12) chevauche la date de l'événement affiché *(fichier :
+      `src/components/PlanningGrid.tsx`)*
+
+### 5. Tests
+
+- [x] **T17** — Tests unitaires `declareAbsence`/`cancelAbsence`/`findAbsenceConflicts` : absence
+      sans conflit, conflit détecté uniquement sur `EN_SERVICE`/`EN_SERVICE_DEBRIEF` (pas
+      `INDISPONIBLE`/`REMPLACANT`/`null`), notification de tous les responsables sans doublon
+      (STAR multi-départements, utilisateur cumulant Resp. + Ministre), 403 si déclarant hors
+      périmètre (STAR pour un autre STAR, Resp. hors département), 403 si `churchId` incohérent
+      avec l'église du membre, annulation notifie les destinataires initiaux (avec/sans conflit
+      préalable), 403 si annulation hors périmètre *(fichier :
+      `src/modules/planning/services/absence.service.test.ts`)*
+- [x] **T18** — Tests de non-fuite multi-église : un utilisateur avec fiche STAR en église A et
+      rôle responsable en église B ne reçoit aucune notification et ne voit aucune absence de
+      l'église A dans le contexte de l'église B, et réciproquement *(même fichier que T17)*
+- [x] **T19** [P] — Tests d'intégration légers des routes : codes 401/403/404/201/200 sur
+      `GET`/`POST /api/absences` et `PATCH /api/absences/[id]` selon rôle/périmètre (self, resp.
+      scopé, resp. hors périmètre, Secrétaire lecture seule, Admin) *(fichier :
+      `src/app/api/absences/route.test.ts`, `src/app/api/absences/[id]/route.test.ts`)*
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits
+- [x] PR ouverte vers `main`

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -34,6 +34,7 @@ export const prismaMock = {
   request: createModelMock(),
   memberLinkRequest: createModelMock(),
   memberUserLink: createModelMock(),
+  absence: createModelMock(),
   announcement: createModelMock(),
   taskAssignment: createModelMock(),
   eventReport: createModelMock(),

--- a/src/app/(auth)/absences/AbsencesClient.tsx
+++ b/src/app/(auth)/absences/AbsencesClient.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Modal from "@/components/ui/Modal";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
+import DataTable from "@/components/ui/DataTable";
+
+interface MemberRef {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface AbsenceRow {
+  id: string;
+  member: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    departments: { id: string; name: string; ministry: { id: string; name: string } }[];
+  };
+  startDate: string;
+  endDate: string;
+  reason: string | null;
+  status: "ACTIVE" | "CANCELLED";
+  createdBy: { id: string; name: string | null };
+  hasConflict: boolean;
+}
+
+interface AbsencesClientProps {
+  churchId: string;
+  canView: boolean;
+  canManage: boolean;
+  selfMembers: MemberRef[];
+  manageableMembers: MemberRef[];
+  ministries: { id: string; name: string }[];
+  departments: { id: string; name: string; ministryId: string }[];
+}
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat("fr-FR", { day: "2-digit", month: "2-digit", year: "numeric" }).format(new Date(iso));
+}
+
+export default function AbsencesClient({
+  churchId,
+  canView,
+  canManage,
+  selfMembers,
+  manageableMembers,
+  ministries,
+  departments,
+}: AbsencesClientProps) {
+  const [selfAbsences, setSelfAbsences] = useState<AbsenceRow[]>([]);
+  const [allAbsences, setAllAbsences] = useState<AbsenceRow[]>([]);
+  const [loadingSelf, setLoadingSelf] = useState(true);
+  const [loadingAll, setLoadingAll] = useState(canView);
+  const [error, setError] = useState<string | null>(null);
+
+  const [ministryFilter, setMinistryFilter] = useState("");
+  const [departmentFilter, setDepartmentFilter] = useState("");
+  const [roleFilter, setRoleFilter] = useState("");
+
+  const [declareOpen, setDeclareOpen] = useState(false);
+  const [declareMode, setDeclareMode] = useState<"self" | "manage">("self");
+  const [formMemberId, setFormMemberId] = useState("");
+  const [formStartDate, setFormStartDate] = useState("");
+  const [formEndDate, setFormEndDate] = useState("");
+  const [formReason, setFormReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const fetchSelf = useCallback(async () => {
+    setLoadingSelf(true);
+    try {
+      const res = await fetch(`/api/absences?churchId=${churchId}&scope=self`);
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      setSelfAbsences(data.absences);
+    } catch {
+      setError("Erreur lors du chargement de vos absences.");
+    } finally {
+      setLoadingSelf(false);
+    }
+  }, [churchId]);
+
+  const fetchAll = useCallback(async () => {
+    if (!canView) return;
+    setLoadingAll(true);
+    try {
+      const params = new URLSearchParams({ churchId, scope: "all" });
+      if (ministryFilter) params.set("ministryId", ministryFilter);
+      if (departmentFilter) params.set("departmentId", departmentFilter);
+      if (roleFilter) params.set("role", roleFilter);
+      const res = await fetch(`/api/absences?${params.toString()}`);
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      setAllAbsences(data.absences);
+    } catch {
+      setError("Erreur lors du chargement de la vue transverse.");
+    } finally {
+      setLoadingAll(false);
+    }
+  }, [churchId, canView, ministryFilter, departmentFilter, roleFilter]);
+
+  useEffect(() => {
+    fetchSelf();
+  }, [fetchSelf]);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  function openDeclareForSelf() {
+    setDeclareMode("self");
+    setFormMemberId(selfMembers[0]?.id ?? "");
+    setFormStartDate("");
+    setFormEndDate("");
+    setFormReason("");
+    setFormError(null);
+    setDeclareOpen(true);
+  }
+
+  function openDeclareForOther() {
+    setDeclareMode("manage");
+    setFormMemberId("");
+    setFormStartDate("");
+    setFormEndDate("");
+    setFormReason("");
+    setFormError(null);
+    setDeclareOpen(true);
+  }
+
+  async function submitDeclare() {
+    if (!formMemberId || !formStartDate || !formEndDate) {
+      setFormError("Membre, date de début et date de fin sont requis.");
+      return;
+    }
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      const res = await fetch("/api/absences", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          churchId,
+          memberId: formMemberId,
+          startDate: new Date(formStartDate).toISOString(),
+          endDate: new Date(formEndDate).toISOString(),
+          reason: formReason || null,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? "Erreur lors de la déclaration");
+      }
+      setDeclareOpen(false);
+      await Promise.all([fetchSelf(), fetchAll()]);
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : "Erreur lors de la déclaration");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function cancelAbsence(id: string) {
+    try {
+      const res = await fetch(`/api/absences/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "cancel" }),
+      });
+      if (!res.ok) throw new Error();
+      await Promise.all([fetchSelf(), fetchAll()]);
+    } catch {
+      setError("Erreur lors de l'annulation.");
+    }
+  }
+
+  const activeAbsences = selfAbsences.filter((a) => a.status === "ACTIVE");
+  const visibleDepartments = ministryFilter
+    ? departments.filter((d) => d.ministryId === ministryFilter)
+    : departments;
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold text-gray-900">Absences</h1>
+
+      {error && <div className="p-3 bg-red-50 text-red-700 text-sm rounded-lg">{error}</div>}
+
+      {selfMembers.length > 0 && (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-900">Mes absences</h2>
+            <Button size="sm" onClick={openDeclareForSelf}>Déclarer une absence</Button>
+          </div>
+          {loadingSelf ? (
+            <p className="text-gray-500 text-sm">Chargement...</p>
+          ) : (
+            <DataTable
+              data={activeAbsences}
+              emptyMessage="Aucune absence déclarée."
+              columns={[
+                { header: "Période", accessor: (a) => `${formatDate(a.startDate)} → ${formatDate(a.endDate)}` },
+                { header: "Motif", accessor: (a) => a.reason ?? "—" },
+                {
+                  header: "Conflit",
+                  accessor: (a) =>
+                    a.hasConflict ? (
+                      <span className="text-orange-700 font-medium">⚠ Conflit planning</span>
+                    ) : (
+                      "—"
+                    ),
+                },
+              ]}
+              actions={(a) => (
+                <Button size="sm" variant="danger" onClick={() => cancelAbsence(a.id)}>
+                  Annuler
+                </Button>
+              )}
+            />
+          )}
+        </section>
+      )}
+
+      {canView && (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <h2 className="text-lg font-semibold text-gray-900">Vue d&apos;ensemble</h2>
+            {canManage && (
+              <Button size="sm" onClick={openDeclareForOther}>Déclarer pour un STAR</Button>
+            )}
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <Select
+              label="Ministère"
+              placeholder="Tous"
+              value={ministryFilter}
+              onChange={(e) => {
+                setMinistryFilter(e.target.value);
+                setDepartmentFilter("");
+              }}
+              options={ministries.map((m) => ({ value: m.id, label: m.name }))}
+            />
+            <Select
+              label="Département"
+              placeholder="Tous"
+              value={departmentFilter}
+              onChange={(e) => setDepartmentFilter(e.target.value)}
+              options={visibleDepartments.map((d) => ({ value: d.id, label: d.name }))}
+            />
+            <Select
+              label="Rôle du déclarant"
+              placeholder="Tous"
+              value={roleFilter}
+              onChange={(e) => setRoleFilter(e.target.value)}
+              options={[
+                { value: "STAR", label: "STAR" },
+                { value: "DEPARTMENT_HEAD", label: "Resp. département" },
+                { value: "MINISTER", label: "Ministre" },
+              ]}
+            />
+          </div>
+
+          {loadingAll ? (
+            <p className="text-gray-500 text-sm">Chargement...</p>
+          ) : (
+            <DataTable
+              data={allAbsences.filter((a) => a.status === "ACTIVE")}
+              emptyMessage="Aucune absence."
+              columns={[
+                { header: "Membre", accessor: (a) => `${a.member.firstName} ${a.member.lastName}` },
+                {
+                  header: "Département",
+                  accessor: (a) => a.member.departments.map((d) => d.name).join(", ") || "—",
+                },
+                {
+                  header: "Ministère",
+                  accessor: (a) =>
+                    Array.from(new Set(a.member.departments.map((d) => d.ministry.name))).join(", ") || "—",
+                },
+                { header: "Période", accessor: (a) => `${formatDate(a.startDate)} → ${formatDate(a.endDate)}` },
+                { header: "Déclaré par", accessor: (a) => a.createdBy.name ?? "—" },
+                {
+                  header: "Conflit",
+                  accessor: (a) => (a.hasConflict ? <span className="text-orange-700 font-medium">⚠</span> : "—"),
+                },
+              ]}
+              actions={
+                canManage
+                  ? (a) => (
+                      <Button size="sm" variant="danger" onClick={() => cancelAbsence(a.id)}>
+                        Annuler
+                      </Button>
+                    )
+                  : undefined
+              }
+            />
+          )}
+        </section>
+      )}
+
+      <Modal
+        open={declareOpen}
+        onClose={() => setDeclareOpen(false)}
+        title={declareMode === "self" ? "Déclarer une absence" : "Déclarer pour un STAR"}
+      >
+        <div className="space-y-4">
+          {declareMode === "self" && selfMembers.length > 1 && (
+            <Select
+              label="Fiche STAR"
+              value={formMemberId}
+              onChange={(e) => setFormMemberId(e.target.value)}
+              options={selfMembers.map((m) => ({ value: m.id, label: `${m.firstName} ${m.lastName}` }))}
+            />
+          )}
+          {declareMode === "manage" && (
+            <Select
+              label="STAR"
+              placeholder="Sélectionner..."
+              value={formMemberId}
+              onChange={(e) => setFormMemberId(e.target.value)}
+              options={manageableMembers.map((m) => ({ value: m.id, label: `${m.firstName} ${m.lastName}` }))}
+            />
+          )}
+
+          <Input
+            type="date"
+            label="Date de début"
+            value={formStartDate}
+            onChange={(e) => setFormStartDate(e.target.value)}
+          />
+          <Input
+            type="date"
+            label="Date de fin"
+            value={formEndDate}
+            onChange={(e) => setFormEndDate(e.target.value)}
+          />
+          <Input
+            label="Motif (optionnel)"
+            value={formReason}
+            onChange={(e) => setFormReason(e.target.value)}
+          />
+
+          {formError && <p className="text-sm text-red-600">{formError}</p>}
+
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => setDeclareOpen(false)}>Annuler</Button>
+            <Button onClick={submitDeclare} disabled={submitting}>
+              {submitting ? "Envoi..." : "Déclarer"}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/(auth)/absences/page.tsx
+++ b/src/app/(auth)/absences/page.tsx
@@ -1,0 +1,72 @@
+import { requireAuth, getCurrentChurchId, getUserDepartmentScope } from "@/lib/auth";
+import { rolePermissions } from "@/lib/registry";
+import { prisma } from "@/lib/prisma";
+import AbsencesClient from "./AbsencesClient";
+
+export default async function AbsencesPage() {
+  const session = await requireAuth();
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) return <p>Aucune église sélectionnée.</p>;
+
+  const userPermissions = new Set(
+    session.user.churchRoles
+      .filter((r) => r.churchId === churchId)
+      .flatMap((r) => rolePermissions[r.role] ?? [])
+  );
+  const canView = session.user.isSuperAdmin || userPermissions.has("absences:view");
+  const canManage = session.user.isSuperAdmin || userPermissions.has("absences:manage");
+
+  const memberLinks = await prisma.memberUserLink.findMany({
+    where: { userId: session.user.id, churchId },
+    select: { memberId: true, member: { select: { firstName: true, lastName: true } } },
+  });
+  const selfMembers = memberLinks.map((l) => ({
+    id: l.memberId,
+    firstName: l.member.firstName,
+    lastName: l.member.lastName,
+  }));
+
+  const ministries = canView
+    ? await prisma.ministry.findMany({
+        where: { churchId },
+        select: { id: true, name: true },
+        orderBy: { name: "asc" },
+      })
+    : [];
+  const departments = canView
+    ? await prisma.department.findMany({
+        where: { ministry: { churchId } },
+        select: { id: true, name: true, ministryId: true },
+        orderBy: { name: "asc" },
+      })
+    : [];
+
+  let manageableMembers: { id: string; firstName: string; lastName: string }[] = [];
+  if (canManage) {
+    const deptScope = getUserDepartmentScope(session, churchId);
+    const members = await prisma.member.findMany({
+      where: {
+        departments: {
+          some: deptScope.scoped
+            ? { departmentId: { in: deptScope.departmentIds } }
+            : { department: { ministry: { churchId } } },
+        },
+      },
+      select: { id: true, firstName: true, lastName: true },
+      orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    });
+    manageableMembers = members;
+  }
+
+  return (
+    <AbsencesClient
+      churchId={churchId}
+      canView={canView}
+      canManage={canManage}
+      selfMembers={selfMembers}
+      manageableMembers={manageableMembers}
+      ministries={ministries}
+      departments={departments}
+    />
+  );
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -376,6 +376,10 @@ export default async function AuthLayout({
     : null;
   const hasMyPlanning = hasPlanningAccess && memberLink !== null;
 
+  // "Absences" — visible pour tout STAR lié (auto-déclaration) ou tout
+  // responsable/ministre/admin ayant la permission de vue transverse.
+  const hasAbsences = memberLink !== null || userPermissions.has("absences:view");
+
   // Determine the user's primary role for the current church
   const currentRole = churchRoles.find((r) => r.churchId === currentChurchId)?.role ?? "DEPARTMENT_HEAD";
 
@@ -402,6 +406,7 @@ export default async function AuthLayout({
       hasReports={hasReports}
       hasMyPlanning={hasMyPlanning}
       showStarEvents={showStarEvents}
+      hasAbsences={hasAbsences}
       userRole={currentRole as "SUPER_ADMIN" | "ADMIN" | "SECRETARY" | "MINISTER" | "DEPARTMENT_HEAD" | "DISCIPLE_MAKER" | "REPORTER" | "STAR" | "ACCOUNTANT"}
       headerColor={churchPrimaryColor}
       header={headerContent}

--- a/src/app/api/absences/[id]/route.ts
+++ b/src/app/api/absences/[id]/route.ts
@@ -1,0 +1,62 @@
+import { prisma } from "@/lib/prisma";
+import { requireAuth, requireChurchPermission, getUserDepartmentScope } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { cancelAbsence, getMemberScope, isMemberLinkedToUser } from "@/modules/planning";
+import { logAudit } from "@/lib/audit";
+import { z } from "zod";
+
+const patchSchema = z.object({
+  action: z.literal("cancel"),
+});
+
+/**
+ * PATCH /api/absences/[id] — annulation uniquement (aucune autre mutation supportée).
+ *
+ * Autorisé : le créateur, la fiche STAR liée elle-même, un resp./ministre du
+ * périmètre du membre, ou un manager global (absences:manage sans scope).
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await requireAuth();
+    const { id } = await params;
+    patchSchema.parse(await request.json());
+
+    const absence = await prisma.absence.findUnique({ where: { id } });
+    if (!absence) throw new ApiError(404, "Absence introuvable");
+
+    const isCreator = absence.createdById === session.user.id;
+    const isSelf = await isMemberLinkedToUser(absence.memberId, session.user.id, absence.churchId);
+
+    if (!isCreator && !isSelf) {
+      const managerSession = await requireChurchPermission("absences:manage", absence.churchId);
+      const deptScope = getUserDepartmentScope(managerSession, absence.churchId);
+      if (deptScope.scoped) {
+        const memberScope = await getMemberScope(absence.memberId);
+        const withinScope = memberScope?.departmentIds.some((d) => deptScope.departmentIds.includes(d)) ?? false;
+        if (!withinScope) throw new ApiError(403, "Ce STAR n'appartient pas à votre périmètre");
+      }
+    }
+
+    const updated = await cancelAbsence({
+      absenceId: id,
+      churchId: absence.churchId,
+      cancelledById: session.user.id,
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId: absence.churchId,
+      action: "UPDATE",
+      entityType: "Absence",
+      entityId: id,
+      details: { status: "CANCELLED" },
+    });
+
+    return successResponse(updated);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/absences/__tests__/security.test.ts
+++ b/src/app/api/absences/__tests__/security.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createAdminSession } from "@/__mocks__/auth";
+
+const mockRequireAuth = vi.fn();
+const mockRequireChurchPermission = vi.fn();
+const mockGetUserDepartmentScope = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+  requireChurchPermission: (...args: unknown[]) => mockRequireChurchPermission(...args),
+  getUserDepartmentScope: (...args: unknown[]) => mockGetUserDepartmentScope(...args),
+}));
+
+const mockDeclareAbsence = vi.fn();
+const mockCancelAbsence = vi.fn();
+const mockGetMemberScope = vi.fn();
+const mockIsMemberLinkedToUser = vi.fn();
+vi.mock("@/modules/planning", () => ({
+  declareAbsence: (...args: unknown[]) => mockDeclareAbsence(...args),
+  cancelAbsence: (...args: unknown[]) => mockCancelAbsence(...args),
+  findAbsenceConflicts: vi.fn().mockResolvedValue([]),
+  getMemberScope: (...args: unknown[]) => mockGetMemberScope(...args),
+  isMemberLinkedToUser: (...args: unknown[]) => mockIsMemberLinkedToUser(...args),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/audit", () => ({ logAudit: vi.fn().mockResolvedValue(undefined) }));
+
+const { GET, POST } = await import("../route");
+const { PATCH } = await import("../[id]/route");
+
+const validBody = {
+  churchId: "church-1",
+  memberId: "member-1",
+  startDate: "2026-08-01T00:00:00.000Z",
+  endDate: "2026-08-10T00:00:00.000Z",
+};
+
+describe("GET /api/absences", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 without churchId", async () => {
+    const res = await GET(new Request("http://localhost/api/absences"));
+    expect(res.status).toBe(400);
+  });
+
+  it("scope=self does not require any permission, only auth", async () => {
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+    prismaMock.memberUserLink.findMany.mockResolvedValue([]);
+
+    const res = await GET(new Request("http://localhost/api/absences?churchId=church-1&scope=self"));
+
+    expect(res.status).toBe(200);
+    expect(mockRequireChurchPermission).not.toHaveBeenCalled();
+  });
+
+  it("scope=all requires absences:view and returns 403 when missing", async () => {
+    mockRequireChurchPermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const res = await GET(new Request("http://localhost/api/absences?churchId=church-1&scope=all"));
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/absences — authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+    mockGetMemberScope.mockResolvedValue({ churchId: "church-1", departmentIds: ["dept-1"] });
+    mockDeclareAbsence.mockResolvedValue({ id: "abs-1" });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAuth.mockRejectedValue(new Error("UNAUTHORIZED"));
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(validBody) }));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 with invalid body", async () => {
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify({}) }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the STAR record does not exist", async () => {
+    mockGetMemberScope.mockResolvedValue(null);
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(validBody) }));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when memberId belongs to another church", async () => {
+    mockGetMemberScope.mockResolvedValue({ churchId: "church-other", departmentIds: ["dept-1"] });
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(validBody) }));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows self-declaration without absences:manage permission", async () => {
+    mockIsMemberLinkedToUser.mockResolvedValue(true);
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(validBody) }));
+
+    expect(res.status).toBe(201);
+    expect(mockRequireChurchPermission).not.toHaveBeenCalled();
+    expect(mockDeclareAbsence).toHaveBeenCalled();
+  });
+
+  it("returns 403 for a STAR declaring on behalf of another STAR (no absences:manage)", async () => {
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+    mockRequireChurchPermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(validBody) }));
+
+    expect(res.status).toBe(403);
+    expect(mockDeclareAbsence).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when a scoped manager declares for a member outside their departments", async () => {
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockGetUserDepartmentScope.mockReturnValue({ scoped: true, departmentIds: ["dept-mine"] });
+    mockGetMemberScope.mockResolvedValue({ churchId: "church-1", departmentIds: ["dept-other"] });
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(validBody) }));
+
+    expect(res.status).toBe(403);
+    expect(mockDeclareAbsence).not.toHaveBeenCalled();
+  });
+
+  it("allows a scoped manager to declare for a member within their departments", async () => {
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockGetUserDepartmentScope.mockReturnValue({ scoped: true, departmentIds: ["dept-1"] });
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(validBody) }));
+
+    expect(res.status).toBe(201);
+    expect(mockDeclareAbsence).toHaveBeenCalled();
+  });
+
+  it("allows a global manager (unscoped) to declare for any member", async () => {
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockGetUserDepartmentScope.mockReturnValue({ scoped: false });
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(validBody) }));
+
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("PATCH /api/absences/[id] — authorization", () => {
+  const existingAbsence = { id: "abs-1", churchId: "church-1", memberId: "member-1", createdById: "user-owner", status: "ACTIVE" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+    prismaMock.absence.findUnique.mockResolvedValue(existingAbsence as never);
+    mockCancelAbsence.mockResolvedValue({ ...existingAbsence, status: "CANCELLED" });
+  });
+
+  it("returns 404 when the absence does not exist", async () => {
+    prismaMock.absence.findUnique.mockResolvedValue(null);
+
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/unknown", { method: "PATCH", body: JSON.stringify({ action: "cancel" }) }),
+      { params: Promise.resolve({ id: "unknown" }) }
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("allows the creator to cancel without absences:manage", async () => {
+    mockRequireAuth.mockResolvedValue({ ...createAdminSession(), user: { ...createAdminSession().user, id: "user-owner" } });
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/abs-1", { method: "PATCH", body: JSON.stringify({ action: "cancel" }) }),
+      { params: Promise.resolve({ id: "abs-1" }) }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockRequireChurchPermission).not.toHaveBeenCalled();
+  });
+
+  it("allows the linked STAR themselves to cancel", async () => {
+    mockRequireAuth.mockResolvedValue({ ...createAdminSession(), user: { ...createAdminSession().user, id: "user-star" } });
+    mockIsMemberLinkedToUser.mockResolvedValue(true);
+
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/abs-1", { method: "PATCH", body: JSON.stringify({ action: "cancel" }) }),
+      { params: Promise.resolve({ id: "abs-1" }) }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockRequireChurchPermission).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for an unrelated user without absences:manage", async () => {
+    mockRequireAuth.mockResolvedValue({ ...createAdminSession(), user: { ...createAdminSession().user, id: "user-stranger" } });
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+    mockRequireChurchPermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/abs-1", { method: "PATCH", body: JSON.stringify({ action: "cancel" }) }),
+      { params: Promise.resolve({ id: "abs-1" }) }
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockCancelAbsence).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a scoped manager outside the member's departments", async () => {
+    mockRequireAuth.mockResolvedValue({ ...createAdminSession(), user: { ...createAdminSession().user, id: "user-resp" } });
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockGetUserDepartmentScope.mockReturnValue({ scoped: true, departmentIds: ["dept-mine"] });
+    mockGetMemberScope.mockResolvedValue({ churchId: "church-1", departmentIds: ["dept-other"] });
+
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/abs-1", { method: "PATCH", body: JSON.stringify({ action: "cancel" }) }),
+      { params: Promise.resolve({ id: "abs-1" }) }
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockCancelAbsence).not.toHaveBeenCalled();
+  });
+
+  it("allows a global manager (unscoped) to cancel any absence", async () => {
+    mockRequireAuth.mockResolvedValue({ ...createAdminSession(), user: { ...createAdminSession().user, id: "admin-1" } });
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockGetUserDepartmentScope.mockReturnValue({ scoped: false });
+
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/abs-1", { method: "PATCH", body: JSON.stringify({ action: "cancel" }) }),
+      { params: Promise.resolve({ id: "abs-1" }) }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCancelAbsence).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/absences/route.ts
+++ b/src/app/api/absences/route.ts
@@ -1,0 +1,196 @@
+import { prisma } from "@/lib/prisma";
+import { requireAuth, requireChurchPermission, getUserDepartmentScope } from "@/lib/auth";
+import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import {
+  declareAbsence,
+  findAbsenceConflicts,
+  getMemberScope,
+  isMemberLinkedToUser,
+} from "@/modules/planning";
+import { logAudit } from "@/lib/audit";
+import { z } from "zod";
+
+const createSchema = z
+  .object({
+    churchId: z.string().min(1),
+    memberId: z.string().min(1),
+    startDate: z.string().datetime(),
+    endDate: z.string().datetime(),
+    reason: z.string().max(500).nullable().optional(),
+  })
+  .refine((d) => new Date(d.endDate) >= new Date(d.startDate), {
+    message: "endDate doit être postérieure ou égale à startDate",
+    path: ["endDate"],
+  });
+
+/**
+ * GET /api/absences?churchId=...&scope=self|all&ministryId=&departmentId=&role=
+ *
+ * scope=self  : absences des fiches STAR liées au compte appelant (aucune permission requise).
+ * scope=all   : vue transverse, requiert absences:view, scope départemental comme members:view.
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const churchId = searchParams.get("churchId");
+    const scope = searchParams.get("scope") === "all" ? "all" : "self";
+    const ministryId = searchParams.get("ministryId");
+    const departmentId = searchParams.get("departmentId");
+    const roleFilter = searchParams.get("role");
+
+    if (!churchId) throw new ApiError(400, "churchId requis");
+
+    let memberIdFilter: string[] | undefined;
+
+    if (scope === "self") {
+      const session = await requireAuth();
+      const links = await prisma.memberUserLink.findMany({
+        where: { userId: session.user.id, churchId },
+        select: { memberId: true },
+      });
+      memberIdFilter = links.map((l) => l.memberId);
+      if (memberIdFilter.length === 0) return successResponse({ absences: [] });
+    } else {
+      const session = await requireChurchPermission("absences:view", churchId);
+      const deptScope = getUserDepartmentScope(session, churchId);
+      if (deptScope.scoped) {
+        if (deptScope.departmentIds.length === 0) return successResponse({ absences: [] });
+        const members = await prisma.memberDepartment.findMany({
+          where: { departmentId: { in: deptScope.departmentIds } },
+          select: { memberId: true },
+        });
+        memberIdFilter = Array.from(new Set(members.map((m) => m.memberId)));
+        if (memberIdFilter.length === 0) return successResponse({ absences: [] });
+      }
+    }
+
+    if (ministryId || departmentId) {
+      const deptFilterIds = await prisma.memberDepartment.findMany({
+        where: {
+          department: {
+            ...(departmentId ? { id: departmentId } : {}),
+            ...(ministryId ? { ministryId } : {}),
+          },
+        },
+        select: { memberId: true },
+      });
+      const filteredMemberIds = new Set(deptFilterIds.map((m) => m.memberId));
+      memberIdFilter = memberIdFilter
+        ? memberIdFilter.filter((id) => filteredMemberIds.has(id))
+        : Array.from(filteredMemberIds);
+    }
+
+    const absences = await prisma.absence.findMany({
+      where: {
+        churchId,
+        ...(memberIdFilter ? { memberId: { in: memberIdFilter } } : {}),
+      },
+      include: {
+        member: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            departments: { select: { department: { select: { id: true, name: true, ministry: { select: { id: true, name: true } } } } } },
+          },
+        },
+        createdBy: { select: { id: true, name: true, displayName: true } },
+      },
+      orderBy: { startDate: "desc" },
+    });
+
+    let result = absences;
+    if (roleFilter) {
+      const createdByIds = Array.from(new Set(absences.map((a) => a.createdById)));
+      const roles = await prisma.userChurchRole.findMany({
+        where: { userId: { in: createdByIds }, churchId },
+        select: { userId: true, role: true },
+      });
+      const rolesByUser = new Map<string, string[]>();
+      for (const r of roles) {
+        rolesByUser.set(r.userId, [...(rolesByUser.get(r.userId) ?? []), r.role]);
+      }
+      result = absences.filter((a) => (rolesByUser.get(a.createdById) ?? []).includes(roleFilter));
+    }
+
+    const enriched = await Promise.all(
+      result.map(async (a) => {
+        const conflicts = await findAbsenceConflicts(a.memberId, a.churchId, a.startDate, a.endDate);
+        return {
+          id: a.id,
+          member: {
+            id: a.member.id,
+            firstName: a.member.firstName,
+            lastName: a.member.lastName,
+            departments: a.member.departments.map((d) => d.department),
+          },
+          startDate: a.startDate,
+          endDate: a.endDate,
+          reason: a.reason,
+          status: a.status,
+          createdBy: { id: a.createdBy.id, name: a.createdBy.displayName ?? a.createdBy.name },
+          createdAt: a.createdAt,
+          hasConflict: conflicts.length > 0,
+          conflicts,
+        };
+      })
+    );
+
+    return successResponse({ absences: enriched });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+/**
+ * POST /api/absences — déclare une absence.
+ *
+ * Auto-déclaration (STAR lié à la fiche) : aucune permission requise.
+ * Déclaration pour un tiers : requiert absences:manage + périmètre départemental.
+ */
+export async function POST(request: Request) {
+  try {
+    const session = await requireAuth();
+    const data = createSchema.parse(await request.json());
+    const { churchId, memberId } = data;
+
+    const memberScope = await getMemberScope(memberId);
+    if (!memberScope) throw new ApiError(404, "Fiche STAR introuvable");
+    if (memberScope.churchId && memberScope.churchId !== churchId) {
+      throw new ApiError(403, "Cette fiche n'appartient pas à cette église");
+    }
+
+    const isSelf = await isMemberLinkedToUser(memberId, session.user.id, churchId);
+
+    if (!isSelf) {
+      const managerSession = await requireChurchPermission("absences:manage", churchId);
+      const deptScope = getUserDepartmentScope(managerSession, churchId);
+      if (deptScope.scoped) {
+        const withinScope = memberScope.departmentIds.some((id) => deptScope.departmentIds.includes(id));
+        if (!withinScope) throw new ApiError(403, "Ce STAR n'appartient pas à votre périmètre");
+      }
+    }
+
+    const absence = await declareAbsence({
+      churchId,
+      memberId,
+      startDate: new Date(data.startDate),
+      endDate: new Date(data.endDate),
+      reason: data.reason,
+      createdById: session.user.id,
+    });
+
+    await logAudit({
+      userId: session.user.id,
+      churchId,
+      action: "CREATE",
+      entityType: "Absence",
+      entityId: absence.id,
+      details: { memberId, startDate: data.startDate, endDate: data.endDate },
+    });
+
+    return successResponse(absence, 201);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
@@ -15,6 +15,31 @@ const STATUS_LABELS: Record<string, string> = {
   REMPLACANT: "Remplaçant",
 };
 
+/**
+ * Absences actives chevauchant la date de l'événement, par membre — permet
+ * d'afficher un badge dans la grille de planning avant toute affectation.
+ */
+async function findActiveAbsencesByMember(
+  churchId: string,
+  memberIds: string[],
+  eventDate: Date | undefined
+): Promise<Map<string, { startDate: Date; endDate: Date }>> {
+  if (!eventDate || memberIds.length === 0) return new Map();
+
+  const absences = await prisma.absence.findMany({
+    where: {
+      churchId,
+      status: "ACTIVE",
+      memberId: { in: memberIds },
+      startDate: { lte: eventDate },
+      endDate: { gte: eventDate },
+    },
+    select: { memberId: true, startDate: true, endDate: true },
+  });
+
+  return new Map(absences.map((a) => [a.memberId, { startDate: a.startDate, endDate: a.endDate }]));
+}
+
 export async function GET(
   _request: Request,
   {
@@ -54,7 +79,7 @@ export async function GET(
         eventId_departmentId: { eventId, departmentId },
       },
       include: {
-        event: { select: { planningDeadline: true } },
+        event: { select: { date: true, planningDeadline: true } },
         plannings: {
           include: { member: true },
         },
@@ -87,12 +112,18 @@ export async function GET(
 
       const event = await prisma.event.findUnique({
         where: { id: eventId },
-        select: { planningDeadline: true },
+        select: { date: true, planningDeadline: true },
       });
 
       const deadlinePassed = event?.planningDeadline
         ? new Date() > new Date(event.planningDeadline)
         : false;
+
+      const absenceByMember = await findActiveAbsencesByMember(
+        churchId,
+        department.memberDepts.map(({ member }) => member.id),
+        event?.date
+      );
 
       return successResponse({
         eventDepartment: null,
@@ -100,12 +131,19 @@ export async function GET(
           ...m,
           status: null,
           planningId: null,
+          activeAbsence: absenceByMember.get(m.id) ?? null,
         })),
         planningDeadline: event?.planningDeadline ?? null,
         deadlinePassed,
         canBypassDeadline,
       });
     }
+
+    const absenceByMember = await findActiveAbsencesByMember(
+      churchId,
+      eventDept.department.memberDepts.map(({ member }) => member.id),
+      eventDept.event.date
+    );
 
     const members = eventDept.department.memberDepts.map(({ member }) => {
       const planning = eventDept.plannings.find(
@@ -115,6 +153,7 @@ export async function GET(
         ...member,
         status: planning?.status || null,
         planningId: planning?.id || null,
+        activeAbsence: absenceByMember.get(member.id) ?? null,
       };
     });
 

--- a/src/components/AuthLayoutShell.tsx
+++ b/src/components/AuthLayoutShell.tsx
@@ -37,6 +37,7 @@ interface AuthLayoutShellProps {
   hasReports: boolean;
   hasMyPlanning?: boolean;
   showStarEvents?: boolean;
+  hasAbsences?: boolean;
   hasAccounting?: boolean;
   hasJobs?: boolean;
   hasJobsManage?: boolean;
@@ -75,6 +76,7 @@ export default function AuthLayoutShell({
   hasReports,
   hasMyPlanning = false,
   showStarEvents = false,
+  hasAbsences = false,
   hasAccounting = false,
   hasJobs = false,
   hasJobsManage = false,
@@ -142,6 +144,7 @@ export default function AuthLayoutShell({
             hasReports={hasReports}
             hasMyPlanning={hasMyPlanning}
             showStarEvents={showStarEvents}
+            hasAbsences={hasAbsences}
             hasAccounting={hasAccounting}
             hasJobs={hasJobs}
             hasJobsManage={hasJobsManage}
@@ -169,6 +172,7 @@ export default function AuthLayoutShell({
           hasReports={hasReports}
           hasMyPlanning={hasMyPlanning}
           showStarEvents={showStarEvents}
+          hasAbsences={hasAbsences}
           hasAccounting={hasAccounting}
           hasJobs={hasJobs}
           hasJobsManage={hasJobsManage}

--- a/src/components/MobileNavSheet.tsx
+++ b/src/components/MobileNavSheet.tsx
@@ -24,6 +24,7 @@ interface MobileNavSheetProps {
   hasReports?: boolean;
   hasMyPlanning?: boolean;
   showStarEvents?: boolean;
+  hasAbsences?: boolean;
   hasAccounting?: boolean;
   hasJobs?: boolean;
   hasJobsManage?: boolean;
@@ -62,6 +63,15 @@ function IconMyPlanning({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+    </svg>
+  );
+}
+
+function IconAbsence({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 16l2 2 4-4" />
     </svg>
   );
 }
@@ -248,6 +258,7 @@ export default function MobileNavSheet({
   hasMembersAccess = false,
   hasReports = false,
   hasMyPlanning = false,
+  hasAbsences = false,
   showStarEvents = false,
   hasAccounting = false,
   hasJobs = false,
@@ -409,6 +420,15 @@ export default function MobileNavSheet({
             icon={<IconCalendar className="w-5 h-5" />}
             href="/planning/events"
             isActive={pathname.startsWith("/planning/events")}
+            onClose={onClose}
+          />
+        )}
+        {hasAbsences && (
+          <RootRow
+            label="Absences"
+            icon={<IconAbsence className="w-5 h-5" />}
+            href="/absences"
+            isActive={pathname.startsWith("/absences")}
             onClose={onClose}
           />
         )}

--- a/src/components/PlanningGrid.tsx
+++ b/src/components/PlanningGrid.tsx
@@ -17,14 +17,22 @@ function formatAbsencePeriod(activeAbsence: { startDate: string; endDate: string
   return `Absence déclarée du ${fmt.format(new Date(activeAbsence.startDate))} au ${fmt.format(new Date(activeAbsence.endDate))}`;
 }
 
+function formatAbsencePeriodShort(activeAbsence: { startDate: string; endDate: string }): string {
+  const fmt = new Intl.DateTimeFormat("fr-FR", { day: "2-digit", month: "2-digit" });
+  return `${fmt.format(new Date(activeAbsence.startDate))}–${fmt.format(new Date(activeAbsence.endDate))}`;
+}
+
+// La période est affichée en texte (pas seulement via `title`) car les tooltips
+// hover ne sont pas accessibles au toucher sur mobile.
 function AbsenceBadge({ activeAbsence }: { activeAbsence: { startDate: string; endDate: string } }) {
   return (
     <span
       title={formatAbsencePeriod(activeAbsence)}
-      className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-orange-100 text-orange-700 text-xs shrink-0"
       aria-label={formatAbsencePeriod(activeAbsence)}
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-orange-100 text-orange-700 text-xs shrink-0 whitespace-nowrap"
     >
-      ⚠
+      <span aria-hidden="true">⚠</span>
+      {formatAbsencePeriodShort(activeAbsence)}
     </span>
   );
 }

--- a/src/components/PlanningGrid.tsx
+++ b/src/components/PlanningGrid.tsx
@@ -9,6 +9,24 @@ interface MemberPlanning {
   lastName: string;
   status: string | null;
   planningId: string | null;
+  activeAbsence?: { startDate: string; endDate: string } | null;
+}
+
+function formatAbsencePeriod(activeAbsence: { startDate: string; endDate: string }): string {
+  const fmt = new Intl.DateTimeFormat("fr-FR", { day: "2-digit", month: "2-digit" });
+  return `Absence déclarée du ${fmt.format(new Date(activeAbsence.startDate))} au ${fmt.format(new Date(activeAbsence.endDate))}`;
+}
+
+function AbsenceBadge({ activeAbsence }: { activeAbsence: { startDate: string; endDate: string } }) {
+  return (
+    <span
+      title={formatAbsencePeriod(activeAbsence)}
+      className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-orange-100 text-orange-700 text-xs shrink-0"
+      aria-label={formatAbsencePeriod(activeAbsence)}
+    >
+      ⚠
+    </span>
+  );
 }
 
 interface PlanningGridProps {
@@ -219,8 +237,9 @@ export default function PlanningGrid({
               key={member.id}
               className={`flex items-center justify-between gap-3 p-3 rounded-lg border border-gray-200 ${current.color}`}
             >
-              <span className="text-sm font-medium truncate min-w-0">
-                {member.firstName} {member.lastName}
+              <span className="flex items-center gap-1.5 text-sm font-medium truncate min-w-0">
+                <span className="truncate">{member.firstName} {member.lastName}</span>
+                {member.activeAbsence && <AbsenceBadge activeAbsence={member.activeAbsence} />}
               </span>
               {isReadOnly ? (
                 <span className="text-xs font-semibold shrink-0">{current.label}</span>
@@ -261,7 +280,10 @@ export default function PlanningGrid({
             {members.map((member) => (
               <tr key={member.id} className="hover:bg-gray-50">
                 <td className="px-4 py-3 text-sm text-gray-900">
-                  {member.firstName} {member.lastName}
+                  <span className="flex items-center gap-1.5">
+                    <span>{member.firstName} {member.lastName}</span>
+                    {member.activeAbsence && <AbsenceBadge activeAbsence={member.activeAbsence} />}
+                  </span>
                 </td>
                 <td className="px-4 py-3">
                   <div className="flex items-center justify-center gap-1">

--- a/src/components/PlanningGrid.tsx
+++ b/src/components/PlanningGrid.tsx
@@ -243,29 +243,31 @@ export default function PlanningGrid({
           return (
             <div
               key={member.id}
-              className={`flex items-center justify-between gap-3 p-3 rounded-lg border border-gray-200 ${current.color}`}
+              className={`flex flex-col gap-1.5 p-3 rounded-lg border border-gray-200 ${current.color}`}
             >
-              <span className="flex items-center gap-1.5 text-sm font-medium truncate min-w-0">
-                <span className="truncate">{member.firstName} {member.lastName}</span>
-                {member.activeAbsence && <AbsenceBadge activeAbsence={member.activeAbsence} />}
-              </span>
-              {isReadOnly ? (
-                <span className="text-xs font-semibold shrink-0">{current.label}</span>
-              ) : (
-                <select
-                  value={member.status || ""}
-                  onChange={(e) =>
-                    handleStatusChange(member.id, e.target.value || null)
-                  }
-                  className="text-sm border border-gray-300 rounded-md px-2 py-1.5 bg-white shrink-0"
-                >
-                  {STATUS_OPTIONS.map((option) => (
-                    <option key={option.value || "none"} value={option.value || ""}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              )}
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-medium truncate min-w-0">
+                  {member.firstName} {member.lastName}
+                </span>
+                {isReadOnly ? (
+                  <span className="text-xs font-semibold shrink-0">{current.label}</span>
+                ) : (
+                  <select
+                    value={member.status || ""}
+                    onChange={(e) =>
+                      handleStatusChange(member.id, e.target.value || null)
+                    }
+                    className="text-sm border border-gray-300 rounded-md px-2 py-1.5 bg-white shrink-0"
+                  >
+                    {STATUS_OPTIONS.map((option) => (
+                      <option key={option.value || "none"} value={option.value || ""}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+              {member.activeAbsence && <AbsenceBadge activeAbsence={member.activeAbsence} />}
             </div>
           );
         })}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,6 +22,7 @@ interface SidebarProps {
   hasReports?: boolean;
   hasMyPlanning?: boolean;
   showStarEvents?: boolean;
+  hasAbsences?: boolean;
   hasAccounting?: boolean;
   hasJobs?: boolean;
   hasJobsManage?: boolean;
@@ -59,6 +60,15 @@ function IconMembers({ className }: { className?: string }) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+    </svg>
+  );
+}
+
+function IconAbsence({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 16l2 2 4-4" />
     </svg>
   );
 }
@@ -324,6 +334,7 @@ export default function Sidebar({
   hasReports = false,
   hasMyPlanning = false,
   showStarEvents = false,
+  hasAbsences = false,
   hasAccounting = false,
   hasJobs = false,
   hasJobsManage = false,
@@ -338,6 +349,7 @@ export default function Sidebar({
   const isDashboardActive = pathname === "/dashboard";
   const isMyPlanningActive = pathname === "/planning";
   const isStarEventsActive = pathname.startsWith("/planning/events");
+  const isAbsencesActive = pathname.startsWith("/absences");
   const isEventsActive =
     pathname.startsWith("/events") ||
     pathname.startsWith("/admin/events") ||
@@ -513,6 +525,22 @@ export default function Sidebar({
         >
           <IconMyPlanning className="w-4 h-4" />
           Mon planning
+        </Link>
+      )}
+
+      {/* Absences (STAR liés à une fiche, ou responsables/ministres/admin) */}
+      {hasAbsences && (
+        <Link
+          href="/absences"
+          onClick={onClose}
+          className={`flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm font-semibold tracking-wide transition-colors ${
+            isAbsencesActive
+              ? "bg-icc-violet-light text-icc-violet"
+              : "text-gray-600 hover:bg-gray-50"
+          }`}
+        >
+          <IconAbsence className="w-4 h-4" />
+          Absences
         </Link>
       )}
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -21,6 +21,8 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "accounting:manage",
     "accounting:stats",
     "accounting:submit",
+    "absences:view",
+    "absences:manage",
   ],
   ADMIN: [
     "planning:view",
@@ -39,6 +41,8 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "accounting:manage",
     "accounting:stats",
     "accounting:submit",
+    "absences:view",
+    "absences:manage",
   ],
   SECRETARY: [
     "planning:view",
@@ -52,6 +56,7 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "reports:view",
     "reports:edit",
     "accounting:stats",
+    "absences:view",
   ],
   MINISTER: [
     "planning:view",
@@ -64,6 +69,8 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "discipleship:view",
     "accounting:view",
     "accounting:submit",
+    "absences:view",
+    "absences:manage",
   ],
   DEPARTMENT_HEAD: [
     "planning:view",
@@ -75,6 +82,8 @@ const ROLE_PERMISSIONS: Record<Role, string[]> = {
     "discipleship:view",
     "accounting:view",
     "accounting:submit",
+    "absences:view",
+    "absences:manage",
   ],
   DISCIPLE_MAKER: [
     "discipleship:view",

--- a/src/modules/__tests__/manifests.test.ts
+++ b/src/modules/__tests__/manifests.test.ts
@@ -38,6 +38,8 @@ describe("Manifestes des modules", () => {
     const permNames = Object.keys(perms).sort();
 
     expect(permNames).toEqual([
+      "absences:manage",
+      "absences:view",
       "church:manage",
       "departments:manage",
       "departments:view",

--- a/src/modules/planning/events.ts
+++ b/src/modules/planning/events.ts
@@ -64,4 +64,24 @@ export type PlanningEvents = {
     /** Payload brut de la Request, pour utilisation par les handlers cross-module. */
     payload: Record<string, unknown>;
   };
+
+  /** Une absence a été déclarée pour un STAR (par lui-même ou son responsable/ministre). */
+  "planning:absence:declared": {
+    absenceId: string;
+    churchId: string;
+    memberId: string;
+    startDate: string;
+    endDate: string;
+    createdById: string;
+    hasConflict: boolean;
+  };
+
+  /** Une absence a été annulée. */
+  "planning:absence:cancelled": {
+    absenceId: string;
+    churchId: string;
+    memberId: string;
+    cancelledById: string;
+    hadConflict: boolean;
+  };
 }

--- a/src/modules/planning/index.ts
+++ b/src/modules/planning/index.ts
@@ -5,6 +5,15 @@ export type { PlanningEvents } from "./events";
 export { executeRequest } from "./services/request-executor";
 export type { ExecutionResult } from "./services/request-executor";
 export { deleteEvents } from "./services/event.service";
+export {
+  declareAbsence,
+  cancelAbsence,
+  findAbsenceConflicts,
+  resolveResponsibleUserIds,
+  isMemberLinkedToUser,
+  getMemberScope,
+} from "./services/absence.service";
+export type { AbsenceConflict } from "./services/absence.service";
 
 /**
  * Module planning — ex-Koinonia.
@@ -40,6 +49,9 @@ export const planningModule = defineModule({
     // Comptes rendus
     "reports:view":        ["SUPER_ADMIN", "ADMIN", "SECRETARY", "REPORTER"],
     "reports:edit":        ["SUPER_ADMIN", "ADMIN", "SECRETARY", "REPORTER"],
+    // Absences des STAR
+    "absences:view":       ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD"],
+    "absences:manage":     ["SUPER_ADMIN", "ADMIN", "MINISTER", "DEPARTMENT_HEAD"],
   },
 
   navigation: [

--- a/src/modules/planning/services/absence.service.test.ts
+++ b/src/modules/planning/services/absence.service.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+const { declareAbsence, cancelAbsence, findAbsenceConflicts, resolveResponsibleUserIds } =
+  await import("@/modules/planning");
+const { planningBus } = await import("@/modules/planning");
+
+function notifiedUserIds() {
+  return prismaMock.notification.create.mock.calls.map((c) => (c[0] as { data: { userId: string } }).data.userId);
+}
+
+function notificationsOfType(type: string) {
+  return prismaMock.notification.create.mock.calls
+    .map((c) => (c[0] as { data: { userId: string; type: string } }).data)
+    .filter((d) => d.type === type);
+}
+
+describe("findAbsenceConflicts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ne détecte aucun conflit quand aucun service ne chevauche la période", async () => {
+    prismaMock.planning.findMany.mockResolvedValue([]);
+
+    const conflicts = await findAbsenceConflicts(
+      "member-1",
+      "church-1",
+      new Date("2026-08-01"),
+      new Date("2026-08-10")
+    );
+
+    expect(conflicts).toEqual([]);
+  });
+
+  it("ne filtre que sur EN_SERVICE / EN_SERVICE_DEBRIEF", async () => {
+    prismaMock.planning.findMany.mockResolvedValue([]);
+
+    await findAbsenceConflicts("member-1", "church-1", new Date("2026-08-01"), new Date("2026-08-10"));
+
+    expect(prismaMock.planning.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: ["EN_SERVICE", "EN_SERVICE_DEBRIEF"] },
+        }),
+      })
+    );
+  });
+
+  it("retourne les conflits détectés avec les infos de l'événement", async () => {
+    const eventDate = new Date("2026-08-05");
+    prismaMock.planning.findMany.mockResolvedValue([
+      { eventDepartment: { departmentId: "dept-1", event: { id: "evt-1", title: "Culte", date: eventDate } } },
+    ] as never);
+
+    const conflicts = await findAbsenceConflicts(
+      "member-1",
+      "church-1",
+      new Date("2026-08-01"),
+      new Date("2026-08-10")
+    );
+
+    expect(conflicts).toEqual([{ eventId: "evt-1", title: "Culte", date: eventDate, departmentId: "dept-1" }]);
+  });
+});
+
+describe("resolveResponsibleUserIds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retourne un tableau vide si le membre n'a aucun département", async () => {
+    prismaMock.memberDepartment.findMany.mockResolvedValue([]);
+
+    const ids = await resolveResponsibleUserIds("member-1", "church-1");
+
+    expect(ids).toEqual([]);
+    expect(prismaMock.userDepartment.findMany).not.toHaveBeenCalled();
+  });
+
+  it("dédoublonne un utilisateur qui cumule Resp. département et Ministre", async () => {
+    prismaMock.memberDepartment.findMany.mockResolvedValue([
+      { department: { id: "dept-1", ministryId: "min-1" } },
+      { department: { id: "dept-2", ministryId: "min-2" } },
+    ] as never);
+    prismaMock.userDepartment.findMany.mockResolvedValue([
+      { userChurchRole: { userId: "user-resp1" } },
+    ] as never);
+    prismaMock.userChurchRole.findMany.mockResolvedValue([
+      { userId: "user-resp1" },
+      { userId: "user-resp2" },
+    ] as never);
+
+    const ids = await resolveResponsibleUserIds("member-1", "church-1");
+
+    expect(new Set(ids)).toEqual(new Set(["user-resp1", "user-resp2"]));
+    expect(ids.length).toBe(2);
+  });
+
+  it("scope systématiquement les requêtes sur le churchId fourni (pas de fuite cross-église)", async () => {
+    prismaMock.memberDepartment.findMany.mockResolvedValue([
+      { department: { id: "dept-1", ministryId: "min-1" } },
+    ] as never);
+    prismaMock.userDepartment.findMany.mockResolvedValue([] as never);
+    prismaMock.userChurchRole.findMany.mockResolvedValue([] as never);
+
+    await resolveResponsibleUserIds("member-1", "church-A");
+
+    expect(prismaMock.userDepartment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userChurchRole: expect.objectContaining({ churchId: "church-A" }) }),
+      })
+    );
+    expect(prismaMock.userChurchRole.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ churchId: "church-A" }) })
+    );
+  });
+});
+
+describe("declareAbsence", () => {
+  const baseParams = {
+    churchId: "church-1",
+    memberId: "member-1",
+    startDate: new Date("2026-08-01"),
+    endDate: new Date("2026-08-10"),
+    reason: null,
+    createdById: "user-1",
+  };
+
+  const createdAbsence = {
+    id: "abs-1",
+    churchId: "church-1",
+    memberId: "member-1",
+    startDate: baseParams.startDate,
+    endDate: baseParams.endDate,
+    reason: null,
+    status: "ACTIVE",
+    createdById: "user-1",
+    cancelledById: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    cancelledAt: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    planningBus.clear();
+    prismaMock.member.findUnique.mockResolvedValue({ firstName: "Jean", lastName: "Dupont" } as never);
+    prismaMock.absence.create.mockResolvedValue(createdAbsence as never);
+    prismaMock.memberDepartment.findMany.mockResolvedValue([
+      { department: { id: "dept-1", ministryId: "min-1" } },
+      { department: { id: "dept-2", ministryId: "min-2" } },
+    ] as never);
+    prismaMock.userDepartment.findMany.mockResolvedValue([
+      { userChurchRole: { userId: "user-resp1" } },
+    ] as never);
+    prismaMock.userChurchRole.findMany.mockResolvedValue([
+      { userId: "user-resp1" },
+      { userId: "user-resp2" },
+    ] as never);
+    prismaMock.memberUserLink.findMany.mockResolvedValue([{ userId: "user-star" }] as never);
+    prismaMock.notification.create.mockResolvedValue({} as never);
+  });
+
+  it("crée l'absence et retourne l'enregistrement créé", async () => {
+    prismaMock.planning.findMany.mockResolvedValue([]);
+
+    const result = await declareAbsence(baseParams);
+
+    expect(result).toEqual(createdAbsence);
+  });
+
+  it("notifie tous les responsables de tous les départements sans doublon (sans conflit)", async () => {
+    prismaMock.planning.findMany.mockResolvedValue([]);
+
+    await declareAbsence(baseParams);
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(2);
+    expect(new Set(notifiedUserIds())).toEqual(new Set(["user-resp1", "user-resp2"]));
+    expect(notificationsOfType("ABSENCE_CONFLICT")).toHaveLength(0);
+  });
+
+  it("notifie en plus le STAR quand un conflit est détecté", async () => {
+    prismaMock.planning.findMany.mockResolvedValue([
+      { eventDepartment: { departmentId: "dept-1", event: { id: "evt-1", title: "Culte", date: new Date("2026-08-05") } } },
+    ] as never);
+
+    await declareAbsence(baseParams);
+
+    const declared = notificationsOfType("ABSENCE_DECLARED");
+    const conflicts = notificationsOfType("ABSENCE_CONFLICT");
+
+    expect(declared).toHaveLength(2); // resp1, resp2
+    expect(new Set(conflicts.map((c) => c.userId))).toEqual(new Set(["user-resp1", "user-resp2", "user-star"]));
+  });
+
+  it("émet planning:absence:declared avec hasConflict à jour", async () => {
+    prismaMock.planning.findMany.mockResolvedValue([
+      { eventDepartment: { departmentId: "dept-1", event: { id: "evt-1", title: "Culte", date: new Date("2026-08-05") } } },
+    ] as never);
+    const handler = vi.fn();
+    planningBus.on("planning:absence:declared", handler);
+
+    await declareAbsence(baseParams);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][1]).toMatchObject({ memberId: "member-1", hasConflict: true });
+  });
+
+  it("lève une ApiError 404 si la fiche STAR est introuvable", async () => {
+    prismaMock.member.findUnique.mockResolvedValue(null);
+
+    await expect(declareAbsence(baseParams)).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe("cancelAbsence", () => {
+  const existingAbsence = {
+    id: "abs-1",
+    churchId: "church-1",
+    memberId: "member-1",
+    startDate: new Date("2026-08-01"),
+    endDate: new Date("2026-08-10"),
+    reason: null,
+    status: "ACTIVE",
+    createdById: "user-1",
+    cancelledById: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    cancelledAt: null,
+    member: { firstName: "Jean", lastName: "Dupont" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    planningBus.clear();
+    prismaMock.absence.findUnique.mockResolvedValue(existingAbsence as never);
+    prismaMock.absence.update.mockResolvedValue({ ...existingAbsence, status: "CANCELLED" } as never);
+    prismaMock.memberDepartment.findMany.mockResolvedValue([
+      { department: { id: "dept-1", ministryId: "min-1" } },
+    ] as never);
+    prismaMock.userDepartment.findMany.mockResolvedValue([
+      { userChurchRole: { userId: "user-resp1" } },
+    ] as never);
+    prismaMock.userChurchRole.findMany.mockResolvedValue([] as never);
+    prismaMock.memberUserLink.findMany.mockResolvedValue([{ userId: "user-star" }] as never);
+    prismaMock.notification.create.mockResolvedValue({} as never);
+  });
+
+  it("notifie systématiquement les responsables déjà notifiés à la déclaration", async () => {
+    prismaMock.planning.findMany.mockResolvedValue([]); // pas de conflit préalable
+
+    await cancelAbsence({ absenceId: "abs-1", churchId: "church-1", cancelledById: "user-1" });
+
+    expect(new Set(notifiedUserIds())).toEqual(new Set(["user-resp1"]));
+  });
+
+  it("notifie aussi le STAR si un conflit préexistait", async () => {
+    prismaMock.planning.findMany.mockResolvedValue([
+      { eventDepartment: { departmentId: "dept-1", event: { id: "evt-1", title: "Culte", date: new Date("2026-08-05") } } },
+    ] as never);
+
+    await cancelAbsence({ absenceId: "abs-1", churchId: "church-1", cancelledById: "user-1" });
+
+    expect(new Set(notifiedUserIds())).toEqual(new Set(["user-resp1", "user-star"]));
+  });
+
+  it("refuse (403) si l'absence n'appartient pas à cette église", async () => {
+    prismaMock.absence.findUnique.mockResolvedValue({ ...existingAbsence, churchId: "church-other" } as never);
+
+    await expect(
+      cancelAbsence({ absenceId: "abs-1", churchId: "church-1", cancelledById: "user-1" })
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("refuse (409) si l'absence est déjà annulée", async () => {
+    prismaMock.absence.findUnique.mockResolvedValue({ ...existingAbsence, status: "CANCELLED" } as never);
+
+    await expect(
+      cancelAbsence({ absenceId: "abs-1", churchId: "church-1", cancelledById: "user-1" })
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("lève une ApiError 404 si l'absence est introuvable", async () => {
+    prismaMock.absence.findUnique.mockResolvedValue(null);
+
+    await expect(
+      cancelAbsence({ absenceId: "unknown", churchId: "church-1", cancelledById: "user-1" })
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});

--- a/src/modules/planning/services/absence.service.ts
+++ b/src/modules/planning/services/absence.service.ts
@@ -1,0 +1,288 @@
+import type { Prisma, Absence } from "@/generated/prisma/client";
+import { ApiError } from "@/lib/api-utils";
+import { planningBus } from "../bus";
+
+type DbClient = Prisma.TransactionClient;
+
+/**
+ * Import différé du singleton Prisma — évite d'instancier un vrai client
+ * (driver adapter MariaDB) au simple chargement du module `planning`, ce qui
+ * casserait les tests import ant `@/modules/planning` sans mocker `@/lib/prisma`.
+ */
+async function defaultDb(): Promise<DbClient> {
+  const { prisma } = await import("@/lib/prisma");
+  return prisma;
+}
+
+export interface AbsenceConflict {
+  eventId: string;
+  title: string;
+  date: Date;
+  departmentId: string;
+}
+
+function formatPeriod(startDate: Date, endDate: Date): string {
+  const fmt = new Intl.DateTimeFormat("fr-FR", { day: "2-digit", month: "2-digit", year: "numeric" });
+  return `${fmt.format(startDate)} au ${fmt.format(endDate)}`;
+}
+
+/**
+ * Cherche les services déjà planifiés (EN_SERVICE / EN_SERVICE_DEBRIEF) du membre
+ * dont la date chevauche la période donnée. Jamais persisté : recalculé à chaque appel.
+ */
+export async function findAbsenceConflicts(
+  memberId: string,
+  churchId: string,
+  startDate: Date,
+  endDate: Date,
+  db?: DbClient
+): Promise<AbsenceConflict[]> {
+  db ??= await defaultDb();
+  const plannings = await db.planning.findMany({
+    where: {
+      memberId,
+      status: { in: ["EN_SERVICE", "EN_SERVICE_DEBRIEF"] },
+      eventDepartment: { event: { churchId, date: { gte: startDate, lte: endDate } } },
+    },
+    select: {
+      eventDepartment: {
+        select: {
+          departmentId: true,
+          event: { select: { id: true, title: true, date: true } },
+        },
+      },
+    },
+  });
+
+  return plannings.map((p) => ({
+    eventId: p.eventDepartment.event.id,
+    title: p.eventDepartment.event.title,
+    date: p.eventDepartment.event.date,
+    departmentId: p.eventDepartment.departmentId,
+  }));
+}
+
+/** Union dédupliquée des Resp. département + Ministres couvrant tous les départements du membre. */
+export async function resolveResponsibleUserIds(
+  memberId: string,
+  churchId: string,
+  db?: DbClient
+): Promise<string[]> {
+  db ??= await defaultDb();
+  const memberDepts = await db.memberDepartment.findMany({
+    where: { memberId },
+    select: { department: { select: { id: true, ministryId: true } } },
+  });
+
+  const departmentIds = memberDepts.map((d) => d.department.id);
+  if (departmentIds.length === 0) return [];
+
+  const ministryIds = Array.from(new Set(memberDepts.map((d) => d.department.ministryId)));
+
+  const deptHeads = await db.userDepartment.findMany({
+    where: { departmentId: { in: departmentIds }, userChurchRole: { churchId, role: "DEPARTMENT_HEAD" } },
+    select: { userChurchRole: { select: { userId: true } } },
+  });
+
+  const ministers = await db.userChurchRole.findMany({
+    where: { churchId, role: "MINISTER", ministryId: { in: ministryIds } },
+    select: { userId: true },
+  });
+
+  return Array.from(
+    new Set([...deptHeads.map((d) => d.userChurchRole.userId), ...ministers.map((m) => m.userId)])
+  );
+}
+
+/** Vrai si `userId` a une fiche STAR (`memberId`) liée dans cette église. */
+export async function isMemberLinkedToUser(
+  memberId: string,
+  userId: string,
+  churchId: string,
+  db?: DbClient
+): Promise<boolean> {
+  db ??= await defaultDb();
+  const link = await db.memberUserLink.findFirst({ where: { memberId, userId, churchId } });
+  return !!link;
+}
+
+/** Église et départements du membre, pour vérifier l'appartenance et le périmètre. */
+export async function getMemberScope(
+  memberId: string,
+  db?: DbClient
+): Promise<{ churchId: string | null; departmentIds: string[] } | null> {
+  db ??= await defaultDb();
+  const member = await db.member.findUnique({
+    where: { id: memberId },
+    select: {
+      departments: { select: { department: { select: { id: true, ministry: { select: { churchId: true } } } } } },
+    },
+  });
+  if (!member) return null;
+
+  const departmentIds = member.departments.map((d) => d.department.id);
+  const churchIds = new Set(member.departments.map((d) => d.department.ministry.churchId));
+  return { churchId: churchIds.size === 1 ? [...churchIds][0] : null, departmentIds };
+}
+
+interface DeclareAbsenceParams {
+  churchId: string;
+  memberId: string;
+  startDate: Date;
+  endDate: Date;
+  reason?: string | null;
+  createdById: string;
+}
+
+/**
+ * Déclare une absence, calcule les conflits avec le planning existant, notifie
+ * les responsables (et le STAR en cas de conflit), puis émet l'événement bus.
+ *
+ * L'autorisation (auto-déclaration ou périmètre resp./ministre) est vérifiée par
+ * la route appelante avant d'invoquer ce service.
+ */
+export async function declareAbsence(params: DeclareAbsenceParams): Promise<Absence> {
+  const { churchId, memberId, startDate, endDate, reason, createdById } = params;
+  const { prisma } = await import("@/lib/prisma");
+
+  const member = await prisma.member.findUnique({
+    where: { id: memberId },
+    select: { firstName: true, lastName: true },
+  });
+  if (!member) throw new ApiError(404, "Fiche STAR introuvable");
+
+  return prisma.$transaction(async (tx) => {
+    const absence = await tx.absence.create({
+      data: { churchId, memberId, startDate, endDate, reason: reason ?? null, createdById },
+    });
+
+    const conflicts = await findAbsenceConflicts(memberId, churchId, startDate, endDate, tx);
+    const hasConflict = conflicts.length > 0;
+    const responsibleUserIds = await resolveResponsibleUserIds(memberId, churchId, tx);
+
+    const memberName = `${member.firstName} ${member.lastName}`;
+    const period = formatPeriod(startDate, endDate);
+
+    for (const userId of responsibleUserIds) {
+      await tx.notification.create({
+        data: {
+          userId,
+          type: "ABSENCE_DECLARED",
+          title: "Absence déclarée",
+          message: `${memberName} a déclaré une absence du ${period}.`,
+          link: "/absences",
+        },
+      });
+    }
+
+    if (hasConflict) {
+      const recipients = new Set(responsibleUserIds);
+      const links = await tx.memberUserLink.findMany({ where: { memberId, churchId }, select: { userId: true } });
+      for (const l of links) recipients.add(l.userId);
+
+      const plural = conflicts.length > 1;
+      for (const userId of recipients) {
+        await tx.notification.create({
+          data: {
+            userId,
+            type: "ABSENCE_CONFLICT",
+            title: "Conflit planning / absence",
+            message: `L'absence de ${memberName} (${period}) chevauche ${plural ? "des services" : "un service"} déjà planifié${plural ? "s" : ""}.`,
+            link: "/absences",
+          },
+        });
+      }
+    }
+
+    await planningBus.emit(
+      "planning:absence:declared",
+      { tx, churchId, userId: createdById },
+      {
+        absenceId: absence.id,
+        churchId,
+        memberId,
+        startDate: absence.startDate.toISOString(),
+        endDate: absence.endDate.toISOString(),
+        createdById,
+        hasConflict,
+      }
+    );
+
+    return absence;
+  });
+}
+
+interface CancelAbsenceParams {
+  absenceId: string;
+  churchId: string;
+  cancelledById: string;
+}
+
+/**
+ * Annule une absence active et notifie systématiquement les responsables notifiés
+ * à la déclaration (et le STAR si un conflit avait été signalé).
+ *
+ * L'autorisation (créateur, membre lui-même, resp./ministre scopé, ou manager
+ * global) est vérifiée par la route appelante avant d'invoquer ce service.
+ */
+export async function cancelAbsence(params: CancelAbsenceParams): Promise<Absence> {
+  const { absenceId, churchId, cancelledById } = params;
+  const { prisma } = await import("@/lib/prisma");
+
+  return prisma.$transaction(async (tx) => {
+    const absence = await tx.absence.findUnique({
+      where: { id: absenceId },
+      include: { member: { select: { firstName: true, lastName: true } } },
+    });
+    if (!absence) throw new ApiError(404, "Absence introuvable");
+    if (absence.churchId !== churchId) throw new ApiError(403, "Absence hors périmètre");
+    if (absence.status === "CANCELLED") throw new ApiError(409, "Absence déjà annulée");
+
+    const conflictsBefore = await findAbsenceConflicts(
+      absence.memberId,
+      churchId,
+      absence.startDate,
+      absence.endDate,
+      tx
+    );
+    const hadConflict = conflictsBefore.length > 0;
+
+    const updated = await tx.absence.update({
+      where: { id: absenceId },
+      data: { status: "CANCELLED", cancelledAt: new Date(), cancelledById },
+    });
+
+    const responsibleUserIds = await resolveResponsibleUserIds(absence.memberId, churchId, tx);
+    const recipients = new Set(responsibleUserIds);
+    if (hadConflict) {
+      const links = await tx.memberUserLink.findMany({
+        where: { memberId: absence.memberId, churchId },
+        select: { userId: true },
+      });
+      for (const l of links) recipients.add(l.userId);
+    }
+
+    const memberName = `${absence.member.firstName} ${absence.member.lastName}`;
+    const period = formatPeriod(absence.startDate, absence.endDate);
+
+    for (const userId of recipients) {
+      await tx.notification.create({
+        data: {
+          userId,
+          type: "ABSENCE_CANCELLED",
+          title: "Absence annulée",
+          message: `L'absence de ${memberName} (${period}) a été annulée.`,
+          link: "/absences",
+        },
+      });
+    }
+
+    await planningBus.emit(
+      "planning:absence:cancelled",
+      { tx, churchId, userId: cancelledById },
+      { absenceId, churchId, memberId: absence.memberId, cancelledById, hadConflict }
+    );
+
+    return updated;
+  });
+}


### PR DESCRIPTION
## Résumé

Implémente la spec [`specs/007-gestion-absences-star/`](specs/007-gestion-absences-star/) : permet à un STAR de déclarer ses absences prévues (ou à son resp. de département/ministre de périmètre), notifie les responsables concernés, détecte les conflits avec le planning existant et expose une vue transverse filtrable.

- STAR : déclare/annule ses propres absences (ownership via `MemberUserLink`, aucune permission requise)
- Resp. département / Ministre : déclare/annule pour un STAR de leur périmètre départemental
- Détection de conflit **calculée à la volée** (jamais persistée) avec les affectations `EN_SERVICE`/`EN_SERVICE_DEBRIEF` existantes — notification distincte au STAR + responsables, badge visuel dans `PlanningGrid`, **aucune bascule automatique de statut**
- Notifications `ABSENCE_DECLARED` / `ABSENCE_CONFLICT` / `ABSENCE_CANCELLED`
- Vue transverse `/absences` (filtres ministère/département/rôle), scope identique à `members:view`
- Nouvelles permissions `absences:view` / `absences:manage` sur le module `planning`
- Multi-tenant strict : rattachement à une seule église, aucune fuite ni vue agrégée cross-église

## Détails techniques

- Nouveau modèle Prisma `Absence` (statut `ACTIVE`/`CANCELLED`) — sous-domaine du module `planning`, pas de module autonome
- `src/modules/planning/services/absence.service.ts` : `declareAbsence`, `cancelAbsence`, `findAbsenceConflicts`, `resolveResponsibleUserIds`
- Événements `planning:absence:declared` / `planning:absence:cancelled` ajoutés à `PlanningEvents`
- Routes `GET/POST /api/absences`, `PATCH /api/absences/[id]`
- Enrichissement de `GET /api/events/[eventId]/departments/[deptId]/planning` avec `activeAbsence` par membre
- UI : page `/absences` (self + vue d'ensemble), badge de conflit dans `PlanningGrid`, entrée nav Sidebar/MobileNavSheet

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries`
- [x] `npm run test` (521/521, incl. 34 nouveaux tests service + sécurité routes)
- [x] Tous les critères d'acceptation de `spec.md` vérifiés
- [ ] Vérification manuelle en environnement de recette avant merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)