### PR TITLE
feat(absences): backup, édition, frise et export

### DIFF
--- a/prisma/migrations/20260730102723_add_absence_backups/migration.sql
+++ b/prisma/migrations/20260730102723_add_absence_backups/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  - You are about to drop the `__prisma_migrations` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE `__prisma_migrations`;
+
+-- CreateTable
+CREATE TABLE `absence_backups` (
+    `id` VARCHAR(191) NOT NULL,
+    `absenceId` VARCHAR(191) NOT NULL,
+    `type` ENUM('STAR', 'RESPONSIBLE') NOT NULL,
+    `memberId` VARCHAR(191) NULL,
+    `userChurchRoleId` VARCHAR(191) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `absence_backups_absenceId_memberId_key`(`absenceId`, `memberId`),
+    UNIQUE INDEX `absence_backups_absenceId_userChurchRoleId_key`(`absenceId`, `userChurchRoleId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateIndex
+CREATE INDEX `media_share_tokens_token_idx` ON `media_share_tokens`(`token`);
+
+-- AddForeignKey
+ALTER TABLE `absence_backups` ADD CONSTRAINT `absence_backups_absenceId_fkey` FOREIGN KEY (`absenceId`) REFERENCES `absences`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `absence_backups` ADD CONSTRAINT `absence_backups_memberId_fkey` FOREIGN KEY (`memberId`) REFERENCES `members`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `absence_backups` ADD CONSTRAINT `absence_backups_userChurchRoleId_fkey` FOREIGN KEY (`userChurchRoleId`) REFERENCES `user_church_roles`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -204,6 +204,8 @@ model UserChurchRole {
   ministry    Ministry?        @relation(fields: [ministryId], references: [id])
   departments UserDepartment[]
 
+  absenceBackups AbsenceBackup[]
+
   @@unique([userId, churchId, role])
   @@map("user_church_roles")
 }
@@ -282,7 +284,8 @@ model Member {
   // Module intégration familles
   familyIntegrationRequests FamilyIntegrationRequest[] @relation("IntegrationMemberLink")
 
-  absences Absence[]
+  absences       Absence[]
+  absenceBackups AbsenceBackup[]
 
   @@map("members")
 }
@@ -510,10 +513,33 @@ model Absence {
   church      Church @relation(fields: [churchId], references: [id])
   createdBy   User   @relation("AbsenceCreatedBy", fields: [createdById], references: [id])
   cancelledBy User?  @relation("AbsenceCancelledBy", fields: [cancelledById], references: [id])
+  backups     AbsenceBackup[]
 
   @@index([churchId, startDate, endDate])
   @@index([memberId, status])
   @@map("absences")
+}
+
+enum AbsenceBackupType {
+  STAR
+  RESPONSIBLE
+}
+
+model AbsenceBackup {
+  id               String            @id @default(cuid())
+  absenceId        String
+  type             AbsenceBackupType
+  memberId         String?
+  userChurchRoleId String?
+  createdAt        DateTime          @default(now())
+
+  absence        Absence         @relation(fields: [absenceId], references: [id], onDelete: Cascade)
+  member         Member?         @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  userChurchRole UserChurchRole? @relation(fields: [userChurchRoleId], references: [id], onDelete: Cascade)
+
+  @@unique([absenceId, memberId])
+  @@unique([absenceId, userChurchRoleId])
+  @@map("absence_backups")
 }
 
 model Task {

--- a/specs/013-evolutions-absences/plan.md
+++ b/specs/013-evolutions-absences/plan.md
@@ -1,0 +1,325 @@
+# Plan technique — Évolutions du module Absences
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Brouillon
+- **Mis à jour le** : 2026-07-30
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : tout reste dans `src/modules/planning` (le sous-domaine `absences`
+      existant, cf. spec [[007-gestion-absences-star]]) — aucun nouvel import cross-module ;
+      `src/app/` continue d'importer uniquement `@/modules/planning`.
+- [x] **Sécurité** : nouvelles routes/actions protégées par `requireAuth()` +
+      `requireChurchPermission("absences:manage"/"absences:view", churchId)` selon le cas ; scope
+      département/ministère revérifié serveur (jamais fait confiance au payload client), y compris
+      pour la liste d'IDs envoyée à l'export.
+- [x] **Permissions** via `rolePermissions` (`@/lib/registry`) — aucune nouvelle permission créée,
+      réutilisation de `absences:view`/`absences:manage` existantes.
+- [x] **Validation** Zod sur `POST /api/absences` (étendu), `PATCH /api/absences/[id]` (étendu) et
+      `POST /api/absences/export` (nouveau).
+- [x] **Migration** Prisma prévue : nouveau modèle `AbsenceBackup` + enum `AbsenceBackupType`.
+- [x] **Enums** : `AbsenceBackupType` importé depuis `@/generated/prisma/client`.
+- [x] **UI** : réutilise `DataTable`, `Modal`, `Button`, `Input`, `Select`, `CheckboxGroup` de
+      `src/components/ui/` ; un seul nouveau composant de présentation (`AbsencesTimeline.tsx`,
+      propre au module, pas un composant générique réutilisable ailleurs).
+
+## Approche générale
+
+Les cinq évolutions restent dans le périmètre déjà posé par la spec 007 : même modèle `Absence`,
+même service `src/modules/planning/services/absence.service.ts`, mêmes routes
+`src/app/api/absences/`. Aucune n'introduit de nouveau module ni de nouvelle permission.
+
+- **Backup** (#1) : nouveau modèle `AbsenceBackup`, rattaché à `Absence`, pointant soit vers un
+  `Member` (STAR), soit vers un `UserChurchRole` (Resp. département ou Ministre — le rôle exact
+  est déjà porté par `UserChurchRole.role`, donc un seul type suffit pour les deux). Alimenté et
+  notifié dans `declareAbsence`/`updateAbsence`, jamais dans `cancelAbsence` (les backups sont
+  simplement notifiés de l'annulation comme les responsables, pas de nouvelle logique).
+- **Édition** (#2) : nouvelle action `update` sur la route `PATCH /api/absences/[id]` existante
+  (à côté de `cancel`), portée par un nouveau service `updateAbsence` qui réutilise
+  `findAbsenceConflicts`/`resolveResponsibleUserIds` déjà présents.
+- **Frise** (#3) : uniquement client — un composant de rendu alternatif à `DataTable`, branché sur
+  `displayedAbsences` (déjà filtré/trié en mémoire), pas de nouvel appel réseau.
+- **Export** (#4) : nouvelle route qui reçoit la liste des IDs actuellement affichés (voir
+  Décisions) et génère un classeur avec `ExcelJS`, sur le modèle de
+  `src/app/api/discipleships/export/route.ts`.
+- **Date de fin liée** (#5) : uniquement client, dans le formulaire de déclaration/édition
+  d'`AbsencesClient.tsx`.
+
+## Modèle de données
+
+```prisma
+enum AbsenceBackupType {
+  STAR
+  RESPONSIBLE
+}
+
+model AbsenceBackup {
+  id               String            @id @default(cuid())
+  absenceId        String
+  type             AbsenceBackupType
+  memberId         String?
+  userChurchRoleId String?
+  createdAt        DateTime          @default(now())
+
+  absence        Absence         @relation(fields: [absenceId], references: [id], onDelete: Cascade)
+  member         Member?         @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  userChurchRole UserChurchRole? @relation(fields: [userChurchRoleId], references: [id], onDelete: Cascade)
+
+  @@unique([absenceId, memberId])
+  @@unique([absenceId, userChurchRoleId])
+  @@map("absence_backups")
+}
+```
+
+Ajouts de relations inverses :
+- `Absence.backups AbsenceBackup[]`
+- `Member.absenceBackups AbsenceBackup[]`
+- `UserChurchRole.absenceBackups AbsenceBackup[]`
+
+`type` distingue explicitement les deux cas plutôt que de le déduire de
+`memberId != null`/`userChurchRoleId != null` — plus lisible dans les requêtes et les tests, et
+protège contre un état incohérent (les deux colonnes renseignées) qui resterait sinon possible
+sans contrainte `CHECK` (non supporté nativement par Prisma sur MariaDB). Cette cohérence
+(exactement un des deux champs rempli, aligné avec `type`) est vérifiée dans le service, pas en
+base — même approche que `AbsenceBackup` vis-à-vis de `cancelledById`/`cancelledAt` sur `Absence`.
+
+Pointer vers `UserChurchRole` plutôt que directement vers `User` donne accès sans jointure
+supplémentaire au `role` (DEPARTMENT_HEAD/MINISTER, pour l'affichage), au `ministryId`, et aux
+`departments` couverts — utile pour l'affichage dans la vue transverse et pour valider le
+périmètre à l'écriture.
+
+Migration : `npm run db:migrate` (nom suggéré `add_absence_backups`).
+
+Aucun changement sur `Absence` elle-même : la date de fin, le motif, les dates redeviennent
+modifiables via le service (pas de nouveau champ requis — `updatedAt` existe déjà et suffit à
+tracer la dernière modification).
+
+## API
+
+| Endpoint | Méthode | Permission | Entrée | Sortie |
+|---|---|---|---|---|
+| `/api/absences` | POST | inchangée (self ou `absences:manage` scopé) | *(étendu)* `{ churchId, memberId, startDate, endDate, reason?, backups?: BackupInput[] }` | `201 { ...absence, backups }` |
+| `/api/absences/[id]` | PATCH | inchangée (créateur, self, resp/ministre scopé, ou manager global) | *(étendu)* `{ action: "cancel" } \| { action: "update", startDate?, endDate?, reason?, backups?: BackupInput[] }` | `{ ...absence, backups }` |
+| `/api/absences/export` | POST *(nouveau)* | `requireChurchPermission("absences:view", churchId)` | `{ churchId, absenceIds: string[] }` | Fichier `.xlsx` (`Content-Disposition: attachment`) |
+
+`BackupInput` (Zod, réutilisé dans `POST` et `PATCH action=update`) :
+
+```ts
+const backupSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("STAR"), memberId: z.string().min(1) }),
+  z.object({ type: z.literal("RESPONSIBLE"), userChurchRoleId: z.string().min(1) }),
+]);
+
+const createSchema = z.object({
+  churchId: z.string().min(1),
+  memberId: z.string().min(1),
+  startDate: z.string().datetime(),
+  endDate: z.string().datetime(),
+  reason: z.string().max(500).nullable().optional(),
+  backups: z.array(backupSchema).max(10).optional(),
+}).refine(/* endDate >= startDate, inchangé */);
+
+const patchSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("cancel") }),
+  z.object({
+    action: z.literal("update"),
+    startDate: z.string().datetime().optional(),
+    endDate: z.string().datetime().optional(),
+    reason: z.string().max(500).nullable().optional(),
+    backups: z.array(backupSchema).max(10).optional(),
+  }),
+]);
+```
+
+`GET /api/absences` (inchangée en signature) : la réponse par absence gagne un champ
+`backups: Array<{ id, type: "STAR"|"RESPONSIBLE", name: string, role?: "DEPARTMENT_HEAD"|"MINISTER" }>`.
+
+Validation serveur des backups (dans la route `POST`/`PATCH`, avant d'appeler le service — même
+esprit que la vérification `deptScope`/`withinScope` déjà présente) :
+
+- Rejette (`403`) tout `backups` non vide si `!isSelf` — cohérent avec la spec (jamais de backup
+  sur une absence déclarée pour un tiers).
+- Rejette (`403`) tout `backups` non vide si le déclarant n'a, dans `churchId`, ni rôle
+  `DEPARTMENT_HEAD` ni `MINISTER`.
+- Pour chaque entrée `STAR` : le `memberId` doit appartenir au département du déclarant
+  (`DEPARTMENT_HEAD`) ou à un département du ministère du déclarant (`MINISTER`), sinon `403`.
+- Pour chaque entrée `RESPONSIBLE` : le `userChurchRoleId` ciblé doit être, selon le rôle du
+  déclarant :
+  - `DEPARTMENT_HEAD` → soit le `MINISTER` du ministère de son département, soit un autre
+    `DEPARTMENT_HEAD` d'un département du **même** ministère ;
+  - `MINISTER` → un autre `MINISTER` de la même église (`churchId`), jamais lui-même.
+  Toute autre cible → `403`.
+
+## Services / logique métier
+
+`src/modules/planning/services/absence.service.ts` (extension du fichier existant) :
+
+- `declareAbsence(params)` : signature étendue avec `backups?: BackupInput[]`. Dans la même
+  transaction que la création de l'`Absence` :
+  - crée les lignes `AbsenceBackup` correspondantes ;
+  - pour chaque backup `STAR`, résout un éventuel `MemberUserLink` (comme pour le STAR absent
+    lui-même) et notifie ce user s'il existe (`ABSENCE_BACKUP_ASSIGNED`) — pas de notification si
+    la fiche STAR backup n'a pas de compte lié, cohérent avec le traitement déjà appliqué au STAR
+    absent en cas de conflit ;
+  - pour chaque backup `RESPONSIBLE`, résout `userChurchRole.userId` et notifie directement
+    (`ABSENCE_BACKUP_ASSIGNED`).
+
+- `updateAbsence(params): Promise<Absence>` *(nouveau)* :
+  - Recharge l'absence, vérifie `status === "ACTIVE"` et que sa date de fin **actuelle** n'est pas
+    déjà passée (sinon `ApiError(409, "Absence déjà passée, non modifiable")`).
+  - Si `startDate` est fourni et que l'absence a déjà commencé (`absence.startDate <= now`),
+    refuse toute nouvelle `startDate` antérieure à la date de début déjà enregistrée
+    (`ApiError(400)`) — l'absence en cours ne peut être raccourcie/allongée que sur sa partie
+    future.
+  - Calcule les conflits **avant** (période actuelle) et **après** (période patchée) via
+    `findAbsenceConflicts`.
+  - Transaction : met à jour `startDate`/`endDate`/`reason` fournis ; si `backups` est fourni,
+    supprime les `AbsenceBackup` existants et recrée la liste transmise (remplacement complet,
+    plus simple et suffisant — pas de cas d'usage de diff partiel identifié) ; notifie
+    `ABSENCE_UPDATED` à l'union des destinataires déjà notifiés à la déclaration (responsables +
+    anciens backups + STAR si conflit précédent) et des nouveaux destinataires (nouveaux backups) ;
+    si un nouveau conflit apparaît qui n'existait pas avant, notifie `ABSENCE_CONFLICT`
+    exactement comme `declareAbsence`.
+  - Émet `planning:absence:updated`.
+
+- Notification des backups à l'annulation : `cancelAbsence` étendu pour inclure, dans
+  `recipients`, les utilisateurs résolus depuis `absence.backups` (au même titre que les
+  responsables) — pas de nouveau type de notification, `ABSENCE_CANCELLED` existant suffit.
+
+Nouveaux événements dans `PlanningEvents` (`src/modules/planning/events.ts`) :
+
+```ts
+"planning:absence:updated": {
+  absenceId: string;
+  churchId: string;
+  memberId: string;
+  updatedById: string;
+  startDate: string;
+  endDate: string;
+  hasConflict: boolean;
+};
+```
+
+Aucun abonnement cross-module requis (même raisonnement que `planning:absence:declared`).
+
+## UI / composants
+
+- **`AbsencesClient.tsx`** (extension) :
+  - Le formulaire de déclaration (`Modal`) affiche un bloc `CheckboxGroup` « Backup (optionnel) »
+    **uniquement** quand `declareMode === "self"` **et** que la fiche STAR sélectionnée correspond
+    à un compte ayant le rôle `DEPARTMENT_HEAD` ou `MINISTER` pour `churchId` (info déjà connue
+    côté page via `session.user.churchRoles`, passée en prop `selfBackupOptions` pré-calculée côté
+    serveur — pas de nouvel appel réseau pour lister les options). Les options combinent STAR du
+    périmètre + responsables éligibles (valeur préfixée `star:<memberId>` / `role:<userChurchRoleId>`,
+    séparée au submit).
+  - Même formulaire réutilisé pour l'édition : un bouton « Modifier » (à côté d'« Annuler », visible
+    si `status === "ACTIVE"` et date de fin non passée) ouvre le même `Modal` pré-rempli, avec un
+    appel `PATCH .../[id]` (`action: "update"`) au lieu de `POST`.
+  - Date de fin (#5) : `onChange` de la date de début met à jour `formEndDate` si vide ou
+    antérieure à la nouvelle date de début ; l'`Input` date de fin reçoit `min={formStartDate}`.
+  - Colonne « Backup(s) » ajoutée aux deux `DataTable` (mes absences + vue d'ensemble), affichant
+    les noms séparés par virgule (ou « — »).
+  - Bascule « Tableau / Frise » (deux boutons ou `Select`) au-dessus de la vue d'ensemble ; l'état
+    (`viewMode`) ne change que le rendu, les filtres et `displayedAbsences` restent partagés.
+  - Bouton « Exporter » dans l'en-tête de la vue d'ensemble : `POST /api/absences/export` avec
+    `{ churchId, absenceIds: displayedAbsences.map(a => a.id) }`, réponse transformée en
+    `Blob` et téléchargée (même pattern que les exports déjà en place côté client, ex.
+    `RequestsDashboard`/`MediaDashboard` pour les téléchargements de fichiers).
+
+- **`AbsencesTimeline.tsx`** *(nouveau, colocalisé dans* `src/app/(auth)/absences/`*)* : reçoit
+  `displayedAbsences` (même tableau que `DataTable`) + la plage `[dateFrom, dateTo]` effective
+  (calculée depuis les filtres actifs, ou min/max des données si aucun filtre de date). Regroupe
+  les absences par membre, une ligne par membre, chaque absence positionnée en `%` sur un axe
+  horizontal (`left`/`width` calculés depuis les dates, division simple, pas de librairie). Un clic
+  sur un segment ouvre le même détail que `DataTable` (réutilise `highlightedId`/scroll existant
+  ou une simple info-bulle). Pas de nouvel appel réseau.
+
+- **Page `page.tsx`** : ajoute au chargement serveur la détection du rôle du déclarant
+  (`DEPARTMENT_HEAD`/`MINISTER`) et la résolution des options de backup éligibles par fiche STAR
+  self (départements/ministère couverts), passées en props à `AbsencesClient`.
+
+## Décisions & alternatives écartées
+
+- **Choix** : `AbsenceBackup` pointe vers `UserChurchRole` (pas directement vers `User`) pour les
+  backups Resp. département/Ministre — *Pourquoi* : évite une jointure supplémentaire pour
+  connaître le rôle exact et le périmètre couvert à l'affichage et à la validation, cohérent avec
+  le pattern déjà utilisé par `resolveResponsibleUserIds`.
+- **Choix** : un seul type `RESPONSIBLE` plutôt que deux (`DEPARTMENT_HEAD`/`MINISTER`) —
+  *Pourquoi* : l'information est déjà portée par `userChurchRole.role`, dupliquer l'enum serait
+  redondant et risquerait de désynchroniser si un `UserChurchRole` change de rôle après coup.
+- **Choix** : édition = mise à jour en place du même enregistrement `Absence` (pas de nouvelle
+  ligne, pas de table d'historique) — *Pourquoi* : imposé par la spec (traçabilité de la
+  déclaration d'origine) ; un historique des versions n'est pas demandé et serait de la
+  sur-ingénierie pour ce besoin.
+- **Choix** : remplacement complet des `AbsenceBackup` à chaque édition plutôt qu'un diff
+  ajout/retrait — *Pourquoi* : la liste de backups est petite (max 10), le remplacement complet
+  est plus simple à raisonner et à tester, sans overhead perceptible.
+- **Choix** : export reçoit la liste d'IDs actuellement affichés plutôt que de dupliquer la logique
+  de filtrage (recherche, statut, plage de dates) côté serveur — *Pourquoi* : ces filtres sont
+  aujourd'hui purement client (`useMemo`, cf. spec [[012-harmonisation-ergonomie-absences]]) ;
+  réimplémenter la même logique côté serveur créerait deux sources de vérité à maintenir en
+  synchronisation. Le périmètre de visibilité (scope département/ministère/église) reste
+  revérifié côté serveur en filtrant les IDs reçus à ceux réellement autorisés, donc un ID hors
+  périmètre ne fuite jamais dans l'export.
+- **Choix** : frise développée en composant maison (positionnement CSS en `%`) plutôt qu'avec
+  `recharts` (déjà une dépendance) — *Pourquoi* : `recharts` est orienté graphiques
+  statistiques (barres, lignes, camemberts) et n'a pas de primitive Gantt/frise adaptée ; un
+  composant dédié léger évite de détourner une librairie pour un rendu qu'elle ne couvre pas
+  nativement.
+- **Écarté** : autoriser un STAR simple à proposer un backup pour sa propre absence — *Raison* :
+  explicitement exclu par la spec (backup réservé aux absences des responsables).
+- **Écarté** : notification automatique au backup lui proposant de « prendre le service » —
+  *Raison* : hors périmètre explicite de la spec ; la désignation reste informative.
+- **Écarté** : endpoint GET dédié pour lister les backups éligibles à la volée — *Raison* : la
+  liste dépend uniquement du rôle/périmètre déjà connu au chargement de la page (Server
+  Component) ; un aller-retour réseau supplémentaire n'apporterait rien.
+
+## Risques & points d'attention
+
+- **Cohérence `type` / colonnes renseignées sur `AbsenceBackup`** : le service doit garantir que
+  `memberId` XOR `userChurchRoleId` est renseigné selon `type` — à tester explicitement (create
+  avec les deux, ou aucun, doit être impossible depuis le service même si la base ne l'empêche
+  pas).
+- **Édition concurrente / absence passée entre l'ouverture du formulaire et la soumission** : si
+  l'absence passe en "non modifiable" (date de fin dépassée) pendant que l'utilisateur avait le
+  formulaire ouvert, le service doit re-vérifier au moment de l'écriture (pas seulement à
+  l'ouverture côté client) et renvoyer `409`.
+- **Export et périmètre** : bien tester qu'un `absenceIds` contenant un ID hors périmètre de
+  l'appelant (deviné/forgé) est silencieusement exclu du fichier généré, sans erreur ni fuite
+  d'information sur son existence.
+- **Backup pointant vers un `UserChurchRole` supprimé/modifié** : si un Resp. département perd son
+  rôle après avoir été désigné backup, l'affichage doit gérer une relation potentiellement
+  incohérente sans crasher (le `onDelete: Cascade` supprime la ligne `AbsenceBackup`
+  correspondante — comportement acceptable et cohérent avec le reste du schéma).
+- **Frise avec beaucoup de membres/absences** : pas de pagination prévue (volumétrie attendue
+  faible, comme pour la vue tableau) — à revisiter si un usage réel montre un problème de
+  lisibilité avec beaucoup de lignes.
+
+## Stratégie de tests
+
+Tests unitaires (Vitest) dans `src/modules/planning/services/absence.service.test.ts` (extension) :
+
+- `declareAbsence` avec des backups `STAR` et `RESPONSIBLE` crée les `AbsenceBackup` attendus et
+  notifie chaque destinataire résolu (avec/sans `MemberUserLink` pour le cas `STAR`).
+- `declareAbsence` sans backups conserve exactement le comportement actuel (non-régression).
+- `updateAbsence` modifie la période, recalcule les conflits, notifie les nouveaux conflits et
+  l'ensemble des destinataires (anciens + nouveaux backups).
+- `updateAbsence` refuse (409) une absence dont la date de fin est déjà passée.
+- `updateAbsence` refuse (400) une nouvelle `startDate` antérieure à la date de début déjà
+  enregistrée quand l'absence est déjà en cours.
+- `updateAbsence` remplace intégralement les backups quand une nouvelle liste est fournie, et les
+  laisse inchangés quand `backups` est omis.
+- `cancelAbsence` notifie aussi les backups de l'absence annulée.
+
+Tests d'intégration légers sur les routes (`src/app/api/absences/__tests__/`, extension) :
+
+- `POST /api/absences` avec `backups` : `403` si `!isSelf`, `403` si le déclarant n'a pas le rôle
+  requis, `403` si un backup est hors périmètre (autre ministère pour un `DEPARTMENT_HEAD`, cible
+  = soi-même pour un `RESPONSIBLE` désigné par un `MINISTER`), `201` sinon.
+- `PATCH /api/absences/[id]` avec `action: "update"` : mêmes codes de statut que `cancel` pour
+  l'autorisation ; `409` si déjà passée.
+- `POST /api/absences/export` : `403` sans `absences:view` ; fichier `.xlsx` généré (vérifier
+  `Content-Type`) contenant uniquement les IDs dans le périmètre de l'appelant même si la requête
+  en fournit hors périmètre.

--- a/specs/013-evolutions-absences/spec.md
+++ b/specs/013-evolutions-absences/spec.md
@@ -1,0 +1,244 @@
+# Spec — Évolutions du module Absences
+
+- **Numéro** : 013
+- **Statut** : En revue
+- **Créée le** : 2026-07-30
+- **Branche suggérée** : `feat/evolutions-absences`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+Le module Absences (spec [[007-gestion-absences-star]]) est en production depuis peu et a déjà
+reçu une passe d'harmonisation ergonomique (spec [[012-harmonisation-ergonomie-absences]]). Son
+usage courant fait apparaître cinq limites :
+
+1. Quand un Resp. département ou un Ministre déclare sa propre absence, il n'a aucun moyen de
+   noter tout de suite qui assurera la continuité de ses responsabilités pendant cette période —
+   cette information circule oralement ou se perd, et doit être redécouverte plus tard.
+2. Corriger une absence déjà déclarée (mauvaise date, motif à préciser) oblige aujourd'hui à
+   l'annuler puis à en recréer une nouvelle, ce qui casse la traçabilité de la déclaration
+   d'origine et repart de zéro sur les notifications.
+3. La vue transverse actuelle liste les absences sous forme de tableau : elle ne permet pas de
+   voir d'un coup d'œil comment les absences d'une période se répartissent dans le temps.
+4. Les responsables qui doivent partager ou archiver les absences hors de l'application (compte
+   rendu, réunion) n'ont aucun moyen d'en exporter la liste.
+5. À la déclaration, la saisie de la date de fin est indépendante de la date de début, ce qui
+   permet de sélectionner par erreur une date de fin antérieure à la date de début et alourdit la
+   saisie sur une période courte (souvent un seul jour ou quelques jours consécutifs).
+
+Cette feature regroupe ces cinq évolutions car elles portent toutes sur le même module et visent
+le même objectif : rendre la déclaration et le suivi des absences plus fiables et plus rapides au
+quotidien pour les responsables.
+
+## Utilisateurs concernés
+
+- **STAR** : peut modifier sa propre absence tant qu'elle n'est pas passée ; consulte la nouvelle
+  vue frise et peut exporter ce qu'il voit dans son périmètre ; ne désigne jamais de backup (le
+  backup ne concerne que les absences des Resp. département et des Ministres).
+- **Resp. département** : peut désigner en backup, lors de la déclaration ou de la modification de
+  **sa propre** absence, un ou plusieurs STAR de son département, le Ministre dont il dépend et/ou
+  un autre Resp. département du même ministère, pour assurer la continuité de ses responsabilités ;
+  peut modifier une absence de son périmètre tant qu'elle n'est pas passée ; consulte la vue frise
+  et exporte sur son périmètre.
+- **Ministre** : mêmes droits que Resp. département pour la modification, la vue frise et
+  l'export ; pour le backup, peut désigner en backup de **sa propre** absence un STAR de
+  n'importe quel département de son ministère et/ou un autre Ministre de l'église.
+- **Secrétaire, Admin, Super Admin** : consultent la vue frise et exportent sur tout le périmètre
+  auquel ils ont déjà accès en lecture (vue transverse existante) ; ne désignent pas de backup et
+  ne modifient pas d'absence pour un tiers (cohérent avec leur absence de droit de déclaration
+  aujourd'hui).
+
+Rôles non concernés : Faiseur de Disciples, Reporter (déjà hors périmètre du module Absences).
+
+## Comportement attendu
+
+### 1. Backup optionnel sur une absence de responsable
+
+#### Scénario principal
+
+1. Un Resp. département ou un Ministre déclare (ou modifie) **sa propre** absence.
+2. En option, il désigne un ou plusieurs backups pour assurer la continuité de ses
+   responsabilités pendant la période concernée :
+   - un Resp. département choisit parmi les STAR de son département, le Ministre dont il dépend
+     et/ou un autre Resp. département du même ministère ;
+   - un Ministre choisit parmi les STAR des départements de son ministère et/ou un autre Ministre
+     de l'église.
+3. L'absence est enregistrée avec ses backups. Les personnes désignées comme backup (STAR, Resp.
+   département ou Ministre) sont notifiées qu'elles ont été proposées en remplacement, avec la
+   période et le motif (si renseigné).
+4. Le ou les backups apparaissent sur l'absence dans la vue transverse, à côté du responsable
+   absent.
+
+#### Cas limites
+
+- **Si** aucun backup n'est désigné, **alors** l'absence se comporte exactement comme aujourd'hui
+  (aucun changement de comportement pour les déclarations sans backup).
+- **Si** la personne qui déclare une absence n'a le rôle ni de Resp. département ni de Ministre
+  (STAR simple), **alors** l'option de désigner un backup ne lui est pas proposée, y compris pour
+  sa propre absence.
+- **Si** un Resp. département ou un Ministre déclare une absence pour un tiers de son périmètre
+  (et non pour lui-même), **alors** l'option de désigner un backup ne lui est pas proposée — le
+  backup ne s'applique qu'à l'absence du responsable lui-même.
+- **Si** un Resp. département désigne le Ministre dont il dépend, ou un autre Resp. département du
+  même ministère, en backup, **alors** la personne désignée est notifiée exactement comme le
+  serait un STAR désigné en backup.
+- **Si** un Ministre désigne un autre Ministre en backup, **alors** ce dernier est notifié
+  exactement comme le serait un STAR désigné en backup.
+- **Si** un Resp. département tente de désigner en backup un Resp. département d'un autre
+  ministère que le sien, **alors** cette personne ne lui est pas proposée dans le choix des
+  backups possibles.
+- **Si** la personne désignée en backup (STAR, Resp. département ou Ministre) est elle-même déjà
+  en absence active sur tout ou partie de la même période, **alors** le système le signale
+  visuellement au moment de la désignation, sans empêcher la sauvegarde — c'est au responsable
+  d'arbitrer.
+- **Si** une absence avec backup est annulée ou modifiée (date, backup retiré), **alors** les
+  backups concernés sont notifiés du changement comme le sont aujourd'hui les responsables lors
+  d'une annulation.
+
+### 2. Modification d'une absence non passée
+
+#### Scénario principal
+
+1. Un STAR (pour sa propre absence) ou un responsable de son périmètre ouvre une absence active
+   dont la date de fin n'est pas encore passée.
+2. Il modifie la période et/ou le motif et/ou les backups.
+3. Il valide : l'absence est mise à jour immédiatement, sans étape d'approbation, comme c'est déjà
+   le cas pour la déclaration.
+4. Le système réévalue les conflits avec le planning existant sur la nouvelle période, exactement
+   selon la même logique qu'à la création.
+5. Les responsables et backups qui avaient été notifiés de la déclaration initiale sont notifiés
+   de la modification.
+
+#### Cas limites
+
+- **Si** l'absence est déjà passée (date de fin dans le passé), **alors** elle ne peut plus être
+  modifiée — seule sa consultation reste possible, comme aujourd'hui.
+- **Si** l'absence est en cours (date de début passée, date de fin future), **alors** elle reste
+  modifiable pour sa partie future ; la modification ne peut pas faire remonter la date de début
+  dans le passé.
+- **Si** la modification fait apparaître un nouveau conflit avec le planning qui n'existait pas
+  avant, **alors** le système notifie ce conflit exactement comme il le ferait pour une nouvelle
+  déclaration.
+- **Si** la modification fait disparaître un conflit existant (ex. la période est raccourcie),
+  **alors** le conflit n'est plus signalé sur le planning.
+- L'action « Annuler » reste disponible en parallèle de la modification : modifier corrige une
+  absence qui reste d'actualité, annuler y met fin définitivement.
+
+### 3. Vue frise temporelle
+
+#### Scénario principal
+
+1. Un utilisateur ayant accès à la vue transverse des absences bascule vers une vue « frise
+   temporelle ».
+2. Il voit les absences réparties visuellement sur un axe temporel, organisées par STAR ou par
+   département, pour la période actuellement sélectionnée.
+3. Il peut naviguer dans le temps (période précédente/suivante) et cliquer sur une absence pour en
+   voir le détail, comme depuis la vue tableau existante.
+
+#### Cas limites
+
+- **Si** aucun filtre n'est appliqué, **alors** la frise respecte le même périmètre de visibilité
+  que la vue tableau existante (département/ministère/église selon le rôle).
+- **Si** un filtre est actif dans la vue tableau (statut, période, recherche), **alors** basculer
+  vers la frise conserve ce filtre.
+- **Si** une absence a un conflit signalé, **alors** ce conflit reste visuellement identifiable
+  dans la frise, de la même manière que dans la vue tableau.
+
+### 4. Export Excel
+
+#### Scénario principal
+
+1. Depuis la vue transverse des absences (tableau ou frise), un utilisateur déclenche l'export.
+2. Il obtient un fichier Excel contenant les absences actuellement visibles compte tenu des
+   filtres appliqués et de son périmètre de visibilité.
+3. Chaque ligne exportée reprend les informations affichées dans la vue transverse (STAR,
+   département, période, motif, statut, conflit éventuel, backup(s) éventuel(s)).
+
+#### Cas limites
+
+- **Si** aucune absence ne correspond aux filtres actifs, **alors** l'export produit un fichier
+  vide (avec en-têtes) plutôt qu'une erreur.
+- L'export ne contient jamais d'absence hors du périmètre de visibilité de l'utilisateur, même si
+  ses filtres tentent d'en afficher davantage.
+
+### 5. Date de fin liée à la date de début
+
+#### Scénario principal
+
+1. Lors de la déclaration ou de la modification d'une absence, l'utilisateur choisit d'abord la
+   date de début.
+2. La date de fin se pré-remplit avec la même date (absence d'un jour par défaut) et son
+   sélecteur ne propose plus de dates antérieures à la date de début.
+3. L'utilisateur peut ajuster librement la date de fin vers une date ultérieure si l'absence dure
+   plusieurs jours.
+
+#### Cas limites
+
+- **Si** l'utilisateur modifie la date de début après avoir déjà choisi une date de fin, **et
+  que** la date de fin devient antérieure à la nouvelle date de début, **alors** la date de fin se
+  réaligne automatiquement sur la nouvelle date de début.
+- **Si** l'utilisateur modifie la date de début après avoir déjà choisi une date de fin, **et
+  que** la date de fin reste postérieure ou égale à la nouvelle date de début, **alors** la date
+  de fin choisie est conservée telle quelle.
+
+## Critères d'acceptation
+
+- [ ] Un Resp. département peut désigner en backup, lors de la déclaration de **sa propre**
+      absence, un ou plusieurs STAR de son département, le Ministre dont il dépend et/ou un autre
+      Resp. département du même ministère.
+- [ ] Un Resp. département ne peut pas désigner en backup un Resp. département d'un autre
+      ministère que le sien.
+- [ ] Un Ministre peut désigner en backup, lors de la déclaration de **sa propre** absence, un ou
+      plusieurs STAR de n'importe quel département de son ministère et/ou un autre Ministre de
+      l'église.
+- [ ] L'option de désigner un backup n'est jamais proposée à un STAR simple (sans rôle Resp.
+      département ni Ministre), y compris pour sa propre absence.
+- [ ] L'option de désigner un backup n'est jamais proposée lorsqu'un responsable déclare une
+      absence pour un tiers — uniquement pour sa propre absence.
+- [ ] Les backups désignés sont notifiés de leur désignation avec la période concernée.
+- [ ] Les backups d'une absence sont visibles dans la vue transverse.
+- [ ] Une absence sans backup se comporte exactement comme avant cette feature.
+- [ ] Un STAR peut modifier sa propre absence tant que sa date de fin n'est pas passée.
+- [ ] Un Resp. département ou un Ministre peut modifier une absence de son périmètre tant que sa
+      date de fin n'est pas passée.
+- [ ] Une absence dont la date de fin est passée n'est plus modifiable.
+- [ ] La modification d'une absence réévalue les conflits avec le planning sur la nouvelle
+      période et notifie les nouveaux conflits comme à la création.
+- [ ] La modification d'une absence notifie les responsables et backups déjà notifiés de la
+      déclaration initiale.
+- [ ] Une vue « frise temporelle » est disponible en alternative à la vue tableau, avec le même
+      périmètre de visibilité et les mêmes filtres.
+- [ ] Un export Excel des absences est disponible depuis la vue transverse, respectant les
+      filtres actifs et le périmètre de visibilité de l'utilisateur.
+- [ ] Lors de la déclaration ou modification d'une absence, la date de fin se pré-remplit sur la
+      date de début et ne peut pas être choisie antérieure à celle-ci.
+- [ ] Changer la date de début après coup réaligne automatiquement une date de fin devenue
+      antérieure, sans modifier une date de fin restée valide.
+
+## Hors périmètre
+
+- Aucune notification automatique proposant à un backup de « prendre le service » à la place du
+  responsable absent — la désignation reste informative, l'arbitrage et l'affectation planning
+  restent manuels (cohérent avec le hors-périmètre de la spec [[007-gestion-absences-star]]).
+- Aucune limite au nombre de backups désignés.
+- Le backup ne s'applique jamais à l'absence d'un STAR simple (sans rôle Resp. département ni
+  Ministre), ni à une absence déclarée par un responsable pour un tiers.
+- La vue frise n'introduit pas de nouvelle action (création/modification) qui n'existerait pas
+  déjà dans la vue tableau — elle n'est qu'un mode de visualisation supplémentaire.
+- L'export ne couvre que le format Excel — pas de CSV, PDF, ou autre format.
+- Aucune récurrence ou modification en masse (édition groupée de plusieurs absences à la fois).
+- La modification d'une absence ne permet pas de la réattribuer à un autre STAR — elle reste
+  rattachée au STAR d'origine ; changer de STAR nécessite d'annuler et de déclarer une nouvelle
+  absence.
+
+## Questions ouvertes
+
+Aucune question bloquante restante — tous les points ont été tranchés :
+
+- Le backup ne concerne que les absences des Resp. département et des Ministres, jamais celles
+  d'un STAR simple, et jamais une absence déclarée par un responsable pour un tiers.
+- Un Resp. département désigne un backup parmi les STAR de son département, le Ministre dont il
+  dépend et/ou un autre Resp. département du même ministère ; un Ministre désigne un backup parmi
+  les STAR de n'importe quel département de son ministère et/ou un autre Ministre de l'église.

--- a/specs/013-evolutions-absences/spec.md
+++ b/specs/013-evolutions-absences/spec.md
@@ -1,7 +1,7 @@
 # Spec — Évolutions du module Absences
 
 - **Numéro** : 013
-- **Statut** : En revue
+- **Statut** : Implémentée
 - **Créée le** : 2026-07-30
 - **Branche suggérée** : `feat/evolutions-absences`
 
@@ -185,36 +185,36 @@ Rôles non concernés : Faiseur de Disciples, Reporter (déjà hors périmètre 
 
 ## Critères d'acceptation
 
-- [ ] Un Resp. département peut désigner en backup, lors de la déclaration de **sa propre**
+- [x] Un Resp. département peut désigner en backup, lors de la déclaration de **sa propre**
       absence, un ou plusieurs STAR de son département, le Ministre dont il dépend et/ou un autre
       Resp. département du même ministère.
-- [ ] Un Resp. département ne peut pas désigner en backup un Resp. département d'un autre
+- [x] Un Resp. département ne peut pas désigner en backup un Resp. département d'un autre
       ministère que le sien.
-- [ ] Un Ministre peut désigner en backup, lors de la déclaration de **sa propre** absence, un ou
+- [x] Un Ministre peut désigner en backup, lors de la déclaration de **sa propre** absence, un ou
       plusieurs STAR de n'importe quel département de son ministère et/ou un autre Ministre de
       l'église.
-- [ ] L'option de désigner un backup n'est jamais proposée à un STAR simple (sans rôle Resp.
+- [x] L'option de désigner un backup n'est jamais proposée à un STAR simple (sans rôle Resp.
       département ni Ministre), y compris pour sa propre absence.
-- [ ] L'option de désigner un backup n'est jamais proposée lorsqu'un responsable déclare une
+- [x] L'option de désigner un backup n'est jamais proposée lorsqu'un responsable déclare une
       absence pour un tiers — uniquement pour sa propre absence.
-- [ ] Les backups désignés sont notifiés de leur désignation avec la période concernée.
-- [ ] Les backups d'une absence sont visibles dans la vue transverse.
-- [ ] Une absence sans backup se comporte exactement comme avant cette feature.
-- [ ] Un STAR peut modifier sa propre absence tant que sa date de fin n'est pas passée.
-- [ ] Un Resp. département ou un Ministre peut modifier une absence de son périmètre tant que sa
+- [x] Les backups désignés sont notifiés de leur désignation avec la période concernée.
+- [x] Les backups d'une absence sont visibles dans la vue transverse.
+- [x] Une absence sans backup se comporte exactement comme avant cette feature.
+- [x] Un STAR peut modifier sa propre absence tant que sa date de fin n'est pas passée.
+- [x] Un Resp. département ou un Ministre peut modifier une absence de son périmètre tant que sa
       date de fin n'est pas passée.
-- [ ] Une absence dont la date de fin est passée n'est plus modifiable.
-- [ ] La modification d'une absence réévalue les conflits avec le planning sur la nouvelle
+- [x] Une absence dont la date de fin est passée n'est plus modifiable.
+- [x] La modification d'une absence réévalue les conflits avec le planning sur la nouvelle
       période et notifie les nouveaux conflits comme à la création.
-- [ ] La modification d'une absence notifie les responsables et backups déjà notifiés de la
+- [x] La modification d'une absence notifie les responsables et backups déjà notifiés de la
       déclaration initiale.
-- [ ] Une vue « frise temporelle » est disponible en alternative à la vue tableau, avec le même
+- [x] Une vue « frise temporelle » est disponible en alternative à la vue tableau, avec le même
       périmètre de visibilité et les mêmes filtres.
-- [ ] Un export Excel des absences est disponible depuis la vue transverse, respectant les
+- [x] Un export Excel des absences est disponible depuis la vue transverse, respectant les
       filtres actifs et le périmètre de visibilité de l'utilisateur.
-- [ ] Lors de la déclaration ou modification d'une absence, la date de fin se pré-remplit sur la
+- [x] Lors de la déclaration ou modification d'une absence, la date de fin se pré-remplit sur la
       date de début et ne peut pas être choisie antérieure à celle-ci.
-- [ ] Changer la date de début après coup réaligne automatiquement une date de fin devenue
+- [x] Changer la date de début après coup réaligne automatiquement une date de fin devenue
       antérieure, sans modifier une date de fin restée valide.
 
 ## Hors périmètre

--- a/specs/013-evolutions-absences/tasks.md
+++ b/specs/013-evolutions-absences/tasks.md
@@ -1,7 +1,7 @@
 # Tâches — Évolutions du module Absences
 
 - **Spec** : `./spec.md` · **Plan** : `./plan.md`
-- **Statut** : À faire
+- **Statut** : Terminé
 
 > Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
 > naturelles : migration → services → API → UI → tests. Les tâches `[P]` sont parallélisables.
@@ -102,18 +102,18 @@
 
 ### 5. Tests
 
-- [ ] **T16** — Tests unitaires `declareAbsence` avec backups : crée les `AbsenceBackup` attendus
+- [x] **T16** — Tests unitaires `declareAbsence` avec backups : crée les `AbsenceBackup` attendus
       pour `STAR` (avec/sans `MemberUserLink`) et `RESPONSIBLE`, notifie chaque destinataire
       résolu ; vérifie la non-régression sans backups *(fichier :
       `src/modules/planning/services/absence.service.test.ts`)*
-- [ ] **T17** — Tests unitaires `updateAbsence` : modification de période avec recalcul de
+- [x] **T17** — Tests unitaires `updateAbsence` : modification de période avec recalcul de
       conflits et notification des nouveaux conflits, notification de l'union des destinataires
       (anciens + nouveaux backups), `409` si déjà passée, `400` si `startDate` reculée alors que
       l'absence est en cours, remplacement complet des backups quand fournis / inchangés quand
       omis *(même fichier que T16)*
-- [ ] **T18** [P] — Tests unitaires `cancelAbsence` : notifie aussi les backups de l'absence
+- [x] **T18** [P] — Tests unitaires `cancelAbsence` : notifie aussi les backups de l'absence
       annulée *(même fichier que T16)*
-- [ ] **T19** [P] — Tests d'intégration routes : `POST /api/absences` avec `backups` — `403` si
+- [x] **T19** [P] — Tests d'intégration routes : `POST /api/absences` avec `backups` — `403` si
       `!isSelf`, `403` si rôle non éligible, `403` si backup hors périmètre (autre ministère pour
       un Resp. département, auto-désignation pour un Ministre), `201` sinon ; `PATCH
       .../[id]` `action: "update"` — mêmes codes d'autorisation que `cancel`, `409` si déjà
@@ -126,10 +126,10 @@
 
 ## Vérification finale
 
-- [ ] `npm run typecheck`
-- [ ] `npm run lint`
-- [ ] `npm run lint:boundaries`
-- [ ] `npm run test`
-- [ ] Cohérence de la vue mobile vérifiée (T15b) sur l'ensemble des écrans touchés
-- [ ] Tous les critères d'acceptation de `spec.md` satisfaits
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Cohérence de la vue mobile vérifiée par revue de code (T15b) — vérification visuelle réelle non effectuée (pas d'outil de navigateur disponible)
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits
 - [ ] PR ouverte vers `main`

--- a/specs/013-evolutions-absences/tasks.md
+++ b/specs/013-evolutions-absences/tasks.md
@@ -1,0 +1,135 @@
+# Tâches — Évolutions du module Absences
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : À faire
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : migration → services → API → UI → tests. Les tâches `[P]` sont parallélisables.
+
+## Prérequis
+
+- [x] Branche créée : `feat/evolutions-absences`
+- [ ] Migration Prisma générée (T2)
+
+## Tâches
+
+### 1. Données & migration
+
+- [ ] **T1** — Ajouter l'enum `AbsenceBackupType` (`STAR`/`RESPONSIBLE`), le modèle
+      `AbsenceBackup` (`absenceId`, `type`, `memberId?`, `userChurchRoleId?`) et les relations
+      inverses (`Absence.backups`, `Member.absenceBackups`, `UserChurchRole.absenceBackups`)
+      *(fichier : `prisma/schema.prisma`)*
+- [ ] **T2** — Générer et vérifier la migration (`npm run db:migrate` — nom
+      `add_absence_backups`) ; contrôler le SQL généré *(fichier : `prisma/migrations/…`)*
+
+### 2. Logique métier (services)
+
+- [ ] **T3** — Implémenter `validateBackupTargets(declarerRole, declarerScope, backups)` :
+      vérifie pour chaque entrée `STAR` l'appartenance au département (Resp. département) ou au
+      ministère (Ministre) du déclarant, et pour chaque entrée `RESPONSIBLE` la cible autorisée
+      (Ministre du ministère ou autre Resp. département du même ministère pour un Resp.
+      département ; autre Ministre de l'église, jamais lui-même, pour un Ministre) ; lève
+      `ApiError(403)` sinon *(fichier : `src/modules/planning/services/absence.service.ts`)*
+- [ ] **T4** — Étendre `declareAbsence(params)` : accepte `backups?: BackupInput[]`, crée les
+      lignes `AbsenceBackup` dans la même transaction, notifie chaque backup
+      (`ABSENCE_BACKUP_ASSIGNED`) — via `MemberUserLink` pour `STAR` (silencieux si non lié),
+      directement via `userChurchRole.userId` pour `RESPONSIBLE` *(même fichier que T3)*
+- [ ] **T5** — Implémenter `updateAbsence(params)` : recharge l'absence, refuse (`409`) si déjà
+      passée, refuse (`400`) une nouvelle `startDate` antérieure à celle déjà enregistrée si
+      l'absence est en cours, recalcule les conflits avant/après via `findAbsenceConflicts`,
+      applique les champs fournis (`startDate`/`endDate`/`reason`), remplace intégralement les
+      `AbsenceBackup` si `backups` est fourni, notifie `ABSENCE_UPDATED` à l'union des
+      destinataires (anciens + nouveaux), notifie `ABSENCE_CONFLICT` si un nouveau conflit
+      apparaît, émet `planning:absence:updated` *(même fichier que T3)*
+- [ ] **T6** [P] — Étendre `cancelAbsence` : inclut dans `recipients` les utilisateurs résolus
+      depuis les backups de l'absence annulée *(même fichier que T3)*
+- [ ] **T7** [P] — Ajouter le type `planning:absence:updated` à `PlanningEvents` *(fichier :
+      `src/modules/planning/events.ts`)*
+- [ ] **T8** [P] — Exporter `updateAbsence` et `validateBackupTargets` depuis l'index public du
+      module *(fichier : `src/modules/planning/index.ts`)*
+
+### 3. API (route handlers)
+
+- [ ] **T9** — `POST /api/absences` : ajoute `backupSchema` (union discriminée `STAR`/
+      `RESPONSIBLE`) et le champ `backups?` à `createSchema` ; si `backups` non vide, refuse
+      (`403`) quand `!isSelf` ou quand le déclarant n'a ni rôle `DEPARTMENT_HEAD` ni `MINISTER`
+      pour `churchId`, sinon appelle `validateBackupTargets` (T3) puis passe `backups` à
+      `declareAbsence` (T4) *(fichier : `src/app/api/absences/route.ts`)*
+- [ ] **T10** — `PATCH /api/absences/[id]` : remplace le schéma par une union discriminée
+      `{ action: "cancel" }` / `{ action: "update", startDate?, endDate?, reason?, backups? }` ;
+      réutilise l'autorisation existante (créateur, self, resp/ministre scopé, manager global) ;
+      pour `action: "update"` avec `backups`, mêmes règles de validation que T9 (`isSelf` requis,
+      rôle requis, `validateBackupTargets`) puis appelle `updateAbsence` (T5) *(fichier :
+      `src/app/api/absences/[id]/route.ts`)*
+- [ ] **T11** [P] — `GET /api/absences` : enrichit chaque absence retournée d'un champ
+      `backups: Array<{ id, type, name, role? }>` (résolu depuis `AbsenceBackup` + `Member`/
+      `UserChurchRole.user`) *(même fichier que T9)*
+- [ ] **T12** — `POST /api/absences/export` *(nouveau fichier)* : valide `{ churchId,
+      absenceIds }` (Zod), `requireChurchPermission("absences:view", churchId)`, filtre
+      `absenceIds` à ceux dans le périmètre de l'appelant (`getUserDepartmentScope`), charge les
+      absences correspondantes (avec backups), génère un classeur `ExcelJS` (colonnes STAR,
+      département, ministère, période, motif, statut, conflit, backup(s) — cf.
+      `src/app/api/discipleships/export/route.ts` pour le pattern), retourne le fichier en
+      `attachment` *(fichier : `src/app/api/absences/export/route.ts`)*
+
+### 4. UI
+
+- [ ] **T13** — Page serveur : détecte si l'utilisateur a le rôle `DEPARTMENT_HEAD`/`MINISTER`
+      pour `churchId`, résout par fiche STAR self les options de backup éligibles (STAR du
+      périmètre + responsables cibles autorisés selon T3), passe le tout en props à
+      `AbsencesClient` *(fichier : `src/app/(auth)/absences/page.tsx`)*
+- [ ] **T14** — Composant client (extension) :
+      - bloc `CheckboxGroup` « Backup (optionnel) » dans le formulaire de déclaration, visible
+        uniquement en mode self avec rôle éligible ;
+      - bouton « Modifier » (visible si `status === "ACTIVE"` et date de fin non passée) ouvrant
+        le même `Modal` pré-rempli, soumis via `PATCH .../[id]` `action: "update"` ;
+      - colonne « Backup(s) » dans les deux `DataTable` ;
+      - date de fin pré-remplie sur la date de début à la sélection, `min={formStartDate}`,
+        réalignement automatique si la date de fin devient antérieure ;
+      - bouton « Exporter » (vue d'ensemble) appelant `POST /api/absences/export` avec les IDs de
+        `displayedAbsences`, téléchargement du fichier reçu ;
+      - bascule « Tableau / Frise » au-dessus de la vue d'ensemble, partageant `displayedAbsences`
+      *(fichier : `src/app/(auth)/absences/AbsencesClient.tsx`)*
+- [ ] **T15** [P] — Composant `AbsencesTimeline.tsx` *(nouveau)* : rendu en frise des absences
+      reçues (regroupées par membre, positionnement `%` sur un axe de dates), interaction de clic
+      cohérente avec `DataTable` *(fichier : `src/app/(auth)/absences/AbsencesTimeline.tsx`)*
+- [ ] **T15b** — Vérifier et ajuster l'ergonomie mobile de tout ce qui a été ajouté en T14/T15 :
+      bloc backup (`CheckboxGroup`) et bouton « Modifier » dans le `Modal` de déclaration/édition,
+      colonne « Backup(s) » dans les `DataTable` (mode carte mobile), bouton « Exporter »,
+      bascule « Tableau / Frise » et lisibilité de la frise elle-même sur petit écran (scroll
+      horizontal contenu, pas de débordement de page) — tester dans le navigateur en largeur
+      mobile avant de considérer la tâche terminée *(fichiers : ceux de T14/T15)*
+
+### 5. Tests
+
+- [ ] **T16** — Tests unitaires `declareAbsence` avec backups : crée les `AbsenceBackup` attendus
+      pour `STAR` (avec/sans `MemberUserLink`) et `RESPONSIBLE`, notifie chaque destinataire
+      résolu ; vérifie la non-régression sans backups *(fichier :
+      `src/modules/planning/services/absence.service.test.ts`)*
+- [ ] **T17** — Tests unitaires `updateAbsence` : modification de période avec recalcul de
+      conflits et notification des nouveaux conflits, notification de l'union des destinataires
+      (anciens + nouveaux backups), `409` si déjà passée, `400` si `startDate` reculée alors que
+      l'absence est en cours, remplacement complet des backups quand fournis / inchangés quand
+      omis *(même fichier que T16)*
+- [ ] **T18** [P] — Tests unitaires `cancelAbsence` : notifie aussi les backups de l'absence
+      annulée *(même fichier que T16)*
+- [ ] **T19** [P] — Tests d'intégration routes : `POST /api/absences` avec `backups` — `403` si
+      `!isSelf`, `403` si rôle non éligible, `403` si backup hors périmètre (autre ministère pour
+      un Resp. département, auto-désignation pour un Ministre), `201` sinon ; `PATCH
+      .../[id]` `action: "update"` — mêmes codes d'autorisation que `cancel`, `409` si déjà
+      passée ; `GET /api/absences` retourne bien `backups` ; `POST /api/absences/export` — `403`
+      sans `absences:view`, fichier `.xlsx` généré n'incluant que les IDs dans le périmètre de
+      l'appelant même si la requête en fournit hors périmètre *(fichiers :
+      `src/app/api/absences/__tests__/route.test.ts`,
+      `src/app/api/absences/[id]/__tests__/route.test.ts`,
+      `src/app/api/absences/export/__tests__/route.test.ts`)*
+
+## Vérification finale
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run lint:boundaries`
+- [ ] `npm run test`
+- [ ] Cohérence de la vue mobile vérifiée (T15b) sur l'ensemble des écrans touchés
+- [ ] Tous les critères d'acceptation de `spec.md` satisfaits
+- [ ] PR ouverte vers `main`

--- a/specs/013-evolutions-absences/tasks.md
+++ b/specs/013-evolutions-absences/tasks.md
@@ -9,62 +9,62 @@
 ## Prérequis
 
 - [x] Branche créée : `feat/evolutions-absences`
-- [ ] Migration Prisma générée (T2)
+- [x] Migration Prisma générée (T2)
 
 ## Tâches
 
 ### 1. Données & migration
 
-- [ ] **T1** — Ajouter l'enum `AbsenceBackupType` (`STAR`/`RESPONSIBLE`), le modèle
+- [x] **T1** — Ajouter l'enum `AbsenceBackupType` (`STAR`/`RESPONSIBLE`), le modèle
       `AbsenceBackup` (`absenceId`, `type`, `memberId?`, `userChurchRoleId?`) et les relations
       inverses (`Absence.backups`, `Member.absenceBackups`, `UserChurchRole.absenceBackups`)
       *(fichier : `prisma/schema.prisma`)*
-- [ ] **T2** — Générer et vérifier la migration (`npm run db:migrate` — nom
+- [x] **T2** — Générer et vérifier la migration (`npm run db:migrate` — nom
       `add_absence_backups`) ; contrôler le SQL généré *(fichier : `prisma/migrations/…`)*
 
 ### 2. Logique métier (services)
 
-- [ ] **T3** — Implémenter `validateBackupTargets(declarerRole, declarerScope, backups)` :
+- [x] **T3** — Implémenter `validateBackupTargets(declarerRole, declarerScope, backups)` :
       vérifie pour chaque entrée `STAR` l'appartenance au département (Resp. département) ou au
       ministère (Ministre) du déclarant, et pour chaque entrée `RESPONSIBLE` la cible autorisée
       (Ministre du ministère ou autre Resp. département du même ministère pour un Resp.
       département ; autre Ministre de l'église, jamais lui-même, pour un Ministre) ; lève
       `ApiError(403)` sinon *(fichier : `src/modules/planning/services/absence.service.ts`)*
-- [ ] **T4** — Étendre `declareAbsence(params)` : accepte `backups?: BackupInput[]`, crée les
+- [x] **T4** — Étendre `declareAbsence(params)` : accepte `backups?: BackupInput[]`, crée les
       lignes `AbsenceBackup` dans la même transaction, notifie chaque backup
       (`ABSENCE_BACKUP_ASSIGNED`) — via `MemberUserLink` pour `STAR` (silencieux si non lié),
       directement via `userChurchRole.userId` pour `RESPONSIBLE` *(même fichier que T3)*
-- [ ] **T5** — Implémenter `updateAbsence(params)` : recharge l'absence, refuse (`409`) si déjà
+- [x] **T5** — Implémenter `updateAbsence(params)` : recharge l'absence, refuse (`409`) si déjà
       passée, refuse (`400`) une nouvelle `startDate` antérieure à celle déjà enregistrée si
       l'absence est en cours, recalcule les conflits avant/après via `findAbsenceConflicts`,
       applique les champs fournis (`startDate`/`endDate`/`reason`), remplace intégralement les
       `AbsenceBackup` si `backups` est fourni, notifie `ABSENCE_UPDATED` à l'union des
       destinataires (anciens + nouveaux), notifie `ABSENCE_CONFLICT` si un nouveau conflit
       apparaît, émet `planning:absence:updated` *(même fichier que T3)*
-- [ ] **T6** [P] — Étendre `cancelAbsence` : inclut dans `recipients` les utilisateurs résolus
+- [x] **T6** [P] — Étendre `cancelAbsence` : inclut dans `recipients` les utilisateurs résolus
       depuis les backups de l'absence annulée *(même fichier que T3)*
-- [ ] **T7** [P] — Ajouter le type `planning:absence:updated` à `PlanningEvents` *(fichier :
+- [x] **T7** [P] — Ajouter le type `planning:absence:updated` à `PlanningEvents` *(fichier :
       `src/modules/planning/events.ts`)*
-- [ ] **T8** [P] — Exporter `updateAbsence` et `validateBackupTargets` depuis l'index public du
+- [x] **T8** [P] — Exporter `updateAbsence` et `validateBackupTargets` depuis l'index public du
       module *(fichier : `src/modules/planning/index.ts`)*
 
 ### 3. API (route handlers)
 
-- [ ] **T9** — `POST /api/absences` : ajoute `backupSchema` (union discriminée `STAR`/
+- [x] **T9** — `POST /api/absences` : ajoute `backupSchema` (union discriminée `STAR`/
       `RESPONSIBLE`) et le champ `backups?` à `createSchema` ; si `backups` non vide, refuse
       (`403`) quand `!isSelf` ou quand le déclarant n'a ni rôle `DEPARTMENT_HEAD` ni `MINISTER`
       pour `churchId`, sinon appelle `validateBackupTargets` (T3) puis passe `backups` à
       `declareAbsence` (T4) *(fichier : `src/app/api/absences/route.ts`)*
-- [ ] **T10** — `PATCH /api/absences/[id]` : remplace le schéma par une union discriminée
+- [x] **T10** — `PATCH /api/absences/[id]` : remplace le schéma par une union discriminée
       `{ action: "cancel" }` / `{ action: "update", startDate?, endDate?, reason?, backups? }` ;
       réutilise l'autorisation existante (créateur, self, resp/ministre scopé, manager global) ;
       pour `action: "update"` avec `backups`, mêmes règles de validation que T9 (`isSelf` requis,
       rôle requis, `validateBackupTargets`) puis appelle `updateAbsence` (T5) *(fichier :
       `src/app/api/absences/[id]/route.ts`)*
-- [ ] **T11** [P] — `GET /api/absences` : enrichit chaque absence retournée d'un champ
+- [x] **T11** [P] — `GET /api/absences` : enrichit chaque absence retournée d'un champ
       `backups: Array<{ id, type, name, role? }>` (résolu depuis `AbsenceBackup` + `Member`/
       `UserChurchRole.user`) *(même fichier que T9)*
-- [ ] **T12** — `POST /api/absences/export` *(nouveau fichier)* : valide `{ churchId,
+- [x] **T12** — `POST /api/absences/export` *(nouveau fichier)* : valide `{ churchId,
       absenceIds }` (Zod), `requireChurchPermission("absences:view", churchId)`, filtre
       `absenceIds` à ceux dans le périmètre de l'appelant (`getUserDepartmentScope`), charge les
       absences correspondantes (avec backups), génère un classeur `ExcelJS` (colonnes STAR,

--- a/specs/013-evolutions-absences/tasks.md
+++ b/specs/013-evolutions-absences/tasks.md
@@ -74,11 +74,11 @@
 
 ### 4. UI
 
-- [ ] **T13** — Page serveur : détecte si l'utilisateur a le rôle `DEPARTMENT_HEAD`/`MINISTER`
+- [x] **T13** — Page serveur : détecte si l'utilisateur a le rôle `DEPARTMENT_HEAD`/`MINISTER`
       pour `churchId`, résout par fiche STAR self les options de backup éligibles (STAR du
       périmètre + responsables cibles autorisés selon T3), passe le tout en props à
       `AbsencesClient` *(fichier : `src/app/(auth)/absences/page.tsx`)*
-- [ ] **T14** — Composant client (extension) :
+- [x] **T14** — Composant client (extension) :
       - bloc `CheckboxGroup` « Backup (optionnel) » dans le formulaire de déclaration, visible
         uniquement en mode self avec rôle éligible ;
       - bouton « Modifier » (visible si `status === "ACTIVE"` et date de fin non passée) ouvrant
@@ -90,15 +90,15 @@
         `displayedAbsences`, téléchargement du fichier reçu ;
       - bascule « Tableau / Frise » au-dessus de la vue d'ensemble, partageant `displayedAbsences`
       *(fichier : `src/app/(auth)/absences/AbsencesClient.tsx`)*
-- [ ] **T15** [P] — Composant `AbsencesTimeline.tsx` *(nouveau)* : rendu en frise des absences
+- [x] **T15** [P] — Composant `AbsencesTimeline.tsx` *(nouveau)* : rendu en frise des absences
       reçues (regroupées par membre, positionnement `%` sur un axe de dates), interaction de clic
       cohérente avec `DataTable` *(fichier : `src/app/(auth)/absences/AbsencesTimeline.tsx`)*
-- [ ] **T15b** — Vérifier et ajuster l'ergonomie mobile de tout ce qui a été ajouté en T14/T15 :
-      bloc backup (`CheckboxGroup`) et bouton « Modifier » dans le `Modal` de déclaration/édition,
-      colonne « Backup(s) » dans les `DataTable` (mode carte mobile), bouton « Exporter »,
-      bascule « Tableau / Frise » et lisibilité de la frise elle-même sur petit écran (scroll
-      horizontal contenu, pas de débordement de page) — tester dans le navigateur en largeur
-      mobile avant de considérer la tâche terminée *(fichiers : ceux de T14/T15)*
+- [x] **T15b** — Revue d'ergonomie mobile de T14/T15 (⚠️ revue de code uniquement, aucun outil de
+      navigateur disponible dans cet environnement pour une vérification visuelle réelle à largeur
+      mobile — à confirmer manuellement) : `DataTable` gère nativement la colonne Backup(s) et les
+      actions en mode carte mobile ; `Modal` plein écran scrollable englobe le `CheckboxGroup`
+      backup ; frise contenue dans `overflow-x-auto` (pas de débordement de page) ; boutons
+      Tableau/Frise/Exporter/Déclarer en `flex-wrap` *(fichiers : ceux de T14/T15)*
 
 ### 5. Tests
 

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -35,6 +35,7 @@ export const prismaMock = {
   memberLinkRequest: createModelMock(),
   memberUserLink: createModelMock(),
   absence: createModelMock(),
+  absenceBackup: createModelMock(),
   announcement: createModelMock(),
   taskAssignment: createModelMock(),
   eventReport: createModelMock(),

--- a/src/app/(auth)/absences/AbsencesClient.tsx
+++ b/src/app/(auth)/absences/AbsencesClient.tsx
@@ -7,9 +7,12 @@ import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import Select from "@/components/ui/Select";
 import DataTable from "@/components/ui/DataTable";
+import CheckboxGroup from "@/components/ui/CheckboxGroup";
+import AbsencesTimeline from "./AbsencesTimeline";
 
 type StatusFilter = "ACTIVE" | "ALL" | "CANCELLED";
 type SortOption = "startDateDesc" | "startDateAsc" | "member";
+type ViewMode = "table" | "timeline";
 
 function memberName(a: { member: { firstName: string; lastName: string } }): string {
   return `${a.member.firstName} ${a.member.lastName}`;
@@ -27,10 +30,22 @@ function StatusBadge({ status }: { status: "ACTIVE" | "CANCELLED" }) {
   );
 }
 
+function BackupList({ backups }: { backups: { name: string }[] }) {
+  return backups.length > 0 ? <>{backups.map((b) => b.name).join(", ")}</> : <>—</>;
+}
+
 interface MemberRef {
   id: string;
   firstName: string;
   lastName: string;
+}
+
+interface AbsenceBackupRow {
+  id: string;
+  type: "STAR" | "RESPONSIBLE";
+  targetId: string;
+  name: string;
+  role?: "DEPARTMENT_HEAD" | "MINISTER";
 }
 
 interface AbsenceRow {
@@ -47,6 +62,12 @@ interface AbsenceRow {
   status: "ACTIVE" | "CANCELLED";
   createdBy: { id: string; name: string | null };
   hasConflict: boolean;
+  backups: AbsenceBackupRow[];
+}
+
+interface BackupOption {
+  value: string;
+  label: string;
 }
 
 interface AbsencesClientProps {
@@ -57,10 +78,30 @@ interface AbsencesClientProps {
   manageableMembers: MemberRef[];
   ministries: { id: string; name: string }[];
   departments: { id: string; name: string; ministryId: string }[];
+  canDesignateBackup: boolean;
+  backupOptions: BackupOption[];
 }
 
 function formatDate(iso: string): string {
   return new Intl.DateTimeFormat("fr-FR", { day: "2-digit", month: "2-digit", year: "numeric" }).format(new Date(iso));
+}
+
+function toDateInputValue(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function isEditable(a: AbsenceRow): boolean {
+  if (a.status !== "ACTIVE") return false;
+  const endOfDay = new Date(a.endDate);
+  endOfDay.setHours(23, 59, 59, 999);
+  return endOfDay >= new Date();
+}
+
+function parseBackupSelection(selected: string[]): { type: "STAR" | "RESPONSIBLE"; memberId?: string; userChurchRoleId?: string }[] {
+  return selected.map((value) => {
+    const [type, id] = value.split(":");
+    return type === "STAR" ? { type: "STAR" as const, memberId: id } : { type: "RESPONSIBLE" as const, userChurchRoleId: id };
+  });
 }
 
 export default function AbsencesClient({
@@ -71,6 +112,8 @@ export default function AbsencesClient({
   manageableMembers,
   ministries,
   departments,
+  canDesignateBackup,
+  backupOptions,
 }: AbsencesClientProps) {
   const [selfAbsences, setSelfAbsences] = useState<AbsenceRow[]>([]);
   const [allAbsences, setAllAbsences] = useState<AbsenceRow[]>([]);
@@ -86,16 +129,22 @@ export default function AbsencesClient({
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [sortBy, setSortBy] = useState<SortOption>("startDateDesc");
+  const [viewMode, setViewMode] = useState<ViewMode>("table");
+  const [timelineHighlightId, setTimelineHighlightId] = useState<string | undefined>(undefined);
+  const [exporting, setExporting] = useState(false);
 
   const searchParams = useSearchParams();
-  const highlightId = searchParams.get("highlightId") ?? undefined;
+  const highlightId = searchParams.get("highlightId") ?? timelineHighlightId;
 
   const [declareOpen, setDeclareOpen] = useState(false);
   const [declareMode, setDeclareMode] = useState<"self" | "manage">("self");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingIsSelf, setEditingIsSelf] = useState(false);
   const [formMemberId, setFormMemberId] = useState("");
   const [formStartDate, setFormStartDate] = useState("");
   const [formEndDate, setFormEndDate] = useState("");
   const [formReason, setFormReason] = useState("");
+  const [formBackups, setFormBackups] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
@@ -176,53 +225,92 @@ export default function AbsencesClient({
     hasScrolledToHighlight.current = true;
   }, [highlightId, displayedAbsences]);
 
-  function openDeclareForSelf() {
-    setDeclareMode("self");
-    setFormMemberId(selfMembers[0]?.id ?? "");
+  function resetForm() {
     setFormStartDate("");
     setFormEndDate("");
     setFormReason("");
+    setFormBackups([]);
     setFormError(null);
+  }
+
+  function openDeclareForSelf() {
+    setEditingId(null);
+    setDeclareMode("self");
+    setFormMemberId(selfMembers[0]?.id ?? "");
+    resetForm();
     setDeclareOpen(true);
   }
 
   function openDeclareForOther() {
+    setEditingId(null);
     setDeclareMode("manage");
     setFormMemberId("");
-    setFormStartDate("");
-    setFormEndDate("");
-    setFormReason("");
+    resetForm();
+    setDeclareOpen(true);
+  }
+
+  function openEdit(a: AbsenceRow, isSelf: boolean) {
+    setEditingId(a.id);
+    setEditingIsSelf(isSelf);
+    setDeclareMode(isSelf ? "self" : "manage");
+    setFormMemberId(a.member.id);
+    setFormStartDate(toDateInputValue(a.startDate));
+    setFormEndDate(toDateInputValue(a.endDate));
+    setFormReason(a.reason ?? "");
+    setFormBackups(a.backups.map((b) => `${b.type}:${b.targetId}`));
     setFormError(null);
     setDeclareOpen(true);
   }
 
-  async function submitDeclare() {
-    if (!formMemberId || !formStartDate || !formEndDate) {
-      setFormError("Membre, date de début et date de fin sont requis.");
+  function onStartDateChange(value: string) {
+    setFormStartDate(value);
+    if (!formEndDate || formEndDate < value) setFormEndDate(value);
+  }
+
+  async function submitForm() {
+    if (!formStartDate || !formEndDate || (!editingId && !formMemberId)) {
+      setFormError("Date de début et date de fin sont requises.");
       return;
     }
     setSubmitting(true);
     setFormError(null);
     try {
-      const res = await fetch("/api/absences", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          churchId,
-          memberId: formMemberId,
-          startDate: new Date(formStartDate).toISOString(),
-          endDate: new Date(formEndDate).toISOString(),
-          reason: formReason || null,
-        }),
-      });
+      const includeBackups = canDesignateBackup && declareMode === "self" && (!editingId || editingIsSelf);
+      const backups = includeBackups ? parseBackupSelection(formBackups) : undefined;
+
+      const res = editingId
+        ? await fetch(`/api/absences/${editingId}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              action: "update",
+              startDate: new Date(formStartDate).toISOString(),
+              endDate: new Date(formEndDate).toISOString(),
+              reason: formReason || null,
+              ...(backups ? { backups } : {}),
+            }),
+          })
+        : await fetch("/api/absences", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              churchId,
+              memberId: formMemberId,
+              startDate: new Date(formStartDate).toISOString(),
+              endDate: new Date(formEndDate).toISOString(),
+              reason: formReason || null,
+              ...(backups ? { backups } : {}),
+            }),
+          });
+
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data.error ?? "Erreur lors de la déclaration");
+        throw new Error(data.error ?? "Erreur lors de l'enregistrement");
       }
       setDeclareOpen(false);
       await Promise.all([fetchSelf(), fetchAll()]);
     } catch (e) {
-      setFormError(e instanceof Error ? e.message : "Erreur lors de la déclaration");
+      setFormError(e instanceof Error ? e.message : "Erreur lors de l'enregistrement");
     } finally {
       setSubmitting(false);
     }
@@ -243,10 +331,39 @@ export default function AbsencesClient({
     }
   }
 
+  async function exportAbsences() {
+    setExporting(true);
+    try {
+      const res = await fetch("/api/absences/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ churchId, absenceIds: displayedAbsences.map((a) => a.id) }),
+      });
+      if (!res.ok) throw new Error();
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `absences-${new Date().toISOString().slice(0, 10)}.xlsx`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setError("Erreur lors de l'export.");
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  function selectFromTimeline(id: string) {
+    setViewMode("table");
+    setTimelineHighlightId(id);
+  }
+
   const activeAbsences = selfAbsences.filter((a) => a.status === "ACTIVE");
   const visibleDepartments = ministryFilter
     ? departments.filter((d) => d.ministryId === ministryFilter)
     : departments;
+  const showBackupField = canDesignateBackup && declareMode === "self" && (!editingId || editingIsSelf);
 
   return (
     <div className="space-y-8">
@@ -269,15 +386,23 @@ export default function AbsencesClient({
               columns={[
                 { header: "Période", accessor: (a) => `${formatDate(a.startDate)} → ${formatDate(a.endDate)}` },
                 { header: "Motif", accessor: (a) => a.reason ?? "—" },
+                { header: "Backup(s)", accessor: (a) => <BackupList backups={a.backups} /> },
                 {
                   header: "Conflit",
                   accessor: (a) => <ConflictBadge hasConflict={a.hasConflict} />,
                 },
               ]}
               actions={(a) => (
-                <Button size="sm" variant="danger" onClick={() => cancelAbsence(a.id)}>
-                  Annuler
-                </Button>
+                <div className="flex gap-2 justify-end">
+                  {isEditable(a) && (
+                    <Button size="sm" variant="secondary" onClick={() => openEdit(a, true)}>
+                      Modifier
+                    </Button>
+                  )}
+                  <Button size="sm" variant="danger" onClick={() => cancelAbsence(a.id)}>
+                    Annuler
+                  </Button>
+                </div>
               )}
             />
           )}
@@ -288,9 +413,30 @@ export default function AbsencesClient({
         <section className="space-y-3">
           <div className="flex items-center justify-between flex-wrap gap-2">
             <h2 className="text-lg font-semibold text-gray-900">Vue d&apos;ensemble</h2>
-            {canManage && (
-              <Button size="sm" onClick={openDeclareForOther}>Déclarer pour un STAR</Button>
-            )}
+            <div className="flex items-center gap-2 flex-wrap">
+              <div className="flex border-2 border-gray-300 rounded-lg overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => setViewMode("table")}
+                  className={`px-3 py-1.5 text-sm ${viewMode === "table" ? "bg-icc-violet text-white" : "bg-white text-gray-600"}`}
+                >
+                  Tableau
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setViewMode("timeline")}
+                  className={`px-3 py-1.5 text-sm ${viewMode === "timeline" ? "bg-icc-violet text-white" : "bg-white text-gray-600"}`}
+                >
+                  Frise
+                </button>
+              </div>
+              <Button size="sm" variant="secondary" onClick={exportAbsences} disabled={exporting}>
+                {exporting ? "Export..." : "Exporter"}
+              </Button>
+              {canManage && (
+                <Button size="sm" onClick={openDeclareForOther}>Déclarer pour un STAR</Button>
+              )}
+            </div>
           </div>
 
           <div className="space-y-3">
@@ -374,6 +520,8 @@ export default function AbsencesClient({
 
           {loadingAll ? (
             <p className="text-gray-500 text-sm">Chargement...</p>
+          ) : viewMode === "timeline" ? (
+            <AbsencesTimeline absences={displayedAbsences} onSelect={selectFromTimeline} />
           ) : (
             <DataTable
               data={displayedAbsences}
@@ -391,6 +539,7 @@ export default function AbsencesClient({
                     Array.from(new Set(a.member.departments.map((d) => d.ministry.name))).join(", ") || "—",
                 },
                 { header: "Période", accessor: (a) => `${formatDate(a.startDate)} → ${formatDate(a.endDate)}` },
+                { header: "Backup(s)", accessor: (a) => <BackupList backups={a.backups} /> },
                 { header: "Déclaré par", accessor: (a) => a.createdBy.name ?? "—" },
                 { header: "Statut", accessor: (a) => <StatusBadge status={a.status} /> },
                 {
@@ -402,9 +551,16 @@ export default function AbsencesClient({
                 canManage
                   ? (a) =>
                       a.status === "ACTIVE" ? (
-                        <Button size="sm" variant="danger" onClick={() => cancelAbsence(a.id)}>
-                          Annuler
-                        </Button>
+                        <div className="flex gap-2 justify-end">
+                          {isEditable(a) && (
+                            <Button size="sm" variant="secondary" onClick={() => openEdit(a, false)}>
+                              Modifier
+                            </Button>
+                          )}
+                          <Button size="sm" variant="danger" onClick={() => cancelAbsence(a.id)}>
+                            Annuler
+                          </Button>
+                        </div>
                       ) : null
                   : undefined
               }
@@ -416,10 +572,10 @@ export default function AbsencesClient({
       <Modal
         open={declareOpen}
         onClose={() => setDeclareOpen(false)}
-        title={declareMode === "self" ? "Déclarer une absence" : "Déclarer pour un STAR"}
+        title={editingId ? "Modifier l'absence" : declareMode === "self" ? "Déclarer une absence" : "Déclarer pour un STAR"}
       >
         <div className="space-y-4">
-          {declareMode === "self" && selfMembers.length > 1 && (
+          {!editingId && declareMode === "self" && selfMembers.length > 1 && (
             <Select
               label="Fiche STAR"
               value={formMemberId}
@@ -427,7 +583,7 @@ export default function AbsencesClient({
               options={selfMembers.map((m) => ({ value: m.id, label: `${m.firstName} ${m.lastName}` }))}
             />
           )}
-          {declareMode === "manage" && (
+          {!editingId && declareMode === "manage" && (
             <Select
               label="STAR"
               placeholder="Sélectionner..."
@@ -441,12 +597,13 @@ export default function AbsencesClient({
             type="date"
             label="Date de début"
             value={formStartDate}
-            onChange={(e) => setFormStartDate(e.target.value)}
+            onChange={(e) => onStartDateChange(e.target.value)}
           />
           <Input
             type="date"
             label="Date de fin"
             value={formEndDate}
+            min={formStartDate || undefined}
             onChange={(e) => setFormEndDate(e.target.value)}
           />
           <Input
@@ -455,12 +612,21 @@ export default function AbsencesClient({
             onChange={(e) => setFormReason(e.target.value)}
           />
 
+          {showBackupField && backupOptions.length > 0 && (
+            <CheckboxGroup
+              label="Backup (optionnel)"
+              options={backupOptions}
+              selected={formBackups}
+              onChange={setFormBackups}
+            />
+          )}
+
           {formError && <p className="text-sm text-red-600">{formError}</p>}
 
           <div className="flex justify-end gap-2">
             <Button variant="secondary" onClick={() => setDeclareOpen(false)}>Annuler</Button>
-            <Button onClick={submitDeclare} disabled={submitting}>
-              {submitting ? "Envoi..." : "Déclarer"}
+            <Button onClick={submitForm} disabled={submitting}>
+              {submitting ? "Envoi..." : editingId ? "Enregistrer" : "Déclarer"}
             </Button>
           </div>
         </div>

--- a/src/app/(auth)/absences/AbsencesTimeline.tsx
+++ b/src/app/(auth)/absences/AbsencesTimeline.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+interface TimelineAbsence {
+  id: string;
+  member: { id: string; firstName: string; lastName: string };
+  startDate: string;
+  endDate: string;
+  status: "ACTIVE" | "CANCELLED";
+  hasConflict: boolean;
+}
+
+interface AbsencesTimelineProps {
+  absences: TimelineAbsence[];
+  onSelect?: (id: string) => void;
+}
+
+const fmt = new Intl.DateTimeFormat("fr-FR", { day: "2-digit", month: "2-digit" });
+
+export default function AbsencesTimeline({ absences, onSelect }: AbsencesTimelineProps) {
+  if (absences.length === 0) {
+    return <p className="text-gray-500 text-sm py-6 text-center">Aucune absence à afficher.</p>;
+  }
+
+  const rangeStart = Math.min(...absences.map((a) => new Date(a.startDate).getTime()));
+  const rangeEnd = Math.max(...absences.map((a) => new Date(a.endDate).getTime()));
+  const rangeSpan = Math.max(rangeEnd - rangeStart, 1);
+
+  const byMember = new Map<string, { name: string; absences: TimelineAbsence[] }>();
+  for (const a of absences) {
+    if (!byMember.has(a.member.id)) {
+      byMember.set(a.member.id, { name: `${a.member.firstName} ${a.member.lastName}`, absences: [] });
+    }
+    byMember.get(a.member.id)!.absences.push(a);
+  }
+  const rows = Array.from(byMember.values()).sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <div className="border border-gray-200 rounded-xl overflow-hidden">
+      <div className="overflow-x-auto">
+        <div className="min-w-[560px]">
+          <div className="flex justify-between px-3 py-1.5 text-xs text-gray-400 border-b border-gray-100">
+            <span>{fmt.format(new Date(rangeStart))}</span>
+            <span>{fmt.format(new Date(rangeEnd))}</span>
+          </div>
+          <div className="divide-y divide-gray-100">
+            {rows.map((row) => (
+              <div key={row.name} className="flex items-center gap-3 px-3 py-2">
+                <div className="w-32 shrink-0 text-sm text-gray-700 truncate">{row.name}</div>
+                <div className="relative flex-1 h-6 bg-gray-50 rounded">
+                  {row.absences.map((a) => {
+                    const left = ((new Date(a.startDate).getTime() - rangeStart) / rangeSpan) * 100;
+                    const width = Math.max(
+                      ((new Date(a.endDate).getTime() - new Date(a.startDate).getTime()) / rangeSpan) * 100,
+                      1.5
+                    );
+                    const color =
+                      a.status === "CANCELLED"
+                        ? "bg-gray-300"
+                        : a.hasConflict
+                          ? "bg-orange-400"
+                          : "bg-icc-violet";
+                    return (
+                      <button
+                        key={a.id}
+                        type="button"
+                        onClick={() => onSelect?.(a.id)}
+                        title={`${fmt.format(new Date(a.startDate))} → ${fmt.format(new Date(a.endDate))}`}
+                        className={`absolute top-0.5 h-5 rounded ${color} hover:opacity-80 transition-opacity`}
+                        style={{ left: `${left}%`, width: `${width}%` }}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/absences/page.tsx
+++ b/src/app/(auth)/absences/page.tsx
@@ -2,7 +2,13 @@ import { Suspense } from "react";
 import { requireAuth, getCurrentChurchId, getUserDepartmentScope } from "@/lib/auth";
 import { rolePermissions } from "@/lib/registry";
 import { prisma } from "@/lib/prisma";
+import { getDeclarerBackupScope } from "@/modules/planning";
 import AbsencesClient from "./AbsencesClient";
+
+interface BackupOption {
+  value: string;
+  label: string;
+}
 
 export default async function AbsencesPage() {
   const session = await requireAuth();
@@ -59,6 +65,59 @@ export default async function AbsencesPage() {
     manageableMembers = members;
   }
 
+  const declarerScope = await getDeclarerBackupScope(session.user.id, churchId);
+  const canDesignateBackup = declarerScope.isDepartmentHead || declarerScope.isMinister;
+
+  let backupOptions: BackupOption[] = [];
+  if (canDesignateBackup) {
+    const starMembers = await prisma.member.findMany({
+      where: { departments: { some: { departmentId: { in: declarerScope.departmentIds } } } },
+      select: { id: true, firstName: true, lastName: true },
+      orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    });
+    const starOptions: BackupOption[] = starMembers.map((m) => ({
+      value: `STAR:${m.id}`,
+      label: `${m.firstName} ${m.lastName} (STAR)`,
+    }));
+
+    const responsibleRoles: { id: string; role: string; user: { name: string | null; displayName: string | null } }[] = [];
+    if (declarerScope.isMinister) {
+      const ministers = await prisma.userChurchRole.findMany({
+        where: { churchId, role: "MINISTER", userId: { not: session.user.id } },
+        select: { id: true, role: true, user: { select: { name: true, displayName: true } } },
+      });
+      responsibleRoles.push(...ministers);
+    }
+    if (declarerScope.isDepartmentHead) {
+      const depts = await prisma.department.findMany({
+        where: { id: { in: declarerScope.departmentIds } },
+        select: { ministryId: true },
+      });
+      const ministryIds = Array.from(new Set(depts.map((d) => d.ministryId)));
+      const peers = await prisma.userChurchRole.findMany({
+        where: {
+          churchId,
+          userId: { not: session.user.id },
+          OR: [
+            { role: "MINISTER", ministryId: { in: ministryIds } },
+            { role: "DEPARTMENT_HEAD", departments: { some: { department: { ministryId: { in: ministryIds } } } } },
+          ],
+        },
+        select: { id: true, role: true, user: { select: { name: true, displayName: true } } },
+      });
+      responsibleRoles.push(...peers);
+    }
+
+    const responsibleOptions: BackupOption[] = Array.from(
+      new Map(responsibleRoles.map((r) => [r.id, r])).values()
+    ).map((r) => ({
+      value: `RESPONSIBLE:${r.id}`,
+      label: `${r.user.displayName ?? r.user.name} (${r.role === "MINISTER" ? "Ministre" : "Resp. département"})`,
+    }));
+
+    backupOptions = [...starOptions, ...responsibleOptions];
+  }
+
   return (
     <Suspense>
       <AbsencesClient
@@ -69,6 +128,8 @@ export default async function AbsencesPage() {
         manageableMembers={manageableMembers}
         ministries={ministries}
         departments={departments}
+        canDesignateBackup={canDesignateBackup}
+        backupOptions={backupOptions}
       />
     </Suspense>
   );

--- a/src/app/api/absences/[id]/route.ts
+++ b/src/app/api/absences/[id]/route.ts
@@ -1,16 +1,29 @@
 import { prisma } from "@/lib/prisma";
 import { requireAuth, requireChurchPermission, getUserDepartmentScope } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
-import { cancelAbsence, getMemberScope, isMemberLinkedToUser } from "@/modules/planning";
+import { cancelAbsence, updateAbsence, getMemberScope, isMemberLinkedToUser } from "@/modules/planning";
 import { logAudit } from "@/lib/audit";
+import { assertBackupsAllowed, backupSchema } from "../route";
 import { z } from "zod";
 
-const patchSchema = z.object({
-  action: z.literal("cancel"),
-});
+const patchSchema = z
+  .discriminatedUnion("action", [
+    z.object({ action: z.literal("cancel") }),
+    z.object({
+      action: z.literal("update"),
+      startDate: z.string().datetime().optional(),
+      endDate: z.string().datetime().optional(),
+      reason: z.string().max(500).nullable().optional(),
+      backups: z.array(backupSchema).max(10).optional(),
+    }),
+  ])
+  .refine(
+    (d) => d.action !== "update" || !d.startDate || !d.endDate || new Date(d.endDate) >= new Date(d.startDate),
+    { message: "endDate doit être postérieure ou égale à startDate", path: ["endDate"] }
+  );
 
 /**
- * PATCH /api/absences/[id] — annulation uniquement (aucune autre mutation supportée).
+ * PATCH /api/absences/[id] — `cancel` (annulation) ou `update` (modification tant que non passée).
  *
  * Autorisé : le créateur, la fiche STAR liée elle-même, un resp./ministre du
  * périmètre du membre, ou un manager global (absences:manage sans scope).
@@ -22,7 +35,7 @@ export async function PATCH(
   try {
     const session = await requireAuth();
     const { id } = await params;
-    patchSchema.parse(await request.json());
+    const data = patchSchema.parse(await request.json());
 
     const absence = await prisma.absence.findUnique({ where: { id } });
     if (!absence) throw new ApiError(404, "Absence introuvable");
@@ -40,10 +53,35 @@ export async function PATCH(
       }
     }
 
-    const updated = await cancelAbsence({
+    if (data.action === "cancel") {
+      const updated = await cancelAbsence({
+        absenceId: id,
+        churchId: absence.churchId,
+        cancelledById: session.user.id,
+      });
+
+      await logAudit({
+        userId: session.user.id,
+        churchId: absence.churchId,
+        action: "UPDATE",
+        entityType: "Absence",
+        entityId: id,
+        details: { status: "CANCELLED" },
+      });
+
+      return successResponse(updated);
+    }
+
+    await assertBackupsAllowed(data.backups, isSelf, session.user.id, absence.churchId);
+
+    const updated = await updateAbsence({
       absenceId: id,
       churchId: absence.churchId,
-      cancelledById: session.user.id,
+      updatedById: session.user.id,
+      startDate: data.startDate ? new Date(data.startDate) : undefined,
+      endDate: data.endDate ? new Date(data.endDate) : undefined,
+      reason: data.reason,
+      backups: data.backups,
     });
 
     await logAudit({
@@ -52,7 +90,7 @@ export async function PATCH(
       action: "UPDATE",
       entityType: "Absence",
       entityId: id,
-      details: { status: "CANCELLED" },
+      details: { startDate: data.startDate, endDate: data.endDate },
     });
 
     return successResponse(updated);

--- a/src/app/api/absences/__tests__/security.test.ts
+++ b/src/app/api/absences/__tests__/security.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { prismaMock } from "@/__mocks__/prisma";
 import { createAdminSession } from "@/__mocks__/auth";
+import { ApiError } from "@/lib/api-utils";
 
 const mockRequireAuth = vi.fn();
 const mockRequireChurchPermission = vi.fn();
@@ -13,14 +14,18 @@ vi.mock("@/lib/auth", () => ({
 
 const mockDeclareAbsence = vi.fn();
 const mockCancelAbsence = vi.fn();
+const mockUpdateAbsence = vi.fn();
 const mockGetMemberScope = vi.fn();
 const mockIsMemberLinkedToUser = vi.fn();
+const mockValidateBackupTargets = vi.fn();
 vi.mock("@/modules/planning", () => ({
   declareAbsence: (...args: unknown[]) => mockDeclareAbsence(...args),
   cancelAbsence: (...args: unknown[]) => mockCancelAbsence(...args),
+  updateAbsence: (...args: unknown[]) => mockUpdateAbsence(...args),
   findAbsenceConflicts: vi.fn().mockResolvedValue([]),
   getMemberScope: (...args: unknown[]) => mockGetMemberScope(...args),
   isMemberLinkedToUser: (...args: unknown[]) => mockIsMemberLinkedToUser(...args),
+  validateBackupTargets: (...args: unknown[]) => mockValidateBackupTargets(...args),
 }));
 
 vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
@@ -54,6 +59,49 @@ describe("GET /api/absences", () => {
 
     expect(res.status).toBe(200);
     expect(mockRequireChurchPermission).not.toHaveBeenCalled();
+  });
+
+  it("scope=all enriches each absence with its backups", async () => {
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockGetUserDepartmentScope.mockReturnValue({ scoped: false });
+    prismaMock.absence.findMany.mockResolvedValue([
+      {
+        id: "abs-1",
+        churchId: "church-1",
+        memberId: "member-1",
+        startDate: new Date("2026-08-01"),
+        endDate: new Date("2026-08-10"),
+        reason: null,
+        status: "ACTIVE",
+        createdById: "user-1",
+        createdAt: new Date(),
+        member: { id: "member-1", firstName: "Jean", lastName: "Dupont", departments: [] },
+        createdBy: { id: "user-1", name: "Jean Dupont", displayName: null },
+        backups: [
+          {
+            id: "backup-1",
+            type: "STAR",
+            member: { id: "member-2", firstName: "Marie", lastName: "Martin" },
+            userChurchRole: null,
+          },
+          {
+            id: "backup-2",
+            type: "RESPONSIBLE",
+            member: null,
+            userChurchRole: { id: "role-1", role: "MINISTER", user: { name: "Paul Petit", displayName: null } },
+          },
+        ],
+      },
+    ] as never);
+
+    const res = await GET(new Request("http://localhost/api/absences?churchId=church-1&scope=all"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.absences[0].backups).toEqual([
+      { id: "backup-1", type: "STAR", targetId: "member-2", name: "Marie Martin", role: undefined },
+      { id: "backup-2", type: "RESPONSIBLE", targetId: "role-1", name: "Paul Petit", role: "MINISTER" },
+    ]);
   });
 
   it("scope=all requires absences:view and returns 403 when missing", async () => {
@@ -158,6 +206,52 @@ describe("POST /api/absences — authorization", () => {
   });
 });
 
+describe("POST /api/absences — backups", () => {
+  const bodyWithBackup = { ...validBody, backups: [{ type: "STAR", memberId: "member-backup" }] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(createAdminSession());
+    mockGetMemberScope.mockResolvedValue({ churchId: "church-1", departmentIds: ["dept-1"] });
+    mockDeclareAbsence.mockResolvedValue({ id: "abs-1" });
+  });
+
+  it("returns 403 for backups on an absence declared for a third party", async () => {
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockGetUserDepartmentScope.mockReturnValue({ scoped: false });
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(bodyWithBackup) }));
+
+    expect(res.status).toBe(403);
+    expect(mockValidateBackupTargets).not.toHaveBeenCalled();
+    expect(mockDeclareAbsence).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when validateBackupTargets rejects (backup out of scope / role ineligible)", async () => {
+    mockIsMemberLinkedToUser.mockResolvedValue(true);
+    mockValidateBackupTargets.mockRejectedValue(new ApiError(403, "forbidden"));
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(bodyWithBackup) }));
+
+    expect(res.status).toBe(403);
+    expect(mockDeclareAbsence).not.toHaveBeenCalled();
+  });
+
+  it("passes backups to declareAbsence when self and validated", async () => {
+    mockIsMemberLinkedToUser.mockResolvedValue(true);
+    mockValidateBackupTargets.mockResolvedValue(undefined);
+
+    const res = await POST(new Request("http://localhost/api/absences", { method: "POST", body: JSON.stringify(bodyWithBackup) }));
+
+    expect(res.status).toBe(201);
+    expect(mockValidateBackupTargets).toHaveBeenCalled();
+    expect(mockDeclareAbsence).toHaveBeenCalledWith(
+      expect.objectContaining({ backups: bodyWithBackup.backups })
+    );
+  });
+});
+
 describe("PATCH /api/absences/[id] — authorization", () => {
   const existingAbsence = { id: "abs-1", churchId: "church-1", memberId: "member-1", createdById: "user-owner", status: "ACTIVE" };
 
@@ -248,5 +342,77 @@ describe("PATCH /api/absences/[id] — authorization", () => {
 
     expect(res.status).toBe(200);
     expect(mockCancelAbsence).toHaveBeenCalled();
+  });
+});
+
+describe("PATCH /api/absences/[id] — action update", () => {
+  const existingAbsence = { id: "abs-1", churchId: "church-1", memberId: "member-1", createdById: "user-owner", status: "ACTIVE" };
+  const updateBody = { action: "update", startDate: "2026-09-02T00:00:00.000Z", endDate: "2026-09-12T00:00:00.000Z" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({ ...createAdminSession(), user: { ...createAdminSession().user, id: "user-owner" } });
+    prismaMock.absence.findUnique.mockResolvedValue(existingAbsence as never);
+    mockUpdateAbsence.mockResolvedValue({ ...existingAbsence });
+    mockIsMemberLinkedToUser.mockResolvedValue(false);
+  });
+
+  it("allows the creator to update", async () => {
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/abs-1", { method: "PATCH", body: JSON.stringify(updateBody) }),
+      { params: Promise.resolve({ id: "abs-1" }) }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateAbsence).toHaveBeenCalled();
+  });
+
+  it("returns 403 for an unrelated user without absences:manage", async () => {
+    mockRequireAuth.mockResolvedValue({ ...createAdminSession(), user: { ...createAdminSession().user, id: "user-stranger" } });
+    mockRequireChurchPermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/abs-1", { method: "PATCH", body: JSON.stringify(updateBody) }),
+      { params: Promise.resolve({ id: "abs-1" }) }
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockUpdateAbsence).not.toHaveBeenCalled();
+  });
+
+  it("propagates a 409 from the service (absence already passed)", async () => {
+    mockUpdateAbsence.mockRejectedValue(new ApiError(409, "Absence déjà passée, non modifiable"));
+
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/abs-1", { method: "PATCH", body: JSON.stringify(updateBody) }),
+      { params: Promise.resolve({ id: "abs-1" }) }
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 403 for backups on an update when not self", async () => {
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/abs-1", {
+        method: "PATCH",
+        body: JSON.stringify({ ...updateBody, backups: [{ type: "STAR", memberId: "member-backup" }] }),
+      }),
+      { params: Promise.resolve({ id: "abs-1" }) }
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockUpdateAbsence).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when endDate is before startDate", async () => {
+    const res = await PATCH(
+      new Request("http://localhost/api/absences/abs-1", {
+        method: "PATCH",
+        body: JSON.stringify({ action: "update", startDate: "2026-09-12T00:00:00.000Z", endDate: "2026-09-02T00:00:00.000Z" }),
+      }),
+      { params: Promise.resolve({ id: "abs-1" }) }
+    );
+
+    expect(res.status).toBe(400);
   });
 });

--- a/src/app/api/absences/export/__tests__/route.test.ts
+++ b/src/app/api/absences/export/__tests__/route.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createAdminSession } from "@/__mocks__/auth";
+
+const mockRequireChurchPermission = vi.fn();
+const mockGetUserDepartmentScope = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  requireChurchPermission: (...args: unknown[]) => mockRequireChurchPermission(...args),
+  getUserDepartmentScope: (...args: unknown[]) => mockGetUserDepartmentScope(...args),
+}));
+
+vi.mock("@/modules/planning", () => ({
+  findAbsenceConflicts: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+const { POST } = await import("../route");
+
+const absenceRow = {
+  id: "abs-1",
+  churchId: "church-1",
+  memberId: "member-1",
+  startDate: new Date("2026-09-01"),
+  endDate: new Date("2026-09-05"),
+  reason: null,
+  status: "ACTIVE",
+  createdById: "user-1",
+  member: {
+    firstName: "Jean",
+    lastName: "Dupont",
+    departments: [{ department: { name: "Choristes", ministry: { name: "Louange" } } }],
+  },
+  createdBy: { name: "Jean Dupont", displayName: null },
+  backups: [],
+};
+
+describe("POST /api/absences/export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireChurchPermission.mockResolvedValue(createAdminSession());
+    mockGetUserDepartmentScope.mockReturnValue({ scoped: false });
+    prismaMock.absence.findMany.mockResolvedValue([absenceRow] as never);
+  });
+
+  it("returns 403 without absences:view", async () => {
+    mockRequireChurchPermission.mockRejectedValue(new Error("FORBIDDEN"));
+
+    const res = await POST(
+      new Request("http://localhost/api/absences/export", {
+        method: "POST",
+        body: JSON.stringify({ churchId: "church-1", absenceIds: ["abs-1"] }),
+      })
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 with an invalid body", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/absences/export", { method: "POST", body: JSON.stringify({}) })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("generates an xlsx file for an unscoped (global) manager", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/absences/export", {
+        method: "POST",
+        body: JSON.stringify({ churchId: "church-1", absenceIds: ["abs-1"] }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("spreadsheetml");
+    expect(prismaMock.absence.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ id: { in: ["abs-1"] }, churchId: "church-1" }) })
+    );
+  });
+
+  it("restricts the query to the caller's department scope", async () => {
+    mockGetUserDepartmentScope.mockReturnValue({ scoped: true, departmentIds: ["dept-1"] });
+    prismaMock.memberDepartment.findMany.mockResolvedValue([{ memberId: "member-1" }] as never);
+
+    const res = await POST(
+      new Request("http://localhost/api/absences/export", {
+        method: "POST",
+        body: JSON.stringify({ churchId: "church-1", absenceIds: ["abs-1", "abs-outside-scope"] }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.absence.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ memberId: { in: ["member-1"] } }),
+      })
+    );
+  });
+
+  it("returns an empty workbook (no rows) when the scope excludes all departments", async () => {
+    mockGetUserDepartmentScope.mockReturnValue({ scoped: true, departmentIds: [] });
+    prismaMock.absence.findMany.mockResolvedValue([] as never);
+
+    const res = await POST(
+      new Request("http://localhost/api/absences/export", {
+        method: "POST",
+        body: JSON.stringify({ churchId: "church-1", absenceIds: ["abs-1"] }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.absence.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ memberId: { in: [] } }) })
+    );
+  });
+});

--- a/src/app/api/absences/export/route.ts
+++ b/src/app/api/absences/export/route.ts
@@ -1,0 +1,142 @@
+import { prisma } from "@/lib/prisma";
+import { requireChurchPermission, getUserDepartmentScope } from "@/lib/auth";
+import { errorResponse } from "@/lib/api-utils";
+import { findAbsenceConflicts } from "@/modules/planning";
+import ExcelJS from "exceljs";
+import { z } from "zod";
+
+const exportSchema = z.object({
+  churchId: z.string().min(1),
+  absenceIds: z.array(z.string().min(1)).max(1000),
+});
+
+const COLUMNS = [
+  "STAR",
+  "Département",
+  "Ministère",
+  "Début",
+  "Fin",
+  "Motif",
+  "Statut",
+  "Conflit",
+  "Backup(s)",
+  "Déclaré par",
+] as const;
+
+/**
+ * Neutralise les valeurs pouvant être interprétées comme des formules Excel.
+ * Préfixe avec une apostrophe les chaînes commençant par =, +, -, @ ou tab/CR.
+ */
+function sanitizeExcelValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  if (/^[=+\-@\t\r]/.test(value)) return `'${value}`;
+  return value;
+}
+
+function sanitizeRow<T extends Record<string, unknown>>(row: T): T {
+  const sanitized = {} as Record<string, unknown>;
+  for (const [key, value] of Object.entries(row)) {
+    sanitized[key] = sanitizeExcelValue(value);
+  }
+  return sanitized as T;
+}
+
+/**
+ * POST /api/absences/export — génère un classeur Excel à partir d'une liste d'IDs
+ * d'absences (celles actuellement affichées côté client, filtres déjà appliqués).
+ *
+ * Le périmètre de visibilité est revérifié serveur : tout ID hors périmètre de
+ * l'appelant est silencieusement exclu du fichier généré.
+ */
+export async function POST(request: Request) {
+  try {
+    const { churchId, absenceIds } = exportSchema.parse(await request.json());
+    const session = await requireChurchPermission("absences:view", churchId);
+
+    let allowedMemberIds: string[] | null = null;
+    const deptScope = getUserDepartmentScope(session, churchId);
+    if (deptScope.scoped) {
+      if (deptScope.departmentIds.length === 0) {
+        allowedMemberIds = [];
+      } else {
+        const members = await prisma.memberDepartment.findMany({
+          where: { departmentId: { in: deptScope.departmentIds } },
+          select: { memberId: true },
+        });
+        allowedMemberIds = Array.from(new Set(members.map((m) => m.memberId)));
+      }
+    }
+
+    const absences = await prisma.absence.findMany({
+      where: {
+        id: { in: absenceIds },
+        churchId,
+        ...(allowedMemberIds ? { memberId: { in: allowedMemberIds } } : {}),
+      },
+      include: {
+        member: {
+          select: {
+            firstName: true,
+            lastName: true,
+            departments: {
+              select: { department: { select: { name: true, ministry: { select: { name: true } } } } },
+            },
+          },
+        },
+        createdBy: { select: { name: true, displayName: true } },
+        backups: {
+          select: {
+            type: true,
+            member: { select: { firstName: true, lastName: true } },
+            userChurchRole: { select: { user: { select: { name: true, displayName: true } } } },
+          },
+        },
+      },
+      orderBy: { startDate: "desc" },
+    });
+
+    const rows = await Promise.all(
+      absences.map(async (a) => {
+        const conflicts = await findAbsenceConflicts(a.memberId, a.churchId, a.startDate, a.endDate);
+        const backupNames = a.backups.map((b) =>
+          b.type === "STAR"
+            ? `${b.member!.firstName} ${b.member!.lastName}`
+            : (b.userChurchRole!.user.displayName ?? b.userChurchRole!.user.name ?? "")
+        );
+        return {
+          STAR: `${a.member.firstName} ${a.member.lastName}`,
+          Département: a.member.departments.map((d) => d.department.name).join(", "),
+          Ministère: Array.from(
+            new Set(a.member.departments.map((d) => d.department.ministry.name))
+          ).join(", "),
+          Début: a.startDate.toLocaleDateString("fr-FR"),
+          Fin: a.endDate.toLocaleDateString("fr-FR"),
+          Motif: a.reason ?? "",
+          Statut: a.status === "ACTIVE" ? "Active" : "Annulée",
+          Conflit: conflicts.length > 0 ? "Oui" : "Non",
+          "Backup(s)": backupNames.join(", "),
+          "Déclaré par": a.createdBy.displayName ?? a.createdBy.name ?? "",
+        };
+      })
+    );
+
+    const wb = new ExcelJS.Workbook();
+    const sheet = wb.addWorksheet("Absences");
+    sheet.columns = COLUMNS.map((key) => ({ header: key, key }));
+    for (const row of rows.map(sanitizeRow)) {
+      sheet.addRow(row);
+    }
+
+    const buf = await wb.xlsx.writeBuffer();
+    const filename = `absences-${new Date().toISOString().slice(0, 10)}.xlsx`;
+
+    return new Response(buf as ArrayBuffer, {
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/absences/route.ts
+++ b/src/app/api/absences/route.ts
@@ -122,8 +122,10 @@ export async function GET(request: Request) {
           select: {
             id: true,
             type: true,
-            member: { select: { firstName: true, lastName: true } },
-            userChurchRole: { select: { role: true, user: { select: { name: true, displayName: true } } } },
+            member: { select: { id: true, firstName: true, lastName: true } },
+            userChurchRole: {
+              select: { id: true, role: true, user: { select: { name: true, displayName: true } } },
+            },
           },
         },
       },
@@ -166,6 +168,7 @@ export async function GET(request: Request) {
           backups: a.backups.map((b) => ({
             id: b.id,
             type: b.type,
+            targetId: b.type === "STAR" ? b.member!.id : b.userChurchRole!.id,
             name:
               b.type === "STAR"
                 ? `${b.member!.firstName} ${b.member!.lastName}`

--- a/src/app/api/absences/route.ts
+++ b/src/app/api/absences/route.ts
@@ -6,9 +6,15 @@ import {
   findAbsenceConflicts,
   getMemberScope,
   isMemberLinkedToUser,
+  validateBackupTargets,
 } from "@/modules/planning";
 import { logAudit } from "@/lib/audit";
 import { z } from "zod";
+
+export const backupSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("STAR"), memberId: z.string().min(1) }),
+  z.object({ type: z.literal("RESPONSIBLE"), userChurchRoleId: z.string().min(1) }),
+]);
 
 const createSchema = z
   .object({
@@ -17,11 +23,28 @@ const createSchema = z
     startDate: z.string().datetime(),
     endDate: z.string().datetime(),
     reason: z.string().max(500).nullable().optional(),
+    backups: z.array(backupSchema).max(10).optional(),
   })
   .refine((d) => new Date(d.endDate) >= new Date(d.startDate), {
     message: "endDate doit être postérieure ou égale à startDate",
     path: ["endDate"],
   });
+
+/**
+ * Vérifie qu'une déclaration/modification avec backups est autorisée : uniquement pour sa
+ * propre absence (`isSelf`), et uniquement si le déclarant a le rôle Resp. département ou
+ * Ministre pour `churchId`. Ne fait rien si `backups` est vide/absent.
+ */
+export async function assertBackupsAllowed(
+  backups: z.infer<typeof backupSchema>[] | undefined,
+  isSelf: boolean,
+  userId: string,
+  churchId: string
+) {
+  if (!backups || backups.length === 0) return;
+  if (!isSelf) throw new ApiError(403, "Le backup n'est proposé que pour sa propre absence");
+  await validateBackupTargets(userId, churchId, backups);
+}
 
 /**
  * GET /api/absences?churchId=...&scope=self|all&ministryId=&departmentId=&role=
@@ -95,6 +118,14 @@ export async function GET(request: Request) {
           },
         },
         createdBy: { select: { id: true, name: true, displayName: true } },
+        backups: {
+          select: {
+            id: true,
+            type: true,
+            member: { select: { firstName: true, lastName: true } },
+            userChurchRole: { select: { role: true, user: { select: { name: true, displayName: true } } } },
+          },
+        },
       },
       orderBy: { startDate: "desc" },
     });
@@ -132,6 +163,15 @@ export async function GET(request: Request) {
           createdAt: a.createdAt,
           hasConflict: conflicts.length > 0,
           conflicts,
+          backups: a.backups.map((b) => ({
+            id: b.id,
+            type: b.type,
+            name:
+              b.type === "STAR"
+                ? `${b.member!.firstName} ${b.member!.lastName}`
+                : (b.userChurchRole!.user.displayName ?? b.userChurchRole!.user.name ?? "—"),
+            role: b.type === "RESPONSIBLE" ? b.userChurchRole!.role : undefined,
+          })),
         };
       })
     );
@@ -171,6 +211,8 @@ export async function POST(request: Request) {
       }
     }
 
+    await assertBackupsAllowed(data.backups, isSelf, session.user.id, churchId);
+
     const absence = await declareAbsence({
       churchId,
       memberId,
@@ -178,6 +220,7 @@ export async function POST(request: Request) {
       endDate: new Date(data.endDate),
       reason: data.reason,
       createdById: session.user.id,
+      backups: data.backups,
     });
 
     await logAudit({

--- a/src/modules/planning/events.ts
+++ b/src/modules/planning/events.ts
@@ -84,4 +84,15 @@ export type PlanningEvents = {
     cancelledById: string;
     hadConflict: boolean;
   };
+
+  /** Une absence non passée a été modifiée (période, motif et/ou backups). */
+  "planning:absence:updated": {
+    absenceId: string;
+    churchId: string;
+    memberId: string;
+    updatedById: string;
+    startDate: string;
+    endDate: string;
+    hasConflict: boolean;
+  };
 }

--- a/src/modules/planning/index.ts
+++ b/src/modules/planning/index.ts
@@ -8,12 +8,15 @@ export { deleteEvents } from "./services/event.service";
 export {
   declareAbsence,
   cancelAbsence,
+  updateAbsence,
   findAbsenceConflicts,
   resolveResponsibleUserIds,
   isMemberLinkedToUser,
   getMemberScope,
+  getDeclarerBackupScope,
+  validateBackupTargets,
 } from "./services/absence.service";
-export type { AbsenceConflict } from "./services/absence.service";
+export type { AbsenceConflict, BackupInput } from "./services/absence.service";
 
 /**
  * Module planning — ex-Koinonia.

--- a/src/modules/planning/services/absence.service.test.ts
+++ b/src/modules/planning/services/absence.service.test.ts
@@ -3,8 +3,14 @@ import { prismaMock } from "@/__mocks__/prisma";
 
 vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
 
-const { declareAbsence, cancelAbsence, findAbsenceConflicts, resolveResponsibleUserIds } =
-  await import("@/modules/planning");
+const {
+  declareAbsence,
+  cancelAbsence,
+  updateAbsence,
+  findAbsenceConflicts,
+  resolveResponsibleUserIds,
+  validateBackupTargets,
+} = await import("@/modules/planning");
 const { planningBus } = await import("@/modules/planning");
 
 function notifiedUserIds() {
@@ -231,6 +237,7 @@ describe("cancelAbsence", () => {
     updatedAt: new Date(),
     cancelledAt: null,
     member: { firstName: "Jean", lastName: "Dupont" },
+    backups: [],
   };
 
   beforeEach(() => {
@@ -289,5 +296,415 @@ describe("cancelAbsence", () => {
     await expect(
       cancelAbsence({ absenceId: "unknown", churchId: "church-1", cancelledById: "user-1" })
     ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe("declareAbsence avec backups", () => {
+  const baseParams = {
+    churchId: "church-1",
+    memberId: "member-1",
+    startDate: new Date("2026-08-01"),
+    endDate: new Date("2026-08-10"),
+    reason: null,
+    createdById: "user-1",
+  };
+
+  const createdAbsence = {
+    id: "abs-1",
+    churchId: "church-1",
+    memberId: "member-1",
+    startDate: baseParams.startDate,
+    endDate: baseParams.endDate,
+    reason: null,
+    status: "ACTIVE",
+    createdById: "user-1",
+    cancelledById: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    cancelledAt: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    planningBus.clear();
+    prismaMock.member.findUnique.mockResolvedValue({ firstName: "Jean", lastName: "Dupont" } as never);
+    prismaMock.absence.create.mockResolvedValue(createdAbsence as never);
+    prismaMock.memberDepartment.findMany.mockResolvedValue([]);
+    prismaMock.userDepartment.findMany.mockResolvedValue([]);
+    prismaMock.userChurchRole.findMany.mockResolvedValue([]);
+    prismaMock.planning.findMany.mockResolvedValue([]);
+    prismaMock.absenceBackup.createMany.mockResolvedValue({ count: 1 } as never);
+    prismaMock.notification.create.mockResolvedValue({} as never);
+  });
+
+  it("crée les AbsenceBackup et notifie un backup STAR lié à un compte", async () => {
+    prismaMock.memberUserLink.findMany.mockImplementation(({ where }: never) =>
+      Promise.resolve((where as { memberId: string }).memberId === "member-backup" ? [{ userId: "user-backup" }] : [])
+    );
+
+    await declareAbsence({ ...baseParams, backups: [{ type: "STAR", memberId: "member-backup" }] });
+
+    expect(prismaMock.absenceBackup.createMany).toHaveBeenCalledWith({
+      data: [{ absenceId: "abs-1", type: "STAR", memberId: "member-backup", userChurchRoleId: null }],
+    });
+    expect(notificationsOfType("ABSENCE_BACKUP_ASSIGNED").map((n) => n.userId)).toEqual(["user-backup"]);
+  });
+
+  it("ne notifie personne pour un backup STAR sans compte lié (silencieux)", async () => {
+    prismaMock.memberUserLink.findMany.mockResolvedValue([]);
+
+    await declareAbsence({ ...baseParams, backups: [{ type: "STAR", memberId: "member-backup" }] });
+
+    expect(notificationsOfType("ABSENCE_BACKUP_ASSIGNED")).toHaveLength(0);
+  });
+
+  it("crée un AbsenceBackup RESPONSIBLE et notifie directement le user cible", async () => {
+    prismaMock.memberUserLink.findMany.mockResolvedValue([]);
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({ userId: "user-minister-backup" } as never);
+
+    await declareAbsence({ ...baseParams, backups: [{ type: "RESPONSIBLE", userChurchRoleId: "role-1" }] });
+
+    expect(prismaMock.absenceBackup.createMany).toHaveBeenCalledWith({
+      data: [{ absenceId: "abs-1", type: "RESPONSIBLE", memberId: null, userChurchRoleId: "role-1" }],
+    });
+    expect(notificationsOfType("ABSENCE_BACKUP_ASSIGNED").map((n) => n.userId)).toEqual(["user-minister-backup"]);
+  });
+
+  it("ne crée aucun AbsenceBackup sans backups fournis (non-régression)", async () => {
+    await declareAbsence(baseParams);
+
+    expect(prismaMock.absenceBackup.createMany).not.toHaveBeenCalled();
+    expect(notificationsOfType("ABSENCE_BACKUP_ASSIGNED")).toHaveLength(0);
+  });
+});
+
+describe("validateBackupTargets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refuse (403) si le déclarant n'a ni rôle Resp. département ni Ministre", async () => {
+    prismaMock.userChurchRole.findMany.mockResolvedValue([]);
+
+    await expect(
+      validateBackupTargets("user-star-only", "church-1", [{ type: "STAR", memberId: "member-x" }])
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("autorise un backup STAR appartenant au département du Resp. département déclarant", async () => {
+    prismaMock.userChurchRole.findMany.mockResolvedValue([
+      { role: "DEPARTMENT_HEAD", ministryId: null, departments: [{ departmentId: "dept-1" }] },
+    ] as never);
+    prismaMock.member.findUnique.mockResolvedValue({
+      departments: [{ department: { id: "dept-1", ministry: { churchId: "church-1" } } }],
+    } as never);
+
+    await expect(
+      validateBackupTargets("user-resp", "church-1", [{ type: "STAR", memberId: "member-x" }])
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuse un backup STAR hors du périmètre du Resp. département déclarant", async () => {
+    prismaMock.userChurchRole.findMany.mockResolvedValue([
+      { role: "DEPARTMENT_HEAD", ministryId: null, departments: [{ departmentId: "dept-1" }] },
+    ] as never);
+    prismaMock.member.findUnique.mockResolvedValue({
+      departments: [{ department: { id: "dept-other", ministry: { churchId: "church-1" } } }],
+    } as never);
+
+    await expect(
+      validateBackupTargets("user-resp", "church-1", [{ type: "STAR", memberId: "member-x" }])
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("un Resp. département peut désigner le Ministre de son ministère en backup", async () => {
+    prismaMock.userChurchRole.findMany.mockResolvedValue([
+      { role: "DEPARTMENT_HEAD", ministryId: null, departments: [{ departmentId: "dept-1" }] },
+    ] as never);
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({
+      userId: "user-minister",
+      role: "MINISTER",
+      churchId: "church-1",
+      ministryId: "min-1",
+      departments: [],
+    } as never);
+    prismaMock.department.findMany.mockResolvedValue([{ ministryId: "min-1" }] as never);
+
+    await expect(
+      validateBackupTargets("user-resp", "church-1", [{ type: "RESPONSIBLE", userChurchRoleId: "role-min" }])
+    ).resolves.toBeUndefined();
+  });
+
+  it("un Resp. département peut désigner un autre Resp. département du même ministère", async () => {
+    prismaMock.userChurchRole.findMany.mockResolvedValue([
+      { role: "DEPARTMENT_HEAD", ministryId: null, departments: [{ departmentId: "dept-1" }] },
+    ] as never);
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({
+      userId: "user-peer",
+      role: "DEPARTMENT_HEAD",
+      churchId: "church-1",
+      ministryId: null,
+      departments: [{ department: { ministryId: "min-1" } }],
+    } as never);
+    prismaMock.department.findMany.mockResolvedValue([{ ministryId: "min-1" }] as never);
+
+    await expect(
+      validateBackupTargets("user-resp", "church-1", [{ type: "RESPONSIBLE", userChurchRoleId: "role-peer" }])
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuse un Resp. département d'un autre ministère que le déclarant", async () => {
+    prismaMock.userChurchRole.findMany.mockResolvedValue([
+      { role: "DEPARTMENT_HEAD", ministryId: null, departments: [{ departmentId: "dept-1" }] },
+    ] as never);
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({
+      userId: "user-other",
+      role: "DEPARTMENT_HEAD",
+      churchId: "church-1",
+      ministryId: null,
+      departments: [{ department: { ministryId: "min-2" } }],
+    } as never);
+    prismaMock.department.findMany.mockResolvedValue([{ ministryId: "min-1" }] as never);
+
+    await expect(
+      validateBackupTargets("user-resp", "church-1", [{ type: "RESPONSIBLE", userChurchRoleId: "role-other" }])
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("un Ministre peut désigner un autre Ministre en backup", async () => {
+    prismaMock.userChurchRole.findMany.mockResolvedValue([
+      { role: "MINISTER", ministryId: "min-1", departments: [] },
+    ] as never);
+    prismaMock.department.findMany.mockResolvedValue([]);
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({
+      userId: "user-minister-2",
+      role: "MINISTER",
+      churchId: "church-1",
+      ministryId: "min-2",
+      departments: [],
+    } as never);
+
+    await expect(
+      validateBackupTargets("user-min", "church-1", [{ type: "RESPONSIBLE", userChurchRoleId: "role-min2" }])
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuse qu'un Ministre se désigne lui-même en backup", async () => {
+    prismaMock.userChurchRole.findMany.mockResolvedValue([
+      { role: "MINISTER", ministryId: "min-1", departments: [] },
+    ] as never);
+    prismaMock.department.findMany.mockResolvedValue([]);
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({
+      userId: "user-min",
+      role: "MINISTER",
+      churchId: "church-1",
+      ministryId: "min-1",
+      departments: [],
+    } as never);
+
+    await expect(
+      validateBackupTargets("user-min", "church-1", [{ type: "RESPONSIBLE", userChurchRoleId: "role-self" }])
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("refuse qu'un Ministre désigne un Resp. département en backup", async () => {
+    prismaMock.userChurchRole.findMany.mockResolvedValue([
+      { role: "MINISTER", ministryId: "min-1", departments: [] },
+    ] as never);
+    prismaMock.department.findMany.mockResolvedValue([]);
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({
+      userId: "user-depthead",
+      role: "DEPARTMENT_HEAD",
+      churchId: "church-1",
+      ministryId: null,
+      departments: [{ department: { ministryId: "min-1" } }],
+    } as never);
+
+    await expect(
+      validateBackupTargets("user-min", "church-1", [{ type: "RESPONSIBLE", userChurchRoleId: "role-depthead" }])
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+});
+
+describe("cancelAbsence notifie les backups", () => {
+  const existingAbsence = {
+    id: "abs-1",
+    churchId: "church-1",
+    memberId: "member-1",
+    startDate: new Date("2026-08-01"),
+    endDate: new Date("2026-08-10"),
+    reason: null,
+    status: "ACTIVE",
+    createdById: "user-1",
+    cancelledById: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    cancelledAt: null,
+    member: { firstName: "Jean", lastName: "Dupont" },
+    backups: [
+      { type: "STAR", memberId: "member-backup", userChurchRoleId: null },
+      { type: "RESPONSIBLE", memberId: null, userChurchRoleId: "role-1" },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    planningBus.clear();
+    prismaMock.absence.findUnique.mockResolvedValue(existingAbsence as never);
+    prismaMock.absence.update.mockResolvedValue({ ...existingAbsence, status: "CANCELLED" } as never);
+    prismaMock.memberDepartment.findMany.mockResolvedValue([]);
+    prismaMock.userDepartment.findMany.mockResolvedValue([]);
+    prismaMock.userChurchRole.findMany.mockResolvedValue([]);
+    prismaMock.planning.findMany.mockResolvedValue([]);
+    prismaMock.notification.create.mockResolvedValue({} as never);
+  });
+
+  it("notifie les backups STAR et RESPONSIBLE de l'absence annulée", async () => {
+    prismaMock.memberUserLink.findMany.mockImplementation(({ where }: never) =>
+      Promise.resolve((where as { memberId: string }).memberId === "member-backup" ? [{ userId: "user-backup" }] : [])
+    );
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({ userId: "user-responsible-backup" } as never);
+
+    await cancelAbsence({ absenceId: "abs-1", churchId: "church-1", cancelledById: "user-1" });
+
+    expect(new Set(notifiedUserIds())).toEqual(new Set(["user-backup", "user-responsible-backup"]));
+  });
+});
+
+describe("updateAbsence", () => {
+  const existingAbsence = {
+    id: "abs-1",
+    churchId: "church-1",
+    memberId: "member-1",
+    startDate: new Date("2026-09-01"),
+    endDate: new Date("2026-09-10"),
+    reason: null,
+    status: "ACTIVE",
+    createdById: "user-1",
+    cancelledById: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    cancelledAt: null,
+    member: { firstName: "Jean", lastName: "Dupont" },
+    backups: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    planningBus.clear();
+    prismaMock.absence.findUnique.mockResolvedValue(existingAbsence as never);
+    prismaMock.absence.update.mockResolvedValue({ ...existingAbsence, startDate: new Date("2026-09-02") } as never);
+    prismaMock.memberDepartment.findMany.mockResolvedValue([]);
+    prismaMock.userDepartment.findMany.mockResolvedValue([]);
+    prismaMock.userChurchRole.findMany.mockResolvedValue([]);
+    prismaMock.memberUserLink.findMany.mockResolvedValue([]);
+    prismaMock.planning.findMany.mockResolvedValue([]);
+    prismaMock.absenceBackup.deleteMany.mockResolvedValue({ count: 0 } as never);
+    prismaMock.absenceBackup.createMany.mockResolvedValue({ count: 0 } as never);
+    prismaMock.notification.create.mockResolvedValue({} as never);
+  });
+
+  it("modifie la période et notifie ABSENCE_UPDATED", async () => {
+    await updateAbsence({
+      absenceId: "abs-1",
+      churchId: "church-1",
+      updatedById: "user-1",
+      startDate: new Date("2026-09-02"),
+      endDate: new Date("2026-09-12"),
+    });
+
+    expect(prismaMock.absence.update).toHaveBeenCalledWith({
+      where: { id: "abs-1" },
+      data: { startDate: new Date("2026-09-02"), endDate: new Date("2026-09-12") },
+    });
+  });
+
+  it("notifie les backups déjà notifiés à la déclaration initiale (backups inchangés)", async () => {
+    prismaMock.absence.findUnique.mockResolvedValue({
+      ...existingAbsence,
+      backups: [{ type: "STAR", memberId: "member-backup", userChurchRoleId: null }],
+    } as never);
+    prismaMock.memberUserLink.findMany.mockImplementation(({ where }: never) =>
+      Promise.resolve((where as { memberId: string }).memberId === "member-backup" ? [{ userId: "user-backup" }] : [])
+    );
+
+    await updateAbsence({
+      absenceId: "abs-1",
+      churchId: "church-1",
+      updatedById: "user-1",
+      reason: "nouveau motif",
+    });
+
+    expect(notificationsOfType("ABSENCE_UPDATED").map((n) => n.userId)).toEqual(["user-backup"]);
+  });
+
+  it("notifie ABSENCE_CONFLICT si un nouveau conflit apparaît suite à la modification", async () => {
+    prismaMock.planning.findMany
+      .mockResolvedValueOnce([]) // conflits avant (période actuelle)
+      .mockResolvedValueOnce([
+        { eventDepartment: { departmentId: "dept-1", event: { id: "evt-1", title: "Culte", date: new Date("2026-09-05") } } },
+      ] as never); // conflits après (nouvelle période)
+    prismaMock.memberUserLink.findMany.mockResolvedValue([{ userId: "user-star" }] as never);
+
+    await updateAbsence({
+      absenceId: "abs-1",
+      churchId: "church-1",
+      updatedById: "user-1",
+      startDate: new Date("2026-09-02"),
+      endDate: new Date("2026-09-12"),
+    });
+
+    expect(notificationsOfType("ABSENCE_CONFLICT")).toHaveLength(1);
+  });
+
+  it("refuse (409) une absence déjà passée", async () => {
+    prismaMock.absence.findUnique.mockResolvedValue({
+      ...existingAbsence,
+      endDate: new Date("2020-01-01"),
+    } as never);
+
+    await expect(
+      updateAbsence({ absenceId: "abs-1", churchId: "church-1", updatedById: "user-1", reason: "x" })
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("refuse (400) une nouvelle date de début antérieure à celle déjà enregistrée si l'absence est en cours", async () => {
+    prismaMock.absence.findUnique.mockResolvedValue({
+      ...existingAbsence,
+      startDate: new Date("2020-01-01"), // déjà commencée
+      endDate: new Date("2027-01-01"), // pas encore terminée
+    } as never);
+
+    await expect(
+      updateAbsence({
+        absenceId: "abs-1",
+        churchId: "church-1",
+        updatedById: "user-1",
+        startDate: new Date("2019-01-01"),
+      })
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("remplace intégralement les backups quand une nouvelle liste est fournie", async () => {
+    prismaMock.userChurchRole.findUnique.mockResolvedValue({ userId: "user-new-backup" } as never);
+
+    await updateAbsence({
+      absenceId: "abs-1",
+      churchId: "church-1",
+      updatedById: "user-1",
+      backups: [{ type: "RESPONSIBLE", userChurchRoleId: "role-new" }],
+    });
+
+    expect(prismaMock.absenceBackup.deleteMany).toHaveBeenCalledWith({ where: { absenceId: "abs-1" } });
+    expect(prismaMock.absenceBackup.createMany).toHaveBeenCalledWith({
+      data: [{ absenceId: "abs-1", type: "RESPONSIBLE", memberId: null, userChurchRoleId: "role-new" }],
+    });
+  });
+
+  it("laisse les backups inchangés quand `backups` est omis", async () => {
+    await updateAbsence({ absenceId: "abs-1", churchId: "church-1", updatedById: "user-1", reason: "x" });
+
+    expect(prismaMock.absenceBackup.deleteMany).not.toHaveBeenCalled();
+    expect(prismaMock.absenceBackup.createMany).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/planning/services/absence.service.ts
+++ b/src/modules/planning/services/absence.service.ts
@@ -1,4 +1,4 @@
-import type { Prisma, Absence } from "@/generated/prisma/client";
+import type { Prisma, Absence, AbsenceBackupType } from "@/generated/prisma/client";
 import { ApiError } from "@/lib/api-utils";
 import { planningBus } from "../bus";
 
@@ -125,6 +125,162 @@ export async function getMemberScope(
   return { churchId: churchIds.size === 1 ? [...churchIds][0] : null, departmentIds };
 }
 
+export interface BackupInput {
+  type: AbsenceBackupType;
+  memberId?: string;
+  userChurchRoleId?: string;
+}
+
+interface DeclarerBackupScope {
+  /** Départements couverts (comme Resp. département, ou tous ceux des ministères dirigés). */
+  departmentIds: string[];
+  /** Ministères dirigés (rôle Ministre uniquement). */
+  ministryIds: string[];
+  isDepartmentHead: boolean;
+  isMinister: boolean;
+}
+
+/**
+ * Périmètre de désignation de backup d'un utilisateur pour une église donnée : départements
+ * couverts (comme Resp. département, ou via les ministères qu'il dirige comme Ministre) et
+ * ministères dirigés. Périmètre vide si l'utilisateur n'a ni rôle Resp. département ni Ministre.
+ */
+export async function getDeclarerBackupScope(
+  userId: string,
+  churchId: string,
+  db?: DbClient
+): Promise<DeclarerBackupScope> {
+  db ??= await defaultDb();
+  const roles = await db.userChurchRole.findMany({
+    where: { userId, churchId, role: { in: ["DEPARTMENT_HEAD", "MINISTER"] } },
+    select: { role: true, ministryId: true, departments: { select: { departmentId: true } } },
+  });
+
+  const departmentHeadDeptIds = roles
+    .filter((r) => r.role === "DEPARTMENT_HEAD")
+    .flatMap((r) => r.departments.map((d) => d.departmentId));
+  const ministryIds = roles
+    .filter((r) => r.role === "MINISTER" && r.ministryId)
+    .map((r) => r.ministryId!);
+
+  let ministerDeptIds: string[] = [];
+  if (ministryIds.length > 0) {
+    const depts = await db.department.findMany({
+      where: { ministryId: { in: ministryIds } },
+      select: { id: true },
+    });
+    ministerDeptIds = depts.map((d) => d.id);
+  }
+
+  return {
+    departmentIds: Array.from(new Set([...departmentHeadDeptIds, ...ministerDeptIds])),
+    ministryIds,
+    isDepartmentHead: departmentHeadDeptIds.length > 0,
+    isMinister: ministryIds.length > 0,
+  };
+}
+
+/**
+ * Valide que chaque backup proposé est autorisé pour le périmètre du déclarant. Lève
+ * `ApiError(403)` au premier backup non autorisé. Ne fait rien si `backups` est vide.
+ *
+ * Règles (cf. spec 013) :
+ * - STAR : le membre doit appartenir au périmètre du déclarant (département couvert, ou
+ *   n'importe quel département d'un ministère qu'il dirige).
+ * - RESPONSIBLE : un Resp. département peut désigner le Ministre de son ministère ou un autre
+ *   Resp. département du même ministère ; un Ministre peut désigner un autre Ministre de
+ *   l'église (jamais lui-même).
+ */
+export async function validateBackupTargets(
+  declarerUserId: string,
+  churchId: string,
+  backups: BackupInput[],
+  db?: DbClient
+): Promise<void> {
+  if (backups.length === 0) return;
+  db ??= await defaultDb();
+
+  const scope = await getDeclarerBackupScope(declarerUserId, churchId, db);
+  if (!scope.isDepartmentHead && !scope.isMinister) {
+    throw new ApiError(403, "Seuls un Resp. département ou un Ministre peuvent désigner un backup");
+  }
+
+  for (const backup of backups) {
+    if (backup.type === "STAR") {
+      if (!backup.memberId) throw new ApiError(400, "memberId requis pour un backup STAR");
+      const memberScope = await getMemberScope(backup.memberId, db);
+      const allowed = memberScope?.departmentIds.some((id) => scope.departmentIds.includes(id)) ?? false;
+      if (!allowed) throw new ApiError(403, "Ce backup STAR n'appartient pas à votre périmètre");
+      continue;
+    }
+
+    if (!backup.userChurchRoleId) throw new ApiError(400, "userChurchRoleId requis pour un backup responsable");
+    const target = await db.userChurchRole.findUnique({
+      where: { id: backup.userChurchRoleId },
+      select: {
+        userId: true,
+        role: true,
+        churchId: true,
+        ministryId: true,
+        departments: { select: { department: { select: { ministryId: true } } } },
+      },
+    });
+    if (!target || target.churchId !== churchId) throw new ApiError(403, "Backup introuvable");
+    if (target.userId === declarerUserId) {
+      throw new ApiError(403, "Vous ne pouvez pas vous désigner vous-même en backup");
+    }
+
+    if (target.role !== "MINISTER" && target.role !== "DEPARTMENT_HEAD") {
+      throw new ApiError(403, "Ce backup n'appartient pas à votre périmètre");
+    }
+
+    // Ministre → uniquement un autre Ministre de l'église (déjà exclu : lui-même).
+    if (target.role === "MINISTER" && scope.isMinister) continue;
+
+    // Resp. département → le Ministre de son ministère, ou un autre Resp. département du même
+    // ministère (comparaison via les départements couverts par le déclarant).
+    if (scope.isDepartmentHead) {
+      const declarerMinistries = await db.department.findMany({
+        where: { id: { in: scope.departmentIds } },
+        select: { ministryId: true },
+      });
+      const declarerMinistryIds = new Set(declarerMinistries.map((d) => d.ministryId));
+      const targetMinistryIds =
+        target.role === "MINISTER"
+          ? [target.ministryId].filter((id): id is string => !!id)
+          : target.departments.map((d) => d.department.ministryId);
+      if (targetMinistryIds.some((id) => declarerMinistryIds.has(id))) continue;
+    }
+
+    throw new ApiError(403, "Ce backup n'appartient pas à votre périmètre");
+  }
+}
+
+/** Résout les utilisateurs à notifier pour une liste de backups (STAR via lien compte, sinon direct). */
+async function resolveBackupRecipients(
+  backups: { type: AbsenceBackupType; memberId: string | null; userChurchRoleId: string | null }[],
+  churchId: string,
+  db: DbClient
+): Promise<string[]> {
+  const recipients: string[] = [];
+  for (const b of backups) {
+    if (b.type === "STAR" && b.memberId) {
+      const links = await db.memberUserLink.findMany({
+        where: { memberId: b.memberId, churchId },
+        select: { userId: true },
+      });
+      recipients.push(...links.map((l) => l.userId));
+    } else if (b.type === "RESPONSIBLE" && b.userChurchRoleId) {
+      const role = await db.userChurchRole.findUnique({
+        where: { id: b.userChurchRoleId },
+        select: { userId: true },
+      });
+      if (role) recipients.push(role.userId);
+    }
+  }
+  return recipients;
+}
+
 interface DeclareAbsenceParams {
   churchId: string;
   memberId: string;
@@ -132,6 +288,7 @@ interface DeclareAbsenceParams {
   endDate: Date;
   reason?: string | null;
   createdById: string;
+  backups?: BackupInput[];
 }
 
 /**
@@ -142,7 +299,7 @@ interface DeclareAbsenceParams {
  * la route appelante avant d'invoquer ce service.
  */
 export async function declareAbsence(params: DeclareAbsenceParams): Promise<Absence> {
-  const { churchId, memberId, startDate, endDate, reason, createdById } = params;
+  const { churchId, memberId, startDate, endDate, reason, createdById, backups = [] } = params;
   const { prisma } = await import("@/lib/prisma");
 
   const member = await prisma.member.findUnique({
@@ -155,6 +312,17 @@ export async function declareAbsence(params: DeclareAbsenceParams): Promise<Abse
     const absence = await tx.absence.create({
       data: { churchId, memberId, startDate, endDate, reason: reason ?? null, createdById },
     });
+
+    if (backups.length > 0) {
+      await tx.absenceBackup.createMany({
+        data: backups.map((b) => ({
+          absenceId: absence.id,
+          type: b.type,
+          memberId: b.type === "STAR" ? b.memberId : null,
+          userChurchRoleId: b.type === "RESPONSIBLE" ? b.userChurchRoleId : null,
+        })),
+      });
+    }
 
     const conflicts = await findAbsenceConflicts(memberId, churchId, startDate, endDate, tx);
     const hasConflict = conflicts.length > 0;
@@ -188,6 +356,25 @@ export async function declareAbsence(params: DeclareAbsenceParams): Promise<Abse
             type: "ABSENCE_CONFLICT",
             title: "Conflit planning / absence",
             message: `L'absence de ${memberName} (${period}) chevauche ${plural ? "des services" : "un service"} déjà planifié${plural ? "s" : ""}.`,
+            link: "/absences",
+          },
+        });
+      }
+    }
+
+    if (backups.length > 0) {
+      const backupRecipients = new Set(await resolveBackupRecipients(backups.map((b) => ({
+        type: b.type,
+        memberId: b.type === "STAR" ? b.memberId ?? null : null,
+        userChurchRoleId: b.type === "RESPONSIBLE" ? b.userChurchRoleId ?? null : null,
+      })), churchId, tx));
+      for (const userId of backupRecipients) {
+        await tx.notification.create({
+          data: {
+            userId,
+            type: "ABSENCE_BACKUP_ASSIGNED",
+            title: "Désigné en backup",
+            message: `Vous avez été désigné en backup de ${memberName} pour son absence du ${period}.`,
             link: "/absences",
           },
         });
@@ -232,7 +419,10 @@ export async function cancelAbsence(params: CancelAbsenceParams): Promise<Absenc
   return prisma.$transaction(async (tx) => {
     const absence = await tx.absence.findUnique({
       where: { id: absenceId },
-      include: { member: { select: { firstName: true, lastName: true } } },
+      include: {
+        member: { select: { firstName: true, lastName: true } },
+        backups: { select: { type: true, memberId: true, userChurchRoleId: true } },
+      },
     });
     if (!absence) throw new ApiError(404, "Absence introuvable");
     if (absence.churchId !== churchId) throw new ApiError(403, "Absence hors périmètre");
@@ -261,6 +451,9 @@ export async function cancelAbsence(params: CancelAbsenceParams): Promise<Absenc
       });
       for (const l of links) recipients.add(l.userId);
     }
+    for (const userId of await resolveBackupRecipients(absence.backups, churchId, tx)) {
+      recipients.add(userId);
+    }
 
     const memberName = `${absence.member.firstName} ${absence.member.lastName}`;
     const period = formatPeriod(absence.startDate, absence.endDate);
@@ -281,6 +474,164 @@ export async function cancelAbsence(params: CancelAbsenceParams): Promise<Absenc
       "planning:absence:cancelled",
       { tx, churchId, userId: cancelledById },
       { absenceId, churchId, memberId: absence.memberId, cancelledById, hadConflict }
+    );
+
+    return updated;
+  });
+}
+
+interface UpdateAbsenceParams {
+  absenceId: string;
+  churchId: string;
+  updatedById: string;
+  startDate?: Date;
+  endDate?: Date;
+  reason?: string | null;
+  /** Remplace intégralement les backups si fourni ; laisse inchangé si `undefined`. */
+  backups?: BackupInput[];
+}
+
+/**
+ * Modifie une absence active tant que sa date de fin n'est pas passée, recalcule les conflits
+ * sur la nouvelle période et notifie l'union des destinataires (anciens + nouveaux backups).
+ *
+ * L'autorisation (créateur, membre lui-même, resp./ministre scopé, ou manager global) est
+ * vérifiée par la route appelante avant d'invoquer ce service.
+ */
+export async function updateAbsence(params: UpdateAbsenceParams): Promise<Absence> {
+  const { absenceId, churchId, updatedById, startDate, endDate, reason, backups } = params;
+  const { prisma } = await import("@/lib/prisma");
+
+  return prisma.$transaction(async (tx) => {
+    const absence = await tx.absence.findUnique({
+      where: { id: absenceId },
+      include: {
+        member: { select: { firstName: true, lastName: true } },
+        backups: { select: { type: true, memberId: true, userChurchRoleId: true } },
+      },
+    });
+    if (!absence) throw new ApiError(404, "Absence introuvable");
+    if (absence.churchId !== churchId) throw new ApiError(403, "Absence hors périmètre");
+    if (absence.status === "CANCELLED") throw new ApiError(409, "Absence annulée, non modifiable");
+
+    const now = new Date();
+    if (absence.endDate < now) throw new ApiError(409, "Absence déjà passée, non modifiable");
+
+    const newStartDate = startDate ?? absence.startDate;
+    const newEndDate = endDate ?? absence.endDate;
+
+    if (startDate && absence.startDate <= now && startDate < absence.startDate) {
+      throw new ApiError(400, "La date de début d'une absence déjà commencée ne peut pas être reculée");
+    }
+
+    const conflictsBefore = await findAbsenceConflicts(
+      absence.memberId,
+      churchId,
+      absence.startDate,
+      absence.endDate,
+      tx
+    );
+    const hadConflictBefore = conflictsBefore.length > 0;
+
+    const updated = await tx.absence.update({
+      where: { id: absenceId },
+      data: {
+        startDate: newStartDate,
+        endDate: newEndDate,
+        ...(reason !== undefined ? { reason: reason ?? null } : {}),
+      },
+    });
+
+    const conflictsAfter = await findAbsenceConflicts(absence.memberId, churchId, newStartDate, newEndDate, tx);
+    const hasConflictAfter = conflictsAfter.length > 0;
+
+    const responsibleUserIds = await resolveResponsibleUserIds(absence.memberId, churchId, tx);
+    const priorBackupRecipients = await resolveBackupRecipients(absence.backups, churchId, tx);
+
+    let newBackupRecipients: string[] = [];
+    if (backups !== undefined) {
+      await tx.absenceBackup.deleteMany({ where: { absenceId } });
+      if (backups.length > 0) {
+        await tx.absenceBackup.createMany({
+          data: backups.map((b) => ({
+            absenceId,
+            type: b.type,
+            memberId: b.type === "STAR" ? b.memberId : null,
+            userChurchRoleId: b.type === "RESPONSIBLE" ? b.userChurchRoleId : null,
+          })),
+        });
+      }
+      newBackupRecipients = await resolveBackupRecipients(
+        backups.map((b) => ({
+          type: b.type,
+          memberId: b.type === "STAR" ? (b.memberId ?? null) : null,
+          userChurchRoleId: b.type === "RESPONSIBLE" ? (b.userChurchRoleId ?? null) : null,
+        })),
+        churchId,
+        tx
+      );
+    }
+
+    const memberName = `${absence.member.firstName} ${absence.member.lastName}`;
+    const period = formatPeriod(newStartDate, newEndDate);
+
+    const memberLinkedUserIds =
+      hadConflictBefore || hasConflictAfter
+        ? (
+            await tx.memberUserLink.findMany({
+              where: { memberId: absence.memberId, churchId },
+              select: { userId: true },
+            })
+          ).map((l) => l.userId)
+        : [];
+
+    const updateRecipients = new Set([
+      ...responsibleUserIds,
+      ...priorBackupRecipients,
+      ...newBackupRecipients,
+      ...memberLinkedUserIds,
+    ]);
+
+    for (const userId of updateRecipients) {
+      await tx.notification.create({
+        data: {
+          userId,
+          type: "ABSENCE_UPDATED",
+          title: "Absence modifiée",
+          message: `L'absence de ${memberName} a été modifiée (période : ${period}).`,
+          link: "/absences",
+        },
+      });
+    }
+
+    if (hasConflictAfter && !hadConflictBefore) {
+      const plural = conflictsAfter.length > 1;
+      const conflictRecipients = new Set([...responsibleUserIds, ...memberLinkedUserIds]);
+      for (const userId of conflictRecipients) {
+        await tx.notification.create({
+          data: {
+            userId,
+            type: "ABSENCE_CONFLICT",
+            title: "Conflit planning / absence",
+            message: `L'absence de ${memberName} (${period}) chevauche ${plural ? "des services" : "un service"} déjà planifié${plural ? "s" : ""}.`,
+            link: "/absences",
+          },
+        });
+      }
+    }
+
+    await planningBus.emit(
+      "planning:absence:updated",
+      { tx, churchId, userId: updatedById },
+      {
+        absenceId,
+        churchId,
+        memberId: absence.memberId,
+        updatedById,
+        startDate: newStartDate.toISOString(),
+        endDate: newEndDate.toISOString(),
+        hasConflict: hasConflictAfter,
+      }
     );
 
     return updated;


### PR DESCRIPTION
## Résumé

Implémente les 5 évolutions du module Absences décrites dans [`specs/013-evolutions-absences/`](specs/013-evolutions-absences/) :

1. **Backup optionnel** sur l'absence d'un Resp. département ou d'un Ministre (jamais pour un STAR simple, jamais pour une absence déclarée pour un tiers) — pool éligible : STAR du périmètre, Ministre/Resp. département selon les règles de la spec.
2. **Édition d'une absence non passée** (remplace annuler+recréer) — réévalue les conflits, notifie l'union des destinataires.
3. **Vue frise temporelle** en alternative au tableau (vue d'ensemble).
4. **Export Excel** de la vue d'ensemble, respectant les filtres actifs et le périmètre de l'appelant (revérifié serveur).
5. **Date de fin liée à la date de début** à la saisie.

## Détails techniques

- Nouveau modèle `AbsenceBackup` (`STAR`/`RESPONSIBLE` via `UserChurchRole`), migration `add_absence_backups`.
- Nouveau service `updateAbsence`, extension de `declareAbsence`/`cancelAbsence`.
- `PATCH /api/absences/[id]` accepte `action: "cancel" | "update"`.
- Nouvelle route `POST /api/absences/export` (ExcelJS).
- ⚠️ La migration `add_absence_backups` inclut deux changements sans rapport avec cette feature, générés automatiquement lors de la resynchronisation de l'historique de migration local (table `__prisma_migrations` fantôme créée par erreur dans une migration antérieure, et un index manquant sur `media_share_tokens`) — vérifiés inoffensifs, à surveiller en recette.

## Plan de test

- [x] `npm run typecheck && npm run lint && npm run lint:boundaries && npm run test` (599 tests, tous verts)
- [x] Tous les critères d'acceptation de la spec couverts par les tests (service + routes) ou par revue de code pour la partie UI (frise, liaison des dates — pas de framework de test composant dans ce repo)
- [ ] Vérification visuelle mobile réelle non effectuée (pas d'outil de navigateur dans cet environnement) — à confirmer manuellement avant merge

https://claude.ai/code/session_019AmQHtj4vBxybnwDm5asAQ