### PR TITLE
fix(admin): permettre l'attribution des rôles AGENDA_QUALIFIER et ACCOUNTANT

### DIFF
--- a/src/app/(auth)/admin/access/AccessClient.tsx
+++ b/src/app/(auth)/admin/access/AccessClient.tsx
@@ -65,18 +65,20 @@ interface Props {
 
 type Tab = "requests" | "roles" | "transverse" | "reporters" | "stars";
 
-type TransverseRole = "ADMIN" | "SECRETARY" | "DISCIPLE_MAKER";
+type TransverseRole = "ADMIN" | "SECRETARY" | "DISCIPLE_MAKER" | "AGENDA_QUALIFIER";
 
 const TRANSVERSE_ROLE_LABELS: Record<TransverseRole, string> = {
   ADMIN: "Admin",
   SECRETARY: "Secrétaire",
   DISCIPLE_MAKER: "Faiseur de Disciples",
+  AGENDA_QUALIFIER: "Qualificateur Agenda",
 };
 
 const TRANSVERSE_ROLE_COLORS: Record<TransverseRole, string> = {
   ADMIN: "bg-red-100 text-red-700 border-red-200",
   SECRETARY: "bg-blue-100 text-blue-700 border-blue-200",
   DISCIPLE_MAKER: "bg-green-100 text-green-700 border-green-200",
+  AGENDA_QUALIFIER: "bg-purple-100 text-purple-700 border-purple-200",
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -931,7 +933,7 @@ export default function AccessClient({ users, ministries, churchId, isSuperAdmin
             className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet mb-2"
           />
           {filteredTransverseUsers.map((user) => {
-            const userTransverseRoles = (["ADMIN", "SECRETARY", "DISCIPLE_MAKER"] as TransverseRole[]).filter(
+            const userTransverseRoles = (["ADMIN", "SECRETARY", "DISCIPLE_MAKER", "AGENDA_QUALIFIER"] as TransverseRole[]).filter(
               (role) => {
                 if (role === "ADMIN" || role === "SECRETARY") return isSuperAdmin;
                 return true;
@@ -946,7 +948,7 @@ export default function AccessClient({ users, ministries, churchId, isSuperAdmin
                   <p className="text-sm font-medium text-gray-900 truncate">{user.name}</p>
                   <p className="text-xs text-gray-400 truncate">{user.email}</p>
                   <div className="flex flex-wrap gap-1.5 mt-1.5">
-                    {(["ADMIN", "SECRETARY", "DISCIPLE_MAKER"] as TransverseRole[])
+                    {(["ADMIN", "SECRETARY", "DISCIPLE_MAKER", "AGENDA_QUALIFIER"] as TransverseRole[])
                       .filter((role) => user.churchRoles.some((r) => r.role === role))
                       .map((role) => (
                         <span

--- a/src/app/(auth)/admin/access/AccessClient.tsx
+++ b/src/app/(auth)/admin/access/AccessClient.tsx
@@ -65,13 +65,14 @@ interface Props {
 
 type Tab = "requests" | "roles" | "transverse" | "reporters" | "stars";
 
-type TransverseRole = "ADMIN" | "SECRETARY" | "DISCIPLE_MAKER" | "AGENDA_QUALIFIER";
+type TransverseRole = "ADMIN" | "SECRETARY" | "DISCIPLE_MAKER" | "AGENDA_QUALIFIER" | "ACCOUNTANT";
 
 const TRANSVERSE_ROLE_LABELS: Record<TransverseRole, string> = {
   ADMIN: "Admin",
   SECRETARY: "Secrétaire",
   DISCIPLE_MAKER: "Faiseur de Disciples",
   AGENDA_QUALIFIER: "Qualificateur Agenda",
+  ACCOUNTANT: "Comptable",
 };
 
 const TRANSVERSE_ROLE_COLORS: Record<TransverseRole, string> = {
@@ -79,6 +80,7 @@ const TRANSVERSE_ROLE_COLORS: Record<TransverseRole, string> = {
   SECRETARY: "bg-blue-100 text-blue-700 border-blue-200",
   DISCIPLE_MAKER: "bg-green-100 text-green-700 border-green-200",
   AGENDA_QUALIFIER: "bg-purple-100 text-purple-700 border-purple-200",
+  ACCOUNTANT: "bg-yellow-100 text-yellow-700 border-yellow-200",
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -933,7 +935,7 @@ export default function AccessClient({ users, ministries, churchId, isSuperAdmin
             className="w-full border-2 border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-icc-violet mb-2"
           />
           {filteredTransverseUsers.map((user) => {
-            const userTransverseRoles = (["ADMIN", "SECRETARY", "DISCIPLE_MAKER", "AGENDA_QUALIFIER"] as TransverseRole[]).filter(
+            const userTransverseRoles = (["ADMIN", "SECRETARY", "DISCIPLE_MAKER", "AGENDA_QUALIFIER", "ACCOUNTANT"] as TransverseRole[]).filter(
               (role) => {
                 if (role === "ADMIN" || role === "SECRETARY") return isSuperAdmin;
                 return true;
@@ -948,7 +950,7 @@ export default function AccessClient({ users, ministries, churchId, isSuperAdmin
                   <p className="text-sm font-medium text-gray-900 truncate">{user.name}</p>
                   <p className="text-xs text-gray-400 truncate">{user.email}</p>
                   <div className="flex flex-wrap gap-1.5 mt-1.5">
-                    {(["ADMIN", "SECRETARY", "DISCIPLE_MAKER", "AGENDA_QUALIFIER"] as TransverseRole[])
+                    {(["ADMIN", "SECRETARY", "DISCIPLE_MAKER", "AGENDA_QUALIFIER", "ACCOUNTANT"] as TransverseRole[])
                       .filter((role) => user.churchRoles.some((r) => r.role === role))
                       .map((role) => (
                         <span

--- a/src/app/(auth)/admin/users/UsersClient.tsx
+++ b/src/app/(auth)/admin/users/UsersClient.tsx
@@ -17,6 +17,7 @@ const ROLES = [
   { value: "DISCIPLE_MAKER", label: "Faiseur de Disciples" },
   { value: "REPORTER", label: "Reporter (Comptes rendus)" },
   { value: "AGENDA_QUALIFIER", label: "Qualificateur Agenda" },
+  { value: "ACCOUNTANT", label: "Comptable" },
 ];
 
 const ROLE_LABELS: Record<string, string> = Object.fromEntries(

--- a/src/app/api/users/[userId]/roles/route.ts
+++ b/src/app/api/users/[userId]/roles/route.ts
@@ -23,6 +23,7 @@ const roleSchema = z.object({
     "DISCIPLE_MAKER",
     "REPORTER",
     "STAR",
+    "AGENDA_QUALIFIER",
   ]),
   ministryId: z.string().optional(),
   // Supporte les deux formats : string[] (legacy) ou { id, isDeputy }[]

--- a/src/app/api/users/[userId]/roles/route.ts
+++ b/src/app/api/users/[userId]/roles/route.ts
@@ -24,6 +24,7 @@ const roleSchema = z.object({
     "REPORTER",
     "STAR",
     "AGENDA_QUALIFIER",
+    "ACCOUNTANT",
   ]),
   ministryId: z.string().optional(),
   // Supporte les deux formats : string[] (legacy) ou { id, isDeputy }[]


### PR DESCRIPTION
## Summary
Deux rôles définis dans des manifestes de modules étaient impossibles à attribuer via l'admin : absents à la fois du schéma Zod `roleSchema` (`POST/DELETE /api/users/[userId]/roles`) et du tableau `TransverseRole` de l'UI `/admin/access`.

- `AGENDA_QUALIFIER` (module `agenda`, permission `agenda:qualify`)
- `ACCOUNTANT` (module `accounting`, permissions `accounting:view/manage/stats`)

Ajout des deux rôles au schéma Zod et au tableau des rôles transverses (toggle +/-, même pattern que `DISCIPLE_MAKER`), assignables par `SECRETARY` comme les autres rôles non-privilégiés. Ajout aussi du label "Comptable" dans `UsersClient.tsx` (cosmétique, évite un fallback brut "ACCOUNTANT" dans les badges).

J'ai vérifié exhaustivement l'enum Prisma `Role` (10 valeurs) contre ces deux points de contrôle : les 10 rôles y figurent maintenant tous.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test -- --run` (625 tests passés)
- [ ] Vérifier manuellement dans `/admin/access` (onglet "Rôles transverses") que les boutons "+ Qualificateur Agenda" et "+ Comptable" apparaissent et fonctionnent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AmQHtj4vBxybnwDm5asAQ