### PR TITLE
feat(absences): harmonisation et ergonomie du module Absences

### DIFF
--- a/specs/012-harmonisation-ergonomie-absences/plan.md
+++ b/specs/012-harmonisation-ergonomie-absences/plan.md
@@ -1,0 +1,163 @@
+# Plan technique — Harmonisation et ergonomie du module Absences
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Validé
+- **Mis à jour le** : 2026-07-29
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : aucun nouvel import cross-module ; `PlanningGrid` reste dans `src/components/`, `AbsencesClient` dans `src/app/(auth)/absences/`
+- [x] **Sécurité** : aucune route existante affaiblie ; le lien vers le détail d'une absence n'est affiché que si l'utilisateur a déjà `absences:view` sur l'église concernée
+- [x] **Permissions** via `rolePermissions` (`@/lib/registry`) — réutilisé tel quel, pas de nouvelle permission
+- [x] **Validation** Zod — aucune mutation nouvelle ; les schémas Zod existants ne changent pas
+- [x] **Migration** Prisma : `[Aucun changement]`, aucun champ de schéma ajouté
+- [x] **Enums** : `AbsenceStatus` déjà importé depuis `@/generated/prisma/client`, inchangé
+- [x] **UI** : réutilisation de `Input`, `Select`, `Button`, `DataTable` existants — aucun nouveau composant `components/ui/`
+
+## Approche générale
+
+Cette feature est purement une passe d'ergonomie/cohérence sur de l'existant, pas une nouvelle
+règle métier. Le fil directeur :
+
+1. **Filtres/tri de la vue d'ensemble** : appliqués **côté client**, sur les données déjà
+   chargées par `GET /api/absences?scope=all` (qui renvoie déjà les statuts `ACTIVE` **et**
+   `CANCELLED`, filtrés côté client aujourd'hui). Même pattern que `RoomsBookingClient`/
+   `RoomChecklistsClient` (spec 010) : pas de nouveau paramètre d'API, `useMemo` pour dériver la
+   liste affichée à partir des filtres + tri choisis. Aucun changement serveur nécessaire pour
+   recherche/statut/période/tri.
+2. **Cohérence visuelle** : les variants de `Button` du module sont déjà globalement cohérents
+   (déclarer = primaire, annuler une absence = `danger`, fermer une modale = `secondary`) —
+   l'audit n'a trouvé qu'une incohérence réelle : le badge de conflit est affiché en texte complet
+   dans une table et en icône seule dans l'autre. On unifie sur un seul rendu (texte complet,
+   cohérent avec la carte mobile de `DataTable` qui a la largeur pour l'afficher).
+3. **Lien conflit → détail** : le badge d'absence affiché dans `PlanningGrid` devient un lien vers
+   la vue d'ensemble des absences, avec l'absence concernée mise en évidence. Nécessite d'exposer
+   l'`id` de l'absence (actuellement non renvoyé par la route de planning) et de connaître, côté
+   page appelante, si l'utilisateur a `absences:view` sur l'église courante (déjà calculable sans
+   requête supplémentaire).
+4. **Mobile** : réorganisation des contrôles de filtre de la vue d'ensemble en groupes hiérarchisés
+   (recherche + statut sur une ligne, période sur une autre, filtres organisationnels + tri sur une
+   troisième), chaque groupe s'empilant proprement en dessous de 640px — même leçon tirée de la
+   spec 009/010 sur les salles.
+
+## Modèle de données
+
+`[Aucun changement]` — le modèle `Absence` (statut, dates, motif) couvre déjà tous les besoins de
+filtrage exprimés dans la spec.
+
+## API
+
+| Endpoint | Méthode | Permission | Changement |
+|---|---|---|---|
+| `/api/absences` | GET | `absences:view` (scope `all`) / aucune (scope `self`) | **Aucun** — réponse déjà suffisante (statut, dates, `conflicts`) |
+| `/api/events/[eventId]/departments/[deptId]/planning` | GET | `planning:view` | `activeAbsence` gagne le champ `id` (en plus de `startDate`/`endDate`) |
+
+Le schéma Zod du `PUT` de la route planning n'est pas concerné (aucune mutation touchée).
+
+## Services / logique métier
+
+Aucun changement dans `src/modules/planning/services/absence.service.ts` ni dans les événements du
+bus — la spec exclut explicitement toute évolution des règles métier (permissions, périmètre,
+workflow de déclaration/annulation).
+
+`findActiveAbsencesByMember` (dans la route de planning, pas un service — logique déjà locale à la
+route) est étendue pour sélectionner et renvoyer `id` en plus de `startDate`/`endDate`.
+
+## UI / composants
+
+### `src/app/(auth)/absences/AbsencesClient.tsx`
+
+- **Filtres vue d'ensemble**, réorganisés en groupes (mobile : `flex-col`, desktop : `flex-row`) :
+  - Groupe 1 — recherche & statut : `Input` recherche par nom de membre (filtrage client sur
+    `firstName`/`lastName`), `Select` statut (`Actives` par défaut / `Toutes` / `Annulées`).
+  - Groupe 2 — période : deux `Input type="date"` (Du / Au), filtrage client sur chevauchement
+    avec `[startDate, endDate]` de l'absence.
+  - Groupe 3 — filtres organisationnels existants (Ministère, Département, Rôle du déclarant) +
+    `Select` de tri (Date de début ↓ par défaut / Date de début ↑ / Nom du membre).
+- Les filtres organisationnels (Ministère/Département/Rôle) restent envoyés à l'API comme
+  aujourd'hui (ils réduisent le volume chargé) ; recherche/statut/période/tri s'appliquent en plus,
+  côté client, via `useMemo`.
+- Badge de conflit : un seul rendu (texte complet `⚠ Conflit planning`) utilisé dans les deux
+  tables (« Mes absences » et « Vue d'ensemble »).
+- Support d'un paramètre d'URL `highlightId` (lu via `useSearchParams`) : si présent et que
+  l'absence correspondante est dans la liste affichée (elle l'est par défaut puisque active), la
+  ligne est mise en évidence visuellement (ex. anneau/fond coloré) et amenée dans le viewport au
+  chargement (`scrollIntoView`). Nécessite d'englober la lecture des search params dans une
+  limite `Suspense` côté page serveur (`page.tsx`) — contrainte Next.js App Router.
+- Aucun changement aux variants de `Button` existants (ils sont déjà cohérents) — vérification
+  incluse dans les critères d'acceptation plutôt que remaniement.
+
+### `src/components/PlanningGrid.tsx`
+
+- `MemberPlanning.activeAbsence` gagne `id: string`.
+- `AbsenceBadge` : si un `canViewAbsences` (nouvelle prop `PlanningGridProps`) est vrai, le badge
+  est rendu comme lien (`next/link`) vers `/absences?highlightId=<id>`, en conservant exactement
+  le même style visuel qu'aujourd'hui (pas de changement de couleur/forme, juste une action de
+  clic ajoutée). Si `canViewAbsences` est faux, le badge reste un `<span>` passif (comportement
+  actuel, respecte le périmètre de visibilité).
+- Les boutons de statut (`EN_SERVICE`/`INDISPONIBLE`/etc.) restent des `<button>` natifs stylés en
+  dur : **hors périmètre** de cette feature — ce ne sont pas des actions génériques
+  (créer/annuler/fermer) mais un sélecteur de statut à état multiple avec un design spécifique
+  (pastilles colorées par statut), donc pas comparable aux variants de `Button`. Les inclure dans
+  le système `variant` serait de la sur-ingénierie sans bénéfice observable pour l'utilisateur.
+
+### `src/app/(auth)/dashboard/page.tsx`
+
+- Calcule `canViewAbsences` de la même façon que `canEditPlanning`/`isAdmin` existants (scope par
+  église courante à partir de `session.user.churchRoles` + `rolePermissions`), sans requête
+  supplémentaire, et le passe en prop à `PlanningGrid`.
+
+## Décisions & alternatives écartées
+
+- **Choix** : filtres/tri de la vue d'ensemble en client-side (`useMemo`) — *Pourquoi* : c'est le
+  pattern déjà établi et validé sur le module Salles (specs 009-011), l'API renvoie déjà toutes
+  les données nécessaires (y compris les absences annulées), et le volume attendu par église ne
+  justifie pas une pagination serveur.
+- **Choix** : le clic sur le badge de conflit renvoie vers la ligne mise en évidence dans la vue
+  d'ensemble existante plutôt que vers une nouvelle modale de détail dédiée — *Pourquoi* : la vue
+  d'ensemble affiche déjà toutes les informations pertinentes (membre, département, ministère,
+  période, déclarant, conflit) ; créer un second composant de détail dupliquerait l'information
+  sans valeur ajoutée (contrairement au module Salles où la main courante n'avait *aucune* vue de
+  détail avant la spec 011).
+- **Écarté** : filtre par statut exposé côté API (`GET /api/absences?status=...`) — *Raison* :
+  l'API renvoie déjà tous les statuts, ajouter un paramètre serveur dupliquerait une logique déjà
+  faisable côté client sans coût de performance notable.
+- **Écarté** : harmoniser les boutons de statut de `PlanningGrid` avec le composant `Button` —
+  *Raison* : ce sont des indicateurs d'état multi-valeurs avec un design intentionnellement
+  distinct (couleur = signification du statut), pas des actions ponctuelles ; la spec vise la
+  cohérence des *actions*, pas la refonte d'un composant fonctionnellement différent.
+- **Écarté** : « Mes absences » avec les mêmes filtres que la vue d'ensemble — *Raison* : décision
+  utilisateur explicite (voir spec, questions ouvertes tranchées) — volume par compte trop faible
+  pour justifier des contrôles supplémentaires.
+
+## Risques & points d'attention
+
+- `useSearchParams` dans `AbsencesClient` (Client Component) impose une limite `Suspense` dans
+  `page.tsx` pour éviter l'avertissement/erreur de build Next.js App Router sur le rendu statique —
+  à vérifier avec `npm run build`.
+- La mise en évidence via `highlightId` ne fonctionne que pour une absence **active** (cas d'usage
+  du badge de `PlanningGrid`, qui n'affiche que des absences actives) — pas besoin de gérer le cas
+  où l'absence est annulée entre le clic et l'affichage de la vue d'ensemble, mais si cela se
+  produit (annulée entre-temps), la ligne ne sera simplement pas visible avec le filtre par défaut
+  (comportement dégradé acceptable, pas une erreur).
+- Vérifier que le nouveau lien du badge n'introduit pas de régression d'accessibilité tactile sur
+  mobile (le commentaire existant sur les tooltips non accessibles au toucher doit rester valide —
+  le lien doit rester visible et cliquable, pas dépendant d'un hover).
+- Repasser une vérification manuelle mobile (captures d'écran, comme pour la spec 009) sur
+  `/absences` (vue d'ensemble avec les nouveaux filtres) et sur la grille de planning (badge
+  cliquable) avant de considérer la feature terminée.
+
+## Stratégie de tests
+
+- **`src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts`** :
+  étendre les cas existants qui vérifient `activeAbsence` pour couvrir la présence du champ `id`.
+- Pas de nouveau test API pour `/api/absences` (aucun changement de contrat).
+- Les filtres/tri/recherche/mise en évidence étant de la logique de présentation pure (dérivée par
+  `useMemo` dans un Client Component), ils suivent le même choix que pour `RoomsBookingClient` :
+  pas de test unitaire dédié à ce niveau (pas de suite de tests de composants React dans ce repo à
+  ce jour) — validation par `npm run typecheck`/`npm run lint` + vérification manuelle
+  (desktop + mobile) documentée dans les tâches d'implémentation.
+- `npm run typecheck && npm run lint && npm run lint:boundaries && npm run test` doivent passer
+  avant toute PR (constitution, section V).

--- a/specs/012-harmonisation-ergonomie-absences/spec.md
+++ b/specs/012-harmonisation-ergonomie-absences/spec.md
@@ -1,0 +1,120 @@
+# Spec — Harmonisation et ergonomie du module Absences
+
+- **Numéro** : 012
+- **Statut** : Implémentée
+- **Créée le** : 2026-07-29
+- **Branche suggérée** : `feat/harmonisation-ergonomie-absences`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+Le module de gestion des absences des STAR a été livré (spec 007) avec un périmètre volontairement
+restreint. Depuis, la fonctionnalité de réservation des salles a fait l'objet de plusieurs passes
+d'harmonisation (couleurs de boutons cohérentes, filtres/tri sur chaque vue, ergonomie mobile
+vérifiée). Le module Absences n'a pas bénéficié du même traitement et présente aujourd'hui des
+écarts :
+
+- Les couleurs/styles des actions ne sont pas garanties cohérentes avec le reste de l'application
+  ni entre les différentes vues du module lui-même.
+- La vue d'ensemble des absences ne permet pas de trier les résultats, de rechercher un membre par
+  nom, de filtrer par statut (impossible de retrouver une absence annulée, donc pas d'historique
+  consultable) ni de filtrer sur une période précise — alors que le volume de données peut devenir
+  important pour une église avec beaucoup de STAR et d'absences déclarées dans la durée.
+- Un même indicateur (le signal de conflit entre une absence et une affectation planifiée) est
+  présenté différemment selon l'endroit où on le consulte, ce qui peut créer de la confusion.
+- Rien ne garantit que les contrôles de filtrage s'affichent correctement sur mobile (empilement,
+  lisibilité, zones de clic).
+
+Cette spec vise à aligner le module Absences sur le niveau d'ergonomie et de cohérence déjà atteint
+sur le module Salles, sans changer les règles métier de gestion des absences elles-mêmes.
+
+## Utilisateurs concernés
+
+- **STAR** : déclare et consulte ses propres absences.
+- **Resp. département** : consulte et déclare des absences pour les STAR de son département,
+  consulte la vue d'ensemble de son périmètre.
+- **Ministre** : consulte la vue d'ensemble de son ministère.
+- **Admin / Secrétaire / Super Admin** : consultent et gèrent les absences sur l'ensemble de
+  l'église.
+
+Ces rôles ne changent pas par rapport à l'existant ; seule l'ergonomie des écrans qu'ils utilisent
+déjà est concernée.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Un responsable ouvre la vue d'ensemble des absences de son périmètre.
+2. Il recherche une absence par le nom du membre concerné.
+3. Il filtre pour ne voir que les absences en cours (ou, au contraire, inclut les absences
+   annulées pour consulter l'historique).
+4. Il restreint l'affichage à une période donnée (par exemple les absences à venir sur le mois).
+5. Il trie les résultats (par exemple par date de début, la plus proche en premier).
+6. Sur chaque écran du module, les actions proposées (déclarer, annuler, fermer une fenêtre) sont
+   présentées avec une couleur/un style cohérent avec leur nature (action de création, action
+   destructive, action neutre), et cette cohérence est la même que celle du reste de l'application.
+7. Le même signal de conflit entre une absence et une affectation planifiée est présenté de façon
+   identique partout où il apparaît.
+8. Sur mobile, tous les contrôles de recherche/filtre/tri restent utilisables : lisibles, bien
+   empilés, sans chevauchement ni débordement horizontal.
+
+### Scénarios alternatifs / cas limites
+
+- **Si** aucune absence ne correspond aux filtres choisis **alors** un message clair l'indique
+  (pas de tableau vide sans explication).
+- **Si** un utilisateur n'a pas la permission de gérer les absences des autres **alors** il ne voit
+  ni les filtres ni les actions de gestion réservés à ce périmètre (comportement déjà existant, à
+  préserver).
+- **Si** une absence a été annulée **alors** toute personne ayant accès à la vue d'ensemble doit
+  pouvoir la retrouver via le filtre statut, sans que cela alourdisse la vue par défaut (qui reste
+  centrée sur les absences actives).
+- **Quand** un responsable consulte le planning d'un événement/département et voit un signal
+  d'absence sur un membre, il doit pouvoir cliquer dessus pour accéder directement au détail de
+  cette absence (plutôt que de devoir la rechercher manuellement dans la vue d'ensemble).
+
+## Critères d'acceptation
+
+- [ ] Sur la vue d'ensemble des absences, un utilisateur peut rechercher par nom de membre.
+- [ ] Sur la vue d'ensemble des absences, un utilisateur peut filtrer par statut (actives
+      uniquement par défaut ; option pour inclure/afficher les absences annulées).
+- [ ] Sur la vue d'ensemble des absences, un utilisateur peut filtrer sur une période (date de
+      début et/ou de fin).
+- [ ] Sur la vue d'ensemble des absences, un utilisateur peut trier les résultats selon au moins
+      un critère pertinent (ex. date).
+- [ ] Toutes les actions du module (déclarer, annuler une absence, fermer une fenêtre de saisie)
+      utilisent un style/couleur cohérent avec leur nature et avec les conventions déjà en place
+      ailleurs dans l'application.
+- [ ] Le signal de conflit entre une absence et une affectation planifiée est présenté de la même
+      façon dans toutes les vues où il apparaît.
+- [ ] Sur un écran de taille mobile, les contrôles de recherche/filtre/tri de chaque vue concernée
+      s'affichent correctement (pas de chevauchement, pas de débordement horizontal, contrôles
+      empilés lisiblement).
+- [ ] Le filtre statut de la vue d'ensemble permet à toute personne y ayant accès de faire
+      apparaître les absences annulées (historique), sans que celles-ci soient affichées par
+      défaut.
+- [ ] Depuis le planning d'un événement/département, cliquer sur le signal d'absence d'un membre
+      amène au détail de l'absence correspondante.
+- [ ] La vue « Mes absences » n'est pas modifiée dans son fonctionnement (pas de nouveaux
+      contrôles de recherche/filtre/tri) au-delà de l'harmonisation visuelle des actions déjà
+      couverte par les critères ci-dessus.
+- [ ] Aucune règle métier existante (permissions, périmètre de visibilité, workflow de
+      déclaration/annulation) n'est modifiée par cette feature.
+
+## Hors périmètre
+
+- Ajout d'un workflow d'approbation des absences (toujours hors périmètre, comme en spec 007).
+- Ajout de la récurrence des absences.
+- Édition d'une absence existante après sa création (seule l'annulation existe).
+- Pagination ou choix technique de rendu — seul le comportement observable (pouvoir filtrer/trier/
+  rechercher, voir des contrôles utilisables sur mobile) est spécifié ici.
+- Toute nouvelle permission ou tout nouveau rôle.
+
+## Questions ouvertes
+
+Aucune question bloquante restante — décisions validées avec l'utilisateur :
+- La vue « Mes absences » n'est pas étendue avec de nouveaux contrôles de filtre/tri.
+- L'historique des absences annulées est accessible à toute personne ayant accès à la vue
+  d'ensemble (via le filtre statut), pas seulement aux gestionnaires.
+- Le signal de conflit sur le planning devient cliquable et mène au détail de l'absence.

--- a/specs/012-harmonisation-ergonomie-absences/tasks.md
+++ b/specs/012-harmonisation-ergonomie-absences/tasks.md
@@ -1,0 +1,100 @@
+# Tâches — Harmonisation et ergonomie du module Absences
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : Terminé
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : migration → services → API → UI → tests. Les tâches `[P]` sont parallélisables.
+
+## Prérequis
+
+- [x] Branche créée : `feat/harmonisation-ergonomie-absences`
+- [ ] Migration Prisma : `[Aucune]` — pas de changement de schéma (voir `plan.md`)
+
+## Tâches
+
+### 1. Données & migration
+
+`[Aucun changement]` — aucun champ Prisma ajouté (voir `plan.md`, section « Modèle de données »).
+
+### 2. Logique métier (services)
+
+`[Aucun changement]` — aucune règle métier de `absence.service.ts` n'est modifiée (spec hors
+périmètre).
+
+### 3. API (route handlers)
+
+- [x] **T1** — Étendre `findActiveAbsencesByMember` pour sélectionner et renvoyer le champ `id` de
+      l'absence, en plus de `startDate`/`endDate`, dans les deux branches (`eventDept` existant et
+      cas `!eventDept`) *(fichier : `src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts`)*
+
+### 4. UI
+
+- [x] **T2** — Calculer `canViewAbsences` (scope église courante, permission `absences:view`) dans
+      `DashboardPage`, sur le même modèle que `canEditPlanning`/`isAdmin`, et le passer en prop à
+      `PlanningGrid` *(fichier : `src/app/(auth)/dashboard/page.tsx`)*
+- [x] **T3** — Ajouter la prop `canViewAbsences` et le champ `id` sur `activeAbsence` dans
+      `PlanningGridProps`/`MemberPlanning` ; transformer `AbsenceBadge` en lien (`next/link`) vers
+      `/absences?highlightId=<id>` quand `canViewAbsences` est vrai, en conservant le style visuel
+      actuel à l'identique (span passif sinon, comportement inchangé) *(fichier :
+      `src/components/PlanningGrid.tsx`)*
+- [x] **T4** [P] — Unifier le rendu du badge de conflit (« ⚠ Conflit planning » en texte complet)
+      entre la table « Mes absences » et la table « Vue d'ensemble » *(fichier :
+      `src/app/(auth)/absences/AbsencesClient.tsx`)*
+- [x] **T5** [P] — Ajouter la recherche par nom de membre (`Input`) et le filtre statut (`Select` :
+      Actives par défaut / Toutes / Annulées) sur la vue d'ensemble, appliqués côté client via
+      `useMemo` sur les données déjà chargées *(fichier :
+      `src/app/(auth)/absences/AbsencesClient.tsx`)*
+- [x] **T6** [P] — Ajouter le filtre de période (deux `Input type="date"` Du/Au) sur la vue
+      d'ensemble, filtrage client par chevauchement avec `[startDate, endDate]` *(fichier :
+      `src/app/(auth)/absences/AbsencesClient.tsx`)*
+- [x] **T7** [P] — Ajouter le tri (`Select` : Date de début ↓ par défaut / Date de début ↑ / Nom du
+      membre) sur la vue d'ensemble, appliqué côté client *(fichier :
+      `src/app/(auth)/absences/AbsencesClient.tsx`)*
+- [x] **T8** — Réorganiser les contrôles de filtre de la vue d'ensemble en 3 groupes hiérarchisés
+      (recherche+statut / période / organisationnel+tri), empilement mobile propre
+      (`flex-col sm:flex-row` par groupe), à faire après T5-T7 pour éviter de réorganiser deux fois
+      *(fichier : `src/app/(auth)/absences/AbsencesClient.tsx`)*
+- [x] **T9** — Lire le paramètre d'URL `highlightId` via `useSearchParams`, mettre en évidence
+      visuellement la ligne correspondante dans la vue d'ensemble et l'amener dans le viewport au
+      chargement (`scrollIntoView`) *(fichier : `src/app/(auth)/absences/AbsencesClient.tsx`)*
+- [x] **T10** — Envelopper le rendu de `AbsencesClient` dans une limite `Suspense` côté page
+      serveur pour satisfaire la contrainte Next.js App Router sur `useSearchParams` *(fichier :
+      `src/app/(auth)/absences/page.tsx`)*
+
+### 5. Tests
+
+- [x] **T11** — Étendre les tests existants de la route de planning pour vérifier que `id` est bien
+      présent dans `activeAbsence` (cas `eventDept` existant et cas `!eventDept`) *(fichier :
+      `src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts`)*
+
+### 6. Vérification manuelle
+
+- [x] **T12** — Vérifier manuellement le rendu mobile (375px) : filtres de la vue d'ensemble des
+      absences (groupes empilés, lisibles), badge cliquable dans `PlanningGrid`, mise en évidence
+      après clic sur le badge — captures d'écran comme pour la spec 009
+- [x] **T13** — Vérifier manuellement que le lien du badge de conflit n'apparaît pas pour un
+      utilisateur sans `absences:view` sur l'église courante (ex. un simple STAR consultant le
+      planning d'un autre département via une affectation) et que le comportement reste identique
+      à l'existant dans ce cas
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Critère spec : recherche par nom de membre sur la vue d'ensemble (T5)
+- [x] Critère spec : filtre par statut, actives par défaut, annulées consultables par tout
+      visualiseur (T5)
+- [x] Critère spec : filtre par période (T6)
+- [x] Critère spec : tri sur au moins un critère (T7)
+- [x] Critère spec : actions du module avec style/couleur cohérent (audit T4 + vérification, pas de
+      remaniement nécessaire au-delà du badge de conflit — voir `plan.md`)
+- [x] Critère spec : signal de conflit identique dans toutes les vues (T4)
+- [x] Critère spec : contrôles filtre/tri utilisables sur mobile (T8, vérifié en T12)
+- [x] Critère spec : clic sur le signal d'absence dans le planning → détail de l'absence (T3, T9)
+- [x] Critère spec : « Mes absences » non modifiée fonctionnellement (aucune tâche ne touche à sa
+      logique, seulement au rendu partagé du badge de conflit en T4)
+- [x] Critère spec : aucune règle métier modifiée (confirmé — sections 1 et 2 vides par design)
+- [ ] PR ouverte vers `main`

--- a/src/app/(auth)/absences/AbsencesClient.tsx
+++ b/src/app/(auth)/absences/AbsencesClient.tsx
@@ -1,11 +1,31 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import Modal from "@/components/ui/Modal";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import Select from "@/components/ui/Select";
 import DataTable from "@/components/ui/DataTable";
+
+type StatusFilter = "ACTIVE" | "ALL" | "CANCELLED";
+type SortOption = "startDateDesc" | "startDateAsc" | "member";
+
+function memberName(a: { member: { firstName: string; lastName: string } }): string {
+  return `${a.member.firstName} ${a.member.lastName}`;
+}
+
+function ConflictBadge({ hasConflict }: { hasConflict: boolean }) {
+  return hasConflict ? <span className="text-orange-700 font-medium">⚠ Conflit planning</span> : <>—</>;
+}
+
+function StatusBadge({ status }: { status: "ACTIVE" | "CANCELLED" }) {
+  return status === "ACTIVE" ? (
+    <span className="text-green-700 font-medium">Active</span>
+  ) : (
+    <span className="text-gray-400">Annulée</span>
+  );
+}
 
 interface MemberRef {
   id: string;
@@ -61,6 +81,14 @@ export default function AbsencesClient({
   const [ministryFilter, setMinistryFilter] = useState("");
   const [departmentFilter, setDepartmentFilter] = useState("");
   const [roleFilter, setRoleFilter] = useState("");
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("ACTIVE");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+  const [sortBy, setSortBy] = useState<SortOption>("startDateDesc");
+
+  const searchParams = useSearchParams();
+  const highlightId = searchParams.get("highlightId") ?? undefined;
 
   const [declareOpen, setDeclareOpen] = useState(false);
   const [declareMode, setDeclareMode] = useState<"self" | "manage">("self");
@@ -111,6 +139,42 @@ export default function AbsencesClient({
   useEffect(() => {
     fetchAll();
   }, [fetchAll]);
+
+  const displayedAbsences = useMemo(() => {
+    let rows = allAbsences;
+    if (statusFilter !== "ALL") {
+      rows = rows.filter((a) => a.status === statusFilter);
+    }
+    if (search.trim()) {
+      const q = search.trim().toLowerCase();
+      rows = rows.filter((a) => memberName(a).toLowerCase().includes(q));
+    }
+    if (dateFrom) {
+      const from = new Date(dateFrom);
+      rows = rows.filter((a) => new Date(a.endDate) >= from);
+    }
+    if (dateTo) {
+      const to = new Date(dateTo);
+      rows = rows.filter((a) => new Date(a.startDate) <= to);
+    }
+
+    const sorted = [...rows];
+    sorted.sort((a, b) => {
+      if (sortBy === "member") return memberName(a).localeCompare(memberName(b));
+      const diff = new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
+      return sortBy === "startDateAsc" ? diff : -diff;
+    });
+    return sorted;
+  }, [allAbsences, statusFilter, search, dateFrom, dateTo, sortBy]);
+
+  const hasScrolledToHighlight = useRef(false);
+  useEffect(() => {
+    if (!highlightId || hasScrolledToHighlight.current) return;
+    const el = document.getElementById(`row-${highlightId}`);
+    if (!el) return;
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    hasScrolledToHighlight.current = true;
+  }, [highlightId, displayedAbsences]);
 
   function openDeclareForSelf() {
     setDeclareMode("self");
@@ -206,12 +270,7 @@ export default function AbsencesClient({
                 { header: "Motif", accessor: (a) => a.reason ?? "—" },
                 {
                   header: "Conflit",
-                  accessor: (a) =>
-                    a.hasConflict ? (
-                      <span className="text-orange-700 font-medium">⚠ Conflit planning</span>
-                    ) : (
-                      "—"
-                    ),
+                  accessor: (a) => <ConflictBadge hasConflict={a.hasConflict} />,
                 },
               ]}
               actions={(a) => (
@@ -233,45 +292,94 @@ export default function AbsencesClient({
             )}
           </div>
 
-          <div className="flex flex-wrap gap-3">
-            <Select
-              label="Ministère"
-              placeholder="Tous"
-              value={ministryFilter}
-              onChange={(e) => {
-                setMinistryFilter(e.target.value);
-                setDepartmentFilter("");
-              }}
-              options={ministries.map((m) => ({ value: m.id, label: m.name }))}
-            />
-            <Select
-              label="Département"
-              placeholder="Tous"
-              value={departmentFilter}
-              onChange={(e) => setDepartmentFilter(e.target.value)}
-              options={visibleDepartments.map((d) => ({ value: d.id, label: d.name }))}
-            />
-            <Select
-              label="Rôle du déclarant"
-              placeholder="Tous"
-              value={roleFilter}
-              onChange={(e) => setRoleFilter(e.target.value)}
-              options={[
-                { value: "STAR", label: "STAR" },
-                { value: "DEPARTMENT_HEAD", label: "Resp. département" },
-                { value: "MINISTER", label: "Ministre" },
-              ]}
-            />
+          <div className="space-y-3">
+            <div className="flex flex-col sm:flex-row sm:items-end gap-3">
+              <div className="flex-1 min-w-0">
+                <Input
+                  label="Rechercher un membre"
+                  placeholder="Nom, prénom..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                />
+              </div>
+              <div className="sm:w-48">
+                <Select
+                  label="Statut"
+                  value={statusFilter}
+                  onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+                  options={[
+                    { value: "ACTIVE", label: "Actives" },
+                    { value: "ALL", label: "Toutes" },
+                    { value: "CANCELLED", label: "Annulées" },
+                  ]}
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-3">
+              <div className="flex gap-3 flex-1">
+                <div className="w-1/2 sm:w-40">
+                  <Input type="date" label="Du" value={dateFrom} onChange={(e) => setDateFrom(e.target.value)} />
+                </div>
+                <div className="w-1/2 sm:w-40">
+                  <Input type="date" label="Au" value={dateTo} onChange={(e) => setDateTo(e.target.value)} />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+              <Select
+                label="Ministère"
+                placeholder="Tous"
+                value={ministryFilter}
+                onChange={(e) => {
+                  setMinistryFilter(e.target.value);
+                  setDepartmentFilter("");
+                }}
+                options={ministries.map((m) => ({ value: m.id, label: m.name }))}
+              />
+              <Select
+                label="Département"
+                placeholder="Tous"
+                value={departmentFilter}
+                onChange={(e) => setDepartmentFilter(e.target.value)}
+                options={visibleDepartments.map((d) => ({ value: d.id, label: d.name }))}
+              />
+              <Select
+                label="Rôle du déclarant"
+                placeholder="Tous"
+                value={roleFilter}
+                onChange={(e) => setRoleFilter(e.target.value)}
+                options={[
+                  { value: "STAR", label: "STAR" },
+                  { value: "DEPARTMENT_HEAD", label: "Resp. département" },
+                  { value: "MINISTER", label: "Ministre" },
+                ]}
+              />
+              <div className="sm:ml-auto sm:w-56">
+                <Select
+                  label="Trier par"
+                  value={sortBy}
+                  onChange={(e) => setSortBy(e.target.value as SortOption)}
+                  options={[
+                    { value: "startDateDesc", label: "Date de début (récent d'abord)" },
+                    { value: "startDateAsc", label: "Date de début (ancien d'abord)" },
+                    { value: "member", label: "Nom du membre" },
+                  ]}
+                />
+              </div>
+            </div>
           </div>
 
           {loadingAll ? (
             <p className="text-gray-500 text-sm">Chargement...</p>
           ) : (
             <DataTable
-              data={allAbsences.filter((a) => a.status === "ACTIVE")}
-              emptyMessage="Aucune absence."
+              data={displayedAbsences}
+              highlightedId={highlightId}
+              emptyMessage="Aucune absence ne correspond à ces filtres."
               columns={[
-                { header: "Membre", accessor: (a) => `${a.member.firstName} ${a.member.lastName}` },
+                { header: "Membre", accessor: (a) => memberName(a) },
                 {
                   header: "Département",
                   accessor: (a) => a.member.departments.map((d) => d.name).join(", ") || "—",
@@ -283,18 +391,20 @@ export default function AbsencesClient({
                 },
                 { header: "Période", accessor: (a) => `${formatDate(a.startDate)} → ${formatDate(a.endDate)}` },
                 { header: "Déclaré par", accessor: (a) => a.createdBy.name ?? "—" },
+                { header: "Statut", accessor: (a) => <StatusBadge status={a.status} /> },
                 {
                   header: "Conflit",
-                  accessor: (a) => (a.hasConflict ? <span className="text-orange-700 font-medium">⚠</span> : "—"),
+                  accessor: (a) => <ConflictBadge hasConflict={a.hasConflict} />,
                 },
               ]}
               actions={
                 canManage
-                  ? (a) => (
-                      <Button size="sm" variant="danger" onClick={() => cancelAbsence(a.id)}>
-                        Annuler
-                      </Button>
-                    )
+                  ? (a) =>
+                      a.status === "ACTIVE" ? (
+                        <Button size="sm" variant="danger" onClick={() => cancelAbsence(a.id)}>
+                          Annuler
+                        </Button>
+                      ) : null
                   : undefined
               }
             />

--- a/src/app/(auth)/absences/page.tsx
+++ b/src/app/(auth)/absences/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { requireAuth, getCurrentChurchId, getUserDepartmentScope } from "@/lib/auth";
 import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
@@ -59,14 +60,16 @@ export default async function AbsencesPage() {
   }
 
   return (
-    <AbsencesClient
-      churchId={churchId}
-      canView={canView}
-      canManage={canManage}
-      selfMembers={selfMembers}
-      manageableMembers={manageableMembers}
-      ministries={ministries}
-      departments={departments}
-    />
+    <Suspense>
+      <AbsencesClient
+        churchId={churchId}
+        canView={canView}
+        canManage={canManage}
+        selfMembers={selfMembers}
+        manageableMembers={manageableMembers}
+        ministries={ministries}
+        departments={departments}
+      />
+    </Suspense>
   );
 }

--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -38,6 +38,9 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
     session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
   );
   const canEditPlanning = userPermissions.has("planning:edit");
+  const canViewAbsences = session.user.churchRoles.some(
+    (r) => r.churchId === currentChurchId && (rolePermissions[r.role] ?? []).includes("absences:view")
+  );
 
   // Auto-trigger guided tour on first visit with a role
   const shouldTriggerTour =
@@ -190,7 +193,12 @@ export default async function DashboardPage({ searchParams }: DashboardProps) {
           </div>
         )
       ) : selectedEventId && selectedDeptId ? (
-        <PlanningGrid eventId={selectedEventId} departmentId={selectedDeptId} readOnly={!canEditPlanning} />
+        <PlanningGrid
+          eventId={selectedEventId}
+          departmentId={selectedDeptId}
+          readOnly={!canEditPlanning}
+          canViewAbsences={canViewAbsences}
+        />
       ) : (
         <div className="p-8 text-center text-gray-400 border-2 border-gray-200 border-dashed rounded-lg">
           {!selectedDeptId

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/__tests__/route.test.ts
@@ -89,6 +89,59 @@ describe("GET /api/events/[eventId]/departments/[deptId]/planning", () => {
     expect(body.members[0].status).toBeNull();
   });
 
+  it("includes the absence id in activeAbsence (eventDept path)", async () => {
+    const eventDept = {
+      id: "ed-1",
+      eventId: "evt-1",
+      departmentId: "dept-1",
+      event: { date: new Date("2026-08-01"), planningDeadline: null },
+      plannings: [],
+      department: {
+        memberDepts: [{ member: { id: "m-1", firstName: "Jean", lastName: "Dupont" } }],
+      },
+    };
+    prismaMock.eventDepartment.findUnique.mockResolvedValue(eventDept);
+    prismaMock.absence.findMany.mockResolvedValue([
+      {
+        id: "abs-1",
+        memberId: "m-1",
+        startDate: new Date("2026-07-30"),
+        endDate: new Date("2026-08-05"),
+      },
+    ] as never);
+
+    const request = new Request("http://localhost/api/events/evt-1/departments/dept-1/planning");
+    const res = await GET(request, { params: makeParams("evt-1", "dept-1") });
+
+    const body = await res.json();
+    expect(body.members[0].activeAbsence).toMatchObject({ id: "abs-1" });
+  });
+
+  it("includes the absence id in activeAbsence (fallback path, no event-department link)", async () => {
+    prismaMock.eventDepartment.findUnique.mockResolvedValue(null);
+    prismaMock.department.findUnique
+      .mockResolvedValueOnce(mockDeptChurchCheck as never)
+      .mockResolvedValueOnce({
+        id: "dept-1",
+        memberDepts: [{ member: { id: "m-1", firstName: "Jean", lastName: "Dupont" } }],
+      } as never);
+    prismaMock.event.findUnique.mockResolvedValue({ id: "evt-1", date: new Date("2026-08-01"), planningDeadline: null } as never);
+    prismaMock.absence.findMany.mockResolvedValue([
+      {
+        id: "abs-2",
+        memberId: "m-1",
+        startDate: new Date("2026-07-30"),
+        endDate: new Date("2026-08-05"),
+      },
+    ] as never);
+
+    const request = new Request("http://localhost/api/events/evt-1/departments/dept-1/planning");
+    const res = await GET(request, { params: makeParams("evt-1", "dept-1") });
+
+    const body = await res.json();
+    expect(body.members[0].activeAbsence).toMatchObject({ id: "abs-2" });
+  });
+
   it("detects deadline passed", async () => {
     const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
     prismaMock.eventDepartment.findUnique.mockResolvedValue({

--- a/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
+++ b/src/app/api/events/[eventId]/departments/[deptId]/planning/route.ts
@@ -23,7 +23,7 @@ async function findActiveAbsencesByMember(
   churchId: string,
   memberIds: string[],
   eventDate: Date | undefined
-): Promise<Map<string, { startDate: Date; endDate: Date }>> {
+): Promise<Map<string, { id: string; startDate: Date; endDate: Date }>> {
   if (!eventDate || memberIds.length === 0) return new Map();
 
   const absences = await prisma.absence.findMany({
@@ -34,10 +34,10 @@ async function findActiveAbsencesByMember(
       startDate: { lte: eventDate },
       endDate: { gte: eventDate },
     },
-    select: { memberId: true, startDate: true, endDate: true },
+    select: { id: true, memberId: true, startDate: true, endDate: true },
   });
 
-  return new Map(absences.map((a) => [a.memberId, { startDate: a.startDate, endDate: a.endDate }]));
+  return new Map(absences.map((a) => [a.memberId, { id: a.id, startDate: a.startDate, endDate: a.endDate }]));
 }
 
 export async function GET(

--- a/src/components/PlanningGrid.tsx
+++ b/src/components/PlanningGrid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import Link from "next/link";
 import TaskPanel from "./TaskPanel";
 
 interface MemberPlanning {
@@ -9,7 +10,7 @@ interface MemberPlanning {
   lastName: string;
   status: string | null;
   planningId: string | null;
-  activeAbsence?: { startDate: string; endDate: string } | null;
+  activeAbsence?: { id: string; startDate: string; endDate: string } | null;
 }
 
 function formatAbsencePeriod(activeAbsence: { startDate: string; endDate: string }): string {
@@ -24,15 +25,38 @@ function formatAbsencePeriodShort(activeAbsence: { startDate: string; endDate: s
 
 // La période est affichée en texte (pas seulement via `title`) car les tooltips
 // hover ne sont pas accessibles au toucher sur mobile.
-function AbsenceBadge({ activeAbsence }: { activeAbsence: { startDate: string; endDate: string } }) {
-  return (
-    <span
-      title={formatAbsencePeriod(activeAbsence)}
-      aria-label={formatAbsencePeriod(activeAbsence)}
-      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-orange-100 text-orange-700 text-xs shrink-0 whitespace-nowrap"
-    >
+function AbsenceBadge({
+  activeAbsence,
+  canViewAbsences,
+}: {
+  activeAbsence: { id: string; startDate: string; endDate: string };
+  canViewAbsences: boolean;
+}) {
+  const className =
+    "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-orange-100 text-orange-700 text-xs shrink-0 whitespace-nowrap";
+  const content = (
+    <>
       <span aria-hidden="true">⚠</span>
       {formatAbsencePeriodShort(activeAbsence)}
+    </>
+  );
+
+  if (canViewAbsences) {
+    return (
+      <Link
+        href={`/absences?highlightId=${activeAbsence.id}`}
+        title={formatAbsencePeriod(activeAbsence)}
+        aria-label={`${formatAbsencePeriod(activeAbsence)} — voir le détail`}
+        className={`${className} hover:bg-orange-200`}
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <span title={formatAbsencePeriod(activeAbsence)} aria-label={formatAbsencePeriod(activeAbsence)} className={className}>
+      {content}
     </span>
   );
 }
@@ -41,6 +65,7 @@ interface PlanningGridProps {
   eventId: string;
   departmentId: string;
   readOnly?: boolean;
+  canViewAbsences?: boolean;
 }
 
 const STATUS_OPTIONS = [
@@ -71,6 +96,7 @@ export default function PlanningGrid({
   eventId,
   departmentId,
   readOnly = false,
+  canViewAbsences = false,
 }: PlanningGridProps) {
   const [members, setMembers] = useState<MemberPlanning[]>([]);
   const [loading, setLoading] = useState(true);
@@ -267,7 +293,9 @@ export default function PlanningGrid({
                   </select>
                 )}
               </div>
-              {member.activeAbsence && <AbsenceBadge activeAbsence={member.activeAbsence} />}
+              {member.activeAbsence && (
+                <AbsenceBadge activeAbsence={member.activeAbsence} canViewAbsences={canViewAbsences} />
+              )}
             </div>
           );
         })}
@@ -292,7 +320,9 @@ export default function PlanningGrid({
                 <td className="px-4 py-3 text-sm text-gray-900">
                   <span className="flex items-center gap-1.5">
                     <span>{member.firstName} {member.lastName}</span>
-                    {member.activeAbsence && <AbsenceBadge activeAbsence={member.activeAbsence} />}
+                    {member.activeAbsence && (
+                      <AbsenceBadge activeAbsence={member.activeAbsence} canViewAbsences={canViewAbsences} />
+                    )}
                   </span>
                 </td>
                 <td className="px-4 py-3">

--- a/src/components/ui/DataTable.tsx
+++ b/src/components/ui/DataTable.tsx
@@ -15,6 +15,8 @@ interface DataTableProps<T> {
   selectable?: boolean;
   selectedIds?: Set<string>;
   onSelectionChange?: (ids: Set<string>) => void;
+  /** Id de ligne à mettre en évidence visuellement (ex. arrivée depuis un lien externe). */
+  highlightedId?: string;
 }
 
 function getCellValue<T>(row: T, accessor: Column<T>["accessor"]): ReactNode {
@@ -29,6 +31,7 @@ export default function DataTable<T extends { id: string }>({
   selectable = false,
   selectedIds,
   onSelectionChange,
+  highlightedId,
 }: DataTableProps<T>) {
   const allSelected = selectable && data.length > 0 && data.every((row) => selectedIds?.has(row.id));
   const someSelected = selectable && data.some((row) => selectedIds?.has(row.id)) && !allSelected;
@@ -68,8 +71,13 @@ export default function DataTable<T extends { id: string }>({
         {data.map((row) => (
           <div
             key={row.id}
+            id={`row-${row.id}`}
             className={`rounded-lg border border-gray-200 bg-white p-4 shadow-sm ${
-              selectedIds?.has(row.id) ? "ring-2 ring-icc-violet bg-icc-violet-light" : ""
+              row.id === highlightedId
+                ? "ring-2 ring-icc-jaune bg-yellow-50"
+                : selectedIds?.has(row.id)
+                  ? "ring-2 ring-icc-violet bg-icc-violet-light"
+                  : ""
             }`}
           >
             {selectable && (
@@ -135,7 +143,17 @@ export default function DataTable<T extends { id: string }>({
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {data.map((row) => (
-              <tr key={row.id} className={`hover:bg-gray-50 ${selectedIds?.has(row.id) ? "bg-icc-violet-light" : ""}`}>
+              <tr
+                key={row.id}
+                id={`row-${row.id}`}
+                className={`hover:bg-gray-50 ${
+                  row.id === highlightedId
+                    ? "ring-2 ring-inset ring-icc-jaune bg-yellow-50"
+                    : selectedIds?.has(row.id)
+                      ? "bg-icc-violet-light"
+                      : ""
+                }`}
+              >
                 {selectable && (
                   <td className="px-4 py-3 w-10">
                     <input


### PR DESCRIPTION
## Résumé

- Ajoute recherche par nom, filtre statut (avec accès à l'historique des absences annulées), filtre de période et tri sur la vue d'ensemble des absences — le tout côté client, sans changement d'API (pattern déjà validé sur le module Salles).
- Unifie le rendu du badge de conflit (texte complet) entre la table « Mes absences » et la table « Vue d'ensemble » — seule incohérence visuelle réelle trouvée lors de l'audit (les variants `Button` étaient déjà cohérents).
- Rend le badge d'absence affiché dans la grille de planning cliquable : il amène désormais au détail de l'absence correspondante dans `/absences`, avec la ligne mise en évidence — uniquement pour les utilisateurs ayant `absences:view` sur l'église courante.
- Réorganise les filtres de la vue d'ensemble en groupes hiérarchisés pour un empilement mobile propre.

Aucune règle métier (permissions, périmètre, workflow de déclaration/annulation) n'est modifiée.

Voir `specs/012-harmonisation-ergonomie-absences/` (spec → plan → tasks, toutes tâches cochées).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries`
- [x] `npm run test` (564 tests, dont 2 nouveaux cas couvrant l'`id` de `activeAbsence`)
- [x] Vérification manuelle mobile (375px) via captures d'écran : filtres empilés lisiblement, historique des annulées accessible, badge cliquable depuis le planning, mise en évidence de la ligne ciblée
- [x] Tous les critères d'acceptation de la spec vérifiés

🤖 Generated with [Claude Code](https://claude.com/claude-code)