### PR TITLE
fix(proxy): rendre public le formulaire rejoindre-icc

### DIFF
--- a/src/app/api/integration/families/suggest/route.ts
+++ b/src/app/api/integration/families/suggest/route.ts
@@ -1,8 +1,11 @@
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { geocodeAddress, findFamilyByCoords } from "@/lib/family-geo";
+import { requireRateLimit } from "@/lib/rate-limit";
 
 export async function GET(request: Request) {
   try {
+    requireRateLimit(request, { prefix: `integration-families-suggest:public:${request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"}`, windowMs: 60_000, max: 20 });
+
     const { searchParams } = new URL(request.url);
     const address = searchParams.get("address");
     if (!address) throw new ApiError(400, "address requis");

--- a/src/app/api/integration/requests/route.ts
+++ b/src/app/api/integration/requests/route.ts
@@ -3,6 +3,7 @@ import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { requireIntegrationAccess, buildConfirmationEmail } from "@/modules/integration";
 import { sendEmail } from "@/lib/email";
 import { geocodeAddress, findFamilyByCoords } from "@/lib/family-geo";
+import { requireRateLimit } from "@/lib/rate-limit";
 import { z } from "zod";
 import type { FamilyAgeRange, FamilyChurchStatus, FamilyIntegrationStatus, Prisma } from "@/generated/prisma/client";
 
@@ -72,6 +73,8 @@ const createSchema = z.object({
 
 export async function POST(request: Request) {
   try {
+    requireRateLimit(request, { prefix: `integration-requests:public:${request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"}`, windowMs: 60_000, max: 5 });
+
     const body = await request.json();
     const data = createSchema.parse(body);
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -26,6 +26,13 @@ export function proxy(request: NextRequest) {
     if (request.nextUrl.pathname === "/api/agenda/requests/public") {
       return NextResponse.next();
     }
+    // Allow public "rejoindre" form (page /rejoindre/[churchSlug], hors session)
+    if (
+      (request.nextUrl.pathname === "/api/integration/requests" && request.method === "POST") ||
+      request.nextUrl.pathname === "/api/integration/families/suggest"
+    ) {
+      return NextResponse.next();
+    }
     if (request.nextUrl.pathname.startsWith("/api/")) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }


### PR DESCRIPTION
## Résumé
- Le middleware (`src/proxy.ts`) exigeait un cookie de session pour toute route `/api/*` (hors `/api/auth/*`), bloquant `POST /api/integration/requests` et `GET /api/integration/families/suggest` appelés par le formulaire public `/rejoindre/[churchSlug]`.
- Ces deux endpoints n'imposent aucune authentification côté handler (contrairement au `GET /api/integration/requests`, protégé par `requireIntegrationAccess`) — ils sont conçus pour être accessibles sans session.
- Ajout de ces deux routes à la liste blanche du middleware, sur le modèle de `/api/agenda/requests/public`.
- Ces routes étant désormais accessibles sans authentification, ajout d'un rate-limit par IP (`requireRateLimit`) pour prévenir le spam automatisé : 5 requêtes/min sur la création de demande, 20 requêtes/min sur la suggestion de famille.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Vérifier en recette qu'un visiteur non connecté peut soumettre le formulaire `/rejoindre/[churchSlug]` de bout en bout
- [ ] Vérifier que le rate-limit se déclenche bien après plusieurs soumissions rapprochées (429)

🤖 Generated with [Claude Code](https://claude.com/claude-code)