### PR TITLE
fix: confirmation avant les actions destructives non protégées

### DIFF
--- a/src/app/(auth)/absences/AbsencesClient.tsx
+++ b/src/app/(auth)/absences/AbsencesClient.tsx
@@ -165,6 +165,7 @@ export default function AbsencesClient({
   }
 
   async function cancelAbsence(id: string) {
+    if (!confirm("Annuler définitivement cette absence ?")) return;
     try {
       const res = await fetch(`/api/absences/${id}`, {
         method: "PATCH",

--- a/src/app/(auth)/accounting/components/AttachmentManager.tsx
+++ b/src/app/(auth)/accounting/components/AttachmentManager.tsx
@@ -91,6 +91,7 @@ export default function AttachmentManager({
   }
 
   async function handleDelete(id: string) {
+    if (!confirm("Supprimer définitivement cette pièce jointe ?")) return;
     setDeletingId(id);
     try {
       const res = await fetch(`/api/accounting/attachments/${id}`, { method: "DELETE" });

--- a/src/app/(auth)/agenda/requests/QualificationDashboard.tsx
+++ b/src/app/(auth)/agenda/requests/QualificationDashboard.tsx
@@ -50,6 +50,7 @@ export default function QualificationDashboard({ requests: initial, profiles }: 
       alert("Veuillez sélectionner un profil pastoral.");
       return;
     }
+    if (action === "REJECT" && !confirm("Rejeter définitivement cette demande ?")) return;
     setProcessing(id);
     try {
       const res = await fetch(`/api/agenda/requests/${id}/qualify`, {

--- a/src/app/(auth)/communication/requests/CommunicationDashboard.tsx
+++ b/src/app/(auth)/communication/requests/CommunicationDashboard.tsx
@@ -55,6 +55,7 @@ export default function CommunicationDashboard({ requests: initial }: Props) {
   const [expandedContent, setExpandedContent] = useState<Set<string>>(new Set());
 
   async function updateRequest(id: string, status: string, deliveryLink?: string) {
+    if (status === "ANNULE" && !confirm("Annuler définitivement cette demande ?")) return;
     setProcessing(id);
     try {
       const res = await fetch(`/api/requests/${id}`, {

--- a/src/app/(auth)/media/requests/MediaDashboard.tsx
+++ b/src/app/(auth)/media/requests/MediaDashboard.tsx
@@ -146,6 +146,7 @@ export default function MediaDashboard({ requests: initial, churchId, mediaProje
     deliveryLink?: string,
     reviewNotes?: string
   ) {
+    if (status === "ANNULE" && !confirm("Annuler définitivement cette demande ?")) return;
     setProcessing(id);
     try {
       const res = await fetch(`/api/requests/${id}`, {

--- a/src/app/(auth)/secretariat/requests/RequestsDashboard.tsx
+++ b/src/app/(auth)/secretariat/requests/RequestsDashboard.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import Button from "@/components/ui/Button";
 
+const DESTRUCTIVE_STATUSES = new Set(["REFUSEE", "ANNULE"]);
+
 const ANNOUNCEMENT_TYPES = ["DIFFUSION_INTERNE", "RESEAUX_SOCIAUX", "VISUEL"];
 const DEMAND_TYPES = [
   "AJOUT_EVENEMENT",
@@ -128,6 +130,7 @@ export default function RequestsDashboard({ requests: initial, canManage = false
   }
 
   async function updateRequest(id: string, status: string, note?: string) {
+    if (DESTRUCTIVE_STATUSES.has(status) && !confirm("Confirmer cette action ? Elle est définitive.")) return;
     setProcessing(id);
     try {
       const res = await fetch(`/api/requests/${id}`, {

--- a/src/components/WeeklyPlanningView.tsx
+++ b/src/components/WeeklyPlanningView.tsx
@@ -125,6 +125,7 @@ export default function WeeklyPlanningView({
   }
 
   async function deleteNotice(eventId: string) {
+    if (!confirm("Supprimer cette note ?")) return;
     setSaving(true);
     setSaveError(null);
     try {


### PR DESCRIPTION
## Résumé

Audit complet de toutes les actions destructives de l'application (boutons `variant="danger"`, suppressions, transitions de statut terminales) pour vérifier la présence d'une confirmation avant exécution — suite à la découverte que « Annuler une absence » s'exécutait au premier clic sans confirmation, contrairement au reste de l'app (Rooms, admin CRUD, etc. protègent systématiquement ces actions via `confirm()` ou `ConfirmModal`).

7 gaps réels trouvés et corrigés, tous avec `confirm()` — cohérent avec le pattern déjà dominant dans l'app (30+ occurrences existantes) pour ce type d'action :

- Annulation d'une absence (`AbsencesClient.tsx`, x2 emplacements via une fonction partagée)
- Suppression d'une pièce jointe comptable (`AttachmentManager.tsx`)
- Refus / annulation d'une demande — secrétariat (`RequestsDashboard.tsx`)
- Annulation d'une demande — production média (`MediaDashboard.tsx`)
- Annulation d'une demande — communication (`CommunicationDashboard.tsx`)
- Rejet d'une demande — qualification agenda (`QualificationDashboard.tsx`)
- Suppression d'une note de planning hebdomadaire (`WeeklyPlanningView.tsx`)

Les actions non-destructives (approuver, livrer, passer en cours, etc.) ne sont pas concernées.

Le reste de l'audit (actions déjà protégées, ou jugées à faible enjeu/facilement réversibles comme le retrait d'un accès salle ou d'une affectation de garde d'accueil) n'a pas nécessité de changement — détail disponible sur demande.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries`
- [x] `npm run test` (562 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)