### PR TITLE
feat(integration): relance d'inactivité pour les suivis MSDP bloqués

### DIFF
--- a/specs/018-relance-inactivite-msdp/plan.md
+++ b/specs/018-relance-inactivite-msdp/plan.md
@@ -1,0 +1,155 @@
+# Plan technique — Relance d'inactivité pour les suivis MSDP bloqués
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Validé
+- **Mis à jour le** : 2026-08-23
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : logique ajoutée dans `src/modules/integration/services/msdp-service.ts`, exportée via `src/modules/integration/index.ts` — pas de nouvel import cross-module
+- [x] **Sécurité** : le nouveau code s'exécute côté serveur dans le cron déjà protégé par `authorizeCron` (`CRON_SECRET`) — pas de nouvelle route API exposée
+- [x] **Permissions** via `rolePermissions` : non applicable (job cron, pas de route utilisateur)
+- [x] **Validation** Zod : non applicable (aucune entrée utilisateur)
+- [x] **Migration** Prisma : `[Aucune]` — `Notification.type` est un `String` libre, pas d'enum à étendre
+- [x] **Enums** importés depuis `@/generated/prisma/client` : `MsdpStatus` déjà généré, réutilisé tel quel
+- [x] **UI** : `[Aucun changement]` — feature 100% backend/notification
+
+## Approche générale
+
+Ajouter `runMsdpInactivityNotifications(appUrl)` dans
+`src/modules/integration/services/msdp-service.ts`, calquée sur
+`runInactivityNotifications` (`family-service.ts:184-283`) mais adaptée au
+modèle `MsdpFollowUp` : mêmes principes (seuil de 7 jours, dédoublonnage par
+notification récente, agrégation Promise.all), messages contextualisés par
+statut, destinataire = conseiller assigné sinon équipe MSDP/intégration.
+L'appeler depuis l'orchestrateur cron existant (`src/app/api/cron/route.ts`)
+en parallèle des tâches déjà en place, sans créer de nouvelle route — exactement
+le pattern que la suppression de la route dupliquée (issue #449) vient de
+renforcer.
+
+## Modèle de données
+
+`[Aucun changement]` — aucun champ ni migration nécessaire.
+
+`MsdpFollowUp.updatedAt` (déjà existant, mis à jour automatiquement par
+Prisma `@updatedAt`) sert de base au calcul d'inactivité, exactement comme
+`FamilyIntegrationRequest.updatedAt` pour le mécanisme existant. Toute
+modification du suivi (changement de statut, assignation, notes) le remet
+donc à jour et réinitialise le délai — couvre le critère d'acceptation
+"le compteur repart de zéro".
+
+`Notification.type = "MSDP_INACTIVITY"` (nouvelle valeur de chaîne libre,
+pas de migration).
+
+## API
+
+`[Aucun changement]` — aucune route ajoutée ni modifiée.
+`POST /api/cron` (existant, protégé par `CRON_SECRET`) invoque la nouvelle
+fonction en plus des tâches déjà orchestrées.
+
+## Services / logique métier
+
+*Fichier : `src/modules/integration/services/msdp-service.ts`*
+
+- **`buildMsdpInactivityEmail(params): string`** — calquée sur
+  `buildInactivityEmail` de `family-service.ts` (même charte visuelle,
+  bandeau `#5E17EB`), avec un `contextMap` propre aux statuts MSDP :
+  ```
+  ASSIGNED      → "Un conseiller a été assigné mais le contact n'a pas encore été établi."
+  CONTACTED     → "Le contact a été établi mais la formation n'a pas encore démarré."
+  IN_FORMATION  → "La personne est en formation mais aucune progression récente n'a été enregistrée."
+  ```
+  (statut `SUBMITTED` inclus par cohérence si un suivi MSDP existe sans
+  conseiller assigné — voir cas limite spec ; message : "Aucun conseiller
+  n'a encore été assigné à ce suivi.")
+
+- **`runMsdpInactivityNotifications(appUrl: string): Promise<{ notified: number; skipped: number; total: number }>`**
+  1. Seuil = 7 jours (`INACTIVITY_DAYS`, même valeur que le flux famille —
+     constante dupliquée localement, pas d'import cross-fichier pour rester
+     dans les frontières module).
+  2. `prisma.msdpFollowUp.findMany({ where: { status: { in: ["SUBMITTED", "ASSIGNED", "CONTACTED", "IN_FORMATION"] }, updatedAt: { lt: threshold } }, include: { assignedConseillerMsdp: {...}, request: { select: { firstName, lastName } }, church: {...} } })`
+     — `COMPLETED`/`ABANDONED` exclus par construction (couvre le critère
+     "jamais concerné").
+  3. Dédoublonnage : recherche des `Notification` de type `MSDP_INACTIVITY`
+     avec `link` correspondant créées dans la fenêtre des 7 derniers jours
+     (même pattern que `family-service.ts`) — couvre "pas de nouvelle alerte
+     tant que l'intervalle n'est pas écoulé".
+  4. Pour chaque suivi stale non déjà notifié :
+     - Si `assignedConseillerMsdpId` renseigné → notification in-app +
+       email (si `SMTP_HOST` configuré et email du conseiller renseigné,
+       même garde que l'existant) au conseiller.
+     - Sinon → notification aux membres du département `function: "MSDP"`
+       de l'église (réutilise le pattern `getManagers` de
+       `family-service.ts`, adapté au filtre `"MSDP"` au lieu de
+       `"INTEGRATION"`).
+  5. Chaque envoi (notification + email) est individuellement `.catch(() => {})`
+     — un échec sur un suivi n'interrompt pas la boucle (couvre le critère
+     "l'échec n'empêche pas le traitement des autres").
+
+*Fichier : `src/modules/integration/index.ts`*
+- Exporter `runMsdpInactivityNotifications` (et `buildMsdpInactivityEmail`
+  pour les tests, même pattern que les exports existants du module).
+
+*Fichier : `src/app/api/cron/route.ts`*
+- Importer `runMsdpInactivityNotifications` depuis `@/modules/integration`.
+- L'ajouter au `Promise.all([...])` existant, résultat exposé sous
+  `msdpInactivity` dans la réponse JSON de l'endpoint.
+
+## UI / composants
+
+`[Aucun changement]`
+
+## Décisions & alternatives écartées
+
+- **Choix** : dupliquer la constante `INACTIVITY_DAYS = 7` localement dans
+  `msdp-service.ts` plutôt que de l'importer depuis `family-service.ts` —
+  *Pourquoi* : les deux fichiers vivent dans le même module (`integration`),
+  un import direct serait techniquement possible, mais le coupler créerait
+  une dépendance artificielle entre deux flux fonctionnellement indépendants
+  (famille vs MSDP) pour économiser une ligne ; si le délai MSDP doit un
+  jour diverger de celui des familles (cf. spec, tranché identique pour
+  l'instant mais pas garanti à vie), le découplage évite un effet de bord.
+- **Choix** : réutiliser le job cron existant (`/api/cron`) plutôt que créer
+  une route dédiée — *Pourquoi* : explicitement demandé par la spec, et
+  cohérent avec la suppression de la route dupliquée `/api/cron/integration-inactivity`
+  (issue #449, PR #456) qui vient d'établir ce pattern comme la norme du
+  projet.
+- **Écarté** : introduire un enum Prisma pour `Notification.type` — *Raison* :
+  hors périmètre de cette feature, le champ est déjà un `String` libre
+  utilisé de façon cohérente par convention (`INTEGRATION_INACTIVITY`,
+  `MSDP_ASSIGNED`...) ; changer ce choix structurel n'est pas nécessaire ici.
+- **Écarté** : notifier systématiquement l'équipe MSDP **en plus** du
+  conseiller assigné (double alerte) — *Raison* : non demandé par la spec
+  (un conseiller assigné est le destinataire suffisant), et risquerait de
+  diluer la responsabilité individuelle du conseiller.
+
+## Risques & points d'attention
+
+- Le filtre `department.function === "MSDP"` suppose qu'un tel département
+  existe et a des membres rattachés dans chaque église concernée — comme
+  pour `"INTEGRATION"` dans le flux famille, si aucun département MSDP
+  n'est configuré, `getManagers` retournera une liste vide et aucune alerte
+  ne sera envoyée pour les suivis sans conseiller (dégradation silencieuse,
+  cohérente avec le comportement déjà accepté du flux famille).
+- Le nom du type de notification (`MSDP_INACTIVITY`) doit être unique et ne
+  pas entrer en collision avec `MSDP_ASSIGNED` déjà utilisé par
+  `notifyMsdpCounselorAssigned` (spec 016) — vérifié, pas de collision.
+
+## Stratégie de tests
+
+*Fichier : `src/modules/integration/__tests__/msdp-service.test.ts` (existant, étendu)*
+
+- `buildMsdpInactivityEmail` : contenu HTML contient le nom de la personne,
+  le statut contextualisé, le lien vers le suivi.
+- `runMsdpInactivityNotifications` :
+  - Suivi `ASSIGNED` inactif depuis 7+ jours avec conseiller → notification +
+    email au conseiller.
+  - Suivi `SUBMITTED`/sans conseiller assigné, inactif → notification aux
+    membres du département `MSDP` de l'église.
+  - Suivi `COMPLETED`/`ABANDONED` inactif → jamais inclus dans les suivis
+    traités (vérifié via l'argument `where` du mock Prisma ou l'absence de
+    notification créée).
+  - Suivi déjà notifié récemment (notification `MSDP_INACTIVITY` < 7 jours)
+    → pas de nouvelle notification (`skipped` incrémenté).
+  - Échec d'envoi d'email sur un suivi → ne lève pas d'exception, les autres
+    suivis du même appel sont bien traités.

--- a/specs/018-relance-inactivite-msdp/spec.md
+++ b/specs/018-relance-inactivite-msdp/spec.md
@@ -1,0 +1,111 @@
+# Spec — Relance d'inactivité pour les suivis MSDP bloqués
+
+- **Numéro** : 018
+- **Statut** : Implémentée
+- **Créée le** : 2026-08-23
+- **Branche suggérée** : `feat/relance-inactivite-msdp`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+
+## Contexte & problème
+
+Le suivi MSDP accompagne un nouveau converti après son appel au salut : un
+conseiller lui est assigné, un premier contact est établi, puis la personne
+est intégrée à la formation des nouveaux convertis, jusqu'à la fin du suivi.
+
+Aujourd'hui, un suivi peut rester bloqué indéfiniment à une étape
+intermédiaire (conseiller assigné mais qui n'a jamais pris contact, contact
+établi mais formation jamais démarrée, etc.) sans qu'aucune alerte ne soit
+émise. Personne — ni le conseiller concerné, ni l'équipe qui supervise le
+parcours d'intégration — n'est prévenu qu'un accompagnement est à l'arrêt.
+Une relance équivalente existe déjà pour les demandes d'intégration en
+famille, mais rien de comparable ne couvre le suivi MSDP, alors qu'il s'agit
+de l'étape la plus sensible du parcours (accompagnement spirituel d'une
+personne récemment convertie).
+
+## Utilisateurs concernés
+
+- **Conseiller MSDP** *(rôle fonctionnel, rattaché à un département dont la
+  fonction est le suivi MSDP — pas un rôle Koinonia global)* : reçoit une
+  alerte quand un suivi qui lui est assigné est resté inactif trop longtemps.
+- **Équipe intégration / MSDP** *(membres du département en charge du
+  parcours d'intégration ou du suivi MSDP)* : reçoit une alerte quand un
+  suivi inactif **n'a pas de conseiller assigné**, faute d'un destinataire
+  individuel plus pertinent.
+- **Super Admin** : peut voir ces alertes comme tout membre de l'équipe
+  concernée, sans traitement particulier.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Un suivi MSDP est à une étape intermédiaire (conseiller assigné, premier
+   contact établi, ou en cours de formation — mais pas encore terminé ni
+   abandonné) depuis plus de N jours sans aucune évolution.
+2. Le système détecte cette inactivité lors de son cycle de vérification
+   périodique.
+3. Le conseiller assigné au suivi reçoit une notification l'informant que ce
+   suivi est resté sans mise à jour, avec le nom de la personne suivie, le
+   temps écoulé, et un lien direct vers le suivi.
+4. Si aucun conseiller n'est assigné, l'alerte est envoyée à l'équipe qui gère
+   le parcours d'intégration/MSDP à la place.
+5. La même relance ne doit pas être répétée à chaque vérification tant que le
+   suivi reste inactif — un intervalle minimal doit s'écouler entre deux
+   alertes pour un même suivi.
+
+### Scénarios alternatifs / cas limites
+
+- **Si** le suivi a évolué (nouveau statut, note ajoutée, changement quelconque)
+  entre-temps, alors **le compteur d'inactivité repart de zéro** — pas
+  d'alerte tant que le nouveau délai n'est pas écoulé.
+- **Si** le suivi est terminé ou abandonné, alors **aucune alerte n'est jamais
+  émise**, quel que soit le temps écoulé depuis sa dernière mise à jour.
+- **Quand** un suivi vient d'être créé (premier statut, personne pas encore
+  prise en charge) et dépasse le délai sans qu'un conseiller lui soit assigné,
+  le système doit alerter l'équipe intégration/MSDP — pas de destinataire
+  individuel possible dans ce cas.
+- **Si** l'envoi d'une alerte échoue techniquement (email indisponible, etc.),
+  cela ne doit **pas** interrompre le traitement des autres suivis inactifs
+  détectés dans le même cycle.
+
+## Critères d'acceptation
+
+- [x] Un suivi MSDP non terminal (ni terminé, ni abandonné) sans mise à jour
+      depuis N jours déclenche une alerte lors du prochain cycle de
+      vérification.
+- [x] L'alerte est adressée au conseiller assigné quand il y en a un, sinon à
+      l'équipe intégration/MSDP.
+- [x] L'alerte identifie clairement la personne suivie, depuis combien de
+      temps le suivi est inactif, et permet d'accéder directement au suivi
+      concerné.
+- [x] Un même suivi inactif ne génère pas de nouvelle alerte tant que
+      l'intervalle minimal entre deux relances n'est pas écoulé.
+- [x] Un suivi terminé ou abandonné n'est jamais concerné par cette relance.
+- [x] Une mise à jour du suivi réinitialise le délai avant la prochaine alerte
+      possible.
+- [x] Le mécanisme s'exécute automatiquement, sans action manuelle requise,
+      selon le même rythme que les autres vérifications périodiques déjà en
+      place dans l'application.
+- [x] L'échec d'envoi d'une alerte pour un suivi n'empêche pas le traitement
+      des autres suivis inactifs du même cycle.
+
+## Hors périmètre
+
+- Modifier les règles ou les transitions de statut du suivi MSDP lui-même.
+- Ajouter une relance pour les statuts terminaux (terminé, abandonné).
+- Permettre à un utilisateur de déclencher une relance manuellement en dehors
+  du cycle automatique.
+- Changer le délai ou l'intervalle de relance existant pour les demandes
+  d'intégration familiale (mécanisme équivalent déjà en place, non concerné
+  par cette feature).
+
+## Questions ouvertes
+
+*Aucune — tranchées avec l'utilisateur avant passage au plan :*
+
+- Délai d'inactivité : identique à celui des demandes d'intégration familiale
+  (7 jours), pas de paramètre distinct pour le suivi MSDP.
+- Le message d'alerte varie selon le statut du suivi (ex. "conseiller assigné
+  sans contact établi" vs "en formation depuis longtemps"), sur le même
+  principe que les demandes d'intégration familiale — plus actionnable pour
+  le destinataire qu'un message générique.

--- a/specs/018-relance-inactivite-msdp/tasks.md
+++ b/specs/018-relance-inactivite-msdp/tasks.md
@@ -1,0 +1,60 @@
+# Tâches — Relance d'inactivité pour les suivis MSDP bloqués
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : À faire
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : services → API → tests. Les tâches `[P]` sont parallélisables.
+
+## Prérequis
+
+- [x] Branche créée : `feat/relance-inactivite-msdp`
+- [x] Migration Prisma : `[Aucune]` — pas de changement de schéma (confirmé dans `plan.md`)
+
+## Tâches
+
+### 1. Logique métier (services)
+
+- [x] **T1** — Ajouter `buildMsdpInactivityEmail(params: { churchName, personName, status, daysSince, link, appUrl }): string` dans `src/modules/integration/services/msdp-service.ts`, calquée sur `buildInactivityEmail` (`family-service.ts:88`) : même charte visuelle (bandeau `#5E17EB`), `contextMap` propre aux statuts MSDP (`SUBMITTED`, `ASSIGNED`, `CONTACTED`, `IN_FORMATION`). *(fichier : `src/modules/integration/services/msdp-service.ts`)*
+
+- [x] **T2** — Ajouter `runMsdpInactivityNotifications(appUrl: string): Promise<{ notified: number; skipped: number; total: number }>` dans `src/modules/integration/services/msdp-service.ts` : constante locale `MSDP_INACTIVITY_DAYS = 7` et `MSDP_INACTIVITY_NOTIF_TYPE = "MSDP_INACTIVITY"` ; requête `prisma.msdpFollowUp.findMany` filtrant `status: { in: ["SUBMITTED", "ASSIGNED", "CONTACTED", "IN_FORMATION"] }` et `updatedAt: { lt: threshold }` ; dédoublonnage via les `Notification` de type `MSDP_INACTIVITY` créées dans la fenêtre des 7 derniers jours. *(fichier : `src/modules/integration/services/msdp-service.ts`)*
+
+- [x] **T3** — Dans `runMsdpInactivityNotifications`, brancher la logique de destinataire : si `assignedConseillerMsdp` renseigné → notification in-app + email (`.catch(() => {})`) au conseiller ; sinon → notification aux membres du département `function: "MSDP"` de l'église (fonction `getMsdpManagers` adaptée du pattern `family-service.ts`, filtrant `"MSDP"` au lieu de `"INTEGRATION"`). Chaque envoi individuellement catché pour ne pas interrompre le traitement des autres suivis. *(fichier : `src/modules/integration/services/msdp-service.ts`)*
+
+### 2. Exports du module
+
+- [x] **T4** — Exporter `runMsdpInactivityNotifications` et `buildMsdpInactivityEmail` depuis `src/modules/integration/index.ts`, aux côtés des exports existants de `msdp-service.ts`. *(fichier : `src/modules/integration/index.ts`)*
+
+### 3. Intégration cron
+
+- [x] **T5** — Dans `src/app/api/cron/route.ts`, importer `runMsdpInactivityNotifications` depuis `@/modules/integration` et l'ajouter au `Promise.all([...])` existant (aux côtés de `runReminders`, `runPlanningDigest`, `runInactivityNotifications`) ; exposer le résultat sous la clé `msdpInactivity` dans la réponse JSON. *(fichier : `src/app/api/cron/route.ts`)*
+
+### 4. Tests
+
+- [x] **T6** [P] — Test unitaire de `buildMsdpInactivityEmail` : vérifie que le HTML généré contient le nom de la personne suivie, un message contextualisé par statut, et le lien vers le suivi. *(fichier : `src/modules/integration/__tests__/msdp-service.test.ts`)*
+
+- [x] **T7** [P] — Tests unitaires de `runMsdpInactivityNotifications` (mock Prisma via `src/__mocks__/prisma.ts`, mock `sendEmail` via `vi.mock("@/lib/email")`) :
+  - Suivi `ASSIGNED` inactif 7+ jours avec conseiller assigné → notification créée + `sendEmail` appelé pour le conseiller.
+  - Suivi `SUBMITTED` sans conseiller assigné, inactif → notification créée pour les membres du département `MSDP` de l'église (pas d'appel `sendEmail` individuel conseiller).
+  - Filtre de statuts non terminaux vérifié via l'argument `where` du mock `msdpFollowUp.findMany` (`COMPLETED`/`ABANDONED` jamais dans la liste).
+  - Suivi déjà notifié dans les 7 derniers jours (notification `MSDP_INACTIVITY` récente existante) → pas de nouvelle notification, `skipped` incrémenté.
+  - `sendEmail` qui rejette pour un suivi → ne lève pas d'exception, les autres suivis du même appel sont bien traités (`notified` reflète les suivis traités avec succès).
+  *(fichier : `src/modules/integration/__tests__/msdp-service.test.ts`)*
+  Note d'implémentation : `prismaMock.msdpFollowUp` manquait dans `src/__mocks__/prisma.ts` — ajouté (nécessaire pour que ces tests s'exécutent).
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint` (0 erreur, 9 warnings préexistants sans rapport)
+- [x] `npm run lint:boundaries` (518 modules, 0 violation)
+- [x] `npm run test` (635/635)
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits :
+  - [x] Suivi non terminal sans mise à jour depuis 7 jours déclenche une alerte au prochain cycle (T2, T5, T7)
+  - [x] Alerte adressée au conseiller assigné, sinon à l'équipe MSDP/intégration (T3, T7)
+  - [x] Alerte identifie la personne suivie, le délai écoulé, et le lien vers le suivi (T1, T6)
+  - [x] Pas de nouvelle alerte tant que l'intervalle minimal n'est pas écoulé (T2, T7)
+  - [x] Suivi terminé/abandonné jamais concerné (T2, T7)
+  - [x] Mise à jour du suivi réinitialise le délai (couvert nativement par `updatedAt` — voir `plan.md` § Modèle de données, pas de tâche dédiée nécessaire)
+  - [x] Exécution automatique sans action manuelle, alignée sur le cycle cron existant (T5)
+  - [x] Échec d'envoi sur un suivi n'empêche pas le traitement des autres (T3, T7)
+- [x] PR ouverte vers `main`

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -51,6 +51,7 @@ export const prismaMock = {
   mediaShareToken: createModelMock(),
   mediaSettings: createModelMock(),
   mrbsUserLink: createModelMock(),
+  msdpFollowUp: createModelMock(),
   // Module agenda
   pastoralProfile: createModelMock(),
   appointmentRequest: createModelMock(),

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { sendEmail, buildReminderEmail, buildPlanningDigestEmail } from "@/lib/email";
-import { runInactivityNotifications } from "@/modules/integration";
+import { runInactivityNotifications, runMsdpInactivityNotifications } from "@/modules/integration";
 
 function authorizeCron(request: Request) {
   const authHeader = request.headers.get("authorization");
@@ -211,16 +211,18 @@ export async function POST(request: Request) {
     authorizeCron(request);
 
     const appUrl = process.env.APP_URL ?? process.env.AUTH_URL ?? process.env.NEXTAUTH_URL ?? "";
-    const [remindersResult, digestResult, integrationInactivityResult] = await Promise.all([
+    const [remindersResult, digestResult, integrationInactivityResult, msdpInactivityResult] = await Promise.all([
       runReminders(),
       runPlanningDigest(),
       runInactivityNotifications(appUrl),
+      runMsdpInactivityNotifications(appUrl),
     ]);
 
     return successResponse({
       reminders: remindersResult,
       planningDigest: digestResult,
       integrationInactivity: integrationInactivityResult,
+      msdpInactivity: msdpInactivityResult,
     });
   } catch (error) {
     return errorResponse(error);

--- a/src/modules/integration/__tests__/msdp-service.test.ts
+++ b/src/modules/integration/__tests__/msdp-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { prismaMock } from "@/__mocks__/prisma";
 
 const mockSendEmail = vi.fn();
@@ -17,9 +17,12 @@ vi.mock("next-auth", () => ({
   }),
 }));
 
-const { buildMsdpCounselorNotifEmail, notifyMsdpCounselorAssigned } = await import(
-  "../services/msdp-service"
-);
+const {
+  buildMsdpCounselorNotifEmail,
+  notifyMsdpCounselorAssigned,
+  buildMsdpInactivityEmail,
+  runMsdpInactivityNotifications,
+} = await import("../services/msdp-service");
 
 describe("buildMsdpCounselorNotifEmail", () => {
   it("inclut le nom du conseiller, le nom de la personne suivie et le lien vers le suivi", () => {
@@ -100,5 +103,132 @@ describe("notifyMsdpCounselorAssigned", () => {
         appUrl: "https://koinonia.example",
       })
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("buildMsdpInactivityEmail", () => {
+  it("inclut le nom de la personne, le message contextualisé par statut et le lien", () => {
+    const html = buildMsdpInactivityEmail({
+      churchName: "ICC Rennes",
+      personName: "Marie Curie",
+      status: "ASSIGNED",
+      daysSince: 9,
+      link: "/admin/integration/msdp/f1",
+      appUrl: "https://koinonia.example",
+    });
+
+    expect(html).toContain("Marie Curie");
+    expect(html).toContain("9 jours");
+    expect(html).toContain("Un conseiller a été assigné mais le contact n'a pas encore été établi.");
+    expect(html).toContain("https://koinonia.example/admin/integration/msdp/f1");
+  });
+});
+
+describe("runMsdpInactivityNotifications", () => {
+  const originalSmtpHost = process.env.SMTP_HOST;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendEmail.mockResolvedValue(undefined);
+    process.env.SMTP_HOST = "smtp.example.com";
+    prismaMock.notification.create.mockResolvedValue({} as never);
+    prismaMock.notification.findMany.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    if (originalSmtpHost === undefined) delete process.env.SMTP_HOST;
+    else process.env.SMTP_HOST = originalSmtpHost;
+  });
+
+  function makeFollowUp(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "f1",
+      churchId: "church-1",
+      status: "ASSIGNED",
+      updatedAt: new Date(Date.now() - 10 * 86_400_000),
+      assignedConseillerMsdp: { id: "counselor-1", name: "Jean Dupont", email: "jean@example.com" },
+      request: { firstName: "Marie", lastName: "Curie" },
+      church: { id: "church-1", name: "ICC Rennes" },
+      ...overrides,
+    };
+  }
+
+  it("notifie et envoie un email au conseiller assigné pour un suivi inactif", async () => {
+    prismaMock.msdpFollowUp.findMany.mockResolvedValue([makeFollowUp()] as never);
+
+    const result = await runMsdpInactivityNotifications("https://koinonia.example");
+
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: "counselor-1", type: "MSDP_INACTIVITY" }),
+      })
+    );
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).toHaveBeenCalledWith(expect.objectContaining({ to: "jean@example.com" }));
+    expect(result).toEqual({ notified: 1, skipped: 0, total: 1 });
+  });
+
+  it("notifie l'équipe MSDP quand aucun conseiller n'est assigné", async () => {
+    prismaMock.msdpFollowUp.findMany.mockResolvedValue([
+      makeFollowUp({ status: "SUBMITTED", assignedConseillerMsdp: null }),
+    ] as never);
+    prismaMock.department.findFirst.mockResolvedValue({ id: "dept-msdp" } as never);
+    prismaMock.userDepartment.findMany.mockResolvedValue([
+      { userChurchRole: { userId: "manager-1", user: { id: "manager-1", email: "manager@example.com" } } },
+    ] as never);
+
+    const result = await runMsdpInactivityNotifications("https://koinonia.example");
+
+    expect(prismaMock.department.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ function: "MSDP" }) })
+    );
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ userId: "manager-1" }) })
+    );
+    expect(result.notified).toBe(1);
+  });
+
+  it("n'interroge que les statuts non terminaux", async () => {
+    prismaMock.msdpFollowUp.findMany.mockResolvedValue([]);
+
+    await runMsdpInactivityNotifications("https://koinonia.example");
+
+    expect(prismaMock.msdpFollowUp.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: ["SUBMITTED", "ASSIGNED", "CONTACTED", "IN_FORMATION"] },
+        }),
+      })
+    );
+  });
+
+  it("ne renotifie pas un suivi déjà notifié récemment", async () => {
+    prismaMock.msdpFollowUp.findMany.mockResolvedValue([makeFollowUp()] as never);
+    prismaMock.notification.findMany.mockResolvedValue([
+      { link: "/admin/integration/msdp/f1" },
+    ] as never);
+
+    const result = await runMsdpInactivityNotifications("https://koinonia.example");
+
+    expect(prismaMock.notification.create).not.toHaveBeenCalled();
+    expect(result).toEqual({ notified: 0, skipped: 1, total: 1 });
+  });
+
+  it("continue de traiter les autres suivis si l'envoi d'email échoue pour l'un d'eux", async () => {
+    prismaMock.msdpFollowUp.findMany.mockResolvedValue([
+      makeFollowUp({ id: "f1" }),
+      makeFollowUp({
+        id: "f2",
+        assignedConseillerMsdp: { id: "counselor-2", name: "Paul", email: "paul@example.com" },
+      }),
+    ] as never);
+    mockSendEmail.mockRejectedValueOnce(new Error("SMTP down")).mockResolvedValueOnce(undefined);
+
+    const result = await expect(
+      runMsdpInactivityNotifications("https://koinonia.example")
+    ).resolves.toEqual({ notified: 2, skipped: 0, total: 2 });
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+    return result;
   });
 });

--- a/src/modules/integration/index.ts
+++ b/src/modules/integration/index.ts
@@ -17,6 +17,8 @@ export {
   computeMsdpTransitionData,
   buildMsdpCounselorNotifEmail,
   notifyMsdpCounselorAssigned,
+  buildMsdpInactivityEmail,
+  runMsdpInactivityNotifications,
 } from "./services/msdp-service";
 export type { MsdpPatchBody } from "./services/msdp-service";
 

--- a/src/modules/integration/services/msdp-service.ts
+++ b/src/modules/integration/services/msdp-service.ts
@@ -159,3 +159,161 @@ export async function notifyMsdpCounselorAssigned(params: {
     }).catch(() => {});
   }
 }
+
+// ─── Inactivité ───────────────────────────────────────────────────────────────
+
+const MSDP_INACTIVITY_DAYS = 7;
+const MSDP_INACTIVITY_NOTIF_TYPE = "MSDP_INACTIVITY";
+
+export function buildMsdpInactivityEmail(params: {
+  churchName: string;
+  personName: string;
+  status: string;
+  daysSince: number;
+  link: string;
+  appUrl: string;
+}): string {
+  const { churchName, personName, status, daysSince, link, appUrl } = params;
+  const contextMap: Record<string, string> = {
+    SUBMITTED: "Aucun conseiller n'a encore été assigné à ce suivi.",
+    ASSIGNED: "Un conseiller a été assigné mais le contact n'a pas encore été établi.",
+    CONTACTED: "Le contact a été établi mais la formation n'a pas encore démarré.",
+    IN_FORMATION: "La personne est en formation mais aucune progression récente n'a été enregistrée.",
+  };
+  const context = contextMap[status] ?? "Aucune mise à jour récente.";
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f9fafb;font-family:Arial,sans-serif;">
+  <div style="max-width:560px;margin:40px auto;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,.08)">
+    <div style="background:#5E17EB;padding:28px 32px">
+      <h1 style="margin:0;color:#ffffff;font-size:20px;font-weight:700">${churchName}</h1>
+      <p style="margin:4px 0 0;color:rgba(255,255,255,.8);font-size:13px">Rappel — Suivi MSDP</p>
+    </div>
+    <div style="padding:28px 32px">
+      <p style="margin:0 0 12px;color:#111827;font-size:15px">Bonjour,</p>
+      <p style="margin:0 0 16px;color:#374151;font-size:14px;line-height:1.6">
+        Le suivi MSDP de <strong>${personName}</strong> est inactif depuis <strong>${daysSince} jours</strong>.
+      </p>
+      <div style="background:#fff7ed;border-left:4px solid #f97316;padding:12px 16px;border-radius:0 8px 8px 0;margin:0 0 20px">
+        <p style="margin:0;color:#92400e;font-size:13px;line-height:1.5">${context}</p>
+      </div>
+      <a href="${appUrl}${link}" style="display:inline-block;background:#5E17EB;color:#ffffff;text-decoration:none;padding:10px 20px;border-radius:8px;font-size:14px;font-weight:600">
+        Voir le suivi →
+      </a>
+      <p style="margin:24px 0 0;color:#6b7280;font-size:13px">
+        À bientôt,<br>
+        <strong style="color:#111827">L'équipe Koinonia — ${churchName}</strong>
+      </p>
+    </div>
+    <div style="background:#f9fafb;padding:14px 32px;border-top:1px solid #e5e7eb">
+      <p style="margin:0;color:#9ca3af;font-size:11px">Message automatique. Ne pas répondre directement.</p>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+export async function runMsdpInactivityNotifications(
+  appUrl: string
+): Promise<{ notified: number; skipped: number; total: number }> {
+  const threshold = new Date();
+  threshold.setDate(threshold.getDate() - MSDP_INACTIVITY_DAYS);
+
+  const dedupeThreshold = new Date();
+  dedupeThreshold.setDate(dedupeThreshold.getDate() - MSDP_INACTIVITY_DAYS);
+
+  const staleFollowUps = await prisma.msdpFollowUp.findMany({
+    where: {
+      status: { in: ["SUBMITTED", "ASSIGNED", "CONTACTED", "IN_FORMATION"] },
+      updatedAt: { lt: threshold },
+    },
+    include: {
+      assignedConseillerMsdp: { select: { id: true, name: true, email: true } },
+      request: { select: { firstName: true, lastName: true } },
+      church: { select: { id: true, name: true } },
+    },
+  });
+
+  if (staleFollowUps.length === 0) return { notified: 0, skipped: 0, total: 0 };
+
+  const followUpIds = staleFollowUps.map((f) => f.id);
+  const recentNotifs = await prisma.notification.findMany({
+    where: {
+      type: MSDP_INACTIVITY_NOTIF_TYPE,
+      link: { in: followUpIds.map((id) => `/admin/integration/msdp/${id}`) },
+      createdAt: { gte: dedupeThreshold },
+    },
+    select: { link: true },
+  });
+  const alreadyNotifiedLinks = new Set(recentNotifs.map((n) => n.link));
+
+  const managersByChurch: Record<string, { id: string; email: string | null }[]> = {};
+
+  async function getMsdpManagers(churchId: string) {
+    if (managersByChurch[churchId]) return managersByChurch[churchId];
+    const msdpDept = await prisma.department.findFirst({
+      where: { function: "MSDP", ministry: { churchId } },
+      select: { id: true },
+    });
+    if (!msdpDept) { managersByChurch[churchId] = []; return []; }
+    const memberships = await prisma.userDepartment.findMany({
+      where: { departmentId: msdpDept.id },
+      include: { userChurchRole: { select: { userId: true, user: { select: { id: true, email: true } } } } },
+    });
+    const managers = memberships.map((m) => ({ id: m.userChurchRole.userId, email: m.userChurchRole.user.email }));
+    managersByChurch[churchId] = managers;
+    return managers;
+  }
+
+  const titleMap: Record<string, string> = {
+    SUBMITTED: "Suivi sans conseiller depuis 7 jours",
+    ASSIGNED: "Contact non établi depuis 7 jours",
+    CONTACTED: "Formation non démarrée depuis 7 jours",
+    IN_FORMATION: "Suivi en formation sans progression depuis 7 jours",
+  };
+
+  let notified = 0;
+  let skipped = 0;
+
+  for (const followUp of staleFollowUps) {
+    const link = `/admin/integration/msdp/${followUp.id}`;
+    if (alreadyNotifiedLinks.has(link)) { skipped++; continue; }
+
+    const personName = `${followUp.request.firstName} ${followUp.request.lastName}`;
+    const daysSince = Math.floor((Date.now() - followUp.updatedAt.getTime()) / 86_400_000);
+    const title = titleMap[followUp.status] ?? "Suivi MSDP inactif";
+    const message = `${personName} — aucune mise à jour depuis ${daysSince} jours.`;
+
+    if (followUp.assignedConseillerMsdp) {
+      await prisma.notification.create({
+        data: { userId: followUp.assignedConseillerMsdp.id, type: MSDP_INACTIVITY_NOTIF_TYPE, title, message, link },
+      }).catch(() => {});
+      notified++;
+      if (process.env.SMTP_HOST && followUp.assignedConseillerMsdp.email) {
+        await sendEmail({
+          to: followUp.assignedConseillerMsdp.email,
+          subject: `${followUp.church.name} — ${title}`,
+          html: buildMsdpInactivityEmail({ churchName: followUp.church.name, personName, status: followUp.status, daysSince, link, appUrl }),
+        }).catch(() => {});
+      }
+    } else {
+      const managers = await getMsdpManagers(followUp.churchId);
+      for (const manager of managers) {
+        await prisma.notification.create({
+          data: { userId: manager.id, type: MSDP_INACTIVITY_NOTIF_TYPE, title, message, link },
+        }).catch(() => {});
+        notified++;
+        if (process.env.SMTP_HOST && manager.email) {
+          await sendEmail({
+            to: manager.email,
+            subject: `${followUp.church.name} — ${title}`,
+            html: buildMsdpInactivityEmail({ churchName: followUp.church.name, personName, status: followUp.status, daysSince, link, appUrl }),
+          }).catch(() => {});
+        }
+      }
+    }
+  }
+
+  return { notified, skipped, total: staleFollowUps.length };
+}


### PR DESCRIPTION
## Résumé
- Ajoute `runMsdpInactivityNotifications` dans `src/modules/integration/services/msdp-service.ts`, calquée sur le mécanisme équivalent déjà en place pour les demandes d'intégration familiale (`runInactivityNotifications`).
- Un `MsdpFollowUp` non terminal (`SUBMITTED`, `ASSIGNED`, `CONTACTED`, `IN_FORMATION`) sans mise à jour depuis 7 jours déclenche une alerte au conseiller assigné, ou à l'équipe du département `MSDP` de l'église à défaut.
- Message contextualisé par statut (ex. "conseiller assigné sans contact établi").
- Dédoublonnage : pas de nouvelle alerte pour un même suivi tant que 7 jours ne se sont pas écoulés depuis la dernière.
- Un échec d'envoi (email) sur un suivi n'interrompt pas le traitement des autres.
- Branché sur l'orchestrateur cron unique `/api/cron` (résultat exposé sous `msdpInactivity`) — pas de nouvelle route, cohérent avec le rattrapage de la #449.

Spec/plan/tasks : `specs/018-relance-inactivite-msdp/`

Closes #450

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries` (518 modules, 0 violation)
- [x] `npm run test` (635/635)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AmQHtj4vBxybnwDm5asAQ