### PR TITLE
fix(build): casser l'import circulaire registry.ts ↔ modules/integration

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -75,6 +75,31 @@ module.exports = {
     },
 
     /**
+     * Règle 2bis — src/lib/registry.ts est la racine de composition : elle importe
+     * tous les modules, donc aucun module ne doit l'importer statiquement (cycle
+     * d'import qui provoque des ReferenceError "Cannot access ... before
+     * initialization" intermittents au build Turbopack — cf. issue #446).
+     *
+     * L'import dynamique (`await import("@/lib/registry")`) reste autorisé : il crée
+     * une frontière de chunk asynchrone qui évite le TDZ (voir modules/integration/auth.ts
+     * et modules/integration/services/msdp-service.ts pour le pattern).
+     */
+    {
+      name: "no-modules-static-import-registry",
+      severity: "error",
+      comment:
+        "src/modules/ ne doit pas importer src/lib/registry.ts statiquement (cycle avec la racine de composition). Utiliser `await import(\"@/lib/registry\")` si rolePermissions est nécessaire.",
+      from: {
+        path: "^src/modules/",
+        pathNot: "/__tests__/",
+      },
+      to: {
+        path: "^src/lib/registry\\.ts$",
+        dynamic: false,
+      },
+    },
+
+    /**
      * Règle 3 — src/app ne peut importer que les points d'entrée publics d'un module.
      *
      * Points d'entrée autorisés :

--- a/src/modules/agenda/auth.ts
+++ b/src/modules/agenda/auth.ts
@@ -1,6 +1,5 @@
 import { requireAuth, requireChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { rolePermissions } from "@/lib/registry";
 import type { Session } from "next-auth";
 
 /**
@@ -31,6 +30,7 @@ export async function requireAgendaView(churchId: string) {
   const roles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   if (roles.length === 0) throw new Error("FORBIDDEN");
 
+  const { rolePermissions } = await import("@/lib/registry");
   const userPerms = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
 
   if (userPerms.has("agenda:view") || await isProtocoleMember(session, churchId))
@@ -51,6 +51,7 @@ export async function requireAgendaManage(churchId: string) {
   const roles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   if (roles.length === 0) throw new Error("FORBIDDEN");
 
+  const { rolePermissions } = await import("@/lib/registry");
   const userPerms = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
 
   if (userPerms.has("agenda:manage") || await isProtocoleMember(session, churchId))

--- a/src/modules/integration/services/msdp-service.ts
+++ b/src/modules/integration/services/msdp-service.ts
@@ -1,5 +1,4 @@
 import { prisma } from "@/lib/prisma";
-import { rolePermissions } from "@/lib/registry";
 import { ApiError } from "@/lib/api-utils";
 import { isIntegrationMember, isMsdpMember } from "../auth";
 import { z } from "zod";
@@ -31,6 +30,7 @@ export async function hasMsdpManagementAccess(session: Session, churchId: string
   if (session.user.isSuperAdmin) return true;
   const roles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   if (roles.length > 0) {
+    const { rolePermissions } = await import("@/lib/registry");
     const perms = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
     if (perms.has("members:manage") || perms.has("events:manage")) return true;
   }


### PR DESCRIPTION
Fixes #446

## Summary
- Cause racine confirmée : `modules/integration/services/msdp-service.ts` importait statiquement `rolePermissions` depuis `@/lib/registry` (racine de composition qui importe tous les modules, dont `integration`) → cycle statique. Turbopack gère cet import circulaire de façon non-déterministe au build de production selon le découpage des chunks, d'où les `ReferenceError "Cannot access ... before initialization"` intermittents.
- `modules/agenda/auth.ts` avait la même violation latente (import statique de `@/lib/registry`), sans provoquer de crash aujourd'hui uniquement parce que `agenda/index.ts` ne réexporte pas `auth.ts` — mais c'était la même dette d'architecture, corrigée par précaution.
- Les deux fichiers utilisent désormais un import dynamique (`await import("@/lib/registry")`), le même pattern déjà en place dans `modules/integration/auth.ts`. Aucun changement de comportement : les fonctions concernées étaient déjà `async`.
- Nouvelle règle dependency-cruiser `no-modules-static-import-registry` : interdit tout import **statique** de `src/lib/registry.ts` depuis `src/modules/` (l'import dynamique reste autorisé comme échappatoire), pour empêcher la régression — gap identifié dans l'issue.
- Vérifié avec `madge --circular` qu'il n'existe plus aucun cycle statique applicatif (seuls des cycles internes au client Prisma généré subsistent, hors périmètre, non liés à ce bug).
- 4 builds de production (`next build`) consécutifs réussis en local pour valider (le bug étant intermittent, ce n'est pas une preuve à 100 %, mais cohérent avec la correction).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries` (nouvelle règle testée : détecte bien l'ancien import statique, laisse passer le dynamique)
- [x] `npm run test -- --run` (625 tests passés)
- [x] `npx madge --circular --ts-config tsconfig.json src` : plus aucun cycle applicatif statique
- [x] 4x `next build` consécutifs réussis en local

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AmQHtj4vBxybnwDm5asAQ