### PR TITLE
chore: release v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Non publie]
 
+## [v1.18.0] - 2026-08-23
+
+### Ajouté
+
+- **Relance d'inactivité pour les suivis MSDP bloqués** : un suivi MSDP (appel au salut) non terminal resté sans mise à jour depuis 7 jours déclenche désormais une alerte automatique au conseiller assigné, ou à l'équipe MSDP si aucun conseiller n'est assigné — même mécanisme que celui déjà en place pour les demandes d'intégration familiale.
+- **Guide utilisateur complété** : les modules Salles, Agenda pastoral, Comptabilité, Emplois et Intégration, absents du guide in-app malgré leur présence dans l'application, sont désormais documentés avec captures d'écran.
+
+### Modifié
+
+- **Rôle Reporter intégré au tableau des rôles transverses** : la page Accès & rôles gérait le rôle Reporter dans un onglet dédié, séparé des autres rôles transverses (Secrétaire, Faiseur de Disciples...) ; il est désormais géré au même endroit qu'eux, pour plus de cohérence.
+
+### Technique
+
+- Suppression de la route cron dupliquée `/api/cron/integration-inactivity`, orpheline depuis l'ajout de l'orchestrateur `/api/cron` principal.
+- Introduction de la pratique des ADR (Architecture Decision Records) dans `docs/adr/`.
+
 ## [v1.17.1] - 2026-08-16
 
 ### Corrigé

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koinonia",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koinonia",
-      "version": "1.17.1",
+      "version": "1.18.0",
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.3",
         "@aws-sdk/client-s3": "^3.1113.0",
@@ -2109,9 +2109,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2127,9 +2124,6 @@
       "integrity": "sha512-JUiPXZKK9wOhjf4MgDiH29GZLxfqOesbLtHq2pDxwH/WwscTRV2ToymnOTh1egzaZf0ueUf8T2+CeYTGHjW0Iw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2147,9 +2141,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2165,9 +2156,6 @@
       "integrity": "sha512-6yy3FT13KgUFOj5H8bl8w/6nKiJwHIvbtwh1V+1acsu+7y4tJjnemSa6mhsh53BeoVrlozE+fMgZhXH46WmjMA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2848,9 +2836,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2868,9 +2853,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2888,9 +2870,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2908,9 +2887,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2928,9 +2904,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2948,9 +2921,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3669,7 +3639,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -12567,9 +12537,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12591,9 +12558,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12615,9 +12579,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12639,9 +12600,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koinonia",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Résumé
Release v1.18.0.

### Ajouté
- Relance d'inactivité pour les suivis MSDP bloqués (#457)
- Guide utilisateur complété (Salles, Agenda pastoral, Comptabilité, Emplois, Intégration) (#459, #460)

### Modifié
- Rôle Reporter intégré au tableau des rôles transverses (#454)

### Technique
- Suppression de la route cron dupliquée `/api/cron/integration-inactivity` (#456)
- Introduction de la pratique des ADR (#455)

## Test plan
- [x] `npm run typecheck && npm run lint && npm run lint:boundaries && npm run test`
- [x] Version bumpée dans `package.json`/`package-lock.json`, CHANGELOG.md à jour