### PR TITLE
fix(securite): clé de rate-limit, ref de déploiement et bornes d'upload audio

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Contexte de build Docker — evite d'embarquer secrets, historique et artefacts locaux
+# dans les couches d'image (docker/Dockerfile.dev fait `COPY . .`).
+
+# Secrets et environnement local
+.env
+.env.*
+!.env.example
+
+# Historique et metadonnees
+.git
+.gitignore
+.github
+
+# Dependances et artefacts de build (reinstalles/regeneres dans l'image)
+node_modules
+.next
+dist
+out
+coverage
+src/generated
+
+# Caches et logs
+.turbo
+.eslintcache
+*.log
+npm-debug.log*
+
+# Donnees locales
+uploads
+tmp
+specs
+
+# Editeurs / OS
+.vscode
+.idea
+.DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,46 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npx prisma generate
+      # `npm run build` produit aussi dist/worker.mjs (esbuild) — le worker audio est bundlé,
+      # il n'a donc besoin ni de src/ ni de tsx sur le serveur (ADR-0007).
       - run: npm run build
+
+      # --- Empaquetage de l'artefact de release (tags uniquement) ---------------------
+      # L'artefact deploye est construit ICI, dans le contexte non privilegie de la CI, et
+      # promu tel quel par deploy.yml. Le workflow de deploiement ne recompile donc jamais
+      # le code : c'est ce qui garantit que le binaire deploye est exactement celui qui a
+      # ete teste, et ce qui evite de faire tourner un build en contexte privilegie
+      # (CodeQL actions/cache-poisoning).
+      - name: Determine version
+        id: version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      # Élague les devDependencies APRÈS le build : l'archive n'embarque plus typescript,
+      # vitest, eslint, esbuild… La CLI `prisma` est en `dependencies` (requise sur le serveur
+      # pour `migrate deploy`) et survit donc à l'élagage.
+      - name: Prune dev dependencies
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: npm prune --omit=dev
+
+      - name: Package artifact
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          tar czf "koinonia-${VERSION}.tar.gz" \
+            --exclude='prisma/scripts' \
+            .next/standalone .next/static dist \
+            prisma prisma.config.ts public package.json \
+            node_modules
+          echo "Built koinonia-${VERSION}.tar.gz"
+          du -sh "koinonia-${VERSION}.tar.gz"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          name: koinonia-${{ steps.version.outputs.version }}
+          path: koinonia-${{ steps.version.outputs.version }}.tar.gz
+          retention-days: 14
 
   check-version:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,10 +44,13 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || format('v{0}', inputs.version) }}
 
+      # Pas de `cache: "npm"` ici : ce job checkout une ref qui n'est pas la branche par
+      # defaut (tag de release), et alimenter le cache Actions depuis une telle ref permet
+      # d'empoisonner le cache des workflows de la branche par defaut (CodeQL
+      # actions/cache-poisoning). Le gain de temps ne vaut pas ce risque sur un deploiement.
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22"
-          cache: "npm"
 
       - name: Determine version
         id: version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,12 @@ jobs:
       NEXT_TELEMETRY_DISABLED: "1"
       DATABASE_URL: "mysql://dummy:dummy@localhost/dummy"
     steps:
+      # Sur workflow_run, sans `ref` explicite le checkout prend le HEAD de la branche
+      # par defaut : on deploierait alors un commit different de celui valide par la CI.
+      # On epingle le SHA exact du run declencheur (le tag pour un dispatch manuel).
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || format('v{0}', inputs.version) }}
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,88 +29,77 @@ jobs:
     steps:
       - run: echo "CI passed, deploy allowed"
 
-  build:
+  # Resout l'artefact de release deja construit et teste par la CI. Ce workflow ne
+  # checkout ni ne compile aucun code : il promeut l'artefact tel quel. C'est ce qui
+  # garantit que le deploiement porte exactement le commit valide par la CI (H-08) et
+  # qu'aucun code n'est execute dans le contexte privilegie du deploiement.
+  resolve:
     needs: gate
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      NEXT_TELEMETRY_DISABLED: "1"
-      DATABASE_URL: "mysql://dummy:dummy@localhost/dummy"
+    timeout-minutes: 5
     steps:
-      # Sur workflow_run, sans `ref` explicite le checkout prend le HEAD de la branche
-      # par defaut : on deploierait alors un commit different de celui valide par la CI.
-      # On epingle le SHA exact du run declencheur (le tag pour un dispatch manuel).
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || format('v{0}', inputs.version) }}
-
-      # Pas de `cache: "npm"` ici : ce job checkout une ref qui n'est pas la branche par
-      # defaut (tag de release), et alimenter le cache Actions depuis une telle ref permet
-      # d'empoisonner le cache des workflows de la branche par defaut (CodeQL
-      # actions/cache-poisoning). Le gain de temps ne vaut pas ce risque sur un deploiement.
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          node-version: "22"
-
-      - name: Determine version
-        id: version
+      - name: Resolve version and CI run
+        id: ci
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-          else
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
             TAG="${{ github.event.workflow_run.head_branch }}"
-            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+            VERSION="${TAG#v}"
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          else
+            VERSION="${{ inputs.version }}"
+            TAG="v${VERSION}"
+            # Deploiement manuel : on retrouve le run CI reussi du tag demande. Un tag sans
+            # run CI vert n'est pas deployable — pas de chemin qui contourne la CI (H-09).
+            RUN=$(gh api "repos/${GH_REPO}/actions/workflows/ci.yml/runs?branch=${TAG}&status=success&per_page=1")
+            RUN_ID=$(echo "$RUN" | jq -r '.workflow_runs[0].id // empty')
+            HEAD_SHA=$(echo "$RUN" | jq -r '.workflow_runs[0].head_sha // empty')
+            if [ -z "$RUN_ID" ]; then
+              echo "::error::Aucun run CI reussi pour le tag ${TAG}. Deploiement refuse."
+              exit 1
+            fi
           fi
 
-      - name: Check tag matches package.json
-        run: |
-          PKG=$(node -p "require('./package.json').version")
-          if [ "${{ steps.version.outputs.version }}" != "$PKG" ]; then
-            echo "::error::Version mismatch: tag=${{ steps.version.outputs.version }} package.json=$PKG"
+          # Le tag doit exister et pointer sur le commit valide par ce run CI.
+          TAG_SHA=$(gh api "repos/${GH_REPO}/git/ref/tags/${TAG}" --jq '.object.sha' 2>/dev/null || true)
+          if [ -z "$TAG_SHA" ]; then
+            echo "::error::Tag ${TAG} introuvable."
+            exit 1
+          fi
+          # Un tag annote pointe sur un objet tag : on deref vers le commit.
+          TAG_TYPE=$(gh api "repos/${GH_REPO}/git/ref/tags/${TAG}" --jq '.object.type')
+          if [ "$TAG_TYPE" = "tag" ]; then
+            TAG_SHA=$(gh api "repos/${GH_REPO}/git/tags/${TAG_SHA}" --jq '.object.sha')
+          fi
+          if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+            echo "::error::Le tag ${TAG} (${TAG_SHA}) ne correspond pas au commit valide par la CI (${HEAD_SHA})."
             exit 1
           fi
 
-      - run: npm ci
-      - run: npx prisma generate
-      # `npm run build` produit aussi dist/worker.mjs (esbuild) — le worker audio est bundlé,
-      # il n'a donc besoin ni de src/ ni de tsx sur le serveur (ADR-0007).
-      - run: npm run build
-
-      # Élague les devDependencies APRÈS le build : l'archive n'embarque plus typescript,
-      # vitest, eslint, esbuild… La CLI `prisma` est en `dependencies` (requise sur le serveur
-      # pour `migrate deploy`) et survit donc à l'élagage.
-      - name: Prune dev dependencies
-        run: npm prune --omit=dev
-
-      - name: Package artifact
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          tar czf "koinonia-${VERSION}.tar.gz" \
-            --exclude='prisma/scripts' \
-            .next/standalone .next/static dist \
-            prisma prisma.config.ts public package.json \
-            node_modules
-          echo "Built koinonia-${VERSION}.tar.gz"
-          du -sh "koinonia-${VERSION}.tar.gz"
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: koinonia-${{ steps.version.outputs.version }}
-          path: koinonia-${{ steps.version.outputs.version }}.tar.gz
-          retention-days: 14
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "run_id=${RUN_ID}"   >> "$GITHUB_OUTPUT"
+          echo "Artefact koinonia-${VERSION} promu depuis le run CI ${RUN_ID} (${HEAD_SHA})"
 
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: ${{ steps.ci.outputs.version }}
+      run_id: ${{ steps.ci.outputs.run_id }}
 
   deploy:
-    needs: build
+    needs: resolve
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 10
     steps:
+      # Artefact telecharge depuis le run CI qui l'a construit et teste (jamais rebuild ici).
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: koinonia-${{ needs.build.outputs.version }}
+          name: koinonia-${{ needs.resolve.outputs.version }}
+          run-id: ${{ needs.resolve.outputs.run_id }}
+          github-token: ${{ github.token }}
 
       - name: Upload artifact to server
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
@@ -119,13 +108,13 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          source: koinonia-${{ needs.build.outputs.version }}.tar.gz
+          source: koinonia-${{ needs.resolve.outputs.version }}.tar.gz
           target: /tmp
 
       - name: Deploy artifact via SSH
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         env:
-          VERSION: ${{ needs.build.outputs.version }}
+          VERSION: ${{ needs.resolve.outputs.version }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}

--- a/docs/production.md
+++ b/docs/production.md
@@ -76,7 +76,7 @@ FLUSH PRIVILEGES;
 
 > **Important** : le deploiement se fait exclusivement via GitHub Actions (artefact pre-compile en CI).
 > Aucune compilation ne doit avoir lieu sur le serveur de production.
-> Le `workflow_dispatch` permet de re-deployer une version existante en cas d'urgence — il execute le meme pipeline CI que le deploiement automatique.
+> Le `workflow_dispatch` permet de re-deployer une version existante en cas d'urgence. Il ne recompile pas : il exige un run CI **reussi** pour le tag `v<version>` demande et promeut l'artefact de ce run. Un tag sans CI verte, ou dont le commit ne correspond pas a celui valide par la CI, est refuse — il n'existe donc aucun chemin de deploiement qui contourne la CI.
 
 ### Premiere installation
 
@@ -245,7 +245,7 @@ https://votre-domaine.com/api/auth/callback/google
 
 ## Deploiement automatise (CD)
 
-Le deploiement est automatise via GitHub Actions. Un push de tag `v*` declenche le CI, et le workflow de deploiement ne s'execute que si le CI passe integralement (typecheck, lint, tests). L'application est construite en CI (artefact immutable) puis deployee sur le serveur sans etape de build.
+Le deploiement est automatise via GitHub Actions. Un push de tag `v*` declenche le CI, et le workflow de deploiement ne s'execute que si le CI passe integralement (typecheck, lint, tests). L'application est construite **une seule fois** par le CI (artefact immutable, attache au run CI du tag) puis promue telle quelle par le workflow de deploiement, qui se contente de la transferer sur le serveur : aucune compilation n'a lieu ni au deploiement ni en production.
 
 ### Prerequis serveur
 
@@ -280,8 +280,8 @@ koinonia ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart koinonia
 ### Fonctionnement
 
 1. Push d'un tag `v*` (ex: `git tag v0.6.0 && git push origin v0.6.0`)
-2. Le CI s'execute (typecheck, tests, verification version)
-3. Si le CI passe, le workflow deploy se connecte en SSH au serveur
+2. Le CI s'execute (typecheck, tests, verification version) et, sur un tag, **empaquette l'artefact de release** puis le publie comme artefact du run
+3. Si le CI passe, le workflow deploy **telecharge cet artefact depuis le run CI** — il ne recompile rien et ne fait aucun checkout — puis se connecte en SSH au serveur
 4. L'artefact pre-compile est transfere par SCP, extrait, les assets statiques assembles — aucune compilation n'a lieu en production. L'artefact inclut `prisma.config.ts` (requis par Prisma 7 pour la configuration CLI)
 5. Les migrations Prisma sont appliquees, le symlink `current` est bascule, le service redemarre
 6. Les anciennes releases sont nettoyees (3 dernieres conservees)

--- a/src/app/api/audio/public/[token]/play/route.ts
+++ b/src/app/api/audio/public/[token]/play/route.ts
@@ -4,7 +4,7 @@
  * par IP pour éviter le gonflage artificiel du compteur (spec §6).
  */
 import { z } from "zod";
-import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
+import { requireRateLimit, getClientIp, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 
@@ -15,10 +15,15 @@ export async function POST(
   { params }: { params: Promise<{ token: string }> }
 ) {
   try {
-    requireRateLimit(request, { prefix: "audio:play", ...RATE_LIMIT_MUTATION });
-
     const { token } = await params;
     const { segmentId } = schema.parse(await request.json());
+
+    // La cle doit identifier l'appelant : un prefixe constant ferait un compteur global
+    // qui bloquerait toutes les lectures publiques apres 30 requetes (cf. requireRateLimit).
+    requireRateLimit(request, {
+      prefix: `audio:play:${token}:${getClientIp(request)}`,
+      ...RATE_LIMIT_MUTATION,
+    });
 
     const shareToken = await prisma.audioShareToken.findUnique({ where: { token } });
     if (!shareToken || shareToken.revokedAt) throw new ApiError(404, "Lien introuvable");

--- a/src/app/api/integration/families/suggest/route.ts
+++ b/src/app/api/integration/families/suggest/route.ts
@@ -1,10 +1,10 @@
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { geocodeAddress, findFamilyByCoords } from "@/lib/family-geo";
-import { requireRateLimit } from "@/lib/rate-limit";
+import { requireRateLimit, getClientIp } from "@/lib/rate-limit";
 
 export async function GET(request: Request) {
   try {
-    requireRateLimit(request, { prefix: `integration-families-suggest:public:${request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"}`, windowMs: 60_000, max: 20 });
+    requireRateLimit(request, { prefix: `integration-families-suggest:public:${getClientIp(request)}`, windowMs: 60_000, max: 20 });
 
     const { searchParams } = new URL(request.url);
     const address = searchParams.get("address");

--- a/src/app/api/integration/requests/route.ts
+++ b/src/app/api/integration/requests/route.ts
@@ -3,7 +3,7 @@ import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { requireIntegrationAccess, buildConfirmationEmail } from "@/modules/integration";
 import { sendEmail } from "@/lib/email";
 import { geocodeAddress, findFamilyByCoords } from "@/lib/family-geo";
-import { requireRateLimit } from "@/lib/rate-limit";
+import { requireRateLimit, getClientIp } from "@/lib/rate-limit";
 import { z } from "zod";
 import type { FamilyAgeRange, FamilyChurchStatus, FamilyIntegrationStatus, Prisma } from "@/generated/prisma/client";
 
@@ -73,7 +73,7 @@ const createSchema = z.object({
 
 export async function POST(request: Request) {
   try {
-    requireRateLimit(request, { prefix: `integration-requests:public:${request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"}`, windowMs: 60_000, max: 5 });
+    requireRateLimit(request, { prefix: `integration-requests:public:${getClientIp(request)}`, windowMs: 60_000, max: 5 });
 
     const body = await request.json();
     const data = createSchema.parse(body);

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { rateLimit } from "@/lib/rate-limit";
+import { rateLimit, requireRateLimit, getClientIp } from "@/lib/rate-limit";
 
 describe("rateLimit", () => {
   it("allows requests within the limit", () => {
@@ -60,5 +60,42 @@ describe("rateLimit", () => {
     const result = rateLimit(key);
     expect(result.success).toBe(true);
     expect(result.remaining).toBe(59);
+  });
+});
+
+describe("requireRateLimit", () => {
+  const req = (ip: string) =>
+    new Request("https://example.test/api/x", {
+      method: "POST",
+      headers: { "x-forwarded-for": `${ip}, 10.0.0.1` },
+    });
+
+  it("extrait l'IP client du premier maillon de x-forwarded-for", () => {
+    expect(getClientIp(req("203.0.113.7"))).toBe("203.0.113.7");
+    expect(getClientIp(new Request("https://example.test/"))).toBe("unknown");
+  });
+
+  // Régression : `prefix` REMPLACE la clé au lieu de s'y ajouter. Un préfixe constant
+  // (ex. "audio:play") faisait donc un compteur global : une fois le quota atteint par
+  // un seul client, tous les autres étaient bloqués. Toute clé doit inclure l'appelant.
+  it("isole les compteurs de deux clients quand la clé inclut l'IP", () => {
+    const prefix = `test-scoped-${Date.now()}`;
+    const opts = { max: 1, windowMs: 60_000 };
+
+    const key = (r: Request) => ({ prefix: `${prefix}:${getClientIp(r)}`, ...opts });
+
+    expect(() => requireRateLimit(req("203.0.113.1"), key(req("203.0.113.1")))).not.toThrow();
+    // Le quota du premier client est epuise, le second doit rester servi.
+    expect(() => requireRateLimit(req("203.0.113.2"), key(req("203.0.113.2")))).not.toThrow();
+    // ... et le premier client, lui, est bien bloque.
+    expect(() => requireRateLimit(req("203.0.113.1"), key(req("203.0.113.1")))).toThrow();
+  });
+
+  it("un préfixe constant partage le compteur entre tous les clients", () => {
+    const prefix = `test-global-${Date.now()}`;
+    const opts = { prefix, max: 1, windowMs: 60_000 };
+
+    expect(() => requireRateLimit(req("203.0.113.1"), opts)).not.toThrow();
+    expect(() => requireRateLimit(req("203.0.113.2"), opts)).toThrow();
   });
 });

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -51,7 +51,12 @@ export const RATE_LIMIT_AUTH: RateLimitOptions = { windowMs: 60_000, max: 10 };
 export const RATE_LIMIT_MUTATION: RateLimitOptions = { windowMs: 60_000, max: 30 };
 export const RATE_LIMIT_SENSITIVE: RateLimitOptions = { windowMs: 60_000, max: 10 };
 
-function getClientIp(request: Request): string {
+/**
+ * IP client telle que vue derriere le proxy. Exportee pour que les routes publiques
+ * composent leur cle de rate-limit avec elle au lieu de reparser l'en-tete a la main.
+ * Voir l'hypothese proxy documentee en tete de fichier.
+ */
+export function getClientIp(request: Request): string {
   const forwarded = request.headers.get("x-forwarded-for");
   if (forwarded) return forwarded.split(",")[0].trim();
   return "unknown";
@@ -59,8 +64,13 @@ function getClientIp(request: Request): string {
 
 /**
  * Throws ApiError(429) if the rate limit is exceeded.
- * Use `prefix` to namespace the key (e.g., "auth", "mut:userId").
- * When no prefix is given, keys by IP (for unauthenticated routes).
+ *
+ * `prefix` REMPLACE la cle, il ne s'y ajoute pas : la cle est exactement `prefix`.
+ * Un prefixe constant (ex: "audio:play") est donc un compteur GLOBAL partage par tous
+ * les appelants, pas une limite par client. Tout prefixe doit inclure ce qui identifie
+ * l'appelant : `mut:${userId}` pour une route authentifiee, `${route}:${getClientIp(request)}`
+ * pour une route publique.
+ * Sans prefixe, la cle est l'IP (routes publiques sans dimension supplementaire).
  */
 export function requireRateLimit(
   request: Request,

--- a/src/modules/audio/index.ts
+++ b/src/modules/audio/index.ts
@@ -47,6 +47,9 @@ export { getCaptureDepartmentId, isCaptureTeamMember, isCaptureTeamLead } from "
 
 export {
   AUDIO_UPLOAD_PART_SIZE,
+  AUDIO_UPLOAD_MAX_SIZE,
+  AUDIO_UPLOAD_ALLOWED_MIME_TYPES,
+  assertUploadWithinLimits,
   getAudioSourceKey,
   partCountFor,
   signSequenceUpload,

--- a/src/modules/audio/services/__tests__/upload.test.ts
+++ b/src/modules/audio/services/__tests__/upload.test.ts
@@ -8,7 +8,8 @@ vi.mock("@/modules/storage", () => ({
   deleteMediaFile: vi.fn(),
 }));
 
-const { deleteAudioSource } = await import("../upload");
+const { deleteAudioSource, assertUploadWithinLimits, AUDIO_UPLOAD_MAX_SIZE, partCountFor } =
+  await import("../upload");
 
 const serviceId = "service-1";
 const churchId = "church-1";
@@ -69,5 +70,26 @@ describe("deleteAudioSource", () => {
     await deleteAudioSource(serviceId, churchId, "src-1");
 
     expect(prismaMock.audioJob.deleteMany).not.toHaveBeenCalled();
+  });
+});
+
+// H-05 : la taille annoncee etait seulement `positive()`. `partCountFor(size)` generant une
+// URL presignee par part, une taille arbitraire faisait signer un nombre illimite d'URLs
+// (au-dela des 10 000 parts S3) — DoS applicatif et cout de stockage.
+describe("assertUploadWithinLimits", () => {
+  it("accepte un fichier audio dans les bornes", () => {
+    expect(() => assertUploadWithinLimits("audio/mpeg", 50 * 1024 * 1024)).not.toThrow();
+  });
+
+  it("refuse un type MIME hors liste", () => {
+    expect(() => assertUploadWithinLimits("application/zip", 1024)).toThrow(ApiError);
+  });
+
+  it("refuse une taille au-dela du maximum", () => {
+    expect(() => assertUploadWithinLimits("audio/mpeg", AUDIO_UPLOAD_MAX_SIZE + 1)).toThrow(ApiError);
+  });
+
+  it("borne le nombre de parts signees bien en deca de la limite S3 de 10 000", () => {
+    expect(partCountFor(AUDIO_UPLOAD_MAX_SIZE)).toBeLessThan(10_000);
   });
 });

--- a/src/modules/audio/services/upload.ts
+++ b/src/modules/audio/services/upload.ts
@@ -25,8 +25,44 @@ export function getAudioSourceKey(serviceId: string, sourceId: string, ext: stri
   return `audio-services/${serviceId}/sources/${sourceId}.${ext}`;
 }
 
+/**
+ * Taille maximale d'une sequence deposee — 2 Gio, soit 256 parts de 8 Mo.
+ * Borne le nombre d'URLs presignees generees par appel (S3 plafonne a 10 000 parts).
+ */
+export const AUDIO_UPLOAD_MAX_SIZE = 2 * 1024 * 1024 * 1024;
+
+/** Types MIME acceptes pour une sequence audio. */
+export const AUDIO_UPLOAD_ALLOWED_MIME_TYPES = [
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/mp4",
+  "audio/aac",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/flac",
+  "audio/x-flac",
+  "audio/ogg",
+  "audio/webm",
+];
+
 export function partCountFor(size: number, partSize = AUDIO_UPLOAD_PART_SIZE): number {
   return Math.max(1, Math.ceil(size / partSize));
+}
+
+/**
+ * Valide taille et type MIME annonces avant tout appel S3 : sans cette borne, une taille
+ * arbitraire fait generer autant d'URLs presignees que de parts (DoS applicatif).
+ */
+export function assertUploadWithinLimits(contentType: string, size: number): void {
+  if (!AUDIO_UPLOAD_ALLOWED_MIME_TYPES.includes(contentType)) {
+    throw new ApiError(400, `Type MIME non supporte : ${contentType}`);
+  }
+  if (size > AUDIO_UPLOAD_MAX_SIZE) {
+    throw new ApiError(
+      400,
+      `Fichier trop lourd (max ${AUDIO_UPLOAD_MAX_SIZE / 1024 / 1024 / 1024} Go)`
+    );
+  }
 }
 
 export interface SignSequenceUploadInput {
@@ -65,6 +101,7 @@ export async function signSequenceUpload(input: SignSequenceUploadInput, db?: Db
     throw new ApiError(404, "Culte audio introuvable");
   }
   assertServiceEditable(service, "déposer de nouvelles séquences");
+  assertUploadWithinLimits(input.contentType, input.size);
 
   const ext = input.filename.split(".").pop()?.toLowerCase() || "mp3";
   const source = await db.audioSource.create({


### PR DESCRIPTION
Corrige trois constats de l'audit DevSecOps du 2026-08-29 (`audit-securite-qualite-2026-08-29.md`), chacun vérifié dans le code avant correction. **H-01 (agrégation de rôles inter-églises dans `requirePermission`) n'est pas traité ici** — c'est un changement de contrat d'autorisation qui mérite sa propre spec.

## M-06 — clé de rate-limit globale sur le compteur de lecture audio

`requireRateLimit` utilise `prefix` comme clé **entière**, pas comme préfixe (`key = prefix ?? ip:...`). `POST /api/audio/public/[token]/play` passait la constante `"audio:play"` : le compteur était donc **global**, et 30 requêtes d'un seul visiteur bloquaient les lectures publiques de tout le monde pendant une minute. Le commentaire de la route annonçait pourtant « rate-limité par IP ».

- La clé inclut désormais le token et l'IP client.
- `getClientIp` est exporté et le contrat de `prefix` est documenté explicitement, pour que le piège ne se retende pas.
- Les deux routes d'intégration publiques utilisent `getClientIp` au lieu de reparser `x-forwarded-for` à la main (elles étaient déjà correctes, juste dupliquées).

Les autres appelants passent tous un préfixe déjà porteur du `userId` : ils sont corrects et restent inchangés — volontairement, car composer systématiquement avec l'IP **affaiblirait** une limite par utilisateur (contournable par rotation d'IP).

## H-08 — déploiement non lié au commit validé par la CI

Sur `workflow_run`, le `checkout` de `deploy.yml` n'avait pas de `ref` et prenait donc le HEAD de la branche par défaut : un déploiement déclenché par le tag `vX.Y.Z` pouvait publier un commit **différent** de celui testé et taggé.

Traité **à la racine, par promotion d'artefact** plutôt que par simple épinglage de ref (voir la note CodeQL ci-dessous) :

- Le **CI** empaquette l'artefact de release sur les tags et le publie comme artefact du run.
- **`deploy.yml` ne fait plus ni checkout ni build** : le job `build` est remplacé par un job `resolve` qui identifie le run CI, et le déploiement télécharge l'artefact de ce run. Le binaire déployé est donc *exactement* celui qui a été testé, sans recompilation intermédiaire.
- Le chemin `workflow_dispatch` exige désormais un run CI **réussi** pour le tag demandé, et vérifie que le tag pointe bien sur le commit validé par ce run (tag annoté déréférencé). Un tag sans CI verte est refusé : **plus aucun chemin de déploiement ne contourne la CI** (ferme aussi H-09).
- `docs/production.md` décrivait déjà ce fonctionnement (« construite en CI, artefact immutable ») — la doc devançait la réalité, elle est maintenant exacte.

Le déploiement d'une **branche** passe par `deploy-staging.yml`, workflow séparé et **inchangé par cette PR**, qui déploie la ref sélectionnée dans l'UI.

### Note CodeQL

Le premier essai épinglait simplement la `ref` au `head_sha`. CodeQL a alors levé **3 alertes high `actions/cache-poisoning`** : le job installait et compilait du code issu d'une ref non-défaut dans un contexte privilégié. Ces alertes n'existaient pas sur `main` uniquement parce que le checkout y retombait sur la branche par défaut — c'est-à-dire à cause du bug H-08 lui-même. La promotion d'artefact les supprime en supprimant leur cause : plus aucun code du dépôt n'est installé ni exécuté dans le workflow privilégié.

## H-05 / M-09 — bornes d'upload audio et contexte Docker

La taille annoncée n'était validée que par `positive()`, alors que `partCountFor(size)` génère **une URL présignée par part** : une taille arbitraire faisait signer un nombre illimité d'URLs (au-delà du plafond S3 de 10 000 parts). Ajout d'un maximum de 2 Gio (256 parts de 8 Mo) et d'une liste MIME audio, vérifiés **avant tout appel S3**, sur le modèle déjà en place dans `media/files/upload/sign`.

Ajout du `.dockerignore` absent (`docker/Dockerfile.dev` fait `COPY . .`, donc `.env`, `.git` et les caches locaux pouvaient entrer dans les couches d'image).

## Vérifications

| Contrôle | Résultat |
|---|---|
| `npm run typecheck` | ✅ |
| `npm run lint` | ✅ 11 avertissements préexistants, inchangés |
| `npm run lint:boundaries` | ✅ 604 modules |
| `npm test` | ✅ 857 tests (+7) |

Les 7 tests ajoutés couvrent la régression de clé de rate-limit (isolation entre deux clients, et démonstration du compteur partagé par un préfixe constant) et les bornes d'upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwEXWCWqPAgjfEnmKCMmSd



