### PR TITLE
docs(guide): compléter le guide utilisateur avec les modules manquants

### DIFF
--- a/docs/guide-screenshots.md
+++ b/docs/guide-screenshots.md
@@ -39,10 +39,16 @@ Utiliser l'église ICC Rennes (seed).
 | Resp. Département | Planning + membres de ses départements + discipolat lecture |
 | Faiseur de Disciples | Discipolat uniquement (ses disciples) |
 | Reporter | Événements lecture + comptes rendus |
+| Qualificateur agenda | Qualification des demandes de RDV pastoral |
+| Comptable | Traitement des demandes financières + statistiques |
+
+Pour les captures Salles / Intégration nécessitant un accès par appartenance de
+département (contrôle des mains courantes, MSDP, bergers de famille), utiliser
+un compte Super Admin ou Admin plutôt qu'un compte dédié.
 
 ---
 
-## Liste des 24 captures
+## Liste des 38 captures
 
 ### Planning (3)
 
@@ -102,11 +108,50 @@ Utiliser l'église ICC Rennes (seed).
 | 22 | `guide-admin-audit-logs.png` | `/admin/audit-logs` | Journal avec entrées horodatées |
 | 23 | `guide-admin-dept-functions.png` | `/admin/departments/functions` | Vue fonctions système + custom |
 
+### Salles (2)
+
+| # | Fichier | URL | État à capturer |
+|---|---|---|---|
+| 24 | `guide-salles-reservation.png` | `/rooms` | Planning des salles avec un créneau réservé |
+| 25 | `guide-salles-mains-courantes.png` | `/rooms/checklists` | Liste de réservations avec état des mains courantes |
+
+### Agenda pastoral (3)
+
+| # | Fichier | URL | État à capturer |
+|---|---|---|---|
+| 26 | `guide-agenda-demande.png` | `/agenda/request` | Formulaire de demande de RDV rempli |
+| 27 | `guide-agenda-qualification.png` | `/agenda/requests` | Demandes en attente avec formulaire de qualification ouvert |
+| 28 | `guide-agenda-planification.png` | `/agenda/schedule` | Demandes validées à planifier |
+
+### Comptabilité (3)
+
+| # | Fichier | URL | État à capturer |
+|---|---|---|---|
+| 29 | `guide-comptabilite-demande.png` | `/accounting/requests/new` | Formulaire de note de frais partiellement rempli |
+| 30 | `guide-comptabilite-gestion.png` | `/accounting/requests` | Liste des demandes financières avec statuts |
+| 31 | `guide-comptabilite-stats.png` | `/accounting/stats` | Statistiques par statut et département |
+
+### Emplois (2)
+
+| # | Fichier | URL | État à capturer |
+|---|---|---|---|
+| 32 | `guide-emplois-liste.png` | `/jobs` | Onglet Offres avec plusieurs annonces |
+| 33 | `guide-emplois-moderation.png` | `/admin/jobs` | Liste des annonces avec actions de modération |
+
+### Intégration (4)
+
+| # | Fichier | URL | État à capturer |
+|---|---|---|---|
+| 34 | `guide-integration-demandes.png` | `/integration/requests` | Liste des demandes d'intégration avec statuts |
+| 35 | `guide-integration-msdp.png` | `/integration/requests/[id]` | Onglet suivi MSDP avec conseiller assigné |
+| 36 | `guide-integration-bergers.png` | `/integration/leaders` | Liste des bergers de famille et affectations |
+| 37 | `guide-integration-stats.png` | `/integration/stats` | Statistiques d'intégration (délais, taux) |
+
 ### Profil (1)
 
 | # | Fichier | URL | État à capturer |
 |---|---|---|---|
-| 24 | `guide-profile.png` | `/profile` | Profil avec section liaison STAR visible |
+| 38 | `guide-profile.png` | `/profile` | Profil avec section liaison STAR visible |
 
 ---
 

--- a/src/components/GuideContent.tsx
+++ b/src/components/GuideContent.tsx
@@ -239,6 +239,128 @@ const FEATURES: Feature[] = [
     screenshotFile: "guide-profile.png",
     access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "edit", MINISTER: "edit", DEPARTMENT_HEAD: "edit", DISCIPLE_MAKER: "edit", REPORTER: "edit", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
   },
+
+  // ── Salles ───────────────────────────────────────────────────────────────
+  {
+    name: "Réserver une salle",
+    description: "Consultez le planning des salles et réservez un créneau depuis /rooms. La réservation est soumise à l'accord de l'équipe de contrôle si la salle le requiert.",
+    category: "Salles",
+    screenshotTitle: "Réservation de salles",
+    screenshotFile: "guide-salles-reservation.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "read", MINISTER: "edit", DEPARTMENT_HEAD: "edit", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "edit", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
+  },
+  {
+    name: "Contrôle des mains courantes",
+    description: "Validez l'état des lieux (ouverture/fermeture) des salles réservées depuis /rooms/checklists. Accessible aux gestionnaires de salles et, par appartenance de département, aux membres de l'équipe de contrôle — indépendamment du rôle global.",
+    category: "Salles",
+    screenshotTitle: "Contrôle des mains courantes",
+    screenshotFile: "guide-salles-mains-courantes.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "none", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
+  },
+
+  // ── Agenda pastoral ──────────────────────────────────────────────────────
+  {
+    name: "Demande de RDV pastoral",
+    description: "Déposez une demande de rendez-vous avec un pasteur ou responsable depuis /agenda/request. Disponible pour toute personne ayant accès au planning de son église.",
+    category: "Agenda pastoral",
+    screenshotTitle: "Demande de RDV pastoral",
+    screenshotFile: "guide-agenda-demande.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "edit", MINISTER: "edit", DEPARTMENT_HEAD: "edit", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "edit", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
+  },
+  {
+    name: "Qualification des demandes",
+    description: "Examinez chaque demande de RDV depuis /agenda/requests : validez-la en l'assignant à un profil pastoral, ou rejetez-la avec un motif.",
+    category: "Agenda pastoral",
+    screenshotTitle: "Qualification des demandes de RDV",
+    screenshotFile: "guide-agenda-qualification.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "none", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "edit", ACCOUNTANT: "none" },
+  },
+  {
+    name: "Vue et planification agenda",
+    description: "Consultez l'agenda hebdomadaire de chaque profil pastoral depuis /agenda, planifiez les créneaux des demandes validées depuis /agenda/schedule, ou ajoutez une entrée manuelle depuis /agenda/new. Un titulaire de profil pastoral voit également \"Mon agenda\", indépendamment de son rôle global.",
+    category: "Agenda pastoral",
+    screenshotTitle: "Vue et planification de l'agenda",
+    screenshotFile: "guide-agenda-planification.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "edit", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
+  },
+
+  // ── Comptabilité ─────────────────────────────────────────────────────────
+  {
+    name: "Soumettre une demande financière",
+    description: "Déposez une note de frais ou une demande d'avance de budget depuis /accounting/requests/new. Un titulaire de profil pastoral peut également soumettre, indépendamment de son rôle global.",
+    category: "Comptabilité",
+    screenshotTitle: "Nouvelle demande financière",
+    screenshotFile: "guide-comptabilite-demande.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "none", MINISTER: "edit", DEPARTMENT_HEAD: "edit", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
+  },
+  {
+    name: "Traiter les demandes financières",
+    description: "Consultez et traitez les notes de frais et avances de budget depuis /accounting/requests : confirmez le paiement ou refusez avec un motif. Les Ministres et Resp. département voient leurs propres demandes en lecture seule.",
+    category: "Comptabilité",
+    screenshotTitle: "Gestion des demandes financières",
+    screenshotFile: "guide-comptabilite-gestion.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "none", MINISTER: "read", DEPARTMENT_HEAD: "read", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "edit" },
+  },
+  {
+    name: "Statistiques comptables",
+    description: "Visualisez le total des demandes financières sur l'année en cours depuis /accounting/stats, par statut et par département.",
+    category: "Comptabilité",
+    screenshotTitle: "Statistiques comptables",
+    screenshotFile: "guide-comptabilite-stats.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "edit", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "edit" },
+  },
+
+  // ── Emplois ──────────────────────────────────────────────────────────────
+  {
+    name: "Offres, recherches d'emploi & freelance",
+    description: "Publiez ou consultez des offres d'emploi, des profils en recherche, et des missions freelance depuis /jobs (trois onglets). Fonctionnalité ouverte à tous les comptes de l'église.",
+    category: "Emplois",
+    screenshotTitle: "Offres et recherches d'emploi",
+    screenshotFile: "guide-emplois-liste.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "edit", MINISTER: "edit", DEPARTMENT_HEAD: "edit", DISCIPLE_MAKER: "edit", REPORTER: "edit", STAR: "edit", AGENDA_QUALIFIER: "edit", ACCOUNTANT: "edit" },
+  },
+  {
+    name: "Modération des annonces",
+    description: "Modérez et supprimez si besoin toute offre, recherche ou mission publiée par un autre compte, depuis /admin/jobs.",
+    category: "Emplois",
+    screenshotTitle: "Modération des annonces",
+    screenshotFile: "guide-emplois-moderation.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "edit", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
+  },
+
+  // ── Intégration ──────────────────────────────────────────────────────────
+  {
+    name: "Demandes d'intégration (familles)",
+    description: "Suivez les demandes d'intégration de nouvelles familles depuis /integration/requests : assignez un berger, changez le statut. Accessible aussi, par appartenance de département (fonction Intégration) ou en tant que berger assigné, indépendamment du rôle global.",
+    category: "Intégration",
+    screenshotTitle: "Demandes d'intégration",
+    screenshotFile: "guide-integration-demandes.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "none", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
+  },
+  {
+    name: "Suivi MSDP (appel au salut)",
+    description: "Depuis la fiche d'une demande d'intégration, démarrez et suivez le parcours MSDP (Mieux Se Découvrir en Personne) : assignez un conseiller, faites progresser le statut, ajoutez des notes. Accessible au conseiller assigné et aux membres du département Intégration, indépendamment du rôle global.",
+    category: "Intégration",
+    screenshotTitle: "Suivi MSDP",
+    screenshotFile: "guide-integration-msdp.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "none", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
+  },
+  {
+    name: "Bergers de famille",
+    description: "Gérez la liste des bergers de famille et leurs affectations depuis /integration/leaders.",
+    category: "Intégration",
+    screenshotTitle: "Bergers de famille",
+    screenshotFile: "guide-integration-bergers.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "none", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
+  },
+  {
+    name: "Parcours & statistiques d'intégration",
+    description: "Consultez le parcours d'intégration type et les statistiques (délais, taux de complétion) depuis /integration/parcours et /integration/stats.",
+    category: "Intégration",
+    screenshotTitle: "Parcours et statistiques d'intégration",
+    screenshotFile: "guide-integration-stats.png",
+    access: { SUPER_ADMIN: "edit", ADMIN: "edit", SECRETARY: "none", MINISTER: "none", DEPARTMENT_HEAD: "none", DISCIPLE_MAKER: "none", REPORTER: "none", STAR: "none", AGENDA_QUALIFIER: "none", ACCOUNTANT: "none" },
+  },
 ];
 
 const ROLES: RoleKey[] = ["SUPER_ADMIN", "ADMIN", "SECRETARY", "MINISTER", "DEPARTMENT_HEAD", "DISCIPLE_MAKER", "REPORTER", "STAR", "AGENDA_QUALIFIER", "ACCOUNTANT"];


### PR DESCRIPTION
## Résumé
Le guide utilisateur in-app (`src/components/GuideContent.tsx`, accessible via `/guide`) listait déjà les rôles `AGENDA_QUALIFIER` et `ACCOUNTANT` sans aucune fonctionnalité associée : les modules `rooms`, `agenda`, `accounting`, `jobs` et `integration` ont été ajoutés à l'application sans que le guide soit mis à jour.

- 14 nouvelles `Feature` ajoutées, réparties en 5 catégories : Salles, Agenda pastoral, Comptabilité, Emplois, Intégration
- Chaque entrée vérifiée contre le code (routes réelles, permissions du manifeste de module) — pas de fonctionnalité inventée
- `docs/guide-screenshots.md` mis à jour en conséquence : 24 → 38 captures listées, table des comptes de test complétée (Qualificateur agenda, Comptable), note ajoutée sur les captures nécessitant un accès par appartenance de département (MSDP, bergers, mains courantes)

Hors périmètre de cette PR : la capture et publication effective des 38 screenshots vers la release GitHub `guide-assets` — étape suivante déjà documentée dans `docs/guide-screenshots.md`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (0 erreur, 9 warnings préexistants sans rapport)