### PR TITLE
feat(integration): email au conseiller MSDP lors de son assignation

### DIFF
--- a/specs/016-email-assignation-conseiller-msdp/plan.md
+++ b/specs/016-email-assignation-conseiller-msdp/plan.md
@@ -1,0 +1,81 @@
+# Plan technique — Email de notification à l'assignation d'un conseiller MSDP
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Validé
+- **Mis à jour le** : 2026-08-16
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : aucun nouvel import cross-module ; tout reste dans `src/modules/integration/` et sa route d'API dédiée `src/app/api/integration/msdp/[id]/route.ts`.
+- [x] **Sécurité** : aucune route nouvelle, aucun changement de permission — `assign_counselor` reste réservé aux managers (`hasMsdpManagementAccess`), déjà vérifié dans le handler `PATCH` existant.
+- [x] **Permissions** via `rolePermissions` : inchangé, pas touché par cette feature.
+- [x] **Validation** Zod : pas de nouveau body/paramètre entrant, `msdpPatchSchema` inchangé.
+- [x] **Migration** Prisma : `[Aucun changement]` — pas de nouveau champ ni modèle.
+- [x] **Enums** : aucun enum ajouté/modifié.
+- [x] **UI** : aucun composant UI ajouté — l'email est un template HTML inline, comme les emails existants du module (`family-service.ts`), pas un composant React.
+
+## Approche générale
+
+Répliquer exactement le pattern déjà utilisé pour la notification du berger (`notifyBergerAssigned` → `buildBergerNotifEmail`, dans `family-service.ts`) mais côté MSDP :
+
+1. Ajouter une fonction `buildMsdpCounselorNotifEmail(...)` dans `msdp-service.ts`, générant un template HTML sobre calqué sur `buildBergerNotifEmail` (identité visuelle ICC, nom de la personne suivie, lien direct vers le suivi).
+2. Étendre `notifyMsdpCounselorAssigned(...)` pour, en plus de créer la notification in-app existante, récupérer l'email du conseiller (`User.email`) et envoyer l'email via `sendEmail` si l'email est renseigné — exactement le garde-fou `if (berger.email) { ... }` déjà utilisé côté famille.
+3. Passer un `appUrl` à `notifyMsdpCounselorAssigned` depuis la route API, dérivé de la même façon que dans `src/app/api/integration/requests/[id]/route.ts:202` (`process.env.APP_URL ?? process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? "http://localhost:3000"`).
+4. Aucun changement de contrat d'API observable : la route `PATCH /api/integration/msdp/[id]` répond exactement comme avant, l'envoi d'email est un effet de bord asynchrone non bloquant (`.catch(() => {})`), au même titre que l'email berger.
+
+## Modèle de données
+
+`[Aucun changement]` — `User.email` existe déjà, `MsdpFollowUp` et `FamilyIntegrationRequest` ne sont pas modifiés.
+
+## API
+
+`[Aucun endpoint ajouté ni modifié dans son contrat]`
+
+| Endpoint | Méthode | Permission | Changement |
+|---|---|---|---|
+| `/api/integration/msdp/[id]` | PATCH | `hasMsdpManagementAccess` (action `assign_counselor` déjà réservée manager) | Effet de bord supplémentaire non bloquant : email envoyé au conseiller assigné, en plus de la notification in-app déjà créée. Réponse HTTP inchangée. |
+
+## Services / logique métier
+
+Dans `src/modules/integration/services/msdp-service.ts` :
+
+- **Nouvelle fonction** `buildMsdpCounselorNotifEmail(params: { counselorName: string; personName: string; followUpId: string; appUrl: string }): string` — template HTML, structure et style identiques à `buildBergerNotifEmail` (même charte : bandeau violet `#5E17EB`, encart avec le nom de la personne, bouton CTA vers `${appUrl}/admin/integration/requests/{requestId}` — à confirmer : le suivi MSDP n'a pas de page dédiée, on renvoie donc vers la fiche `RequestDetail` qui contient le bloc MSDP, comme c'est déjà le cas dans l'UI).
+- **Modification** de `notifyMsdpCounselorAssigned(params)` :
+  - Signature étendue : ajoute `appUrl: string` aux params existants (`counselorId`, `followUpId`, `personName`).
+  - Après la création de la notification in-app (inchangée), récupère `{ id, name, email }` du conseiller via `prisma.user.findUnique`.
+  - Si `counselor.email` est renseigné, appelle `sendEmail({ to, subject, html: buildMsdpCounselorNotifEmail(...) })`, avec `.catch(() => {})` pour ne jamais faire échouer l'assignation (cohérent avec le comportement déjà en place côté berger et avec le critère d'acceptation « un échec technique d'envoi d'email n'empêche pas l'assignation »).
+  - Import ajouté : `sendEmail` depuis `@/lib/email` (déjà utilisé ailleurs dans le module, pas de nouvelle dépendance cross-module).
+
+Dans `src/app/api/integration/msdp/[id]/route.ts` :
+
+- Calcul de `appUrl` (même logique que `requests/[id]/route.ts:202`) juste avant l'appel à `notifyMsdpCounselorAssigned`, et ajout de `appUrl` à l'objet passé.
+
+Aucun événement du bus (`integrationBus`) n'est émis ni consommé — cohérent avec le constat que le bus n'est pas utilisé aujourd'hui dans ce module ; l'ajouter ici serait hors périmètre de la spec.
+
+## UI / composants
+
+`[Aucun changement]` — l'email est un template HTML généré côté serveur, pas un composant. Aucune page ni composant `src/components/ui/` à toucher.
+
+## Décisions & alternatives écartées
+
+- **Choix** : dupliquer le pattern `buildBergerNotifEmail` tel quel (fonction générant une chaîne HTML dans le fichier `services/`) plutôt que de créer un système de templates d'email partagé. *Pourquoi* : cohérence avec l'existant (aucun système de templates générique n'existe dans le projet, chaque email a sa propre fonction `build*Email`), et périmètre de la spec limité à ce seul email — introduire une abstraction de templating serait de la sur-ingénierie pour un seul cas d'usage supplémentaire.
+- **Choix** : lien de l'email pointant vers `RequestDetail` (`/admin/integration/requests/{requestId}`) plutôt qu'une URL MSDP dédiée. *Pourquoi* : il n'existe pas de page MSDP séparée (confirmé lors de l'exploration précédente) — le bloc MSDP est intégré dans la fiche de la demande d'intégration. Créer une route dédiée serait hors périmètre.
+- **Écarté** : introduire une préférence utilisateur pour désactiver cet email. *Raison* : explicitement hors périmètre de la spec — aucun mécanisme de préférence de notification n'existe ailleurs dans l'application.
+- **Écarté** : émettre un événement `integrationBus` (`msdp:counselor_assigned`) plutôt qu'un appel direct de fonction. *Raison* : le bus n'est utilisé nulle part ailleurs dans ce module actuellement ; l'introduire seulement pour cette feature ajouterait de la complexité sans bénéfice immédiat (pas de second abonné identifié).
+
+## Risques & points d'attention
+
+- **Confidentialité** : comme pour le flux famille, l'email évite tout détail sensible (pas de mention explicite « appel au salut » dans le corps, conformément au critère d'acceptation sur la sobriété) — juste le nom de la personne suivie et un lien vers l'application.
+- **Échec silencieux** : `sendEmail(...).catch(() => {})` masque les erreurs d'envoi (SMTP down, etc.) sans les logger — c'est le comportement déjà accepté ailleurs dans le module (`family-service.ts`), donc pas une régression, mais un point de vigilance opérationnelle déjà existant, pas à corriger ici (hors périmètre).
+- **SMTP non configuré en dev** : contrairement au job d'inactivité (`buildInactivityEmail`, qui vérifie `process.env.SMTP_HOST` avant d'envoyer), `notifyBergerAssigned` — le pattern suivi ici — n'a **aucune** garde `SMTP_HOST` : il tente toujours l'envoi si `berger.email` est renseigné, `sendEmail` utilisant `localhost` par défaut si `SMTP_HOST` est absent. On reproduit fidèlement ce comportement (pas de garde `SMTP_HOST` ajoutée pour MSDP) pour rester cohérent avec le seul pattern de référence pertinent — une notification d'assignation, pas un job planifié.
+
+## Stratégie de tests
+
+- **Test unitaire** sur `buildMsdpCounselorNotifEmail` : vérifie que le nom du conseiller, le nom de la personne suivie et le lien vers l'application apparaissent dans le HTML généré (même style de test que ceux existants pour `buildBergerNotifEmail`, si présents — sinon premier test de ce type pour le module).
+- **Test unitaire** sur `notifyMsdpCounselorAssigned` (via mock Prisma déjà en place dans `src/__mocks__/prisma.ts`) :
+  - Cas conseiller avec email → `sendEmail` appelé une fois avec les bons destinataire/sujet.
+  - Cas conseiller sans email → `sendEmail` non appelé, notification in-app toujours créée.
+  - Cas `sendEmail` qui rejette → la fonction ne lève pas, l'appelant (route PATCH) continue normalement.
+- Pas de nouveau test d'intégration de route nécessaire : le comportement de `PATCH /api/integration/msdp/[id]` (statut HTTP, permissions) est inchangé ; les tests de sécurité existants (`src/app/api/agenda/requests/__tests__/security.test.ts` sert de référence de pattern) n'ont pas besoin d'évoluer pour cette feature.

--- a/specs/016-email-assignation-conseiller-msdp/spec.md
+++ b/specs/016-email-assignation-conseiller-msdp/spec.md
@@ -1,0 +1,59 @@
+# Spec — Email de notification à l'assignation d'un conseiller MSDP
+
+- **Numéro** : 016
+- **Statut** : Implémentée
+- **Créée le** : 2026-08-16
+- **Branche suggérée** : `feat/email-assignation-conseiller-msdp`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+Quand une famille suit un parcours d'intégration et qu'un berger lui est affecté, le berger reçoit à la fois une notification dans l'application **et** un email — il est donc informé même s'il n'a pas l'application ouverte ou ne la consulte pas régulièrement.
+
+Quand une personne ayant répondu à un appel au salut est prise en charge dans le suivi MSDP (Ministère de Suivi Des Personnes) et qu'un conseiller lui est assigné, ce conseiller ne reçoit aujourd'hui **qu'une notification dans l'application** — aucun email. S'il ne consulte pas l'application régulièrement, il peut ne pas se rendre compte qu'un suivi lui a été confié, ce qui retarde la prise de contact avec un nouveau converti — l'étape la plus sensible du parcours d'intégration.
+
+On veut aligner ce comportement sur celui déjà en place pour l'affectation d'un berger, afin que tout conseiller assigné à un suivi MSDP soit notifié de façon fiable, qu'il soit connecté à l'application ou non.
+
+## Utilisateurs concernés
+
+- **Conseiller MSDP** : personne assignée à un suivi (rattachée au périmètre MSDP de son église). C'est un rôle fonctionnel spécifique au module intégration, pas un des rôles globaux de Koinonia — il peut être porté par un Admin, un Ministre, un Responsable de département, ou tout autre utilisateur rattaché au département de fonction MSDP de son église.
+- **Équipe intégration / équipe MSDP** (celle qui assigne le conseiller) : aucun changement de comportement pour elle, l'assignation se fait exactement comme aujourd'hui.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Un membre de l'équipe intégration ou de l'équipe MSDP assigne un conseiller à un suivi de nouveau converti.
+2. Le conseiller assigné reçoit immédiatement une notification dans l'application (comportement déjà existant, inchangé).
+3. Le conseiller assigné reçoit également un email l'informant qu'un suivi lui a été confié, avec les informations nécessaires pour identifier de qui il s'agit et retrouver le suivi dans l'application.
+
+### Scénarios alternatifs / cas limites
+
+- **Si** le conseiller assigné n'a pas d'adresse email connue dans l'application, **alors** seule la notification in-app est envoyée (pas d'échec bloquant pour l'action d'assignation).
+- **Si** l'envoi de l'email échoue techniquement (problème de service d'envoi, etc.), **alors** l'assignation du conseiller reste effective et la notification in-app reste envoyée — l'échec de l'email ne doit jamais empêcher ou annuler l'assignation.
+- **Quand** un suivi est réaffecté à un nouveau conseiller (changement de conseiller en cours de suivi), le nouveau conseiller assigné reçoit le même email de notification que lors d'une première assignation.
+- L'assignation d'un conseiller est toujours réalisée par un responsable habilité (équipe intégration/MSDP), jamais par le conseiller lui-même — aucun cas d'auto-assignation à gérer.
+
+## Critères d'acceptation
+
+- [ ] Lorsqu'un conseiller MSDP est assigné à un suivi, il reçoit un email en plus de la notification in-app existante.
+- [ ] L'email identifie clairement la personne suivie et permet d'accéder directement au suivi concerné depuis l'application.
+- [ ] L'absence d'adresse email pour le conseiller n'empêche pas l'assignation de se faire normalement (dégradation silencieuse vers la notification in-app seule).
+- [ ] Un échec technique d'envoi d'email n'empêche pas l'assignation de se faire normalement.
+- [ ] Le ton, la structure et l'identité visuelle de l'email sont cohérents avec les autres emails de notification déjà envoyés par l'application dans ce module.
+
+## Hors périmètre
+
+- Modifier le contenu ou le comportement de la notification in-app existante.
+- Ajouter des préférences utilisateur pour désactiver ce type d'email (aucun mécanisme de préférence de notification n'existe ailleurs dans l'application à ce jour).
+- Modifier les règles d'accès ou d'assignation d'un conseiller MSDP.
+- Ajouter un email pour d'autres étapes du suivi MSDP (contact, formation, clôture, abandon) — seule l'assignation initiale (ou réaffectation) est concernée.
+- Ajouter un rappel automatique en cas de suivi MSDP resté inactif (couvert séparément par l'issue #450).
+
+## Questions ouvertes
+
+Aucune zone d'incertitude restante — spec validée :
+- Pas d'auto-assignation possible : seul un responsable habilité assigne un conseiller.
+- L'email reste sobre (identification de la personne suivie + lien vers l'application), même niveau de discrétion que l'email d'affectation d'un berger — pas de détail sensible du parcours dans le corps de l'email.

--- a/specs/016-email-assignation-conseiller-msdp/tasks.md
+++ b/specs/016-email-assignation-conseiller-msdp/tasks.md
@@ -1,0 +1,50 @@
+# Tâches — Email de notification à l'assignation d'un conseiller MSDP
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : Terminé
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : services → API → tests. Les tâches `[P]` sont parallélisables.
+
+## Prérequis
+
+- [x] Branche créée : `feat/email-assignation-conseiller-msdp`
+- [x] Migration Prisma : `[Aucune]` — pas de changement de schéma (confirmé dans `plan.md`)
+
+## Tâches
+
+### 1. Logique métier (services)
+
+- [x] **T1** — Ajouter `buildMsdpCounselorNotifEmail(params: { counselorName, personName, followUpId, appUrl }): string` dans `src/modules/integration/services/msdp-service.ts`, calquée sur `buildBergerNotifEmail` (`family-service.ts`) : même charte visuelle (bandeau `#5E17EB`), nom de la personne suivie, bouton CTA vers `${appUrl}/admin/integration/requests/{requestId}`, aucun détail sensible du parcours (couvre le critère d'acceptation « ton/structure cohérents » + « pas de détail sensible »). *(fichier : `src/modules/integration/services/msdp-service.ts`)*
+
+- [x] **T2** — Étendre `notifyMsdpCounselorAssigned(params)` : ajouter `appUrl: string` à la signature ; récupérer `{ id, name, email }` du conseiller via `prisma.user.findUnique` après la création de la notification in-app (comportement in-app inchangé) ; si `counselor.email` est renseigné, appeler `sendEmail({ to, subject, html: buildMsdpCounselorNotifEmail(...) })` avec `.catch(() => {})` pour ne jamais faire échouer l'assignation. Importer `sendEmail` depuis `@/lib/email`. *(fichier : `src/modules/integration/services/msdp-service.ts`)* — couvre les critères « email envoyé en plus de la notif », « pas d'email si pas d'adresse », « échec email n'empêche pas l'assignation ».
+
+- [x] **T3** — Vérifier que `requestId` (nécessaire pour le lien de l'email) est bien disponible dans `notifyMsdpCounselorAssigned` : actuellement seul `followUpId` et `personName` sont passés par l'appelant (`route.ts`) ; ajouter `requestId` aux params de la fonction si besoin pour construire le lien vers `RequestDetail`. *(fichier : `src/modules/integration/services/msdp-service.ts`)*
+
+### 2. API (route handler)
+
+- [x] **T4** — Dans `src/app/api/integration/msdp/[id]/route.ts`, calculer `appUrl` avant l'appel à `notifyMsdpCounselorAssigned` (même logique que `requests/[id]/route.ts:202` : `process.env.APP_URL ?? process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? "http://localhost:3000"`), et passer `appUrl` (+ `requestId` si ajouté en T3) dans l'appel existant à `notifyMsdpCounselorAssigned`. *(fichier : `src/app/api/integration/msdp/[id]/route.ts`)*
+
+### 3. Tests
+
+- [x] **T5** [P] — Test unitaire de `buildMsdpCounselorNotifEmail` : vérifie que le HTML généré contient le nom du conseiller, le nom de la personne suivie, et le lien vers l'application avec le bon `requestId`. *(fichier : `src/modules/integration/__tests__/msdp-service.test.ts`)*
+
+- [x] **T6** [P] — Tests unitaires de `notifyMsdpCounselorAssigned` (mock Prisma via `src/__mocks__/prisma.ts`, mock `sendEmail` via `vi.mock("@/lib/email")`) :
+  - Conseiller avec email renseigné → `sendEmail` appelé une fois, avec le bon destinataire et un sujet cohérent ; notification in-app toujours créée.
+  - Conseiller sans email → `sendEmail` non appelé ; notification in-app toujours créée (couvre le critère « dégradation silencieuse »).
+  - `sendEmail` qui rejette (mock rejeté) → la fonction ne lève pas d'exception, se termine normalement (couvre le critère « échec email n'empêche pas l'assignation »).
+  *(fichier : `src/modules/integration/__tests__/msdp-service.test.ts`)*
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits :
+  - [x] Email envoyé en plus de la notification in-app à l'assignation (T2, T4)
+  - [x] Email identifie la personne suivie + lien direct vers le suivi (T1, T3)
+  - [x] Absence d'email du conseiller → pas de blocage, notif in-app seule (T2, T6)
+  - [x] Échec technique d'envoi → pas de blocage de l'assignation (T2, T6)
+  - [x] Ton/structure/identité visuelle cohérents avec les emails existants du module (T1, T5)
+- [ ] PR ouverte vers `main`

--- a/src/app/api/integration/msdp/[id]/route.ts
+++ b/src/app/api/integration/msdp/[id]/route.ts
@@ -89,10 +89,13 @@ export async function PATCH(
         select: { firstName: true, lastName: true },
       });
       if (integrationReq) {
+        const appUrl = process.env.APP_URL ?? process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? "http://localhost:3000";
         notifyMsdpCounselorAssigned({
           counselorId: body.counselorId,
           followUpId: id,
+          requestId: followUp.requestId,
           personName: `${integrationReq.firstName} ${integrationReq.lastName}`,
+          appUrl,
         });
       }
     }

--- a/src/modules/integration/__tests__/msdp-service.test.ts
+++ b/src/modules/integration/__tests__/msdp-service.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+const mockSendEmail = vi.fn();
+const mockAuth = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/email", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: mockAuth,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+
+const { buildMsdpCounselorNotifEmail, notifyMsdpCounselorAssigned } = await import(
+  "../services/msdp-service"
+);
+
+describe("buildMsdpCounselorNotifEmail", () => {
+  it("inclut le nom du conseiller, le nom de la personne suivie et le lien vers le suivi", () => {
+    const html = buildMsdpCounselorNotifEmail({
+      counselorName: "Jean Dupont",
+      personName: "Marie Curie",
+      requestId: "req-123",
+      appUrl: "https://koinonia.example",
+    });
+
+    expect(html).toContain("Jean Dupont");
+    expect(html).toContain("Marie Curie");
+    expect(html).toContain("https://koinonia.example/admin/integration/requests/req-123");
+  });
+});
+
+describe("notifyMsdpCounselorAssigned", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendEmail.mockResolvedValue(undefined);
+  });
+
+  it("envoie un email quand le conseiller a une adresse email", async () => {
+    prismaMock.notification.create.mockResolvedValue({} as never);
+    prismaMock.user.findUnique.mockResolvedValue({
+      name: "Jean Dupont",
+      email: "jean@example.com",
+    } as never);
+
+    await notifyMsdpCounselorAssigned({
+      counselorId: "u1",
+      followUpId: "f1",
+      requestId: "req-123",
+      personName: "Marie Curie",
+      appUrl: "https://koinonia.example",
+    });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "jean@example.com" })
+    );
+  });
+
+  it("n'envoie pas d'email si le conseiller n'a pas d'adresse email, mais crée la notification in-app", async () => {
+    prismaMock.notification.create.mockResolvedValue({} as never);
+    prismaMock.user.findUnique.mockResolvedValue({
+      name: "Jean Dupont",
+      email: null,
+    } as never);
+
+    await notifyMsdpCounselorAssigned({
+      counselorId: "u1",
+      followUpId: "f1",
+      requestId: "req-123",
+      personName: "Marie Curie",
+      appUrl: "https://koinonia.example",
+    });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("ne lève pas d'exception si l'envoi de l'email échoue", async () => {
+    prismaMock.notification.create.mockResolvedValue({} as never);
+    prismaMock.user.findUnique.mockResolvedValue({
+      name: "Jean Dupont",
+      email: "jean@example.com",
+    } as never);
+    mockSendEmail.mockRejectedValue(new Error("SMTP down"));
+
+    await expect(
+      notifyMsdpCounselorAssigned({
+        counselorId: "u1",
+        followUpId: "f1",
+        requestId: "req-123",
+        personName: "Marie Curie",
+        appUrl: "https://koinonia.example",
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/modules/integration/index.ts
+++ b/src/modules/integration/index.ts
@@ -15,6 +15,7 @@ export {
   msdpPatchSchema,
   hasMsdpManagementAccess,
   computeMsdpTransitionData,
+  buildMsdpCounselorNotifEmail,
   notifyMsdpCounselorAssigned,
 } from "./services/msdp-service";
 export type { MsdpPatchBody } from "./services/msdp-service";

--- a/src/modules/integration/services/msdp-service.ts
+++ b/src/modules/integration/services/msdp-service.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { rolePermissions } from "@/lib/registry";
 import { ApiError } from "@/lib/api-utils";
+import { sendEmail } from "@/lib/email";
 import { isIntegrationMember, isMsdpMember } from "../auth";
 import { z } from "zod";
 import type { Session } from "next-auth";
@@ -81,12 +82,50 @@ export function computeMsdpTransitionData(
 
 // ─── Notifications ───────────────────────────────────────────────────────────
 
+export function buildMsdpCounselorNotifEmail(params: {
+  counselorName: string;
+  personName: string;
+  requestId: string;
+  appUrl: string;
+}): string {
+  const { counselorName, personName, requestId, appUrl } = params;
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f9fafb;font-family:Arial,sans-serif;">
+  <div style="max-width:560px;margin:40px auto;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,.08)">
+    <div style="background:#5E17EB;padding:28px 32px 20px">
+      <h1 style="margin:0;color:#fff;font-size:20px;font-weight:700">Nouveau suivi MSDP assigné</h1>
+    </div>
+    <div style="padding:28px 32px">
+      <p style="margin:0 0 14px;color:#111827;font-size:15px">Bonjour ${counselorName},</p>
+      <p style="margin:0 0 16px;color:#374151;font-size:14px;line-height:1.6">
+        Un suivi MSDP vient de vous être confié :
+      </p>
+      <div style="background:#f5f3ff;border-left:4px solid #5E17EB;padding:12px 16px;border-radius:0 8px 8px 0;margin:0 0 20px">
+        <p style="margin:0;color:#111827;font-size:15px;font-weight:600">${personName}</p>
+      </div>
+      <a href="${appUrl}/admin/integration/requests/${requestId}"
+         style="display:inline-block;background:#5E17EB;color:#fff;text-decoration:none;padding:10px 20px;border-radius:8px;font-size:14px;font-weight:600">
+        Voir le suivi →
+      </a>
+    </div>
+    <div style="background:#f9fafb;padding:14px 32px;border-top:1px solid #e5e7eb">
+      <p style="margin:0;color:#9ca3af;font-size:11px">Notification automatique Koinonia.</p>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
 export async function notifyMsdpCounselorAssigned(params: {
   counselorId: string;
   followUpId: string;
+  requestId: string;
   personName: string;
+  appUrl: string;
 }): Promise<void> {
-  const { counselorId, followUpId, personName } = params;
+  const { counselorId, followUpId, requestId, personName, appUrl } = params;
   await prisma.notification
     .create({
       data: {
@@ -98,4 +137,22 @@ export async function notifyMsdpCounselorAssigned(params: {
       },
     })
     .catch(() => {});
+
+  const counselor = await prisma.user.findUnique({
+    where: { id: counselorId },
+    select: { name: true, email: true },
+  });
+
+  if (counselor?.email) {
+    await sendEmail({
+      to: counselor.email,
+      subject: "Un suivi MSDP vous a été confié",
+      html: buildMsdpCounselorNotifEmail({
+        counselorName: counselor.name ?? counselor.email,
+        personName,
+        requestId,
+        appUrl,
+      }),
+    }).catch(() => {});
+  }
 }


### PR DESCRIPTION
## Summary
Implémente `specs/016-email-assignation-conseiller-msdp/` (spec → plan → tasks → implement).

- Aligne le comportement du flux MSDP sur celui déjà en place pour l'affectation d'un berger (`notifyBergerAssigned`/`buildBergerNotifEmail`) : le conseiller assigné à un suivi MSDP reçoit désormais un email en plus de la notification in-app existante.
- Nouvelle fonction `buildMsdpCounselorNotifEmail` dans `src/modules/integration/services/msdp-service.ts`, même charte visuelle et même niveau de sobriété que l'email berger (pas de détail sensible du parcours, juste le nom de la personne suivie + lien vers la fiche).
- `notifyMsdpCounselorAssigned` étendue pour envoyer l'email si le conseiller a une adresse connue ; dégradation silencieuse sinon ; `.catch(() => {})` pour ne jamais bloquer l'assignation en cas d'échec technique d'envoi.
- Aucun changement de schéma, d'endpoint, ni de permission.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries`
- [x] `npm run test -- --run` (629 tests passés, dont 4 nouveaux tests ciblés : template email, envoi conditionnel, dégradation sans email, résilience à l'échec d'envoi)
- [x] Tous les critères d'acceptation de la spec vérifiés (voir `tasks.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AmQHtj4vBxybnwDm5asAQ