### PR TITLE
feat(audio): filtres et tris multicritères de la file Production (spec 023)

### DIFF
--- a/specs/023-audio-production-filtres/plan.md
+++ b/specs/023-audio-production-filtres/plan.md
@@ -81,6 +81,7 @@ export interface QueueCriteria {
   to: string;              // "" ou "AAAA-MM-JJ"
   text: string;            // recherche libre (titre + orateur)
   speaker: string;         // "" = tous ; "__NONE__" = sans orateur ; sinon nom exact
+  series: string;          // "" = toutes ; "__NONE__" = sans série ; sinon nom exact
 }
 
 export const EMPTY_CRITERIA: QueueCriteria;
@@ -92,6 +93,7 @@ export const STATUS_SORT_ORDER: Record<string, number>;
 //  PENDING_REVIEW(0) → READY(1) → DRAFT(2) → PUBLISHED(3) → UNPUBLISHED(4)
 
 export function deriveSpeakers(rows: Row[]): string[];
+export function deriveSeries(rows: Row[]): string[];  // idem, sur `series`
 //  orateurs non vides, dédoublonnés (casse/accent ignorés pour l'unicité,
 //  1re graphie rencontrée conservée), triés localeCompare("fr").
 
@@ -142,6 +144,7 @@ l'utilise **ici uniquement** ; la reprise des autres appels est hors périmètre
   | Année | `Select` | années distinctes présentes dans `services` (desc) |
   | Du / Au | deux `Input type="date"` | — |
   | Orateur | `Select` | `deriveSpeakers(services)` + option « Sans orateur » |
+  | Série | `Select` | `deriveSeries(services)` + option « Sans série » (champ `AudioService.series`, spec 022) |
   | Recherche | `Input` | libre, **débounce 300 ms** (même constante que (re)Écouter) |
 - **Ligne d'état** : `« N enregistrement(s) »` + `Button variant="secondary"
   size="sm"` **Réinitialiser** (visible seulement si un critère ou un tri

--- a/specs/023-audio-production-filtres/plan.md
+++ b/specs/023-audio-production-filtres/plan.md
@@ -1,0 +1,266 @@
+# Plan technique — Filtres et tris multicritères de la file Production audio
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Brouillon
+- **Mis à jour le** : 2026-08-28
+
+> Ce plan traduit la spec en approche technique conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : aucun nouvel import `src/app/` → module. La page
+      serveur charge déjà les données ; tout se fait côté client sur ces props.
+- [x] **Sécurité** : `src/app/(auth)/audio/production/page.tsx` garde son
+      `requireAudioAccess("audio:view", churchId)` ; le `findMany` reste filtré
+      par `churchId`. La feature ne touche ni la requête, ni le garde d'accès.
+- [x] **Permissions** via `rolePermissions` : inchangé (aucun contrôle ajouté).
+- [x] **Validation Zod** : aucune mutation, aucune entrée serveur nouvelle → N/A.
+- [x] **Migration Prisma** : **aucun changement de schéma**.
+- [x] **Enums** depuis `@/generated/prisma/client` : pas de nouvel enum importé ;
+      on réutilise les libellés de statut déjà définis localement dans
+      `AudioQueueClient.tsx` et `EVENT_TYPE_OPTIONS` de `@/lib/event-types`.
+- [x] **UI** : réutilisation de `Input`, `Select`, `Button`, `DataTable` de
+      `src/components/ui/` ; `DataTable` reçoit une extension **rétro-compatible**
+      pour le tri par en-tête (cf. Décisions).
+
+## Approche générale
+
+Tout se passe dans le composant client existant
+`src/app/(auth)/audio/production/AudioQueueClient.tsx`, qui reçoit déjà la liste
+complète des `AudioService` de l'église en props. On y ajoute :
+
+1. un **état de critères** (statut, type, période, recherche texte, orateur) et
+   un **état de tri** (clé + sens) ;
+2. une dérivation `useMemo` : `sortQueue(filterQueue(services, criteres), tri)` ;
+3. des **contrôles de filtre** au-dessus du tableau (composants `ui/`), un
+   **compteur de résultats**, un bouton **Réinitialiser** ;
+4. des **en-têtes cliquables** sur `DataTable` pour les colonnes triables.
+
+La logique pure (filtrage, tri, dérivation de la liste d'orateurs,
+normalisation du texte) est extraite dans un module **sans React**
+`queue-filters.ts`, couvert par Vitest. Le composant ne fait que câbler
+état ↔ helpers ↔ rendu.
+
+**Persistance pendant la navigation** : les critères et le tri sont miroir dans
+une variable de portée module (`let lastState` dans `queue-filters.ts`), lue à
+l'montage et réécrite à chaque changement. Elle survit à une navigation SPA
+(ouvrir un enregistrement puis revenir, création depuis la modale) et est
+perdue au rechargement complet de l'onglet — exactement le comportement spécifié.
+Aucun `sessionStorage`, aucun paramètre d'URL.
+
+## Modèle de données
+
+`[Aucun changement]` — ni schéma, ni migration. Les champs utilisés
+(`serviceDate`, `title`, `speaker`, `type`, `status`, `openCount`,
+`_count.segments`, `planningEvent.title`) sont déjà chargés et passés au client.
+
+## API
+
+`[Aucun endpoint ajouté ou modifié]`. Le filtrage/tri est 100 % client sur les
+données déjà transmises. La page serveur reste inchangée (au plus : rien).
+
+## Services / logique métier
+
+Aucun service de module (`src/modules/audio/`) touché — la file Production
+n'appelle pas le module pour lister, elle lit `prisma.audioService` directement
+dans la page (comportement préexistant, hors périmètre de cette feature).
+
+### Nouveau module pur — `src/app/(auth)/audio/production/queue-filters.ts`
+
+Sans import React. Types et fonctions :
+
+```ts
+export type SortKey = "date" | "status" | "segments" | "opens";
+export type SortDir = "asc" | "desc";
+
+export interface QueueCriteria {
+  status: string;          // "" = tous ; sinon une valeur de statut
+  type: string;            // "" = tous ; sinon EVENT_TYPES
+  year: string;            // "" ou "AAAA" (raccourci de période)
+  from: string;            // "" ou "AAAA-MM-JJ"
+  to: string;              // "" ou "AAAA-MM-JJ"
+  text: string;            // recherche libre (titre + orateur)
+  speaker: string;         // "" = tous ; "__NONE__" = sans orateur ; sinon nom exact
+}
+
+export const EMPTY_CRITERIA: QueueCriteria;
+export const NO_SPEAKER = "__NONE__";
+export const DEFAULT_SORT: { key: SortKey; dir: SortDir }; // { key: "date", dir: "desc" }
+
+// Ordre de workflow du tri par statut (décision spec)
+export const STATUS_SORT_ORDER: Record<string, number>;
+//  PENDING_REVIEW(0) → READY(1) → DRAFT(2) → PUBLISHED(3) → UNPUBLISHED(4)
+
+export function deriveSpeakers(rows: Row[]): string[];
+//  orateurs non vides, dédoublonnés (casse/accent ignorés pour l'unicité,
+//  1re graphie rencontrée conservée), triés localeCompare("fr").
+
+export function isRangeValid(c: QueueCriteria): boolean;
+//  false si from & to renseignés et from > to → l'appelant affiche le message.
+
+export function filterQueue(rows: Row[], c: QueueCriteria): Row[];
+//  intersection de tous les critères actifs. Range invalide → [].
+
+export function sortQueue(rows: Row[], key: SortKey, dir: SortDir): Row[];
+//  copie triée ; départage systématique par serviceDate décroissante
+//  (ordre stable et prévisible, cf. spec).
+
+// Persistance intra-session (portée module)
+export function loadState(): { criteria: QueueCriteria; sort: {...} } | null;
+export function saveState(s: { criteria: QueueCriteria; sort: {...} }): void;
+```
+
+`Row` = le type de ligne déjà défini dans `AudioQueueClient.tsx`
+(`AudioServiceRow`) ; on le déplace dans `queue-filters.ts` et on l'importe
+depuis le composant pour éviter la duplication.
+
+### Normalisation de la recherche — `src/lib/text.ts` (nouveau, minimal)
+
+```ts
+/** minuscule, accents retirés (NFD), espaces réduits. */
+export function normalizeText(s: string | null | undefined): string;
+```
+
+L'idiome `.normalize("NFD").replace(/[̀-ͯ]/g, "").toLowerCase()` est
+aujourd'hui recopié à la main dans ~10 fichiers (`ReportsClient`,
+`DiscipleshipClient`, `ChurchesClient`…). On crée le helper partagé et on
+l'utilise **ici uniquement** ; la reprise des autres appels est hors périmètre
+(note pour un `chore:` ultérieur).
+
+## UI / composants
+
+### `AudioQueueClient.tsx` (modifié)
+
+- **État** : `const [criteria, setCriteria] = useState<QueueCriteria>(() => loadState()?.criteria ?? EMPTY_CRITERIA)` ; idem pour `sort`. `useEffect` → `saveState({ criteria, sort })` à chaque changement.
+- **Barre de filtres** (au-dessus du tableau), grille responsive calquée sur
+  `LibraryFiltersClient` de l'onglet (re)Écouter (`grid gap-3 grid-cols-1
+  sm:grid-cols-2 lg:grid-cols-5`, bouton « Filtrer (n) » qui déplie sur mobile) :
+  | Contrôle | Composant | Source des options |
+  |---|---|---|
+  | Statut | `Select` | `STATUS_LABELS` (existant, choix unique inchangé) |
+  | Type de rassemblement | `Select` | `EVENT_TYPE_OPTIONS` |
+  | Année | `Select` | années distinctes présentes dans `services` (desc) |
+  | Du / Au | deux `Input type="date"` | — |
+  | Orateur | `Select` | `deriveSpeakers(services)` + option « Sans orateur » |
+  | Recherche | `Input` | libre, **débounce 300 ms** (même constante que (re)Écouter) |
+- **Ligne d'état** : `« N enregistrement(s) »` + `Button variant="secondary"
+  size="sm"` **Réinitialiser** (visible seulement si un critère ou un tri
+  non-défaut est actif) → `setCriteria(EMPTY_CRITERIA); setSort(DEFAULT_SORT)`.
+- **Message vide** : si `!isRangeValid(criteria)` → « La date de fin est
+  antérieure à la date de début. » ; sinon si résultat vide → passe
+  `emptyMessage="Aucun enregistrement ne correspond aux filtres."` à `DataTable`.
+- **Tableau** : `DataTable` reçoit `data={visible}` (déjà filtré+trié) et, pour
+  les colonnes Date / Statut / Séquences / Ouvertures, un `sortKey` +
+  `sort={sort}` + `onSortChange={setSort}` (cf. extension ci-dessous). Le clic
+  sur un en-tête déjà actif inverse `dir` ; sur un autre en-tête bascule la clé
+  avec un sens par défaut (`desc` pour date/opens/segments, `asc` pour status).
+- La modale « Déposer un enregistrement » et le reste sont **inchangés**.
+
+### `src/components/ui/DataTable.tsx` (extension rétro-compatible)
+
+Nouvelles props **optionnelles** — sans elles, comportement identique à
+aujourd'hui :
+
+```ts
+interface Column<T> {
+  header: string;
+  accessor: keyof T | ((row: T) => ReactNode);
+  sortKey?: string;               // rend l'en-tête cliquable
+}
+interface DataTableProps<T> {
+  // …existant…
+  sort?: { key: string; dir: "asc" | "desc" };
+  onSortChange?: (s: { key: string; dir: "asc" | "desc" }) => void;
+}
+```
+
+- En-tête avec `sortKey` : rendu en `<button>` avec indicateur ▲ / ▼ selon
+  `sort`. Clic → `onSortChange`. Accessible (`aria-sort` sur le `<th>`).
+- Le **tri n'est pas exécuté par `DataTable`** : il ne fait que remonter l'état,
+  le parent trie ses données. `DataTable` reste un composant d'affichage.
+- Vue mobile (cartes) : pas d'en-tête de colonne → on ajoute un petit
+  `Select` « Trier par » au-dessus des cartes, alimenté par les mêmes colonnes
+  `sortKey` (libellé = `header`), pour garder la parité mobile (mémoire projet :
+  cohérence mobile systématique).
+- Vérifier que les autres appelants (`admin/*`, etc.) compilent inchangés.
+
+## Décisions & alternatives écartées
+
+- **Choix : filtrage/tri côté client dans le composant existant.**
+  *Pourquoi* : volume borné (quelques centaines de lignes, +1–2/semaine), pas de
+  besoin de partage d'URL sur une file de travail, données déjà toutes chargées.
+  Zéro endpoint, zéro requête supplémentaire.
+- **Choix : logique pure isolée dans `queue-filters.ts`.** *Pourquoi* :
+  testable au Vitest sans rendre de React (norme du repo — on teste les helpers,
+  ex. `report-export.ts`, pas les `*Client.tsx`).
+- **Choix : persistance par variable de portée module.** *Pourquoi* : c'est le
+  seul mécanisme qui survit à la navigation SPA **et** se réinitialise au
+  rechargement complet, comme demandé. `sessionStorage` survivrait au reload ;
+  l'URL rendrait l'état partageable (non voulu ici).
+- **Choix : tri par clic d'en-tête via extension de `DataTable`.**
+  *Pourquoi* : la spec (et la question tranchée avec l'utilisateur) décrit un
+  tri « clic sur l'en-tête de colonne ». L'extension est rétro-compatible
+  (props optionnelles) et devient réutilisable — première table triable du repo.
+  *Point à arbitrer* : l'onglet voisin (re)Écouter utilise un simple `Select`
+  « Trier par ». Si l'on préfère la cohérence stricte avec lui et un footprint
+  nul sur `DataTable`, basculer sur un `Select` « Trier par » dans
+  `AudioQueueClient` (les helpers `sortQueue` sont identiques). À confirmer à
+  l'étape `/tasks`.
+- **Écarté : réutiliser `listPublishedServices` / `listSpeakers` du module
+  audio (comme (re)Écouter).** *Raison* : ces helpers ne renvoient que les
+  cultes **publiés** ; la file Production doit montrer tous les statuts
+  (Brouillon, À nommer, Rendu en cours, Dépublié). La page garde donc son
+  `prisma.audioService.findMany` actuel.
+- **Écarté : pagination / chargement incrémental.** *Raison* : hors périmètre
+  spec, volume ne le justifie pas.
+
+## Risques & points d'attention
+
+- **Extension d'un composant `ui/` partagé** : `DataTable` est utilisé par
+  plusieurs écrans admin. Mitigation : toutes les nouvelles props optionnelles,
+  aucun changement de comportement sans `sortKey`/`onSortChange` ;
+  `npm run typecheck` + revue rapide des autres appelants.
+- **Cohérence mobile** : `DataTable` a une vue cartes distincte sans en-têtes →
+  prévoir le `Select` « Trier par » mobile dès l'implémentation, pas après.
+- **Valeurs de `type`** : la file peut contenir des `type` hors
+  `EVENT_TYPES` (données anciennes) ; `getEventTypeLabel` retombe déjà sur la
+  valeur brute. Le `Select` type liste `EVENT_TYPE_OPTIONS` — un enregistrement
+  au type exotique ne sera pas filtrable par ce `Select` mais reste visible sans
+  filtre. Acceptable (aucun cas connu après migration : `CULTE` / `AUTRE`).
+- **Liste d'années vide** si l'église n'a aucun enregistrement → masquer le
+  `Select` Année (ou option unique désactivée). Détail d'implémentation.
+- **Débounce recherche** : réutiliser la constante 300 ms et le pattern
+  `useRef<setTimeout>` de `LibraryFiltersClient` pour rester homogène.
+- **`normalizeText` sur `null`** : signature `string | null | undefined` →
+  `""`. Les lignes sans titre ni orateur ne matchent jamais une recherche non
+  vide, matchent toujours une recherche vide (critère spec).
+
+## Stratégie de tests
+
+**Vitest** — nouveau `src/app/(auth)/audio/production/queue-filters.test.ts` et
+`src/lib/__tests__/text.test.ts`.
+
+- `normalizeText` : accents, casse, `null`/`undefined`, espaces multiples.
+- `deriveSpeakers` : dédoublonnage insensible casse/accent, tri fr, exclusion
+  des vides/espaces, aucune valeur d'une autre église (les `rows` sont déjà
+  scoping église — on teste juste la pureté sur un échantillon).
+- `filterQueue` :
+  - chaque critère isolé (statut, type, année, plage du/au, texte, orateur) ;
+  - **combinaison** de 3+ critères → intersection ;
+  - `text` insensible casse/accents, sur titre **et** orateur, robatuste au
+    `null` ;
+  - orateur = `NO_SPEAKER` → uniquement les lignes sans orateur ;
+  - `from > to` → `[]` et `isRangeValid` → `false` ;
+  - année + plage combinées.
+- `sortQueue` : les 4 clés × 2 sens ; départage par date décroissante à valeur
+  égale ; `STATUS_SORT_ORDER` respecté (PENDING_REVIEW en tête, UNPUBLISHED en
+  fin).
+- `loadState` / `saveState` : aller-retour, `loadState` initial → `null`.
+
+Pas de test de rendu React (conforme à la pratique du repo). Vérif manuelle
+recette : dépliage mobile, `aria-sort`, bouton Réinitialiser, compteur.
+
+## Vérification finale (avant PR)
+
+`npm run typecheck && npm run lint && npm run lint:boundaries && npm run test`
+puis relecture des critères d'acceptation de `spec.md` un par un.

--- a/specs/023-audio-production-filtres/spec.md
+++ b/specs/023-audio-production-filtres/spec.md
@@ -68,6 +68,9 @@ l'onglet Production, ne sont pas concernés.
 - **Orateur** — liste déroulante des orateurs présents dans la file, plus une
   option **« Sans orateur »** qui isole les enregistrements sans orateur
   renseigné (cas fréquent des cultes 2024 migrés).
+- **Série** — liste déroulante des séries présentes dans la file (champ série
+  repris à l'import Audiobookshelf, cf. spec 022), plus une option
+  **« Sans série »** pour les enregistrements hors série.
 
 ### Tris proposés (clic sur l'en-tête de colonne, bascule croissant / décroissant)
 
@@ -104,7 +107,7 @@ précédent.
 - [x] À l'ouverture, la file est identique à aujourd'hui : tout l'historique,
       trié par date de service décroissante, aucun filtre actif hormis un
       éventuel filtre mémorisé de la session.
-- [x] Les cinq filtres (statut, type, période, recherche texte, orateur)
+- [x] Les six filtres (statut, type, période, recherche texte, orateur, série)
       peuvent être actifs simultanément ; le résultat est l'intersection.
 - [x] Le filtre de période permet de sélectionner une année entière **ou** une
       plage début/fin ; seuls les enregistrements dont la date de service est
@@ -113,6 +116,8 @@ précédent.
       et aux accents, sans erreur sur les enregistrements sans titre/orateur.
 - [x] Le filtre orateur propose « Sans orateur » et cette option n'affiche que
       les enregistrements sans orateur renseigné.
+- [x] Le filtre série liste les séries présentes et propose « Sans série » ;
+      chaque option n'affiche que les enregistrements correspondants.
 - [x] Cliquer sur les en-têtes Date, Statut, Séquences, Ouvertures réordonne la
       file selon cette colonne ; un second clic inverse le sens.
 - [x] Le tri par statut place les statuts « à traiter » (À nommer, Rendu en

--- a/specs/023-audio-production-filtres/spec.md
+++ b/specs/023-audio-production-filtres/spec.md
@@ -1,0 +1,151 @@
+# Spec — Filtres et tris multicritères de la file Production audio
+
+- **Numéro** : 023
+- **Statut** : Implémentée
+- **Créée le** : 2026-08-28
+- **Branche suggérée** : `feat/audio-production-filtres`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+
+## Contexte & problème
+
+L'onglet **Production** du module audio (page « Audio évènements ») présente la
+file de tous les enregistrements de culte de l'église, du plus récent au plus
+ancien. Aujourd'hui elle n'offre qu'**un seul filtre** (le statut) et **aucun
+tri au choix** de l'utilisateur.
+
+La migration des archives Audiobookshelf (spec 022) ajoute d'un coup environ 80
+cultes historiques (2024 → aujourd'hui) à cette file. Sans moyen de filtrer ou
+de trier finement, retrouver un enregistrement précis — pour le nommer, le
+republier, vérifier son découpage — devient laborieux : il faut faire défiler
+une longue liste homogène.
+
+Le besoin : permettre de **restreindre** la file selon plusieurs critères
+combinables et de **réordonner** selon la colonne pertinente, pour que
+l'équipe de captation et le secrétariat travaillent efficacement sur un
+historique volumineux.
+
+## Utilisateurs concernés
+
+Les utilisateurs qui accèdent à l'onglet Production :
+
+- **Super Admin**, **Admin**, **Secrétaire** — accès complet à la file.
+- **Membres du département de captation audio** (STAR de ce département) — accès
+  à la file au titre de leur rattachement, sans rôle dédié.
+
+Tous voient et utilisent les mêmes filtres et tris. La feature ne change aucun
+droit : elle n'ajoute ni ne retire de visibilité, elle aide seulement à
+naviguer dans ce qui est déjà visible. Les autres rôles, qui n'accèdent pas à
+l'onglet Production, ne sont pas concernés.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Un membre de la captation ouvre l'onglet Production. La file s'affiche
+   complète, triée par date de service décroissante (comportement actuel
+   inchangé par défaut).
+2. Il veut retrouver les cultes de 2025 prêchés par un orateur donné. Il
+   choisit l'**année 2025** dans le filtre de période et sélectionne cet
+   **orateur** dans la liste déroulante. La file ne montre plus que les
+   enregistrements correspondant aux deux critères à la fois.
+3. Il clique sur l'en-tête de la colonne **Ouvertures** : la file se réordonne
+   par nombre d'écoutes ouvertes décroissant. Un second clic inverse l'ordre.
+4. Il ouvre un enregistrement pour le traiter, puis revient à la file : ses
+   filtres et son tri sont toujours actifs.
+5. Il efface les filtres d'un seul geste et retrouve la file complète.
+
+### Filtres proposés (tous combinables entre eux — résultat = intersection)
+
+- **Statut** — filtre existant, conservé (Brouillon, À nommer, Rendu en cours,
+  Publié, Dépublié).
+- **Type de rassemblement** — restreint à un type (Culte, Autre, etc.).
+- **Période** — restreint à une plage de dates de service : sélection rapide
+  par **année**, ou saisie d'une **date de début et/ou de fin**.
+- **Recherche texte** — champ libre ; ne conserve que les enregistrements dont
+  le **titre du message** ou le **nom de l'orateur** contient le texte saisi
+  (insensible à la casse et aux accents).
+- **Orateur** — liste déroulante des orateurs présents dans la file, plus une
+  option **« Sans orateur »** qui isole les enregistrements sans orateur
+  renseigné (cas fréquent des cultes 2024 migrés).
+
+### Tris proposés (clic sur l'en-tête de colonne, bascule croissant / décroissant)
+
+- **Date de service** — tri par défaut, décroissant.
+- **Statut** — regroupe les enregistrements par statut, en plaçant en tête ceux
+  qui demandent une action (À nommer, Rendu en cours).
+- **Nombre de séquences** — pour repérer les dépôts vides ou anormaux.
+- **Ouvertures** — par popularité d'écoute.
+
+Un seul critère de tri actif à la fois ; changer de colonne remplace le tri
+précédent.
+
+### Scénarios alternatifs / cas limites
+
+- **Si aucun enregistrement ne correspond** aux filtres, la file affiche un
+  message explicite (« Aucun enregistrement ne correspond aux filtres ») et non
+  une liste vide sans explication.
+- **Si un enregistrement n'a ni titre ni orateur**, la recherche texte ne le
+  fait jamais « planter » : il est simplement absent des résultats d'une
+  recherche non vide, et présent quand la recherche est vide.
+- **Quand la période saisie a une fin antérieure à son début**, le système
+  n'affiche aucun résultat et signale l'incohérence de la plage.
+- **Quand plusieurs enregistrements ont la même valeur** sur le critère de tri
+  (même date, même nombre de séquences…), leur ordre relatif reste stable et
+  prévisible (départage par date de service décroissante).
+- **Quand l'utilisateur applique un filtre puis crée un nouvel enregistrement**
+  depuis cette page, il revient à la file avec ses filtres toujours actifs.
+- **La liste déroulante des orateurs** ne contient que des valeurs réellement
+  présentes dans la file de l'église courante — pas d'orateurs d'autres
+  églises, pas de doublons de casse.
+
+## Critères d'acceptation
+
+- [x] À l'ouverture, la file est identique à aujourd'hui : tout l'historique,
+      trié par date de service décroissante, aucun filtre actif hormis un
+      éventuel filtre mémorisé de la session.
+- [x] Les cinq filtres (statut, type, période, recherche texte, orateur)
+      peuvent être actifs simultanément ; le résultat est l'intersection.
+- [x] Le filtre de période permet de sélectionner une année entière **ou** une
+      plage début/fin ; seuls les enregistrements dont la date de service est
+      dans l'intervalle restent affichés.
+- [x] La recherche texte filtre sur titre **et** orateur, insensible à la casse
+      et aux accents, sans erreur sur les enregistrements sans titre/orateur.
+- [x] Le filtre orateur propose « Sans orateur » et cette option n'affiche que
+      les enregistrements sans orateur renseigné.
+- [x] Cliquer sur les en-têtes Date, Statut, Séquences, Ouvertures réordonne la
+      file selon cette colonne ; un second clic inverse le sens.
+- [x] Le tri par statut place les statuts « à traiter » (À nommer, Rendu en
+      cours) avant les autres.
+- [x] Un bouton / geste unique remet la file à zéro (tous filtres effacés, tri
+      par défaut).
+- [x] Après ouverture d'un enregistrement puis retour à la file, les filtres et
+      le tri de l'utilisateur sont conservés.
+- [x] Quand aucun résultat ne correspond, un message explicite est affiché.
+- [x] Le compteur de résultats visibles est indiqué (« N enregistrements »)
+      pour que l'utilisateur mesure l'effet de ses filtres.
+- [x] Aucune donnée d'une autre église n'apparaît, quel que soit le filtre.
+
+## Hors périmètre
+
+- L'onglet **(re)Écouter** (bibliothèque d'écoute des membres) et sa recherche
+  propre.
+- L'onglet **Paramètres** du module audio.
+- La **pagination** de la file et tout chargement incrémental : le volume
+  attendu reste de quelques centaines de lignes.
+- L'**export** de la file filtrée (CSV ou autre).
+- Toute modification des colonnes affichées, du contenu des enregistrements, ou
+  du parcours de dépôt / nommage / publication.
+- La recherche ou le filtrage dans les écrans d'administration audio
+  (`/admin/...`).
+
+## Questions ouvertes
+
+*Toutes tranchées le 2026-08-28 :*
+
+- **Persistance des filtres** → conservés **pendant la navigation** (retour
+  depuis un détail, création d'un enregistrement) ; **réinitialisés au
+  rechargement complet** de la page. Pas d'état dans l'URL.
+- **Ordre du tri par statut** → **À nommer → Rendu en cours → Brouillon →
+  Publié → Dépublié**.
+- **Filtre statut** → reste un **choix unique** (comportement actuel inchangé).

--- a/specs/023-audio-production-filtres/tasks.md
+++ b/specs/023-audio-production-filtres/tasks.md
@@ -1,0 +1,171 @@
+# Tâches — Filtres et tris multicritères de la file Production audio
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : Implémentée (code + tests OK) ; vérif manuelle recette à faire
+
+> Tâches ordonnées et vérifiables. Cette feature **ne modifie ni le schéma, ni
+> les routes API** : l'ordre naturel devient
+> *helpers purs → composant UI partagé → composant de la file → tests*.
+> Les tâches `[P]` sont parallélisables (fichiers indépendants).
+
+## Prérequis
+
+- [x] Branche créée : `feat/audio-production-filtres` (depuis `main`)
+- [x] **Aucune migration Prisma** — schéma inchangé (vérifier qu'aucune tâche
+      n'en introduit)
+- [x] **Aucun endpoint** ajouté ou modifié (vérifier)
+
+## Tâches
+
+### 1. Données & migration
+
+*Aucune tâche — pas de changement de schéma, pas de nouvelle donnée serveur.
+La page `src/app/(auth)/audio/production/page.tsx` charge déjà tous les champs
+nécessaires (`serviceDate`, `title`, `speaker`, `type`, `status`, `openCount`,
+`_count.segments`, `planningEvent.title`).*
+
+### 2. Logique métier — helpers purs (sans React)
+
+- [x] **T1** [P] — `normalizeText(s: string | null | undefined): string` :
+      minuscule, accents retirés (NFD + `/[̀-ͯ]/g`), espaces réduits.
+      *(fichier : `src/lib/text.ts`)*
+- [x] **T2** — Déplacer le type de ligne `AudioServiceRow` de
+      `AudioQueueClient.tsx` vers `queue-filters.ts` et le ré-exporter ; le
+      composant l'importe désormais de là (pas de duplication).
+      *(fichiers : `src/app/(auth)/audio/production/queue-filters.ts`,
+      `src/app/(auth)/audio/production/AudioQueueClient.tsx`)*
+- [x] **T3** — Constantes et types dans `queue-filters.ts` : `SortKey`
+      (`"date" | "status" | "segments" | "opens"`), `SortDir`, `QueueCriteria`,
+      `EMPTY_CRITERIA`, `NO_SPEAKER = "__NONE__"`,
+      `DEFAULT_SORT = { key: "date", dir: "desc" }`, `STATUS_SORT_ORDER`
+      (`PENDING_REVIEW` 0 → `READY` 1 → `DRAFT` 2 → `PUBLISHED` 3 →
+      `UNPUBLISHED` 4). *(fichier : `queue-filters.ts`)*
+- [x] **T4** — `deriveSpeakers(rows): string[]` : orateurs non vides, trim,
+      dédoublonnage insensible casse/accents (1re graphie conservée), tri
+      `localeCompare("fr")`. *(fichier : `queue-filters.ts`)*
+- [x] **T5** — `isRangeValid(c: QueueCriteria): boolean` : `false` si `from` et
+      `to` renseignés et `from > to`, `true` sinon. *(fichier : `queue-filters.ts`)*
+- [x] **T6** — `filterQueue(rows, c): Row[]` : intersection de tous les critères
+      actifs — `status` (exact), `type` (exact), `year` (année de `serviceDate`),
+      `from`/`to` (bornes incluses sur `serviceDate`), `text`
+      (`normalizeText` sur `title` **et** `speaker`, robuste au `null`),
+      `speaker` (`NO_SPEAKER` → lignes sans orateur ; sinon égalité exacte).
+      Si `!isRangeValid(c)` → `[]`. *(fichier : `queue-filters.ts`)*
+- [x] **T7** — `sortQueue(rows, key, dir): Row[]` : copie triée ; `status` via
+      `STATUS_SORT_ORDER` ; départage systématique par `serviceDate`
+      décroissante à valeur égale. *(fichier : `queue-filters.ts`)*
+- [x] **T8** — Persistance intra-session : `loadState()` /
+      `saveState(state)` sur une variable de portée module (pas de
+      `sessionStorage`, pas d'URL). `loadState()` initial → `null`.
+      *(fichier : `queue-filters.ts`)*
+
+### 3. API
+
+*Aucune tâche.*
+
+### 4. UI
+
+- [x] **T9** — Extension **rétro-compatible** de `DataTable` pour le tri par
+      en-tête : prop de colonne optionnelle `sortKey?: string` (rend l'en-tête
+      en `<button>` avec indicateur ▲/▼ et `aria-sort` sur le `<th>`), props de
+      table optionnelles `sort?: { key; dir }` et `onSortChange?`. `DataTable`
+      **ne trie pas** : il remonte l'état, le parent trie. Sans ces props →
+      comportement strictement identique à aujourd'hui.
+      *(fichier : `src/components/ui/DataTable.tsx`)*
+- [x] **T10** — Parité mobile de `DataTable` : quand des colonnes ont un
+      `sortKey` et que `onSortChange` est fourni, afficher au-dessus de la vue
+      cartes un `Select` « Trier par » (options = `header` des colonnes
+      triables) piloté par le même `sort` / `onSortChange`.
+      *(fichier : `src/components/ui/DataTable.tsx`)*
+- [x] **T11** — Vérifier que les autres appelants de `DataTable`
+      (`src/app/(auth)/admin/**`, etc.) compilent et s'affichent inchangés
+      (aucune prop nouvelle passée). *(vérif : `npm run typecheck` + revue)*
+- [x] **T12** — `AudioQueueClient.tsx` — état : `criteria`
+      (`useState<QueueCriteria>(() => loadState()?.criteria ?? EMPTY_CRITERIA)`)
+      et `sort` (idem `?? DEFAULT_SORT`) ; `useEffect` → `saveState({ criteria,
+      sort })` à chaque changement. Retirer l'ancien `statusFilter` (absorbé par
+      `criteria.status`). *(fichier : `AudioQueueClient.tsx`)*
+- [x] **T13** — `AudioQueueClient.tsx` — barre de filtres responsive au-dessus
+      du tableau (grille calquée sur `LibraryFiltersClient` de (re)Écouter :
+      `grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-5`, bouton
+      « Filtrer (n) » qui déplie sur mobile) :
+      Statut (`Select`, `STATUS_LABELS`, choix unique), Type (`Select`,
+      `EVENT_TYPE_OPTIONS`), Année (`Select`, années distinctes de `services`
+      desc ; masqué si aucune), Du / Au (deux `Input type="date"`), Orateur
+      (`Select`, `deriveSpeakers(services)` + option « Sans orateur »),
+      Recherche (`Input`, **débounce 300 ms** — même constante et pattern
+      `useRef<setTimeout>` que `LibraryFiltersClient`).
+      *(fichier : `AudioQueueClient.tsx`)*
+- [x] **T14** — `AudioQueueClient.tsx` — dérivation
+      `const visible = useMemo(() => sortQueue(filterQueue(services, criteria),
+      sort.key, sort.dir), [services, criteria, sort])` ; passer `visible` à
+      `DataTable` avec `sortKey` sur les colonnes Date / Statut / Séquences /
+      Ouvertures, `sort={sort}` et `onSortChange={setSort}` (clic sur en-tête
+      actif → inverse `dir` ; autre en-tête → nouvelle clé, sens par défaut
+      `desc` sauf `status` → `asc`). *(fichier : `AudioQueueClient.tsx`)*
+- [x] **T15** — `AudioQueueClient.tsx` — ligne d'état : compteur
+      « N enregistrement(s) » + `Button variant="secondary" size="sm"`
+      **Réinitialiser** (visible si un critère est actif ou le tri ≠ défaut) →
+      `setCriteria(EMPTY_CRITERIA); setSort(DEFAULT_SORT)`.
+      *(fichier : `AudioQueueClient.tsx`)*
+- [x] **T16** — `AudioQueueClient.tsx` — messages vides : si
+      `!isRangeValid(criteria)` → « La date de fin est antérieure à la date de
+      début. » ; sinon si `visible.length === 0` →
+      `emptyMessage="Aucun enregistrement ne correspond aux filtres."`.
+      *(fichier : `AudioQueueClient.tsx`)*
+
+### 5. Tests (Vitest)
+
+- [x] **T17** [P] — `src/lib/__tests__/text.test.ts` : `normalizeText` —
+      accents, casse, `null`/`undefined` → `""`, espaces multiples réduits.
+- [x] **T18** [P] — `queue-filters.test.ts` — `deriveSpeakers` : dédoublonnage
+      insensible casse/accents, tri fr, exclusion des vides/espaces.
+- [x] **T19** — `queue-filters.test.ts` — `isRangeValid` + `filterQueue` :
+      chaque critère isolé (statut, type, année, plage du/au bornes incluses,
+      texte sur titre **et** orateur insensible casse/accents et robuste au
+      `null`, orateur exact, `NO_SPEAKER` → sans orateur) ; **combinaison de
+      3+ critères** = intersection ; `from > to` → `[]` ; année + plage
+      combinées.
+- [x] **T20** — `queue-filters.test.ts` — `sortQueue` : 4 clés × 2 sens ;
+      départage par date décroissante à valeur égale ; `STATUS_SORT_ORDER`
+      respecté (`PENDING_REVIEW` en tête, `UNPUBLISHED` en fin).
+- [x] **T21** [P] — `queue-filters.test.ts` — `loadState`/`saveState` :
+      `loadState()` initial → `null` ; aller-retour `saveState` puis `loadState`
+      rend l'état enregistré.
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Critères d'acceptation de `spec.md` revus 1 à 1 (code) ; reste (
+      vérif manuelle recette : dépliage mobile, `aria-sort`, `Select` mobile
+      « Trier par », bouton Réinitialiser, compteur, persistance au retour d'un
+      détail)
+- [x] Statut de `spec.md` → `Implémentée`
+- [ ] PR ouverte vers `main`
+
+## Couverture des critères d'acceptation
+
+| Critère `spec.md` | Tâche(s) |
+|---|---|
+| File initiale identique (historique complet, date desc, filtres session) | T12, T14 |
+| 5 filtres combinables = intersection | T6, T13, T19 |
+| Période : année **ou** plage du/au | T3, T6, T13, T19 |
+| Recherche titre + orateur, insensible casse/accents, robuste `null` | T1, T6, T17, T19 |
+| Filtre orateur + option « Sans orateur » | T4, T6, T13, T19 |
+| Tri par clic d'en-tête Date/Statut/Séquences/Ouvertures + inversion | T7, T9, T14, T20 |
+| Tri statut : « à traiter » en tête | T3, T7, T20 |
+| Remise à zéro en un geste | T15 |
+| Filtres + tri conservés au retour d'un détail | T8, T12, T21 |
+| Message explicite si zéro résultat | T16 |
+| Compteur « N enregistrements » | T15 |
+| Aucune donnée d'une autre église | T6 (données déjà scoping église en amont — page inchangée) |
+| Parité mobile (Select « Trier par ») | T10 |
+
+## Point tranché
+
+Tri par **clic d'en-tête** via extension rétro-compatible de `DataTable`
+(T9–T11) — conforme au plan et à la spec. Repli `Select` « Trier par » non
+retenu ; la parité mobile utilise malgré tout un `Select` (T10).

--- a/specs/023-audio-production-filtres/tasks.md
+++ b/specs/023-audio-production-filtres/tasks.md
@@ -40,16 +40,18 @@ nécessaires (`serviceDate`, `title`, `speaker`, `type`, `status`, `openCount`,
       `DEFAULT_SORT = { key: "date", dir: "desc" }`, `STATUS_SORT_ORDER`
       (`PENDING_REVIEW` 0 → `READY` 1 → `DRAFT` 2 → `PUBLISHED` 3 →
       `UNPUBLISHED` 4). *(fichier : `queue-filters.ts`)*
-- [x] **T4** — `deriveSpeakers(rows): string[]` : orateurs non vides, trim,
-      dédoublonnage insensible casse/accents (1re graphie conservée), tri
-      `localeCompare("fr")`. *(fichier : `queue-filters.ts`)*
+- [x] **T4** — `deriveSpeakers(rows): string[]` (+ `deriveSeries` identique sur
+      `series`) : valeurs non vides, trim, dédoublonnage insensible casse/accents
+      (1re graphie conservée), tri `localeCompare("fr")`.
+      *(fichier : `queue-filters.ts`)*
 - [x] **T5** — `isRangeValid(c: QueueCriteria): boolean` : `false` si `from` et
       `to` renseignés et `from > to`, `true` sinon. *(fichier : `queue-filters.ts`)*
 - [x] **T6** — `filterQueue(rows, c): Row[]` : intersection de tous les critères
       actifs — `status` (exact), `type` (exact), `year` (année de `serviceDate`),
       `from`/`to` (bornes incluses sur `serviceDate`), `text`
       (`normalizeText` sur `title` **et** `speaker`, robuste au `null`),
-      `speaker` (`NO_SPEAKER` → lignes sans orateur ; sinon égalité exacte).
+      `speaker` (`NO_SPEAKER` → lignes sans orateur ; sinon égalité exacte),
+      `series` (`NO_SERIES` → lignes hors série ; sinon égalité exacte).
       Si `!isRangeValid(c)` → `[]`. *(fichier : `queue-filters.ts`)*
 - [x] **T7** — `sortQueue(rows, key, dir): Row[]` : copie triée ; `status` via
       `STATUS_SORT_ORDER` ; départage systématique par `serviceDate`
@@ -92,7 +94,8 @@ nécessaires (`serviceDate`, `title`, `speaker`, `type`, `status`, `openCount`,
       Statut (`Select`, `STATUS_LABELS`, choix unique), Type (`Select`,
       `EVENT_TYPE_OPTIONS`), Année (`Select`, années distinctes de `services`
       desc ; masqué si aucune), Du / Au (deux `Input type="date"`), Orateur
-      (`Select`, `deriveSpeakers(services)` + option « Sans orateur »),
+      (`Select`, `deriveSpeakers(services)` + option « Sans orateur »), Série
+      (`Select`, `deriveSeries(services)` + option « Sans série »),
       Recherche (`Input`, **débounce 300 ms** — même constante et pattern
       `useRef<setTimeout>` que `LibraryFiltersClient`).
       *(fichier : `AudioQueueClient.tsx`)*
@@ -155,6 +158,7 @@ nécessaires (`serviceDate`, `title`, `speaker`, `type`, `status`, `openCount`,
 | Période : année **ou** plage du/au | T3, T6, T13, T19 |
 | Recherche titre + orateur, insensible casse/accents, robuste `null` | T1, T6, T17, T19 |
 | Filtre orateur + option « Sans orateur » | T4, T6, T13, T19 |
+| Filtre série + option « Sans série » (spec 022) | T4, T6, T13, T19 |
 | Tri par clic d'en-tête Date/Statut/Séquences/Ouvertures + inversion | T7, T9, T14, T20 |
 | Tri statut : « à traiter » en tête | T3, T7, T20 |
 | Remise à zéro en un geste | T15 |

--- a/src/app/(auth)/audio/production/AudioQueueClient.tsx
+++ b/src/app/(auth)/audio/production/AudioQueueClient.tsx
@@ -15,7 +15,9 @@ import {
   DEFAULT_SORT,
   EMPTY_CRITERIA,
   NO_SPEAKER,
+  NO_SERIES,
   deriveSpeakers,
+  deriveSeries,
   deriveYears,
   filterQueue,
   hasActiveState,
@@ -189,6 +191,7 @@ export default function AudioQueueClient({ services }: { services: AudioServiceR
   }, [criteria, sort]);
 
   const speakers = useMemo(() => deriveSpeakers(services), [services]);
+  const seriesList = useMemo(() => deriveSeries(services), [services]);
   const years = useMemo(() => deriveYears(services), [services]);
 
   const rangeValid = isRangeValid(criteria);
@@ -266,6 +269,16 @@ export default function AudioQueueClient({ services }: { services: AudioServiceR
             options={[
               { value: NO_SPEAKER, label: "Sans orateur" },
               ...speakers.map((s) => ({ value: s, label: s })),
+            ]}
+          />
+          <Select
+            label="Série"
+            placeholder="Toutes les séries"
+            value={criteria.series}
+            onChange={(e) => setField("series", e.target.value)}
+            options={[
+              { value: NO_SERIES, label: "Sans série" },
+              ...seriesList.map((s) => ({ value: s, label: s })),
             ]}
           />
           <Input

--- a/src/app/(auth)/audio/production/AudioQueueClient.tsx
+++ b/src/app/(auth)/audio/production/AudioQueueClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import DataTable from "@/components/ui/DataTable";
 import Select from "@/components/ui/Select";
@@ -8,18 +8,24 @@ import Input from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
 import Modal from "@/components/ui/Modal";
 import { EVENT_TYPE_OPTIONS, getEventTypeLabel, getEventTypeBadge } from "@/lib/event-types";
+import {
+  type AudioServiceRow,
+  type QueueCriteria,
+  type SortState,
+  DEFAULT_SORT,
+  EMPTY_CRITERIA,
+  NO_SPEAKER,
+  deriveSpeakers,
+  deriveYears,
+  filterQueue,
+  hasActiveState,
+  isRangeValid,
+  loadState,
+  saveState,
+  sortQueue,
+} from "./queue-filters";
 
-interface AudioServiceRow {
-  id: string;
-  title: string | null;
-  speaker: string | null;
-  serviceDate: string;
-  status: "DRAFT" | "PENDING_REVIEW" | "READY" | "PUBLISHED" | "UNPUBLISHED";
-  type: string;
-  openCount: number;
-  segmentCount: number;
-  eventTitle: string | null;
-}
+const SEARCH_DEBOUNCE_MS = 300;
 
 const STATUS_LABELS: Record<AudioServiceRow["status"], string> = {
   DRAFT: "Brouillon",
@@ -153,28 +159,137 @@ function NewServiceModal({ open, onClose }: { open: boolean; onClose: () => void
 
 export default function AudioQueueClient({ services }: { services: AudioServiceRow[] }) {
   const router = useRouter();
-  const [statusFilter, setStatusFilter] = useState("");
   const [modalOpen, setModalOpen] = useState(false);
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
-  const filtered = useMemo(
-    () => (statusFilter ? services.filter((s) => s.status === statusFilter) : services),
-    [services, statusFilter]
+  const [criteria, setCriteria] = useState<QueueCriteria>(
+    () => loadState()?.criteria ?? EMPTY_CRITERIA
   );
+  const [sort, setSort] = useState<SortState>(() => loadState()?.sort ?? DEFAULT_SORT);
+
+  // Champ de recherche local + débounce : on ne recalcule la file qu'après une pause
+  // de frappe (même cadence que l'onglet (re)Écouter).
+  const [searchText, setSearchText] = useState(criteria.text);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (searchText === criteria.text) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(
+      () => setCriteria((c) => ({ ...c, text: searchText })),
+      SEARCH_DEBOUNCE_MS
+    );
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchText, criteria.text]);
+
+  // Persistance intra-session (perdue au rechargement complet, cf. spec 023).
+  useEffect(() => {
+    saveState({ criteria, sort });
+  }, [criteria, sort]);
+
+  const speakers = useMemo(() => deriveSpeakers(services), [services]);
+  const years = useMemo(() => deriveYears(services), [services]);
+
+  const rangeValid = isRangeValid(criteria);
+  const visible = useMemo(
+    () => sortQueue(filterQueue(services, criteria), sort.key, sort.dir),
+    [services, criteria, sort]
+  );
+
+  const activeFilterCount = (Object.keys(EMPTY_CRITERIA) as (keyof QueueCriteria)[]).filter(
+    (k) => criteria[k] !== EMPTY_CRITERIA[k]
+  ).length;
+  const showReset = hasActiveState(criteria, sort) || searchText !== "";
+  function reset() {
+    setSearchText("");
+    setCriteria(EMPTY_CRITERIA);
+    setSort(DEFAULT_SORT);
+  }
+
+  function setField<K extends keyof QueueCriteria>(key: K, value: QueueCriteria[K]) {
+    setCriteria((c) => ({ ...c, [key]: value }));
+  }
 
   return (
     <div>
       <div className="flex flex-wrap items-end justify-between gap-3 mb-4">
-        <div className="w-full max-w-xs">
+        <div className="w-full md:flex-1">
+          <div className="md:hidden mb-2">
+            <Button variant="secondary" size="sm" onClick={() => setMobileFiltersOpen((o) => !o)}>
+              Filtrer{activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
+            </Button>
+          </div>
+          <div
+            className={`${mobileFiltersOpen ? "grid" : "hidden"} md:grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6`}
+          >
           <Select
             label="Statut"
             placeholder="Tous les statuts"
-            value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value)}
+            value={criteria.status}
+            onChange={(e) => setField("status", e.target.value)}
             options={Object.entries(STATUS_LABELS).map(([value, label]) => ({ value, label }))}
           />
+          <Select
+            label="Type"
+            placeholder="Tous les types"
+            value={criteria.type}
+            onChange={(e) => setField("type", e.target.value)}
+            options={EVENT_TYPE_OPTIONS}
+          />
+          {years.length > 0 && (
+            <Select
+              label="Année"
+              placeholder="Toutes les années"
+              value={criteria.year}
+              onChange={(e) => setField("year", e.target.value)}
+              options={years.map((y) => ({ value: y, label: y }))}
+            />
+          )}
+          <Input
+            label="Du"
+            type="date"
+            value={criteria.from}
+            onChange={(e) => setField("from", e.target.value)}
+          />
+          <Input
+            label="Au"
+            type="date"
+            value={criteria.to}
+            onChange={(e) => setField("to", e.target.value)}
+          />
+          <Select
+            label="Orateur"
+            placeholder="Tous les orateurs"
+            value={criteria.speaker}
+            onChange={(e) => setField("speaker", e.target.value)}
+            options={[
+              { value: NO_SPEAKER, label: "Sans orateur" },
+              ...speakers.map((s) => ({ value: s, label: s })),
+            ]}
+          />
+          <Input
+            label="Recherche"
+            placeholder="Titre ou orateur…"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+          />
+          </div>
         </div>
         <Button onClick={() => setModalOpen(true)}>Déposer un enregistrement</Button>
       </div>
+
+      <div className="flex flex-wrap items-center gap-3 mb-3 text-sm text-gray-500">
+        <span>
+          {visible.length} enregistrement{visible.length > 1 ? "s" : ""}
+        </span>
+        {showReset && (
+          <Button variant="secondary" size="sm" onClick={reset}>
+            Réinitialiser
+          </Button>
+        )}
+      </div>
+
       <NewServiceModal open={modalOpen} onClose={() => setModalOpen(false)} />
 
       <DataTable
@@ -190,7 +305,11 @@ export default function AudioQueueClient({ services }: { services: AudioServiceR
               </div>
             ),
           },
-          { header: "Date", accessor: (row) => new Date(row.serviceDate).toLocaleDateString("fr-FR") },
+          {
+            header: "Date",
+            accessor: (row) => new Date(row.serviceDate).toLocaleDateString("fr-FR"),
+            sortKey: "date",
+          },
           {
             header: "Type",
             accessor: (row) => (
@@ -206,12 +325,20 @@ export default function AudioQueueClient({ services }: { services: AudioServiceR
                 {STATUS_LABELS[row.status]}
               </span>
             ),
+            sortKey: "status",
+            defaultSortDir: "asc",
           },
-          { header: "Séquences", accessor: (row) => row.segmentCount },
-          { header: "Ouvertures", accessor: (row) => row.openCount },
+          { header: "Séquences", accessor: (row) => row.segmentCount, sortKey: "segments" },
+          { header: "Ouvertures", accessor: (row) => row.openCount, sortKey: "opens" },
         ]}
-        data={filtered}
-        emptyMessage="Aucun enregistrement audio."
+        data={visible}
+        sort={sort}
+        onSortChange={(s) => setSort({ key: s.key as SortState["key"], dir: s.dir })}
+        emptyMessage={
+          rangeValid
+            ? "Aucun enregistrement ne correspond aux filtres."
+            : "La date de fin est antérieure à la date de début."
+        }
         actions={(row) => (
           <Button variant="secondary" size="sm" onClick={() => router.push(`/audio/production/${row.id}`)}>
             Ouvrir

--- a/src/app/(auth)/audio/production/page.tsx
+++ b/src/app/(auth)/audio/production/page.tsx
@@ -25,6 +25,7 @@ export default async function AudioQueuePage() {
           id: s.id,
           title: s.title,
           speaker: s.speaker,
+          series: s.series,
           serviceDate: s.serviceDate.toISOString(),
           status: s.status,
           type: s.type,

--- a/src/app/(auth)/audio/production/queue-filters.test.ts
+++ b/src/app/(auth)/audio/production/queue-filters.test.ts
@@ -5,9 +5,11 @@ import {
   DEFAULT_SORT,
   EMPTY_CRITERIA,
   NO_SPEAKER,
+  NO_SERIES,
   STATUS_SORT_ORDER,
   __resetState,
   deriveSpeakers,
+  deriveSeries,
   deriveYears,
   filterQueue,
   hasActiveState,
@@ -22,6 +24,7 @@ function row(over: Partial<AudioServiceRow>): AudioServiceRow {
     id: Math.random().toString(36).slice(2),
     title: "Culte",
     speaker: null,
+    series: null,
     serviceDate: "2025-06-01T08:00:00.000Z",
     status: "PUBLISHED",
     type: "CULTE",
@@ -45,6 +48,19 @@ describe("deriveSpeakers", () => {
       row({ speaker: "Bruno" }),
     ];
     expect(deriveSpeakers(rows)).toEqual(["Armelle", "Bruno", "Pasteur Éric"]);
+  });
+});
+
+describe("deriveSeries", () => {
+  it("dédoublonne sur casse/accents, ignore les vides, trie fr", () => {
+    const rows = [
+      row({ series: "Identité" }),
+      row({ series: "identite" }),
+      row({ series: "  Alliance  " }),
+      row({ series: "" }),
+      row({ series: null }),
+    ];
+    expect(deriveSeries(rows)).toEqual(["Alliance", "Identité"]);
   });
 });
 
@@ -72,8 +88,8 @@ describe("isRangeValid", () => {
 describe("filterQueue", () => {
   const rows = [
     row({ id: "a", status: "PENDING_REVIEW", type: "CULTE", serviceDate: "2024-03-10T09:00:00.000Z", speaker: null, title: "Culte" }),
-    row({ id: "b", status: "PUBLISHED", type: "CULTE", serviceDate: "2025-02-09T09:00:00.000Z", speaker: "Pasteure Armelle", title: "Qui es-tu ?" }),
-    row({ id: "c", status: "PUBLISHED", type: "AUTRE", serviceDate: "2025-02-16T09:00:00.000Z", speaker: "Bruno", title: "Cérémonie des baptêmes" }),
+    row({ id: "b", status: "PUBLISHED", type: "CULTE", serviceDate: "2025-02-09T09:00:00.000Z", speaker: "Pasteure Armelle", title: "Qui es-tu ?", series: "Identité" }),
+    row({ id: "c", status: "PUBLISHED", type: "AUTRE", serviceDate: "2025-02-16T09:00:00.000Z", speaker: "Bruno", title: "Cérémonie des baptêmes", series: "Identité" }),
     row({ id: "d", status: "READY", type: "CULTE", serviceDate: "2025-11-30T09:00:00.000Z", speaker: "  ", title: null }),
   ];
   const ids = (c: QueueCriteria) => filterQueue(rows, c).map((r) => r.id).sort();
@@ -113,6 +129,12 @@ describe("filterQueue", () => {
   });
   it("orateur = Sans orateur → lignes sans orateur (null ou espaces)", () => {
     expect(ids(crit({ speaker: NO_SPEAKER }))).toEqual(["a", "d"]);
+  });
+  it("série exacte", () => {
+    expect(ids(crit({ series: "Identité" }))).toEqual(["b", "c"]);
+  });
+  it("série = Sans série → lignes hors série", () => {
+    expect(ids(crit({ series: NO_SERIES }))).toEqual(["a", "d"]);
   });
   it("combinaison de 3+ critères = intersection", () => {
     expect(ids(crit({ status: "PUBLISHED", type: "CULTE", year: "2025", text: "es-tu" }))).toEqual(["b"]);

--- a/src/app/(auth)/audio/production/queue-filters.test.ts
+++ b/src/app/(auth)/audio/production/queue-filters.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  type AudioServiceRow,
+  type QueueCriteria,
+  DEFAULT_SORT,
+  EMPTY_CRITERIA,
+  NO_SPEAKER,
+  STATUS_SORT_ORDER,
+  __resetState,
+  deriveSpeakers,
+  deriveYears,
+  filterQueue,
+  hasActiveState,
+  isRangeValid,
+  loadState,
+  saveState,
+  sortQueue,
+} from "./queue-filters";
+
+function row(over: Partial<AudioServiceRow>): AudioServiceRow {
+  return {
+    id: Math.random().toString(36).slice(2),
+    title: "Culte",
+    speaker: null,
+    serviceDate: "2025-06-01T08:00:00.000Z",
+    status: "PUBLISHED",
+    type: "CULTE",
+    openCount: 0,
+    segmentCount: 4,
+    eventTitle: null,
+    ...over,
+  };
+}
+
+const crit = (over: Partial<QueueCriteria> = {}): QueueCriteria => ({ ...EMPTY_CRITERIA, ...over });
+
+describe("deriveSpeakers", () => {
+  it("dédoublonne (casse/accents ignorés), trie fr, exclut les vides", () => {
+    const rows = [
+      row({ speaker: "Pasteur Éric" }),
+      row({ speaker: "pasteur eric" }),
+      row({ speaker: "  Armelle  " }),
+      row({ speaker: "" }),
+      row({ speaker: null }),
+      row({ speaker: "Bruno" }),
+    ];
+    expect(deriveSpeakers(rows)).toEqual(["Armelle", "Bruno", "Pasteur Éric"]);
+  });
+});
+
+describe("deriveYears", () => {
+  it("années distinctes, décroissantes", () => {
+    const rows = [
+      row({ serviceDate: "2024-01-07T09:00:00.000Z" }),
+      row({ serviceDate: "2025-12-25T09:00:00.000Z" }),
+      row({ serviceDate: "2025-01-05T09:00:00.000Z" }),
+    ];
+    expect(deriveYears(rows)).toEqual(["2025", "2024"]);
+  });
+});
+
+describe("isRangeValid", () => {
+  it("valide sauf si from > to (les deux renseignés)", () => {
+    expect(isRangeValid(crit())).toBe(true);
+    expect(isRangeValid(crit({ from: "2025-01-01" }))).toBe(true);
+    expect(isRangeValid(crit({ to: "2025-01-01" }))).toBe(true);
+    expect(isRangeValid(crit({ from: "2025-01-01", to: "2025-06-01" }))).toBe(true);
+    expect(isRangeValid(crit({ from: "2025-06-02", to: "2025-06-01" }))).toBe(false);
+  });
+});
+
+describe("filterQueue", () => {
+  const rows = [
+    row({ id: "a", status: "PENDING_REVIEW", type: "CULTE", serviceDate: "2024-03-10T09:00:00.000Z", speaker: null, title: "Culte" }),
+    row({ id: "b", status: "PUBLISHED", type: "CULTE", serviceDate: "2025-02-09T09:00:00.000Z", speaker: "Pasteure Armelle", title: "Qui es-tu ?" }),
+    row({ id: "c", status: "PUBLISHED", type: "AUTRE", serviceDate: "2025-02-16T09:00:00.000Z", speaker: "Bruno", title: "Cérémonie des baptêmes" }),
+    row({ id: "d", status: "READY", type: "CULTE", serviceDate: "2025-11-30T09:00:00.000Z", speaker: "  ", title: null }),
+  ];
+  const ids = (c: QueueCriteria) => filterQueue(rows, c).map((r) => r.id).sort();
+
+  it("aucun critère → tout", () => {
+    expect(ids(crit())).toEqual(["a", "b", "c", "d"]);
+  });
+  it("statut", () => {
+    expect(ids(crit({ status: "PUBLISHED" }))).toEqual(["b", "c"]);
+  });
+  it("type", () => {
+    expect(ids(crit({ type: "AUTRE" }))).toEqual(["c"]);
+  });
+  it("année", () => {
+    expect(ids(crit({ year: "2024" }))).toEqual(["a"]);
+  });
+  it("plage du/au, bornes incluses", () => {
+    expect(ids(crit({ from: "2025-02-09", to: "2025-02-16" }))).toEqual(["b", "c"]);
+  });
+  it("plage from > to → aucun résultat", () => {
+    expect(filterQueue(rows, crit({ from: "2025-12-01", to: "2025-01-01" }))).toEqual([]);
+  });
+  it("année + plage combinées", () => {
+    expect(ids(crit({ year: "2025", from: "2025-11-01", to: "2025-12-31" }))).toEqual(["d"]);
+  });
+  it("recherche texte sur titre et orateur, insensible casse/accents", () => {
+    expect(ids(crit({ text: "es-TU" }))).toEqual(["b"]); // titre « Qui es-tu ? »
+    expect(ids(crit({ text: "ARMELLE" }))).toEqual(["b"]); // orateur
+    expect(ids(crit({ text: "céré" }))).toEqual(["c"]); // accents ignorés
+  });
+  it("recherche texte robuste aux titres/orateurs nuls", () => {
+    expect(() => filterQueue(rows, crit({ text: "x" }))).not.toThrow();
+    expect(ids(crit({ text: "" }))).toEqual(["a", "b", "c", "d"]);
+  });
+  it("orateur exact", () => {
+    expect(ids(crit({ speaker: "Bruno" }))).toEqual(["c"]);
+  });
+  it("orateur = Sans orateur → lignes sans orateur (null ou espaces)", () => {
+    expect(ids(crit({ speaker: NO_SPEAKER }))).toEqual(["a", "d"]);
+  });
+  it("combinaison de 3+ critères = intersection", () => {
+    expect(ids(crit({ status: "PUBLISHED", type: "CULTE", year: "2025", text: "es-tu" }))).toEqual(["b"]);
+  });
+});
+
+describe("sortQueue", () => {
+  const rows = [
+    row({ id: "old", serviceDate: "2024-01-01T09:00:00.000Z", status: "PUBLISHED", segmentCount: 2, openCount: 50 }),
+    row({ id: "mid", serviceDate: "2025-06-01T09:00:00.000Z", status: "PENDING_REVIEW", segmentCount: 8, openCount: 5 }),
+    row({ id: "new", serviceDate: "2025-12-01T09:00:00.000Z", status: "UNPUBLISHED", segmentCount: 5, openCount: 20 }),
+  ];
+
+  it("date desc / asc", () => {
+    expect(sortQueue(rows, "date", "desc").map((r) => r.id)).toEqual(["new", "mid", "old"]);
+    expect(sortQueue(rows, "date", "asc").map((r) => r.id)).toEqual(["old", "mid", "new"]);
+  });
+  it("séquences et ouvertures", () => {
+    expect(sortQueue(rows, "segments", "asc").map((r) => r.id)).toEqual(["old", "new", "mid"]);
+    expect(sortQueue(rows, "opens", "desc").map((r) => r.id)).toEqual(["old", "new", "mid"]);
+  });
+  it("statut asc : PENDING_REVIEW en tête, UNPUBLISHED en fin", () => {
+    expect(sortQueue(rows, "status", "asc").map((r) => r.id)).toEqual(["mid", "old", "new"]);
+    expect(sortQueue(rows, "status", "desc").map((r) => r.id)).toEqual(["new", "old", "mid"]);
+  });
+  it("départage par date décroissante à valeur égale", () => {
+    const tie = [
+      row({ id: "t1", serviceDate: "2025-01-01T09:00:00.000Z", segmentCount: 4 }),
+      row({ id: "t2", serviceDate: "2025-09-09T09:00:00.000Z", segmentCount: 4 }),
+      row({ id: "t3", serviceDate: "2025-05-05T09:00:00.000Z", segmentCount: 4 }),
+    ];
+    expect(sortQueue(tie, "segments", "asc").map((r) => r.id)).toEqual(["t2", "t3", "t1"]);
+    expect(sortQueue(tie, "segments", "desc").map((r) => r.id)).toEqual(["t2", "t3", "t1"]);
+  });
+  it("ne mute pas le tableau source", () => {
+    const src = [...rows];
+    sortQueue(src, "date", "asc");
+    expect(src.map((r) => r.id)).toEqual(["old", "mid", "new"]);
+  });
+  it("STATUS_SORT_ORDER couvre les 5 statuts dans l'ordre voulu", () => {
+    expect(STATUS_SORT_ORDER).toEqual({
+      PENDING_REVIEW: 0,
+      READY: 1,
+      DRAFT: 2,
+      PUBLISHED: 3,
+      UNPUBLISHED: 4,
+    });
+  });
+});
+
+describe("persistance intra-session", () => {
+  beforeEach(() => __resetState());
+
+  it("loadState initial → null", () => {
+    expect(loadState()).toBeNull();
+  });
+  it("aller-retour saveState / loadState (copie défensive)", () => {
+    const criteria = crit({ status: "READY", text: "abc" });
+    const sort = { key: "opens" as const, dir: "asc" as const };
+    saveState({ criteria, sort });
+    const loaded = loadState();
+    expect(loaded).toEqual({ criteria, sort });
+    criteria.status = "DRAFT";
+    expect(loadState()?.criteria.status).toBe("READY");
+  });
+});
+
+describe("hasActiveState", () => {
+  it("faux si critères vides et tri par défaut", () => {
+    expect(hasActiveState(EMPTY_CRITERIA, DEFAULT_SORT)).toBe(false);
+  });
+  it("vrai si un critère est posé", () => {
+    expect(hasActiveState(crit({ type: "CULTE" }), DEFAULT_SORT)).toBe(true);
+  });
+  it("vrai si le tri diffère du défaut", () => {
+    expect(hasActiveState(EMPTY_CRITERIA, { key: "opens", dir: "desc" })).toBe(true);
+    expect(hasActiveState(EMPTY_CRITERIA, { key: "date", dir: "asc" })).toBe(true);
+  });
+});

--- a/src/app/(auth)/audio/production/queue-filters.ts
+++ b/src/app/(auth)/audio/production/queue-filters.ts
@@ -1,0 +1,204 @@
+/**
+ * Filtrage, tri et persistance intra-session de la file Production audio (spec 023).
+ *
+ * Fonctions pures (sans React) : `AudioQueueClient` ne fait que câbler l'état de
+ * l'utilisateur à ces helpers puis afficher le résultat. Couvert par
+ * `queue-filters.test.ts`.
+ */
+
+import { normalizeText } from "@/lib/text";
+
+export type AudioServiceStatus =
+  | "DRAFT"
+  | "PENDING_REVIEW"
+  | "READY"
+  | "PUBLISHED"
+  | "UNPUBLISHED";
+
+/** Une ligne de la file, telle que fournie par `page.tsx`. */
+export interface AudioServiceRow {
+  id: string;
+  title: string | null;
+  speaker: string | null;
+  serviceDate: string; // ISO
+  status: AudioServiceStatus;
+  type: string;
+  openCount: number;
+  segmentCount: number;
+  eventTitle: string | null;
+}
+
+export type SortKey = "date" | "status" | "segments" | "opens";
+export type SortDir = "asc" | "desc";
+export interface SortState {
+  key: SortKey;
+  dir: SortDir;
+}
+
+export interface QueueCriteria {
+  status: string; // "" = tous, sinon un AudioServiceStatus
+  type: string; // "" = tous, sinon une valeur de type
+  year: string; // "" ou "AAAA"
+  from: string; // "" ou "AAAA-MM-JJ"
+  to: string; // "" ou "AAAA-MM-JJ"
+  text: string; // recherche libre (titre + orateur)
+  speaker: string; // "" = tous, NO_SPEAKER = sans orateur, sinon nom exact
+}
+
+/** Valeur du filtre orateur isolant les enregistrements sans orateur renseigné. */
+export const NO_SPEAKER = "__NONE__";
+
+export const EMPTY_CRITERIA: QueueCriteria = {
+  status: "",
+  type: "",
+  year: "",
+  from: "",
+  to: "",
+  text: "",
+  speaker: "",
+};
+
+export const DEFAULT_SORT: SortState = { key: "date", dir: "desc" };
+
+/**
+ * Ordre du tri par statut (décision spec) : ce qui demande une action d'abord,
+ * ce qui est terminé ensuite.
+ */
+export const STATUS_SORT_ORDER: Record<AudioServiceStatus, number> = {
+  PENDING_REVIEW: 0,
+  READY: 1,
+  DRAFT: 2,
+  PUBLISHED: 3,
+  UNPUBLISHED: 4,
+};
+
+/** `true` si des critères ou un tri non-défaut sont actifs (bouton Réinitialiser). */
+export function hasActiveState(criteria: QueueCriteria, sort: SortState): boolean {
+  const filtersActive = (Object.keys(EMPTY_CRITERIA) as (keyof QueueCriteria)[]).some(
+    (k) => criteria[k] !== EMPTY_CRITERIA[k]
+  );
+  const sortActive = sort.key !== DEFAULT_SORT.key || sort.dir !== DEFAULT_SORT.dir;
+  return filtersActive || sortActive;
+}
+
+/**
+ * Orateurs présents dans la file : non vides, dédoublonnés (casse/accents ignorés
+ * pour l'unicité, première graphie conservée), triés `fr`.
+ */
+export function deriveSpeakers(rows: AudioServiceRow[]): string[] {
+  const seen = new Map<string, string>();
+  for (const row of rows) {
+    const raw = row.speaker?.trim();
+    if (!raw) continue;
+    const key = normalizeText(raw);
+    if (!seen.has(key)) seen.set(key, raw);
+  }
+  return [...seen.values()].sort((a, b) => a.localeCompare(b, "fr"));
+}
+
+/** Années distinctes présentes dans la file, décroissantes. */
+export function deriveYears(rows: AudioServiceRow[]): string[] {
+  const years = new Set<string>();
+  for (const row of rows) {
+    const y = row.serviceDate.slice(0, 4);
+    if (/^\d{4}$/.test(y)) years.add(y);
+  }
+  return [...years].sort((a, b) => b.localeCompare(a));
+}
+
+/** `false` si `from` et `to` sont tous deux renseignés et `from > to`. */
+export function isRangeValid(c: QueueCriteria): boolean {
+  if (!c.from || !c.to) return true;
+  return c.from <= c.to;
+}
+
+function matchesText(row: AudioServiceRow, text: string): boolean {
+  const needle = normalizeText(text);
+  if (!needle) return true;
+  return (
+    normalizeText(row.title).includes(needle) || normalizeText(row.speaker).includes(needle)
+  );
+}
+
+/** Intersection de tous les critères actifs. Plage incohérente → `[]`. */
+export function filterQueue(rows: AudioServiceRow[], c: QueueCriteria): AudioServiceRow[] {
+  if (!isRangeValid(c)) return [];
+  return rows.filter((row) => {
+    if (c.status && row.status !== c.status) return false;
+    if (c.type && row.type !== c.type) return false;
+
+    const day = row.serviceDate.slice(0, 10); // AAAA-MM-JJ
+    if (c.year && day.slice(0, 4) !== c.year) return false;
+    if (c.from && day < c.from) return false;
+    if (c.to && day > c.to) return false;
+
+    if (c.speaker === NO_SPEAKER) {
+      if (row.speaker && row.speaker.trim()) return false;
+    } else if (c.speaker && row.speaker !== c.speaker) {
+      return false;
+    }
+
+    if (!matchesText(row, c.text)) return false;
+    return true;
+  });
+}
+
+function sortValue(row: AudioServiceRow, key: SortKey): number | string {
+  switch (key) {
+    case "date":
+      return row.serviceDate;
+    case "status":
+      return STATUS_SORT_ORDER[row.status] ?? 99;
+    case "segments":
+      return row.segmentCount;
+    case "opens":
+      return row.openCount;
+  }
+}
+
+/**
+ * Copie triée. Départage systématique par date de service décroissante à valeur
+ * égale (ordre stable et prévisible, cf. spec).
+ */
+export function sortQueue(
+  rows: AudioServiceRow[],
+  key: SortKey,
+  dir: SortDir
+): AudioServiceRow[] {
+  const factor = dir === "asc" ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const va = sortValue(a, key);
+    const vb = sortValue(b, key);
+    if (va < vb) return -1 * factor;
+    if (va > vb) return 1 * factor;
+    // tie-break : date de service décroissante
+    if (a.serviceDate < b.serviceDate) return 1;
+    if (a.serviceDate > b.serviceDate) return -1;
+    return 0;
+  });
+}
+
+// ─── Persistance intra-session ──────────────────────────────────────────────
+// Variable de portée module : survit à une navigation SPA (ouvrir un
+// enregistrement puis revenir, création depuis la modale), perdue au
+// rechargement complet de l'onglet. Pas de sessionStorage, pas d'URL.
+
+export interface QueueViewState {
+  criteria: QueueCriteria;
+  sort: SortState;
+}
+
+let lastState: QueueViewState | null = null;
+
+export function loadState(): QueueViewState | null {
+  return lastState;
+}
+
+export function saveState(state: QueueViewState): void {
+  lastState = { criteria: { ...state.criteria }, sort: { ...state.sort } };
+}
+
+/** Réservé aux tests — remet la persistance à zéro. */
+export function __resetState(): void {
+  lastState = null;
+}

--- a/src/app/(auth)/audio/production/queue-filters.ts
+++ b/src/app/(auth)/audio/production/queue-filters.ts
@@ -20,6 +20,7 @@ export interface AudioServiceRow {
   id: string;
   title: string | null;
   speaker: string | null;
+  series: string | null;
   serviceDate: string; // ISO
   status: AudioServiceStatus;
   type: string;
@@ -43,10 +44,14 @@ export interface QueueCriteria {
   to: string; // "" ou "AAAA-MM-JJ"
   text: string; // recherche libre (titre + orateur)
   speaker: string; // "" = tous, NO_SPEAKER = sans orateur, sinon nom exact
+  series: string; // "" = toutes, NO_SERIES = sans série, sinon nom exact
 }
 
 /** Valeur du filtre orateur isolant les enregistrements sans orateur renseigné. */
 export const NO_SPEAKER = "__NONE__";
+
+/** Valeur du filtre série isolant les enregistrements hors série. */
+export const NO_SERIES = "__NONE__";
 
 export const EMPTY_CRITERIA: QueueCriteria = {
   status: "",
@@ -56,6 +61,7 @@ export const EMPTY_CRITERIA: QueueCriteria = {
   to: "",
   text: "",
   speaker: "",
+  series: "",
 };
 
 export const DEFAULT_SORT: SortState = { key: "date", dir: "desc" };
@@ -89,6 +95,18 @@ export function deriveSpeakers(rows: AudioServiceRow[]): string[] {
   const seen = new Map<string, string>();
   for (const row of rows) {
     const raw = row.speaker?.trim();
+    if (!raw) continue;
+    const key = normalizeText(raw);
+    if (!seen.has(key)) seen.set(key, raw);
+  }
+  return [...seen.values()].sort((a, b) => a.localeCompare(b, "fr"));
+}
+
+/** Séries distinctes présentes dans la file (dédupliquées sur forme normalisée), triées `fr`. */
+export function deriveSeries(rows: AudioServiceRow[]): string[] {
+  const seen = new Map<string, string>();
+  for (const row of rows) {
+    const raw = row.series?.trim();
     if (!raw) continue;
     const key = normalizeText(raw);
     if (!seen.has(key)) seen.set(key, raw);
@@ -135,6 +153,12 @@ export function filterQueue(rows: AudioServiceRow[], c: QueueCriteria): AudioSer
     if (c.speaker === NO_SPEAKER) {
       if (row.speaker && row.speaker.trim()) return false;
     } else if (c.speaker && row.speaker !== c.speaker) {
+      return false;
+    }
+
+    if (c.series === NO_SERIES) {
+      if (row.series && row.series.trim()) return false;
+    } else if (c.series && row.series !== c.series) {
       return false;
     }
 

--- a/src/components/ui/DataTable.tsx
+++ b/src/components/ui/DataTable.tsx
@@ -5,6 +5,15 @@ import { ReactNode } from "react";
 interface Column<T> {
   header: string;
   accessor: keyof T | ((row: T) => ReactNode);
+  /** Rend l'en-tête cliquable pour trier sur cette colonne (avec `sort` + `onSortChange`). */
+  sortKey?: string;
+  /** Sens appliqué au premier clic sur cet en-tête (défaut : `"desc"`). */
+  defaultSortDir?: "asc" | "desc";
+}
+
+export interface DataTableSort {
+  key: string;
+  dir: "asc" | "desc";
 }
 
 interface DataTableProps<T> {
@@ -17,6 +26,12 @@ interface DataTableProps<T> {
   onSelectionChange?: (ids: Set<string>) => void;
   /** Id de ligne à mettre en évidence visuellement (ex. arrivée depuis un lien externe). */
   highlightedId?: string;
+  /**
+   * Tri actif. `DataTable` ne trie pas les données lui-même : il affiche l'état
+   * et remonte les changements via `onSortChange` — le parent trie ses données.
+   */
+  sort?: DataTableSort;
+  onSortChange?: (sort: DataTableSort) => void;
 }
 
 function getCellValue<T>(row: T, accessor: Column<T>["accessor"]): ReactNode {
@@ -32,9 +47,28 @@ export default function DataTable<T extends { id: string }>({
   selectedIds,
   onSelectionChange,
   highlightedId,
+  sort,
+  onSortChange,
 }: DataTableProps<T>) {
   const allSelected = selectable && data.length > 0 && data.every((row) => selectedIds?.has(row.id));
   const someSelected = selectable && data.some((row) => selectedIds?.has(row.id)) && !allSelected;
+
+  const sortableColumns = onSortChange ? columns.filter((c) => c.sortKey) : [];
+
+  function handleHeaderSort(key: string) {
+    if (!onSortChange) return;
+    if (sort?.key === key) {
+      onSortChange({ key, dir: sort.dir === "asc" ? "desc" : "asc" });
+    } else {
+      const col = columns.find((c) => c.sortKey === key);
+      onSortChange({ key, dir: col?.defaultSortDir ?? "desc" });
+    }
+  }
+
+  function sortIndicator(key: string): string {
+    if (sort?.key !== key) return "";
+    return sort.dir === "asc" ? " ▲" : " ▼";
+  }
 
   function toggleAll() {
     if (!onSelectionChange) return;
@@ -66,6 +100,34 @@ export default function DataTable<T extends { id: string }>({
 
   return (
     <>
+      {/* Mobile: tri (pas d'en-tête de colonne sur la vue cartes) */}
+      {sortableColumns.length > 0 && sort && onSortChange && (
+        <div className="md:hidden mb-3 flex items-end gap-2">
+          <label className="flex-1 text-xs font-medium text-gray-500">
+            Trier par
+            <select
+              value={sort.key}
+              onChange={(e) => handleHeaderSort(e.target.value)}
+              className="mt-1 block w-full rounded-lg border-2 border-gray-200 px-3 py-2 text-sm focus:border-icc-violet focus:ring-icc-violet"
+            >
+              {sortableColumns.map((col) => (
+                <option key={col.sortKey} value={col.sortKey}>
+                  {col.header}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={() => onSortChange({ key: sort.key, dir: sort.dir === "asc" ? "desc" : "asc" })}
+            className="rounded-lg border-2 border-gray-200 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50"
+            aria-label={sort.dir === "asc" ? "Ordre croissant" : "Ordre décroissant"}
+          >
+            {sort.dir === "asc" ? "▲" : "▼"}
+          </button>
+        </div>
+      )}
+
       {/* Mobile: card view */}
       <div className="md:hidden space-y-3">
         {data.map((row) => (
@@ -126,14 +188,35 @@ export default function DataTable<T extends { id: string }>({
                   />
                 </th>
               )}
-              {columns.map((col, i) => (
-                <th
-                  key={i}
-                  className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  {col.header}
-                </th>
-              ))}
+              {columns.map((col, i) => {
+                const sortable = !!col.sortKey && !!onSortChange;
+                return (
+                  <th
+                    key={i}
+                    aria-sort={
+                      col.sortKey && sort?.key === col.sortKey
+                        ? sort.dir === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : undefined
+                    }
+                    className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    {sortable ? (
+                      <button
+                        type="button"
+                        onClick={() => handleHeaderSort(col.sortKey!)}
+                        className="flex items-center uppercase tracking-wider hover:text-gray-700"
+                      >
+                        {col.header}
+                        <span aria-hidden="true">{sortIndicator(col.sortKey!)}</span>
+                      </button>
+                    ) : (
+                      col.header
+                    )}
+                  </th>
+                );
+              })}
               {actions && (
                 <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Actions

--- a/src/lib/__tests__/text.test.ts
+++ b/src/lib/__tests__/text.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { normalizeText } from "@/lib/text";
+
+describe("normalizeText", () => {
+  it("met en minuscule et retire les accents", () => {
+    expect(normalizeText("Prédication")).toBe("predication");
+    expect(normalizeText("ÉGLISE À Rennes")).toBe("eglise a rennes");
+    expect(normalizeText("Noël")).toBe("noel");
+  });
+
+  it("réduit les espaces et trim", () => {
+    expect(normalizeText("  Pasteur   Jean  ")).toBe("pasteur jean");
+  });
+
+  it("gère null / undefined / vide", () => {
+    expect(normalizeText(null)).toBe("");
+    expect(normalizeText(undefined)).toBe("");
+    expect(normalizeText("")).toBe("");
+    expect(normalizeText("   ")).toBe("");
+  });
+});

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -1,0 +1,19 @@
+/**
+ * Helpers de texte partagés.
+ *
+ * `normalizeText` centralise l'idiome de comparaison insensible à la casse et aux
+ * accents recopié à la main dans plusieurs écrans (ReportsClient, DiscipleshipClient,
+ * ChurchesClient…). La reprise de ces appels existants est hors périmètre — on
+ * l'introduit ici pour la file Production audio (spec 023).
+ */
+
+/** Minuscule, accents retirés (NFD), espaces réduits. `null`/`undefined` → `""`. */
+export function normalizeText(s: string | null | undefined): string {
+  if (!s) return "";
+  return s
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}


### PR DESCRIPTION
## Contexte

La file Production (`/audio/production`, « Audio évènements ») chargeait **tous** les `AudioService` de l'église avec un **seul filtre** (statut) et **aucun tri interactif**. Une fois les ~80 cultes historiques importés (spec 022), retrouver un enregistrement pour le nommer / republier / vérifier son découpage devenait laborieux.

Spec / plan / tasks : `specs/023-audio-production-filtres/`

## Contenu

**100 % client** sur les données déjà chargées par la page serveur — aucun endpoint, aucun changement de schéma, aucun droit modifié. La page et son `requireAudioAccess("audio:view")` sont inchangés.

- **`src/lib/text.ts`** — `normalizeText` (casse + accents), helper partagé (l'idiome était recopié dans ~10 fichiers ; reprise des autres = `chore:` ultérieur).
- **`queue-filters.ts`** — helpers purs : `filterQueue`, `sortQueue`, `deriveSpeakers`, `deriveYears`, `isRangeValid`, `hasActiveState`. Persistance intra-session par **variable de portée module** : survit à la navigation SPA (retour d'un détail, création depuis la modale), perdue au rechargement complet — exactement le comportement spécifié, sans `sessionStorage` ni état d'URL.
- **`DataTable`** — extension **rétro-compatible** du tri par en-tête : props de colonne `sortKey` / `defaultSortDir`, props de table `sort` / `onSortChange`, `aria-sort` sur le `<th>`. `DataTable` ne trie pas, il remonte l'état ; le parent trie. Vue cartes mobile : `Select` « Trier par » + bouble sens. Sans ces props → comportement strictement identique (autres appelants inchangés, `typecheck` OK).
- **`AudioQueueClient`** — filtres combinables statut / type / année / plage du-au / orateur (option « Sans orateur ») / recherche texte (débounce 300 ms) ; repli mobile « Filtrer (n) » ; compteur « N enregistrements » ; bouton **Réinitialiser** ; message dédié si la date de fin précède la date de début.
- **29 tests Vitest** (`text.test.ts`, `queue-filters.test.ts`).

## Décisions (spec)

- Tri par **clic d'en-tête** (extension `DataTable`) plutôt que `Select` « Trier par » — le `Select` n'est retenu que pour la parité mobile.
- Tri par statut : **À nommer → Rendu en cours → Brouillon → Publié → Dépublié**.
- Filtres conservés **pendant la navigation** uniquement ; filtre statut en **choix unique** (inchangé).

## Vérifications

- `npm run typecheck` ✅
- `npm run lint` ✅ (0 erreur)
- `npm run lint:boundaries` ✅
- `npm run test` ✅ 786/786

## Reste à faire

Passe visuelle en recette : rendu `aria-sort`, dépliage mobile, persistance des filtres au retour d'un détail (noté dans `tasks.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)