### PR TITLE
chore: release v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.16.0] - 2026-07-30
+
+### Ajouté
+
+- **Évolutions du module Absences** : lors de la déclaration de sa propre absence, un Resp. département ou un Ministre peut désigner un ou plusieurs backups (STAR de son périmètre, Ministre de son ministère, ou pair Resp. département du même ministère) — notifiés de leur désignation et visibles dans la vue transverse. Une absence non passée peut désormais être modifiée (période, motif, backups) plutôt qu'annulée puis recréée, avec réévaluation des conflits. Nouvelle vue « frise temporelle » en alternative au tableau. Export Excel de la vue d'ensemble, respectant les filtres actifs. À la déclaration, la date de fin se pré-remplit sur la date de début.
+- **Import des réservations futures MRBS vers Koinonia** : script d'import ponctuel (`prisma/scripts/import-mrbs-reservations.ts`) réutilisant le service métier de réservation (conflits, main courante), idempotent, avec option de rattachement des réservations sans créateur lié à un compte de repli.
+
 ## [v1.15.0] - 2026-07-29
 
 ### Ajouté

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koinonia",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koinonia",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.3",
         "@aws-sdk/client-s3": "^3.1095.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Résumé

Bump de version 1.15.0 → 1.16.0 (minor) suite à l'ajout des évolutions du module Absences (#435) : backup, édition d'une absence non passée, vue frise, export Excel, date de fin liée à la date de début.

## Plan de test

- [x] `npm run typecheck`

https://claude.ai/code/session_019AmQHtj4vBxybnwDm5asAQ