### PR TITLE
docs: rattrapage spec 017 + introduction de la pratique ADR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ koinonia/
 │   │   └── permissions.ts       # DEPRECATED — utiliser rolePermissions de @/lib/registry
 │   └── proxy.ts                 # Middleware Next.js 16 (protection routes, runtime Node.js)
 ├── docs/                        # Documentation detaillee
+│   └── adr/                     # Architecture Decision Records (decisions structurantes)
 ├── docker-compose.yml           # MariaDB locale
 └── package.json
 ```
@@ -293,6 +294,7 @@ Chaque eglise (`Church`) est un tenant isole. Les donnees sont rattachees a une 
 | [Production](docs/production.md) | Deploiement Debian, Traefik, systemd |
 | [Environnement de dev](docs/dev-onboarding.md) | Setup conteneurise, jeu de donnees fictif, connexion sans Google OAuth |
 | [Roadmap](docs/roadmap.md) | Evolutions prevues |
+| [ADR](docs/adr/README.md) | Decisions architecturales structurantes (Architecture Decision Records) |
 
 ## Setup local
 
@@ -405,3 +407,4 @@ Creer une branche `feat/X` comme base. Les sous-features ouvrent des PRs vers `f
 10. **Permissions dans le code** : utiliser `rolePermissions` de `@/lib/registry` (PAS `hasPermission` de `@/lib/permissions` qui est deprecated)
 11. **Imports modules** : `src/app/` ne peut importer depuis un module que via son index (`@/modules/X`) — pas de chemins internes
 12. **Frontieres modules** : verifier `npm run lint:boundaries` apres tout ajout de dependance entre modules
+13. **ADR** : toute decision architecturale/structurante (cross-module, difficile a revenir en arriere, choix de stack ou de pattern durable) est documentee dans `docs/adr/` — voir `docs/adr/README.md` pour la distinguer d'une decision de `plan.md` (portee a une seule feature)

--- a/docs/adr/0001-architecture-modulaire-monolithe.md
+++ b/docs/adr/0001-architecture-modulaire-monolithe.md
@@ -1,0 +1,72 @@
+# ADR-0001 — Architecture modulaire en monolithe (registry + event bus)
+
+- **Statut** : Accepté
+- **Date** : 2026-08-23 *(rédigé rétroactivement — voir `README.md`)*
+
+## Contexte
+
+Koinonia est déployé comme une seule application, mais couvre des domaines
+métier distincts (planning/évènements, discipolat, médias, comptabilité,
+intégration, agenda, jobs...). Sans frontières explicites, un monolithe tend
+à accumuler des dépendances croisées non maîtrisées entre domaines, rendant
+le code de plus en plus difficile à faire évoluer isolément.
+
+## Décision
+
+Koinonia adopte un **monolithe modulaire** : une seule base de code et un
+seul déploiement, mais organisée en modules (`src/modules/X/`) avec des
+frontières strictes, enforced en CI :
+
+- Chaque module expose un **manifeste** (`index.ts` via `defineModule()`)
+  déclarant ses `permissions` (map permission → rôles autorisés) et sa
+  `navigation`.
+- `src/core/module-registry.ts` fournit `ModuleRegistry` (enregistrement,
+  validation des dépendances, ordre de chargement) et `buildRolePermissions()`
+  dérive la matrice rôles→permissions à partir des manifestes.
+- `src/core/event-bus.ts` fournit un `EventBus<TEvents>` typé et
+  **transaction-aware** (les handlers s'exécutent dans le même
+  `Prisma.TransactionClient` que l'émetteur ; un throw dans un handler
+  rollback la transaction) pour la communication cross-module.
+- `src/app/` ne peut importer un module que via son point d'entrée public
+  (`index.ts` ou `auth.ts`), jamais un chemin interne — règle
+  `app-only-module-public-api` dans `.dependency-cruiser.cjs`.
+- Un module ne peut pas importer directement un autre module (une règle
+  dédiée par module dans `.dependency-cruiser.cjs`) — toute communication
+  cross-module passe par l'event bus ou par `src/core`/`src/lib` partagés.
+- `src/core/` reste framework-agnostic et ne dépend d'aucun module
+  applicatif (règle `core-no-modules-import`).
+
+Ces règles sont vérifiées automatiquement (`npm run lint:boundaries`, CI).
+
+## Alternatives considérées
+
+- **Microservices** — *Écarté* : complexité opérationnelle (déploiement,
+  observabilité, transactions distribuées) disproportionnée pour la taille
+  de l'équipe et le volume de trafic d'une association/église.
+- **Monolithe sans frontières internes formalisées** (juste une convention
+  de dossiers) — *Écarté* : sans enforcement CI, les frontières se dégradent
+  naturellement avec le temps (constat empirique du projet : c'est
+  exactement ce qui a motivé la règle ajoutée en ADR-0004 après l'issue #446).
+
+## Conséquences
+
+- **Positif** : un domaine métier peut évoluer, être testé et raisonné
+  isolément ; la matrice de permissions est dérivée automatiquement des
+  manifestes plutôt que maintenue à la main ; `lint:boundaries` détecte
+  immédiatement une violation de frontière en CI, avant le build.
+- **Positif** : le bus d'événements transaction-aware permet des effets de
+  bord cross-module (notifications, création d'entités liées) sans coupler
+  directement les modules entre eux.
+- **Négatif / contrainte** : ajoute un formalisme (manifeste, event bus) même
+  pour des interactions simples entre deux modules ; toute nouvelle
+  dépendance entre modules doit être justifiée et passer `lint:boundaries`.
+- **Négatif / risque connu** : le point de composition (`src/lib/registry.ts`,
+  qui importe tous les modules pour calculer `rolePermissions`) est un point
+  de cycle potentiel si un module l'importe en retour statiquement — voir
+  ADR-0004 pour la règle qui mitige ce risque.
+
+## Références
+
+- `docs/architecture.md` (description détaillée à jour)
+- `.dependency-cruiser.cjs` (règles enforced)
+- `specs/constitution.md` § I (Architecture modulaire)

--- a/docs/adr/0002-multi-tenant-church-id.md
+++ b/docs/adr/0002-multi-tenant-church-id.md
@@ -1,0 +1,63 @@
+# ADR-0002 — Multi-tenant par `churchId` sur chaque donnée
+
+- **Statut** : Accepté
+- **Date** : 2026-08-23 *(rédigé rétroactivement — voir `README.md`)*
+
+## Contexte
+
+Koinonia, bien que développé pour ICC Bretagne, est conçu pour être adaptable
+à toute église structurée en ministères et départements. Plusieurs églises
+(tenants) doivent pouvoir utiliser la même instance de l'application sans que
+les données de l'une soient visibles ou modifiables par l'autre, et un même
+utilisateur peut être rattaché à plusieurs églises avec des rôles différents
+selon l'église.
+
+## Décision
+
+Chaque église (`Church`) est un **tenant isolé au niveau de la donnée** :
+
+- Toute entité métier rattachée à une église porte un champ `churchId`.
+- Un utilisateur (`User`) peut avoir des rôles différents dans plusieurs
+  églises via `UserChurchRole`.
+- Les helpers d'autorisation (`requireChurchPermission(permission, churchId)`,
+  `resolveChurchId(type, resourceId)` dans `src/lib/auth.ts`) imposent la
+  vérification du `churchId` à chaque accès, plutôt que de faire confiance à
+  un filtrage côté client ou à une isolation par schéma de base de données
+  séparé.
+- L'isolement est donc **applicatif** (vérifié à chaque requête via ces
+  helpers), pas structurel (pas de base de données ni de schéma séparé par
+  église).
+
+## Alternatives considérées
+
+- **Une base de données par église (isolation physique)** — *Écarté* :
+  complexité opérationnelle de provisioning/migration multipliée par le
+  nombre d'églises, sans bénéfice de sécurité proportionné pour le volume de
+  données concerné (associations religieuses, pas de contrainte
+  réglementaire de séparation physique connue).
+- **Un schéma PostgreSQL/MariaDB séparé par église** — *Écarté* : mêmes
+  contraintes opérationnelles qu'une base séparée, avec en plus la
+  complexité de gérer les migrations Prisma sur N schémas.
+
+## Conséquences
+
+- **Positif** : une seule base de données à opérer, sauvegarder, migrer ;
+  ajout d'une nouvelle église = une ligne, pas un provisioning
+  d'infrastructure.
+- **Négatif / risque structurel** : l'isolation multi-tenant repose
+  entièrement sur la discipline du code applicatif — un endpoint qui oublie
+  de filtrer par `churchId` ou de vérifier la permission avec le bon
+  `churchId` crée une fuite cross-tenant. C'est pourquoi la constitution du
+  projet (§ II) rend ce contrôle **non-négociable** : "Multi-tenant strict :
+  chaque donnée est rattachée à une église via `churchId` ; jamais de fuite
+  cross-tenant."
+- **Conséquence pratique** : tout nouveau modèle Prisma représentant une
+  donnée propre à une église doit inclure `churchId`, et toute nouvelle route
+  API doit passer par `requireChurchPermission`/`resolveChurchId` plutôt que
+  de faire une vérification de permission "globale" qui ignorerait le tenant.
+
+## Références
+
+- `CLAUDE.md` § Multi-tenant, § Helpers d'authentification
+- `src/lib/auth.ts` (`requireChurchPermission`, `resolveChurchId`)
+- `specs/constitution.md` § II (Sécurité par défaut)

--- a/docs/adr/0003-prisma7-esm-driver-adapter.md
+++ b/docs/adr/0003-prisma7-esm-driver-adapter.md
@@ -1,0 +1,55 @@
+# ADR-0003 — Prisma 7 ESM-only avec driver adapter MariaDB
+
+- **Statut** : Accepté
+- **Date** : 2026-08-23 *(rédigé rétroactivement — voir `README.md`)*
+
+## Contexte
+
+Le projet utilise MariaDB comme base de données et Next.js 16 (App Router,
+Turbopack) comme framework. Prisma 7 a changé son mode de fonctionnement par
+rapport aux versions précédentes : le client généré est **ESM-only** et
+nécessite un **driver adapter** explicite plutôt que le moteur de requête
+binaire historique de Prisma.
+
+## Décision
+
+- Utilisation de **Prisma 7** avec l'adapter `PrismaMariaDb` de
+  `@prisma/adapter-mariadb` (`src/lib/prisma.ts`, singleton via le pattern
+  `globalThis` pour éviter la multiplication de connexions en hot-reload dev).
+- Le client Prisma généré vit dans `src/generated/prisma/` (et non le chemin
+  par défaut `node_modules/@prisma/client`) — les types enum (`Role`, etc.)
+  sont importés depuis `@/generated/prisma/client`.
+- La datasource URL n'est **plus** déclarée dans `schema.prisma` mais dans
+  `prisma.config.ts` à la racine (nouveau mécanisme de configuration CLI de
+  Prisma 7).
+
+## Alternatives considérées
+
+- **Rester sur Prisma 5/6 avec le moteur binaire classique** — *Écarté* :
+  aurait évité la contrainte ESM-only et le driver adapter, mais aurait
+  privé le projet des évolutions de Prisma 7 (accès aux dernières
+  fonctionnalités, correctifs de sécurité, alignement avec l'écosystème qui
+  migre vers les driver adapters comme standard).
+- **Un autre ORM (Drizzle, Kysely)** — *Non documenté comme évalué* : pas de
+  trace d'une évaluation formelle dans ce projet ; Prisma était déjà le choix
+  en place avant l'introduction de cette pratique ADR.
+
+## Conséquences
+
+- **Positif** : accès aux fonctionnalités et correctifs de Prisma 7 ;
+  alignement avec la direction de l'écosystème Prisma (driver adapters).
+- **Négatif / contrainte** : le client Prisma étant ESM-only, toute
+  incompatibilité d'un outil du toolchain avec l'ESM pur peut bloquer la
+  génération ou l'exécution — point de vigilance à chaque montée de version
+  de Next.js/Node.
+- **Négatif / contrainte connue** : `prisma generate` peut échouer localement
+  si les fichiers de `src/generated/prisma/` appartiennent à un autre
+  utilisateur système (`EACCES` constaté en environnement sandbox durant
+  cette session) — ce n'est pas un défaut de la décision elle-même, mais un
+  point d'attention d'environnement à documenter pour l'onboarding.
+
+## Références
+
+- `CLAUDE.md` § Stack technique, § Points d'attention
+- `prisma.config.ts`, `src/lib/prisma.ts`
+- `docs/database.md`

--- a/docs/adr/0004-import-dynamique-anti-cycle-registry.md
+++ b/docs/adr/0004-import-dynamique-anti-cycle-registry.md
@@ -1,0 +1,99 @@
+# ADR-0004 — Import dynamique comme échappatoire au cycle `registry.ts` ↔ modules
+
+- **Statut** : Accepté
+- **Date** : 2026-08-23
+
+## Contexte
+
+`src/lib/registry.ts` est la racine de composition de l'application (ADR-0001) :
+il importe **tous** les modules pour construire `registry` et pré-calculer
+`rolePermissions` via `buildRolePermissions(registry)`. Ce sens de dépendance
+est correct et voulu (`registry → modules`).
+
+Le problème apparaît quand un fichier **à l'intérieur** d'un module importe
+`rolePermissions` depuis `@/lib/registry` de façon statique
+(`import { rolePermissions } from "@/lib/registry"`). Cela crée un cycle
+d'import : `registry.ts → module X → registry.ts`. En développement (Webpack),
+ce cycle est généralement toléré par l'ordre d'évaluation des modules. Mais en
+build de production avec **Turbopack** (Next.js 16), ce même cycle produisait
+un échec intermittent et non déterministe :
+
+```
+ReferenceError: Cannot access '<var>' before initialization
+```
+
+— une erreur de TDZ (Temporal Dead Zone) causée par l'ordre d'évaluation des
+imports circulaires, qui ne se manifestait pas de façon systématique (d'où le
+caractère "intermittent" du bug, issue **#446**).
+
+## Décision
+
+Interdire, via une règle `dependency-cruiser` enforced en CI
+(`no-modules-static-import-registry`), tout **import statique** de
+`src/lib/registry.ts` depuis `src/modules/**` :
+
+```js
+{
+  name: "no-modules-static-import-registry",
+  severity: "error",
+  from: { path: "^src/modules/", pathNot: "/__tests__/" },
+  to: {
+    path: "^src/lib/registry\\.ts$",
+    dependencyTypesNot: ["dynamic-import"],
+  },
+}
+```
+
+Le pattern autorisé à la place est l'**import dynamique**, résolu à
+l'exécution plutôt qu'à l'évaluation statique du module — il ne participe pas
+au graphe de cycle détecté par le bundler :
+
+```ts
+const { rolePermissions } = await import("@/lib/registry");
+```
+
+Ce pattern était déjà utilisé dans `src/lib/auth.ts` avant l'introduction de
+la règle CI ; celle-ci généralise et enforce la convention.
+
+## Alternatives considérées
+
+- **Extraire `rolePermissions` dans un module tiers indépendant** (ni dans
+  `registry.ts`, ni dans un module métier), pour casser le cycle
+  structurellement plutôt que par un import dynamique — *Écarté à ce
+  stade* : `rolePermissions` dépend par construction de l'agrégation de
+  *tous* les manifestes de modules (c'est la raison d'être de `registry.ts`
+  comme racine de composition) ; le déplacer ailleurs ne fait que déplacer
+  le même point de convergence sans supprimer le risque de cycle si un
+  module l'importe en retour. Resterait pertinent si le nombre de call-sites
+  dynamiques devenait difficile à maintenir.
+- **Downgrade vers Webpack pour le build de production** — *Écarté* :
+  reviendrait sur l'adoption de Turbopack (performance de build), et ne
+  ferait que masquer un vrai risque architectural (le cycle) plutôt que le
+  supprimer.
+- **Tolérer le cycle et accepter le risque de build intermittent** —
+  *Écarté* : un échec de build non déterministe en production est
+  inacceptable pour la fiabilité des déploiements.
+
+## Conséquences
+
+- **Positif** : élimine la classe de bug entière (cycle statique vers la
+  racine de composition), pas seulement le cas précis de l'issue #446 —
+  toute nouvelle tentative similaire est bloquée par `lint:boundaries` en
+  CI, avant même d'atteindre un build Turbopack.
+- **Négatif / contrainte** : un module ayant besoin de `rolePermissions` doit
+  systématiquement utiliser `await import(...)`, ce qui introduit une
+  fonction `async` là où un import statique aurait suffi — léger surcoût de
+  lisibilité, compensé par la prévention du bug de build.
+- **Point de vigilance** : cette règle ne protège que le sens
+  `modules → registry`. Un futur point de composition équivalent
+  (autre "racine" qui importe tous les modules) devra recevoir la même
+  protection explicitement — elle n'est pas générique à toute racine de
+  composition future.
+
+## Références
+
+- Issue #446 (build Turbopack intermittent)
+- PR #453 (correctif, mergé directement par l'équipe)
+- PR #448 (tentative équivalente, fermée comme doublon de #453)
+- `.dependency-cruiser.cjs` (règle `no-modules-static-import-registry`)
+- `src/lib/auth.ts` (pattern d'import dynamique préexistant)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,44 @@
+# Architecture Decision Records (ADR)
+
+Ce dossier trace les décisions **architecturales et structurantes** de Koinonia :
+celles qui sont difficiles à revenir en arrière, qui touchent plusieurs modules
+ou l'ensemble du projet, ou qui engagent un choix de stack/pattern durable.
+
+## ADR vs. `plan.md`
+
+Ne pas confondre avec la section "Décisions & alternatives écartées" de
+`specs/NNN-nom/plan.md` :
+
+| | `plan.md` § Décisions | ADR (`docs/adr/`) |
+|---|---|---|
+| Portée | Une feature | Le projet / plusieurs modules |
+| Durée de vie | Liée à la feature | Durable, référencée par tout le code futur |
+| Exemple | "Pourquoi ce champ est optionnel plutôt qu'un enum" | "Pourquoi une architecture modulaire en monolithe" |
+
+Règle pratique : si la décision serait toujours vraie et pertinente même si la
+feature qui l'a motivée était totalement réécrite, c'est un ADR.
+
+## Format
+
+Un ADR par fichier, numéroté `NNNN-titre-court.md`, voir `template.md`.
+Statuts possibles : `Proposé`, `Accepté`, `Rejeté`, `Déprécié`, `Remplacé par ADR-NNNN`.
+
+## Index
+
+| ADR | Titre | Statut |
+|---|---|---|
+| [0001](0001-architecture-modulaire-monolithe.md) | Architecture modulaire en monolithe (registry + event bus) | Accepté |
+| [0002](0002-multi-tenant-church-id.md) | Multi-tenant par `churchId` sur chaque donnée | Accepté |
+| [0003](0003-prisma7-esm-driver-adapter.md) | Prisma 7 ESM-only avec driver adapter MariaDB | Accepté |
+| [0004](0004-import-dynamique-anti-cycle-registry.md) | Import dynamique comme échappatoire au cycle `registry.ts` ↔ modules | Accepté |
+
+## Note sur les ADR 0001–0003
+
+Ces trois décisions étaient déjà en place avant l'introduction de cette
+pratique ADR (2026-08-23) — elles sont documentées **rétroactivement**, à
+partir de l'état actuel du code et de `docs/architecture.md`/`CLAUDE.md`.
+Le contexte historique exact (alternatives réellement évaluées à l'époque,
+contraintes du moment) n'est pas garanti complet : elles décrivent fidèlement
+*la décision telle qu'elle existe aujourd'hui* et son raisonnement tel qu'il
+est inférable du code et de la documentation existante, pas nécessairement
+le débat original. L'ADR 0004 est la première rédigée à chaud (issue #446).

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,25 @@
+# ADR-NNNN — [Titre court de la décision]
+
+- **Statut** : Proposé | Accepté | Rejeté | Déprécié | Remplacé par ADR-NNNN
+- **Date** : AAAA-MM-JJ
+
+## Contexte
+
+*Quel problème ou quelle tension force cette décision ? Quelles contraintes s'appliquent ?*
+
+## Décision
+
+*Ce qui a été décidé, formulé comme une affirmation ("On utilise X pour Y").*
+
+## Alternatives considérées
+
+- **[Option écartée]** — *Raison de l'écarter*
+
+## Conséquences
+
+*Ce que cette décision implique, positif et négatif. Ce qu'elle rend plus facile,
+ce qu'elle rend plus difficile ou plus contraint.*
+
+## Références
+
+*Liens vers issues, PRs, specs, docs liées.*

--- a/specs/017-reporter-role-transverse/plan.md
+++ b/specs/017-reporter-role-transverse/plan.md
@@ -1,0 +1,76 @@
+# Plan technique — Rôle Reporter géré comme rôle transverse
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Validé *(a posteriori, code déjà mergé)*
+- **Mis à jour le** : 2026-08-23
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : aucun changement d'import de module (fichier UI seul)
+- [x] **Sécurité** : aucun changement d'API — `requireAuth`/`requirePermission` déjà en place sur `/api/users/{userId}/roles`
+- [x] **Permissions** : `rolePermissions` inchangé, `REPORTER` déjà dans `roleSchema` de la route
+- [x] **Validation** Zod : inchangée (même endpoint réutilisé)
+- [x] **Migration** Prisma : `[Aucune]` — aucun changement de schéma
+- [x] **Enums** : `Role.REPORTER` déjà existant dans `@/generated/prisma/client`
+- [x] **UI** : réutilisation du mécanisme générique existant (`toggleTransverseRole`), pas de nouveau composant
+
+## Approche générale
+
+Fusionner le rôle `REPORTER` dans le tableau `TransverseRole` déjà utilisé pour
+les 5 autres rôles transverses, et supprimer le code dédié devenu redondant
+(onglet, état, recherche, fonction de toggle). Aucun changement côté API : le
+rôle `REPORTER` était déjà accepté par `roleSchema` dans
+`src/app/api/users/[userId]/roles/route.ts` — seul le point d'entrée UI change.
+
+## Modèle de données
+
+`[Aucun changement]`
+
+## API
+
+`[Aucun changement]` — réutilisation de `POST` / `DELETE /api/users/{userId}/roles`
+déjà existants et déjà compatibles avec `role: "REPORTER"`.
+
+## Services / logique métier
+
+`[Aucun changement]` — fichier purement UI.
+
+## UI / composants
+
+*Fichier : `src/app/(auth)/admin/access/AccessClient.tsx`*
+
+- `TransverseRole` étendu avec `"REPORTER"`.
+- `TRANSVERSE_ROLE_LABELS["REPORTER"] = "Reporter"`, couleur de badge dédiée
+  (`bg-icc-violet/10 text-icc-violet border-icc-violet/20`, reprise du style
+  précédent de l'onglet dédié).
+- Nouvelle constante `TRANSVERSE_ROLES` (tableau) pour éviter la répétition du
+  littéral `["ADMIN", "SECRETARY", "DISCIPLE_MAKER", "AGENDA_QUALIFIER",
+  "ACCOUNTANT", "REPORTER"]` à 3 endroits du rendu.
+- Suppression : onglet `"reporters"` du type `Tab`, bloc JSX associé, état
+  `reporterLoading`/`reporterSearch`, dérivé `filteredReporterUsers`, fonction
+  `toggleReporter`.
+
+## Décisions & alternatives écartées
+
+- **Choix** : réutiliser `toggleTransverseRole` (générique) plutôt que garder
+  `toggleReporter` (dédié) — *Pourquoi* : code strictement identique
+  fonctionnellement (mêmes appels API), la duplication n'apportait rien.
+- **Écarté** : garder l'onglet "Comptes rendus" en plus de l'ajout dans
+  "Rôles transverses" (double affichage) — *Raison* : aurait créé deux façons
+  différentes de faire la même action, source de confusion et de bugs de
+  synchronisation d'état entre les deux onglets.
+
+## Risques & points d'attention
+
+- Un utilisateur ayant un lien/favori vers l'ancien onglet "Comptes rendus"
+  retombera sur l'onglet par défaut (`roles` ou `requests`) — impact mineur,
+  pas de lien profond documenté ou communiqué à l'externe pour cet onglet.
+
+## Stratégie de tests
+
+- Pas de test unitaire dédié ajouté : fichier client React sans logique
+  métier nouvelle (délègue à des endpoints déjà couverts par les tests
+  existants de `src/app/api/users/[userId]/roles/`).
+- Vérification manuelle recommandée (non faite avant merge — à faire) :
+  attribution/retrait de `Reporter` depuis l'onglet "Rôles transverses" en
+  environnement de recette.

--- a/specs/017-reporter-role-transverse/spec.md
+++ b/specs/017-reporter-role-transverse/spec.md
@@ -1,0 +1,72 @@
+# Spec — Rôle Reporter géré comme rôle transverse
+
+- **Numéro** : 017
+- **Statut** : Implémentée
+- **Créée le** : 2026-08-23 *(rédigée a posteriori — voir Note de rattrapage)*
+- **Branche suggérée** : `fix/reporter-transverse-role` *(déjà mergée, voir Historique)*
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+
+## Note de rattrapage
+
+Cette spec est rédigée **après** l'implémentation et le merge (PR #454), en
+rattrapage : le changement aurait dû passer par `/specify` avant le code,
+conformément à la règle du projet selon laquelle une évolution
+ergonomique/UI — même modeste — n'est pas un "fix trivial" exempté de spec.
+Elle documente donc un comportement déjà en production, à titre de traçabilité.
+
+## Contexte & problème
+
+L'écran d'administration des accès (`/admin/access`) attribuait le rôle
+`REPORTER` via un onglet dédié ("Comptes rendus"), avec sa propre recherche et
+son propre bouton d'attribution/retrait — un mécanisme dupliqué de celui déjà
+utilisé pour les autres rôles transverses (`ADMIN`, `SECRETARY`,
+`DISCIPLE_MAKER`, `AGENDA_QUALIFIER`, `ACCOUNTANT`), qui partagent un onglet
+générique "Rôles transverses". Cette duplication rendait l'écran plus long à
+maintenir et incohérent pour l'administrateur (deux façons différentes
+d'attribuer un rôle transverse selon lequel).
+
+## Utilisateurs concernés
+
+- **Super Admin / Admin** : attribuent/retirent le rôle Reporter à un
+  utilisateur, désormais depuis l'onglet "Rôles transverses" au lieu d'un
+  onglet séparé.
+- **Reporter** : aucun changement de son point de vue — les permissions et
+  accès associés au rôle sont inchangés.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Un Admin ouvre `/admin/access`, onglet "Rôles transverses".
+2. Il voit désormais `Reporter` dans la liste des rôles attribuables, au même
+   titre que les autres rôles transverses.
+3. Il clique sur "+ Reporter" pour un utilisateur : le rôle est attribué (même
+   comportement API qu'avant — `POST /api/users/{userId}/roles`).
+4. Il clique sur "Retirer Reporter" : le rôle est retiré (`DELETE`).
+
+### Scénarios alternatifs / cas limites
+
+- **Si** l'onglet "Comptes rendus" existait en favori/lien direct → il n'existe
+  plus ; l'utilisateur est redirigé implicitement vers "Rôles transverses" en
+  retombant sur l'onglet actif par défaut.
+
+## Critères d'acceptation
+
+- [x] Le rôle `Reporter` apparaît dans la liste des rôles de l'onglet "Rôles
+      transverses", avec son libellé et sa couleur de badge.
+- [x] L'attribution/retrait du rôle Reporter depuis cet onglet produit le même
+      résultat API qu'avant (même endpoint, même payload).
+- [x] L'onglet "Comptes rendus" dédié n'existe plus.
+- [x] Aucune régression sur les autres rôles transverses (`ADMIN`,
+      `SECRETARY`, `DISCIPLE_MAKER`, `AGENDA_QUALIFIER`, `ACCOUNTANT`).
+
+## Hors périmètre
+
+- Changement des permissions associées au rôle `REPORTER` (aucune modification
+  de `rolePermissions` ni du module `events`/`reports`).
+- Ajout ou retrait d'autres rôles transverses.
+
+## Questions ouvertes
+
+*Aucune — implémentation déjà validée en production.*

--- a/specs/017-reporter-role-transverse/tasks.md
+++ b/specs/017-reporter-role-transverse/tasks.md
@@ -1,0 +1,38 @@
+# Tâches — Rôle Reporter géré comme rôle transverse
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : Terminé *(a posteriori — code déjà mergé via PR #454)*
+
+## Prérequis
+
+- [x] Branche créée : `fix/reporter-transverse-role`
+- [x] Migration Prisma : `[Aucune]`
+
+## Tâches
+
+### 1. UI
+
+- [x] **T1** — Étendre `TransverseRole`, `TRANSVERSE_ROLE_LABELS`,
+      `TRANSVERSE_ROLE_COLORS` avec `REPORTER` ; extraire la constante
+      `TRANSVERSE_ROLES`. *(fichier : `src/app/(auth)/admin/access/AccessClient.tsx`)*
+- [x] **T2** — Remplacer les 3 littéraux de tableau de rôles par
+      `TRANSVERSE_ROLES` dans le rendu de l'onglet "Rôles transverses".
+      *(fichier : `src/app/(auth)/admin/access/AccessClient.tsx`)*
+- [x] **T3** — Supprimer l'onglet `"reporters"` : retrait du type `Tab`, du
+      bouton d'onglet, du bloc JSX "Comptes rendus", de l'état
+      `reporterLoading`/`reporterSearch`, du dérivé `filteredReporterUsers` et
+      de la fonction `toggleReporter`. *(fichier : `src/app/(auth)/admin/access/AccessClient.tsx`)*
+
+### 2. Tests
+
+- [ ] **T4** — *(non fait)* Vérification manuelle en recette : attribution et
+      retrait du rôle Reporter depuis l'onglet "Rôles transverses".
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries` *(rattrapage post-merge 2026-08-23 : 519 modules, aucune violation)*
+- [x] `npm run test` *(rattrapage post-merge 2026-08-23 : 629/629)*
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits (revue de code)
+- [x] PR ouverte et mergée vers `main` (#454)

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -46,7 +46,8 @@ la constitution l'emporte.
 - Toute feature non triviale commence par une **spec** (`/specify`) avant tout code.
 - Le flux est : `spec.md` (quoi/pourquoi) → `plan.md` (comment) → `tasks.md` (découpage) → implémentation.
 - La spec décrit le **comportement observable** et les critères d'acceptation, pas la technique.
-- Les décisions techniques et les alternatives écartées sont consignées dans `plan.md`.
+- Les décisions techniques et les alternatives écartées **propres à une feature** sont consignées dans `plan.md`.
+- Les décisions **architecturales/structurantes** — celles qui dépassent une seule feature, qui sont difficiles à revenir en arrière, ou qui engagent un choix de stack/pattern durable — sont consignées comme **ADR** dans `docs/adr/` (voir `docs/adr/README.md` pour le critère de distinction et le format). Un `plan.md` qui introduit une telle décision doit créer ou référencer l'ADR correspondant.
 
 ---
 


### PR DESCRIPTION
## Résumé
- Documentation rétroactive (`specs/017-reporter-role-transverse/`) du refactor déjà mergé en #454, qui n'était pas passé par `/specify` malgré la règle du projet.
- Rattrapage de la checklist finale : `lint:boundaries` (519 modules, 0 violation) et `test` (629/629) confirmés verts, non exécutés avant le merge initial de #454.
- **Nouveau** : introduction de la pratique ADR (`docs/adr/`) — revirement de la décision initiale de la constitution de tout consigner dans `plan.md`. Ajout du README/template + 4 ADR fondateurs rédigés en rattrapage (architecture modulaire, multi-tenant `churchId`, Prisma 7 ESM/driver adapter, import dynamique anti-cycle registry issue #446). `specs/constitution.md` § VI et `CLAUDE.md` mis à jour en conséquence.
- Aucun changement de code applicatif — documentation uniquement.

## Test plan
- [x] `npm run lint:boundaries`
- [x] `npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AmQHtj4vBxybnwDm5asAQ