### PR TITLE
fix(architecture): casser l'import circulaire registry.ts <-> modules/integration,agenda

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -59,6 +59,32 @@ module.exports = {
     },
 
     /**
+     * Règle 1bis — src/modules/** ne peut pas importer statiquement src/lib/registry.ts.
+     *
+     * registry.ts est la racine de composition : il importe TOUS les modules pour
+     * calculer rolePermissions. Un import statique dans le sens inverse (un module
+     * important registry.ts) crée un cycle qui peut provoquer un ReferenceError
+     * "Cannot access '<var>' before initialization" (TDZ) non déterministe au build
+     * Turbopack — cf. issue #446. Un import dynamique (`await import("@/lib/registry")`,
+     * résolu à l'exécution plutôt qu'à l'évaluation du module) est le pattern déjà
+     * utilisé dans src/lib/auth.ts et reste autorisé.
+     */
+    {
+      name: "no-modules-static-import-registry",
+      severity: "error",
+      comment:
+        "Un module ne peut pas importer statiquement src/lib/registry.ts (cycle avec la racine de composition) — utiliser un import dynamique si nécessaire.",
+      from: {
+        path: "^src/modules/",
+        pathNot: "/__tests__/",
+      },
+      to: {
+        path: "^src/lib/registry\\.ts$",
+        dependencyTypesNot: ["dynamic-import"],
+      },
+    },
+
+    /**
      * Règle 2 — src/core ne dépend d'aucun module applicatif.
      *
      * Le noyau (ModuleRegistry, EventBus, boot) doit rester indépendant.

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -18,10 +18,7 @@ import { roomsModule } from "@/modules/rooms";
  * Source de vérité pour les permissions dans les contrôles d'accès API.
  */
 // L'ordre du tableau n'a pas de portée sémantique (le vrai ordre de chargement est
-// résolu par tri topologique dans boot()) mais `roomsModule` doit rester avant
-// `integrationModule` : dans l'ordre inverse, le build Turbopack production échoue
-// (ReferenceError "Cannot access 'c' before initialization" lors du bundling de
-// integrationModule — bug de chunking Turbopack, cf. Next.js 16.2.6).
+// résolu par tri topologique dans boot()).
 export const registry = boot({
   modules: [coreModule, planningModule, discipleshipModule, mediaModule, mrbsModule, agendaModule, roomsModule, integrationModule, accountingModule, jobsModule],
 });

--- a/src/modules/agenda/auth.ts
+++ b/src/modules/agenda/auth.ts
@@ -1,6 +1,5 @@
 import { requireAuth, requireChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { rolePermissions } from "@/lib/registry";
 import type { Session } from "next-auth";
 
 /**
@@ -31,6 +30,9 @@ export async function requireAgendaView(churchId: string) {
   const roles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   if (roles.length === 0) throw new Error("FORBIDDEN");
 
+  // Import dynamique : registry.ts importe tous les modules (dont agenda), un
+  // import statique ici créerait un cycle (cf. issue #446).
+  const { rolePermissions } = await import("@/lib/registry");
   const userPerms = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
 
   if (userPerms.has("agenda:view") || await isProtocoleMember(session, churchId))
@@ -51,6 +53,8 @@ export async function requireAgendaManage(churchId: string) {
   const roles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   if (roles.length === 0) throw new Error("FORBIDDEN");
 
+  // Import dynamique : voir requireAgendaView ci-dessus.
+  const { rolePermissions } = await import("@/lib/registry");
   const userPerms = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
 
   if (userPerms.has("agenda:manage") || await isProtocoleMember(session, churchId))

--- a/src/modules/integration/services/msdp-service.ts
+++ b/src/modules/integration/services/msdp-service.ts
@@ -1,5 +1,4 @@
 import { prisma } from "@/lib/prisma";
-import { rolePermissions } from "@/lib/registry";
 import { ApiError } from "@/lib/api-utils";
 import { isIntegrationMember, isMsdpMember } from "../auth";
 import { z } from "zod";
@@ -31,6 +30,10 @@ export async function hasMsdpManagementAccess(session: Session, churchId: string
   if (session.user.isSuperAdmin) return true;
   const roles = session.user.churchRoles.filter((r) => r.churchId === churchId);
   if (roles.length > 0) {
+    // Import dynamique : registry.ts importe tous les modules (dont integration),
+    // un import statique ici créerait un cycle qui provoque un ReferenceError
+    // TDZ non déterministe au build Turbopack (cf. issue #446).
+    const { rolePermissions } = await import("@/lib/registry");
     const perms = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
     if (perms.has("members:manage") || perms.has("events:manage")) return true;
   }


### PR DESCRIPTION
## Résumé

Corrige la cause racine documentée dans #446 (build Turbopack intermittent : `ReferenceError: Cannot access '<var>' before initialization` sur `integrationModule`/`integrationBus`).

**Cause racine** : `msdp-service.ts` (module integration) et `agenda/auth.ts` importaient **statiquement** `rolePermissions` depuis `@/lib/registry.ts`. Or `registry.ts` est la racine de composition qui importe *tous* les modules (dont `integration` et `agenda`) pour calculer `rolePermissions` — d'où un cycle module → registry → module. Turbopack a un ordre d'évaluation non déterministe pour ce genre de cycle en production, provoquant l'erreur TDZ de façon intermittente (observée 3 fois : release v1.17.1 sur `main` et sur le tag, puis PR dependabot #442).

**Fix** : bascule sur un **import dynamique** (`await import("@/lib/registry")`, résolu à l'exécution et non à l'évaluation du module) — pattern déjà utilisé partout dans `src/lib/auth.ts` (`requirePermission`, `requireChurchPermission`, `requireMediaAccess`, etc.) mais que ces deux fichiers n'appliquaient pas.

**Garde-fou** : nouvelle règle `dependency-cruiser` (`no-modules-static-import-registry`) qui interdit tout import *statique* de `src/lib/registry.ts` depuis `src/modules/**`, tout en autorisant explicitement l'import dynamique via `dependencyTypesNot: ["dynamic-import"]`. `npm run lint:boundaries` échouera désormais si ce pattern régresse.

Retire aussi le commentaire de contournement obsolète dans `registry.ts` sur l'ordre `roomsModule`/`integrationModule` (c'était un symptôme du même cycle, pas une vraie contrainte d'ordre).

## Test plan

- [x] `npm run typecheck` — OK
- [x] `npm run lint:boundaries` — OK (518 modules, 1983 dépendances, 0 violation — confirme que la règle passe avec l'import dynamique et qu'aucun autre module n'a le même problème)
- [x] `npm run test` — 625 tests OK
- [x] `rm -rf .next && npm run build` — OK, exécuté **deux fois** de suite pour vérifier la non-régression du bug non déterministe

Closes #446