### PR TITLE
fix(star-view): capture d'export tronquée (régression html2canvas-pro)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tailwindcss/postcss": "^4.3.3",
         "archiver": "^7.0.1",
         "exceljs": "^4.4.0",
-        "html2canvas-pro": "^2.3.1",
+        "html2canvas-pro": "^2.3.2",
         "jspdf": "^4.2.1",
         "mariadb": "^3.5.3",
         "next": "^16.2.11",
@@ -1602,9 +1602,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1620,9 +1617,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1640,9 +1634,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1658,9 +1649,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1678,9 +1666,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1696,9 +1681,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1716,9 +1698,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1735,9 +1714,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1753,9 +1729,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1779,9 +1752,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1803,9 +1773,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1829,9 +1796,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1853,9 +1817,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1879,9 +1840,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1904,9 +1862,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1928,9 +1883,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2185,9 +2137,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,9 +2152,6 @@
       "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2223,9 +2169,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2241,9 +2184,6 @@
       "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2924,9 +2864,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2944,9 +2881,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2964,9 +2898,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2984,9 +2915,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3004,9 +2932,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3024,9 +2949,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3360,9 +3282,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3378,9 +3297,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3398,9 +3314,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3416,9 +3329,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3776,7 +3686,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -8192,9 +8102,9 @@
       }
     },
     "node_modules/html2canvas-pro": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/html2canvas-pro/-/html2canvas-pro-2.3.1.tgz",
-      "integrity": "sha512-w7CCWi0B0kCy/joy5cPN2GIDGW0iwbqBppxxc2Vc5UyqYDQ1K13ZVr+MyGR/34Mq03emCTxVbBTpG299/prACw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html2canvas-pro/-/html2canvas-pro-2.3.2.tgz",
+      "integrity": "sha512-lYFaxtQM8exYVAtXmjdx8cjkw+/2GycRvSTcr2M2MuxXKuYlWe77+KFKuY92y/tzkvzA8XZTQIDlqoVZDB+mqQ==",
       "license": "MIT",
       "dependencies": {
         "css-line-break": "^2.1.0",
@@ -9994,9 +9904,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10012,9 +9919,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -10032,9 +9936,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10050,9 +9951,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -10070,9 +9968,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10088,9 +9983,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -10108,9 +10000,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10127,9 +10016,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10145,9 +10031,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -10171,9 +10054,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10195,9 +10075,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -10221,9 +10098,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10245,9 +10119,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -10271,9 +10142,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10296,9 +10164,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10320,9 +10185,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@tailwindcss/postcss": "^4.3.3",
     "archiver": "^7.0.1",
     "exceljs": "^4.4.0",
-    "html2canvas-pro": "^2.3.1",
+    "html2canvas-pro": "^2.3.2",
     "jspdf": "^4.2.1",
     "mariadb": "^3.5.3",
     "next": "^16.2.11",

--- a/src/app/(auth)/events/[eventId]/star-view/StarViewClient.tsx
+++ b/src/app/(auth)/events/[eventId]/star-view/StarViewClient.tsx
@@ -40,6 +40,7 @@ export default function StarViewClient({ eventId }: Props) {
   const [loading, setLoading] = useState(true);
   const [exporting, setExporting] = useState<"pdf" | "image" | "copy" | null>(null);
   const printRef = useRef<HTMLDivElement>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
 
   const fetchData = useCallback(async () => {
     try {
@@ -62,19 +63,31 @@ export default function StarViewClient({ eventId }: Props) {
     return `STAR-${data?.event.title || "export"}`;
   }
 
-  // Force A4 landscape layout (1122px wide, desktop breakpoints) before html2canvas capture,
-  // regardless of the current mobile viewport — restores original width in all cases.
+  // Force A4 landscape layout (1122px wide) before html2canvas capture, regardless of the
+  // current viewport. Forcing `el.style.width` alone does NOT make Tailwind's `md:`/`lg:`
+  // classes activate — those respond to the real browser viewport width, not this element's
+  // width. On a narrower viewport (mobile, or a non-maximized desktop window), the live DOM
+  // therefore keeps its mobile/tablet column count while html2canvas's clone (rendered at
+  // `windowWidth: 1440`) applies the desktop column count — a mismatch that made the captured
+  // image truncated with blank gaps. Forcing a single fixed column count on the grid during
+  // capture removes that mismatch entirely.
   async function captureForExport(): Promise<HTMLCanvasElement | null> {
     if (!printRef.current) return null;
     const html2canvas = (await import("html2canvas-pro")).default;
     const el = printRef.current;
     const savedWidth = el.style.width;
     el.style.width = "1122px";
+
+    const grid = gridRef.current;
+    const savedGridClassName = grid?.className;
+    if (grid) grid.className = "grid grid-cols-4 gap-3";
+
     await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
     try {
       return await html2canvas(el, { scale: 2, useCORS: true, windowWidth: 1440 });
     } finally {
       el.style.width = savedWidth;
+      if (grid && savedGridClassName !== undefined) grid.className = savedGridClassName;
     }
   }
 
@@ -273,7 +286,7 @@ export default function StarViewClient({ eventId }: Props) {
         {/* Body */}
         <div className="bg-gray-50 px-5 py-5">
           {/* Active departments */}
-          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+          <div ref={gridRef} className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
             {data.departments.filter((d) => d.members.length > 0).map((dept) => (
               <div
                 key={dept.id}

--- a/src/app/(auth)/events/[eventId]/star-view/StarViewClient.tsx
+++ b/src/app/(auth)/events/[eventId]/star-view/StarViewClient.tsx
@@ -40,7 +40,6 @@ export default function StarViewClient({ eventId }: Props) {
   const [loading, setLoading] = useState(true);
   const [exporting, setExporting] = useState<"pdf" | "image" | "copy" | null>(null);
   const printRef = useRef<HTMLDivElement>(null);
-  const gridRef = useRef<HTMLDivElement>(null);
 
   const fetchData = useCallback(async () => {
     try {
@@ -63,31 +62,19 @@ export default function StarViewClient({ eventId }: Props) {
     return `STAR-${data?.event.title || "export"}`;
   }
 
-  // Force A4 landscape layout (1122px wide) before html2canvas capture, regardless of the
-  // current viewport. Forcing `el.style.width` alone does NOT make Tailwind's `md:`/`lg:`
-  // classes activate — those respond to the real browser viewport width, not this element's
-  // width. On a narrower viewport (mobile, or a non-maximized desktop window), the live DOM
-  // therefore keeps its mobile/tablet column count while html2canvas's clone (rendered at
-  // `windowWidth: 1440`) applies the desktop column count — a mismatch that made the captured
-  // image truncated with blank gaps. Forcing a single fixed column count on the grid during
-  // capture removes that mismatch entirely.
+  // Force A4 landscape layout (1122px wide, desktop breakpoints) before html2canvas capture,
+  // regardless of the current mobile viewport — restores original width in all cases.
   async function captureForExport(): Promise<HTMLCanvasElement | null> {
     if (!printRef.current) return null;
     const html2canvas = (await import("html2canvas-pro")).default;
     const el = printRef.current;
     const savedWidth = el.style.width;
     el.style.width = "1122px";
-
-    const grid = gridRef.current;
-    const savedGridClassName = grid?.className;
-    if (grid) grid.className = "grid grid-cols-4 gap-3";
-
     await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
     try {
       return await html2canvas(el, { scale: 2, useCORS: true, windowWidth: 1440 });
     } finally {
       el.style.width = savedWidth;
-      if (grid && savedGridClassName !== undefined) grid.className = savedGridClassName;
     }
   }
 
@@ -286,7 +273,7 @@ export default function StarViewClient({ eventId }: Props) {
         {/* Body */}
         <div className="bg-gray-50 px-5 py-5">
           {/* Active departments */}
-          <div ref={gridRef} className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
             {data.departments.filter((d) => d.members.length > 0).map((dept) => (
               <div
                 key={dept.id}


### PR DESCRIPTION
## Résumé

Corrige la capture d'export du planning STAR (copier image / télécharger PNG / export PDF) tronquée avec des bandes blanches, quel que soit le device/viewport.

**Cause** : `html2canvas-pro` était verrouillé en `2.3.1` (bump dependabot), version affectée par une régression amont — [text baseline shifts down for webfonts, pushing labels out of their box](https://github.com/yorickshan/html2canvas-pro/issues/222) — corrigée en `2.3.2` (sortie 3 jours avant ce fix). Aucun changement de code applicatif n'était en cause.

Une première tentative de fix (forcer `grid-cols-4` pendant la capture, en supposant un décalage de breakpoint Tailwind) a été testée puis écartée — le bug se reproduisait indépendamment du viewport, invalidant cette hypothèse. Ce commit l'annule et applique le vrai correctif : bump de dépendance.

## Plan de test

- [x] `npm run typecheck && npm run lint && npm run lint:boundaries && npm run test` (599 tests)
- [x] Confirmé par l'utilisateur : capture non tronquée sur la branche

https://claude.ai/code/session_019AmQHtj4vBxybnwDm5asAQ