### PR TITLE
fix(securite): isolation inter-eglises des controles de permission (H-01)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ koinonia/
 │   │   └── prisma/              # Client Prisma genere (remplace @prisma/client)
 │   ├── lib/
 │   │   ├── prisma.ts            # Singleton Prisma (globalThis pattern, driver adapter PrismaMariaDb)
-│   │   ├── auth.ts              # Config NextAuth + helpers (requireAuth, requirePermission…)
+│   │   ├── auth.ts              # Config NextAuth + helpers (requireAuth, requireChurchPermission…)
 │   │   ├── registry.ts          # Boot registry + rolePermissions pre-calcule
 │   │   ├── api-utils.ts         # ApiError, successResponse, errorResponse
 │   │   ├── audit.ts             # logAudit() — journal des actions
@@ -188,7 +188,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    await requireAuth();           // ou requirePermission("permission")
+    await requireAuth();           // ou requireCurrentChurchPermission("permission")
     const { id } = await params;   // TOUJOURS await params (Next.js 15)
     // ... logique metier + Prisma
     return successResponse(data);
@@ -201,10 +201,19 @@ export async function GET(
 ### Helpers d'authentification (`src/lib/auth.ts`)
 
 - `requireAuth()` — verifie la session, throw `UNAUTHORIZED`
-- `requirePermission(permission, churchId?)` — verifie une permission, throw `FORBIDDEN`
-- `requireChurchPermission(permission, churchId)` — idem, churchId obligatoire
+- `requireChurchPermission(permission, churchId)` — verifie une permission **dans une eglise
+  precise**, `churchId` obligatoire (jamais optionnel — voir spec 024)
+- `requireCurrentChurchPermission(permission)` — resout l'eglise courante puis verifie la
+  permission dedans ; remplacant de choix pour une route qui n'agit pas sur un objet deja
+  identifie
+- `requireSuperAdmin()` — action reservee a l'administration de la plateforme, jamais evaluee
+  dans une eglise (Super Admin uniquement)
+- `requirePlatformPermission(permission)` — permissions volontairement transverses aux eglises
+  (module emploi), liste blanche testee dans `auth-global-scopes.test.ts`
 - `getUserDepartmentScope(session)` — retourne `{ scoped: false }` (admin) ou `{ scoped: true, departmentIds }` (roles limites)
-- `resolveChurchId(type, resourceId)` — retrouve le `churchId` d'une ressource par son type et ID
+- `resolveChurchId(type, resourceId)` — retrouve le `churchId` d'une ressource par son type et ID.
+  Pour toute action portant sur un objet identifie, cette eglise fait autorite — jamais le
+  contexte d'eglise affiche, qui peut etre manipule cote client
 - `requireAudioAccess(permission, churchId)` — permission de role **ou** membre du departement de captation
 - `requireAudioUnpublishAccess(churchId)` — `audio:manage` ou responsable du departement de captation
 
@@ -442,7 +451,8 @@ Creer une branche `feat/X` comme base. Les sous-features ouvrent des PRs vers `f
 5. **Composants UI** : verifier `src/components/ui/` avant de creer un nouveau composant
 6. **Pas de sur-ingenierie** : faire le minimum necessaire pour la fonctionnalite demandee
 7. **Erreurs** : utiliser `ApiError` pour les erreurs metier, Zod pour la validation
-8. **Permissions** : toujours proteger les routes API avec `requireAuth()` ou `requirePermission()`
+8. **Permissions** : toujours proteger les routes API avec `requireAuth()`, `requireChurchPermission()`
+   ou `requireCurrentChurchPermission()` — jamais de controle de permission sans eglise cible
 9. **Migrations** : toujours creer une migration Prisma (`prisma migrate dev`) au lieu de `db push` pour tout changement de schema
 10. **Permissions dans le code** : utiliser `rolePermissions` de `@/lib/registry` (PAS `hasPermission` de `@/lib/permissions` qui est deprecated)
 11. **Imports modules** : `src/app/` ne peut importer depuis un module que via son index (`@/modules/X`) — pas de chemins internes

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -71,12 +71,24 @@ Cela permet d'assigner le role STAR sans aucune entree `user_departments` : les 
 
 **Helpers** (`src/lib/auth.ts`) :
 - `requireAuth()` — verifie la session et throw `UNAUTHORIZED` si absente
-- `requirePermission(permission, churchId?)` — verifie une permission, throw `FORBIDDEN` si non autorise
-- `requireChurchPermission(permission, churchId)` — idem, churchId obligatoire
+- `requireChurchPermission(permission, churchId)` — verifie une permission **dans une eglise
+  precise**, `churchId` obligatoire, throw `FORBIDDEN` si non autorise
+- `requireCurrentChurchPermission(permission)` — resout l'eglise courante (`getCurrentChurchId`)
+  PUIS verifie la permission dedans ; a utiliser des qu'une route n'agit pas sur un objet deja
+  identifie (sinon preferer `resolveChurchId` + `requireChurchPermission` pour que l'eglise de
+  l'objet fasse autorite, pas le contexte affiche)
+- `requireSuperAdmin()` — reserve une action a l'administration de la plateforme (Super Admin
+  uniquement), jamais evaluee dans une eglise
+- `requirePlatformPermission(permission)` — permissions volontairement transverses aux eglises
+  (module emploi uniquement) ; la liste blanche est dans `src/lib/auth.ts` et testee par
+  `src/lib/__tests__/auth-global-scopes.test.ts`
 - `getUserDepartmentScope(session)` — retourne le perimetre departements selon le role
 - `getDiscipleshipScope(session, churchId)` — portee discipolat (scoped ou non)
 - `resolveChurchId(type, resourceId)` — retrouve le `churchId` d'une ressource
-- `getCurrentChurchId(session)` — eglise active (cookie `current-church` ou premiere de la liste)
+- `getCurrentChurchId(session)` — eglise active (cookie `current-church` ou premiere de la liste).
+  Contexte d'**affichage**, jamais une autorisation a lui seul : la valeur peut venir d'un cookie
+  pose par le client. Toute decision d'autorisation doit verifier la permission **dans** l'eglise
+  ainsi designee (`requireCurrentChurchPermission`), jamais s'y fier seule.
 - `requireAudioAccess(permission, churchId)` — permission de role **ou** appartenance au departement
   de captation audio (`isCaptureTeamMember`, `Department.function = "CAPTATION_AUDIO"`) : un STAR
   de ce departement passe le controle quelle que soit la permission demandee

--- a/specs/024-isolation-permissions-inter-eglises/plan.md
+++ b/specs/024-isolation-permissions-inter-eglises/plan.md
@@ -1,0 +1,193 @@
+# Plan technique — Isolation inter-églises des contrôles de permission
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Brouillon
+- **Mis à jour le** : 2026-08-29
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : aucun nouvel import inter-modules ; le travail porte sur `src/lib/auth.ts` et les route handlers de `src/app/`
+- [x] **Sécurité** : c'est l'objet même du plan — le multi-tenant `churchId` devient structurellement obligatoire
+- [x] **Permissions** via `rolePermissions` (`@/lib/registry`) — inchangé, aucune permission ajoutée ni retirée
+- [x] **Validation** Zod sur les mutations — inchangée, aucun body modifié
+- [x] **Migration** Prisma : **aucune** — pas de changement de schéma
+- [x] **Enums** depuis `@/generated/prisma/client` — inchangé
+- [x] **UI** : aucun nouveau composant ; on corrige le calcul des droits du layout existant
+
+## Approche générale
+
+Le fil directeur est **supprimer la possibilité d'exprimer l'erreur** plutôt que corriger
+31 appels et espérer que le 32ᵉ sera correct.
+
+`requirePermission(permission, churchId?)` est **supprimé**. Comme son `churchId` optionnel
+est la cause racine, sa disparition transforme chaque omission en **erreur de compilation
+TypeScript** — c'est le mécanisme d'application du critère « un contrôle omettant l'église
+est impossible à exprimer ». Aucune règle de lint, aucune convention à retenir.
+
+À sa place, trois gardes aux intentions **explicites et distinctes**, correspondant aux
+trois catégories réelles observées dans le code :
+
+| Catégorie | Garde | Appels concernés |
+|---|---|---|
+| Action dans une église | `requireChurchPermission(permission, churchId)` | 23 |
+| Administration plateforme | `requireSuperAdmin()` | 4 (`church:manage`) |
+| Domaine volontairement transverse | `requirePlatformPermission(permission)` | 4 (module emploi) |
+
+Point décisif : **`requireChurchPermission` existe déjà et implémente la bonne sémantique**,
+supervision pastorale en lecture seule comprise (liste blanche `PASTORAL_READ_PERMISSIONS`).
+Le travail n'est donc pas d'inventer une règle mais de la rendre incontournable, exactement
+comme la spec le formule.
+
+## Modèle de données
+
+`[Aucun changement]` — aucune migration Prisma. Le défaut est entièrement dans la couche
+d'autorisation ; les données sont déjà correctement rattachées à `churchId` (à l'exception
+assumée du module emploi, cf. ci-dessous).
+
+## API
+
+Aucun endpoint ajouté, supprimé ni modifié dans son contrat : **méthodes, entrées, sorties
+et permissions requises sont inchangées**. Seul le *périmètre d'évaluation* de la permission
+change. Un utilisateur mono-église ne verra aucune différence.
+
+Les 23 routes à requalifier, par module :
+
+| Module | Fichiers | Permission | Église cible |
+|---|---|---|---|
+| Accueil (welcome-duty) | 6 | `events:manage` | contexte courant validé |
+| Réservations (mrbs-links) | 2 | `mrbs:manage` | contexte courant validé |
+| Comptabilité | 4 | `accounting:view` / `accounting:submit` | contexte courant validé |
+| Audio (paramètres) | 2 | `audio:manage` | contexte courant validé |
+
+Pour les routes agissant sur un **objet identifié**, l'église est résolue depuis l'objet via
+`resolveChurchId` (déjà existant) et non depuis le contexte affiché — conformément au
+critère « l'église de l'objet fait autorité ».
+
+## Services / logique métier
+
+Tout se joue dans `src/lib/auth.ts` ; aucun service métier n'est touché, aucun événement de
+bus émis.
+
+1. **Supprimer** `requirePermission`. Le compilateur recense alors exhaustivement les
+   appelants : la migration devient pilotée par `npm run typecheck`, pas par un `grep`.
+
+2. **Ajouter `requireCurrentChurchPermission(permission)`** — résout le contexte d'église
+   courant puis délègue à `requireChurchPermission`, et retourne `{ session, churchId }`.
+   C'est le remplaçant ergonomique des 23 appels : il évite de réécrire partout le couple
+   « résoudre le contexte, puis vérifier », qui est précisément l'endroit où l'erreur se
+   glissait. Il ne peut pas être mal utilisé : il ne rend jamais un `churchId` sur lequel la
+   permission n'a pas été vérifiée.
+
+3. **Ajouter `requireSuperAdmin()`** — pour les 4 pages `church:manage`, conformément à la
+   décision « actions transverses réservées au Super Admin ».
+
+4. **Ajouter `requirePlatformPermission(permission)`** — garde explicite pour le module
+   emploi, accompagnée d'une liste blanche des permissions autorisées à être transverses.
+   Nommée pour être visible en revue : une portée globale devient un acte délibéré.
+
+5. **`getCurrentChurchId` est conservé tel quel.** Sa permissivité (il accepte une valeur
+   d'origine cliente) cesse d'être exploitable dès lors que la permission est évaluée dans
+   l'église qu'il retourne : au pire l'utilisateur désigne une église où il a un rattachement
+   légitime, et la permission y est vérifiée normalement. Le durcir en plus serait une
+   défense redondante — mais un commentaire documentera qu'il retourne un **contexte
+   d'affichage, jamais une autorisation**.
+
+### Cas particulier : le module emploi
+
+Les modèles emploi (`JobSeeker`, `FreelanceMission`, `FreelanceProfile`) n'ont **pas** de
+`churchId` : ce domaine est transverse par conception, les annonces étant rattachées à leur
+auteur. Ces 4 appels ne sont donc **pas** des défauts. Les traiter comme church-scoped
+casserait la fonctionnalité ; les laisser en portée implicite reproduirait le défaut. D'où
+la garde dédiée, qui rend cette intention lisible et énumérable.
+
+## UI / composants
+
+Le même défaut existe côté navigation, avec la même cause. Dans `src/app/(auth)/layout.tsx`,
+les droits d'affichage sont calculés à partir de **tous** les rôles, toutes églises
+confondues :
+
+```
+const userRoles = churchRoles.map((r) => r.role);
+```
+
+La barre latérale de l'église B propose donc les liens d'administration parce que la
+personne est Admin dans A. C'est exactement le critère « actions masquées » retenu.
+
+Correction : restreindre ce calcul aux rôles détenus **dans l'église courante**. Aucun
+composant nouveau, aucune modification de `src/components/ui/`. Le masquage reste un confort
+d'affichage — les gardes serveur ci-dessus demeurent la protection réelle, y compris sur
+accès direct à l'URL.
+
+## Décisions & alternatives écartées
+
+- **Choix** : supprimer `requirePermission` — *Pourquoi* : c'est le seul moyen d'obtenir la
+  garantie demandée par la spec. Le compilateur devient le mécanisme d'application, et la
+  migration est exhaustive par construction.
+- **Choix** : réutiliser `requireChurchPermission` — *Pourquoi* : il porte déjà la bonne
+  sémantique, supervision pastorale comprise. Écrire un nouveau garde dupliquerait cette
+  logique subtile et risquerait de la diverger.
+- **Choix** : garde dédiée pour le domaine transverse — *Pourquoi* : rend les portées
+  globales énumérables (critère d'acceptation) au lieu de les confondre avec des oublis.
+- **Écarté** : rendre `churchId` obligatoire en gardant le nom `requirePermission` —
+  *Raison* : une signature qui change sans que le nom change laisse passer les appels
+  fournissant un `churchId` erroné par copier-coller, et n'aide pas à la revue.
+- **Écarté** : une règle ESLint interdisant l'appel sans église — *Raison* : contournable,
+  et surtout inutile si le symbole n'existe plus. Une erreur de compilation est plus forte
+  qu'un avertissement de lint.
+- **Écarté** : durcir `getCurrentChurchId` pour qu'il exige une permission — *Raison* :
+  confondrait « quelle église je regarde » et « qu'ai-je le droit d'y faire », les deux
+  responsabilités dont la fusion a créé le défaut.
+- **Écarté** : ajouter un `churchId` aux modèles emploi — *Raison* : hors périmètre de la
+  spec et changerait une fonctionnalité volontairement transverse.
+
+## Risques & points d'attention
+
+- **Risque principal — régression fonctionnelle silencieuse.** Une personne légitimement
+  Admin qui perdrait un accès par un `churchId` mal résolu. Mitigation : le contexte courant
+  reste la source par défaut, donc le comportement mono-église est strictement identique ;
+  la couverture de tests ci-dessous cible précisément ce cas.
+- **Volume de la migration** : 31 appels dans 7 modules. Chaque site doit être requalifié
+  **individuellement** — la catégorie ne se déduit pas mécaniquement de la permission
+  demandée. Un remplacement automatisé est explicitement déconseillé.
+- **Angle mort connu** : ce plan ne traite pas l'autorisation au niveau de chaque objet
+  (accès par identifiant deviné, constats H-02/H-03 de l'audit). Une route correctement
+  scopée à une église peut encore exposer un objet d'un autre périmètre à l'intérieur de
+  celle-ci. Hors périmètre assumé, à ne pas confondre avec « corrigé ».
+- **Profils pastoraux** : le chemin actuel leur ouvre l'écriture sur une église supervisée
+  lorsqu'ils ont un rôle ailleurs. Après correction ils repassent en lecture seule stricte —
+  c'est l'intention documentée, mais **un usage réel s'appuie peut-être sur ce défaut**. À
+  signaler avant déploiement.
+- Aucune migration de données, aucun risque de perte ; la correction est réversible par
+  simple retour arrière du code.
+
+## Stratégie de tests
+
+L'audit relève (Q-01) qu'aucun test ne démontre l'isolation multi-tenant : la couverture est
+donc un livrable, pas un accompagnement.
+
+**Socle commun** : une session factice à deux églises — rôle privilégié dans A, rôle moindre
+dans B — réutilisée par tous les cas.
+
+1. **Isolation (le cœur)** — `requireChurchPermission("x:manage", B)` refuse alors que le
+   rôle dans A porte cette permission ; la même vérification sur A réussit. En **lecture**
+   comme en **écriture**.
+2. **Non-régression mono-église** : une session à une seule église conserve exactement ses
+   accès.
+3. **Super Admin** : conserve l'accès sur A comme sur B.
+4. **Supervision pastorale** : lecture autorisée sur l'église supervisée ; **écriture
+   refusée**, y compris lorsque la session détient un rôle privilégié dans une autre église
+   (le cas exposé aujourd'hui — ce test échoue sur le code actuel, ce qui vaut preuve du
+   défaut).
+5. **Contexte manipulé** : un contexte d'église sans rattachement ne devient jamais le
+   périmètre de l'action.
+6. **Portées globales énumérables** : un test lit les appels aux gardes globales
+   (`requireSuperAdmin`, `requirePlatformPermission`) et les compare à une liste blanche
+   commitée. Tout nouvel usage fait échouer la suite tant qu'il n'est pas justifié — c'est ce
+   qui rend le critère « énumérable » vérifiable dans le temps plutôt qu'à un instant donné.
+7. **Absence de fuite** : le refus dans B est indiscernable de celui opposé à une session
+   sans aucun droit (même erreur, même message).
+
+Tests unitaires Vitest, sans base réelle, sur le modèle de `src/lib/__tests__/auth-security.test.ts`.
+La suppression de `requirePermission` est elle-même validée par `npm run typecheck`.

--- a/specs/024-isolation-permissions-inter-eglises/spec.md
+++ b/specs/024-isolation-permissions-inter-eglises/spec.md
@@ -1,7 +1,7 @@
 # Spec — Isolation inter-églises des contrôles de permission
 
 - **Numéro** : 024
-- **Statut** : Validée
+- **Statut** : Implémentée
 - **Créée le** : 2026-08-29
 - **Branche suggérée** : `fix/isolation-permissions-inter-eglises`
 

--- a/specs/024-isolation-permissions-inter-eglises/spec.md
+++ b/specs/024-isolation-permissions-inter-eglises/spec.md
@@ -1,0 +1,165 @@
+# Spec — Isolation inter-églises des contrôles de permission
+
+- **Numéro** : 024
+- **Statut** : Validée
+- **Créée le** : 2026-08-29
+- **Branche suggérée** : `fix/isolation-permissions-inter-eglises`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+Koinonia est multi-tenant : une même personne peut servir dans plusieurs églises, avec un
+rôle **différent** dans chacune. Elle peut être Admin de l'église A et simple STAR de
+l'église B.
+
+Aujourd'hui, deux décisions distinctes sont prises séparément lors d'une action :
+
+1. **« A-t-il le droit ? »** — évaluée en agrégeant les droits détenus dans **toutes** les
+   églises de la personne, sans tenir compte de celle sur laquelle l'action porte.
+2. **« Sur quelle église ? »** — déterminée ensuite, à partir du sélecteur d'église courante,
+   dont la valeur est fournie par le navigateur et n'est validée que par la présence d'un
+   rôle **quelconque** dans l'église demandée.
+
+Ces deux décisions ne sont jamais rapprochées. Une personne Admin de A et simple STAR de B
+peut donc désigner B comme église courante : le contrôle de droits est satisfait par son
+rôle dans A, tandis que la lecture ou l'écriture s'applique à B. Elle agit ainsi dans B avec
+des droits qu'elle n'y possède pas.
+
+Le problème n'est pas une route mal écrite mais un **contrat qui autorise cette erreur** :
+le contrôle de droits accepte de ne pas savoir sur quelle église il statue. L'écart mesuré
+dans le code confirme que ce n'est pas un cas isolé — la grande majorité des contrôles est
+effectuée sans préciser l'église concernée, et de nombreux endroits enchaînent ensuite la
+résolution de l'église courante. Les modules touchés couvrent l'audio, la comptabilité,
+l'accueil, l'emploi, les réservations de salles, la gestion des églises et le journal
+d'audit.
+
+Aucun test ne démontre aujourd'hui l'isolation entre deux églises : le défaut peut donc
+réapparaître silencieusement après correction.
+
+**Pourquoi maintenant** : le constat est classé au plus haut niveau de gravité de l'audit
+du 2026-08-29, et c'est le seul dont un chemin d'exploitation concret a été établi. Il
+concerne la confidentialité des données d'églises tierces, qui sont des organisations
+distinctes et juridiquement indépendantes.
+
+## Utilisateurs concernés
+
+| Rôle | Impact attendu |
+|---|---|
+| **Super Admin** | Aucun changement : conserve son accès global à toutes les églises. |
+| **Admin, Secrétaire, Ministre, Resp. département** | Aucun changement **dans leur propre église**. Perdent la capacité — non voulue — d'exercer ces droits dans une autre église où ils ont un rôle moindre. |
+| **STAR, Faiseur de Disciples, Reporter** | Aucun changement dans leur église. Protégés en tant que **victimes** : leurs données cessent d'être exposées à un responsable d'une autre église. |
+| **Personne multi-églises** (quel que soit le rôle) | Seul profil dont le comportement change réellement : ses droits sont désormais évalués église par église. |
+
+Le bénéficiaire principal n'est pas l'utilisateur qui agit, mais **l'église tierce** dont
+les données cessent d'être accessibles.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Marie est Admin de l'église A et simple STAR de l'église B.
+2. Marie bascule son contexte de travail sur l'église B.
+3. Marie tente une action réservée aux Admin (par exemple modifier un paramètre de l'église).
+4. Le système évalue ses droits **dans l'église B uniquement**, où elle n'est que STAR.
+5. L'action est **refusée**, avec le même message d'accès refusé que pour toute personne
+   sans le droit requis — sans révéler qu'elle possède ce droit ailleurs.
+6. Marie rebascule sur l'église A et refait la même action : elle **réussit**.
+
+### Scénarios alternatifs / cas limites
+
+- **Si** la personne n'a qu'une seule église, son expérience est strictement inchangée.
+- **Si** la personne est Super Admin, elle conserve l'accès à toutes les églises.
+- **Si** le contexte d'église transmis par le navigateur désigne une église où la personne
+  n'a **aucun** rattachement, le système ignore cette valeur et n'agit jamais sur cette
+  église — ni en lecture, ni en écriture.
+- **Si** le contexte d'église est absent, invalide ou corrompu, le système applique un
+  contexte par défaut légitime pour cette personne, ou refuse l'action ; il ne devine
+  jamais une église sur laquelle la personne n'a pas de droits.
+- **Quand** une action porte sur un objet précis (un document, un événement, un membre),
+  l'église de rattachement de cet objet fait autorité : le contrôle porte sur **l'église de
+  l'objet**, jamais sur le contexte affiché, afin qu'un contexte manipulé ne puisse pas
+  déplacer l'action vers une autre église.
+- **Quand** une action est légitimement globale (administration de la plateforme,
+  supervision), elle reste possible, mais sa portée globale doit être **explicite et
+  assumée**, pas la conséquence d'une église non précisée.
+- **Si** un profil pastoral supervise une église sans y détenir de rôle, il conserve sa
+  **vue en lecture seule** sur le périmètre de supervision prévu, et **rien de plus** :
+  aucune action de modification ne lui est ouverte sur une église supervisée.
+- **Si** ce même profil pastoral détient par ailleurs un rôle privilégié dans une **autre**
+  église, ce rôle ne lui confère **aucun droit d'écriture** sur l'église supervisée. C'est
+  aujourd'hui le cas le plus exposé : la supervision est correctement restreinte à la
+  lecture là où l'église est explicitement désignée, mais cette restriction est entièrement
+  contournée par le chemin décrit dans « Contexte & problème ».
+
+## Critères d'acceptation
+
+- [ ] Une personne ayant un rôle privilégié dans l'église A et un rôle moindre dans
+      l'église B **ne peut effectuer aucune action** dans B qui excède ses droits dans B,
+      quel que soit le contexte d'église qu'elle transmet.
+- [ ] Cela vaut aussi bien en **lecture** qu'en **écriture** : elle ne peut pas non plus
+      consulter dans B des données réservées aux rôles qu'elle n'y détient pas.
+- [ ] Un refus d'accès est **indiscernable** du refus opposé à une personne ne détenant ce
+      droit dans aucune église (pas de fuite d'information sur les rattachements).
+- [ ] Aucun contrôle d'autorisation ne peut être écrit sans que l'église sur laquelle il
+      statue soit déterminée : un contrôle omettant cette information est **rejeté ou
+      impossible à exprimer**, et non silencieusement traité comme « toutes les églises ».
+- [ ] Les portées volontairement globales sont **énumérables** : on peut lister les endroits
+      qui autorisent une décision sans église, et chacun est justifié.
+- [ ] Un contexte d'église fourni par le navigateur et désignant une église sans
+      rattachement est **sans effet** : il ne devient jamais le périmètre de l'action.
+- [ ] Pour toute action portant sur un objet identifié, l'église retenue est celle de
+      l'objet ; un contexte affiché divergent ne modifie pas la cible de l'action.
+- [ ] Un profil pastoral ne peut effectuer **aucune écriture** sur une église qu'il
+      supervise sans y détenir de rôle, y compris lorsqu'il détient un rôle privilégié dans
+      une autre église.
+- [ ] La restriction de la supervision à la consultation est appliquée **uniformément**,
+      quel que soit le chemin d'accès emprunté.
+- [ ] Les actions transverses (lister les églises, consulter le journal d'audit, créer une
+      église) sont **réservées au Super Admin**.
+- [ ] Dans un contexte d'église donné, les actions non autorisées **ne sont pas proposées**
+      à l'utilisateur ; un accès direct à ces actions reste malgré tout **refusé côté
+      serveur**, le masquage n'étant jamais l'unique protection.
+- [ ] Une personne mono-église ne constate **aucun changement** de comportement.
+- [ ] Le Super Admin conserve son accès global.
+- [ ] Des tests automatisés couvrent explicitement le scénario **deux églises, deux rôles
+      différents**, pour la lecture comme pour l'écriture, et échouent si le défaut
+      réapparaît.
+- [ ] Les modules identifiés comme touchés (audio, comptabilité, accueil, emploi,
+      réservations de salles, gestion des églises, journal d'audit) sont tous couverts.
+
+## Hors périmètre
+
+- Les autres constats de l'audit : accès direct à un objet par identifiant deviné,
+  partage du cookie de session entre sous-domaines, bornes d'envoi de fichiers,
+  chaîne de déploiement. Ils font l'objet de corrections distinctes.
+- La refonte du modèle de rôles et de permissions lui-même : le tableau des droits par
+  rôle reste inchangé.
+- L'ergonomie du sélecteur d'église (son apparence, sa position, la mémorisation du choix).
+- L'ajout de nouveaux rôles ou de nouvelles permissions.
+- La journalisation ou la détection des tentatives d'accès inter-églises.
+- La correction des tests existants qui ne concernent pas l'isolation multi-tenant.
+
+## Décisions prises
+
+- **Profils pastoraux — lecture seule stricte.** La supervision d'une église ne confère
+  jamais de droit de modification. Cette intention est **déjà celle du code** là où
+  l'église est explicitement désignée : la supervision n'y ouvre qu'un ensemble restreint
+  et énuméré de consultations. La correction consiste donc à rendre cette règle
+  **inévitable**, et non à l'inventer. Aucun modèle de droits nouveau n'est nécessaire.
+
+- **Actions transverses — réservées au Super Admin.** Toute action légitimement sans église
+  cible relève du Super Admin, déjà porteur d'un accès global. La liste des portées
+  globales autorisées reste ainsi courte, énumérable et auditable ; aucun autre rôle
+  n'obtient de portée hors église.
+
+- **Expérience utilisateur — actions masquées.** Dans un contexte d'église donné, les
+  actions que la personne n'y est pas autorisée à effectuer ne lui sont pas proposées,
+  plutôt que d'être proposées puis refusées. Le masquage est un confort d'interface, jamais
+  une protection : le refus côté serveur reste appliqué indépendamment, y compris pour un
+  accès direct.
+
+## Questions ouvertes
+
+*Aucune. Les trois points en suspens ont été tranchés ci-dessus ; la spec est prête pour `/plan`.*

--- a/specs/024-isolation-permissions-inter-eglises/tasks.md
+++ b/specs/024-isolation-permissions-inter-eglises/tasks.md
@@ -27,7 +27,7 @@
 
 ### 2. Logique métier (gardes d'autorisation)
 
-- [ ] **T1** — Ajouter les trois gardes explicites, sans encore rien supprimer, pour que les
+- [x] **T1** — Ajouter les trois gardes explicites, sans encore rien supprimer, pour que les
       appelants aient une cible avant la migration : *(fichier : `src/lib/auth.ts`)*
   - `requireCurrentChurchPermission(permission)` → résout le contexte d'église courant puis
     délègue à `requireChurchPermission` ; retourne `{ session, churchId }`. Ne doit **jamais**
@@ -35,32 +35,32 @@
   - `requireSuperAdmin()` → administration plateforme.
   - `requirePlatformPermission(permission)` → domaine transverse, avec liste blanche des
     permissions autorisées (module emploi uniquement).
-- [ ] **T2** — Supprimer `requirePermission` et documenter dans le commentaire de
+- [x] **T2** — Supprimer `requirePermission` et documenter dans le commentaire de
       `getCurrentChurchId` qu'il retourne un **contexte d'affichage, jamais une
       autorisation**. *(fichier : `src/lib/auth.ts`)*
 
 ### 3. API (route handlers) — requalification des 23 appels
 
-- [ ] **T3** [P] — **Accueil** (7 appels) → `requireCurrentChurchPermission("events:manage")`.
+- [x] **T3** [P] — **Accueil** (7 appels) → `requireCurrentChurchPermission("events:manage")`.
       *(fichiers : `src/app/api/welcome-duty/{suggestions,available-families,families,families/[id],assignments,assignments/[id]}/route.ts`, `src/app/(auth)/admin/welcome-duty/page.tsx`)*
-- [ ] **T4** [P] — **Comptabilité** (6 appels) → contexte courant ; pour les routes agissant
+- [x] **T4** [P] — **Comptabilité** (6 appels) → contexte courant ; pour les routes agissant
       sur un objet identifié, résoudre l'église **depuis l'objet**.
       *(fichiers : `src/app/api/accounting/{attachments,requests,series,series/[id]}/route.ts`)*
-- [ ] **T5** [P] — **Réservations de salles** (4 appels) → `mrbs:manage` sur l'église courante.
+- [x] **T5** [P] — **Réservations de salles** (4 appels) → `mrbs:manage` sur l'église courante.
       *(fichiers : `src/app/api/admin/mrbs-links/route.ts`, `src/app/(auth)/admin/mrbs-links/page.tsx`)*
-- [ ] **T6** [P] — **Audio (paramètres)** (3 appels) → `audio:manage` sur l'église courante.
+- [x] **T6** [P] — **Audio (paramètres)** (3 appels) → `audio:manage` sur l'église courante.
       *(fichiers : `src/app/api/audio/settings/route.ts`, `src/app/api/audio/settings/cover/sign/route.ts`)*
-- [ ] **T7** [P] — **Administration plateforme** (4 appels `church:manage`) → `requireSuperAdmin()`.
+- [x] **T7** [P] — **Administration plateforme** (4 appels `church:manage`) → `requireSuperAdmin()`.
       *(fichiers : `src/app/(auth)/admin/churches/page.tsx`, `src/app/(auth)/admin/churches/[churchId]/page.tsx`, `src/app/(auth)/admin/churches/onboard/page.tsx`, `src/app/(auth)/admin/audit-logs/page.tsx`)*
-- [ ] **T8** [P] — **Module emploi** (4 appels) → `requirePlatformPermission(...)`. Ne pas
+- [x] **T8** [P] — **Module emploi** (4 appels) → `requirePlatformPermission(...)`. Ne pas
       rattacher à une église : ces modèles n'ont pas de `churchId`, la portée transverse est
       voulue. *(fichiers : `src/app/api/jobs/route.ts`, `src/app/api/jobs/seekers/route.ts`, `src/app/api/jobs/freelance/{missions,profiles}/route.ts`)*
-- [ ] **T9** — Vérifier que `npm run typecheck` repasse au **vert** : plus aucun appelant
+- [x] **T9** — Vérifier que `npm run typecheck` repasse au **vert** : plus aucun appelant
       orphelin, donc migration exhaustive prouvée par le compilateur.
 
 ### 4. UI
 
-- [ ] **T10** — Restreindre le calcul des droits d'affichage aux rôles détenus **dans
+- [x] **T10** — Restreindre le calcul des droits d'affichage aux rôles détenus **dans
       l'église courante** (aujourd'hui `churchRoles.map(...)` agrège toutes les églises, ce
       qui affiche les liens d'administration de A dans le contexte de B). Conserver l'accès
       global du Super Admin et les permissions de lecture pastorale.
@@ -68,40 +68,40 @@
 
 ### 5. Tests
 
-- [ ] **T11** — Socle de session factice **deux églises** : rôle privilégié dans A, rôle
+- [x] **T11** — Socle de session factice **deux églises** : rôle privilégié dans A, rôle
       moindre dans B. Réutilisé par les cas suivants.
       *(fichier : `src/lib/__tests__/auth-multitenant.test.ts`)*
-- [ ] **T12** — **Isolation (cœur)** : refus dans B avec une permission détenue seulement
+- [x] **T12** — **Isolation (cœur)** : refus dans B avec une permission détenue seulement
       dans A ; succès dans A. En **lecture** comme en **écriture**. *(même fichier)*
-- [ ] **T13** [P] — **Non-régression mono-église** : une session à une seule église conserve
+- [x] **T13** [P] — **Non-régression mono-église** : une session à une seule église conserve
       exactement ses accès. *(même fichier)*
-- [ ] **T14** [P] — **Super Admin** : accès conservé sur A comme sur B. *(même fichier)*
-- [ ] **T15** — **Supervision pastorale** : lecture autorisée sur l'église supervisée ;
+- [x] **T14** [P] — **Super Admin** : accès conservé sur A comme sur B. *(même fichier)*
+- [x] **T15** — **Supervision pastorale** : lecture autorisée sur l'église supervisée ;
       **écriture refusée**, y compris avec un rôle privilégié dans une autre église.
       ⚠️ Ce test doit **échouer sur le code actuel** — le vérifier avant T2 vaut preuve du
       défaut. *(même fichier)*
-- [ ] **T16** [P] — **Contexte manipulé** : un contexte d'église sans rattachement ne devient
+- [x] **T16** [P] — **Contexte manipulé** : un contexte d'église sans rattachement ne devient
       jamais le périmètre de l'action. *(même fichier)*
-- [ ] **T17** [P] — **Absence de fuite** : le refus dans B est indiscernable de celui opposé à
+- [x] **T17** [P] — **Absence de fuite** : le refus dans B est indiscernable de celui opposé à
       une session sans aucun droit (même erreur, même message). *(même fichier)*
-- [ ] **T18** — **Portées globales énumérables** : test comparant les appels aux gardes
+- [x] **T18** — **Portées globales énumérables** : test comparant les appels aux gardes
       globales (`requireSuperAdmin`, `requirePlatformPermission`) à une liste blanche
       commitée ; tout nouvel usage fait échouer la suite tant qu'il n'est pas justifié.
       *(fichier : `src/lib/__tests__/auth-global-scopes.test.ts`)*
 
 ### 6. Documentation
 
-- [ ] **T19** [P] — Mettre à jour la section « Helpers d'authentification » de `CLAUDE.md` et
+- [x] **T19** [P] — Mettre à jour la section « Helpers d'authentification » de `CLAUDE.md` et
       `docs/auth.md` : `requirePermission` n'existe plus, les trois gardes le remplacent, et
       le critère de choix entre elles. *(fichiers : `CLAUDE.md`, `docs/auth.md`)*
 
 ## Vérification finale
 
-- [ ] `npm run typecheck`
-- [ ] `npm run lint`
-- [ ] `npm run lint:boundaries`
-- [ ] `npm run test`
-- [ ] Tous les critères d'acceptation de `spec.md` satisfaits
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits
 - [ ] **Avant déploiement** : signaler aux utilisateurs concernés que les profils pastoraux
       repassent en lecture seule stricte sur les églises supervisées (un usage réel s'appuie
       peut-être sur le défaut actuel — cf. risques du plan)

--- a/specs/024-isolation-permissions-inter-eglises/tasks.md
+++ b/specs/024-isolation-permissions-inter-eglises/tasks.md
@@ -1,0 +1,126 @@
+# Tâches — Isolation inter-églises des contrôles de permission
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : À faire
+
+> Tâches **ordonnées** et **vérifiables**. Les tâches `[P]` sont parallélisables.
+>
+> ⚠️ **Ordre imposé par la méthode** : T2 (suppression de `requirePermission`) casse
+> volontairement la compilation. `npm run typecheck` devient alors la **liste de travail
+> vivante** — chaque erreur est un appel à requalifier, et la compilation ne repasse au vert
+> qu'une fois T4→T8 terminées. Ne pas chercher à garder le vert entre T2 et T8.
+>
+> ⚠️ **Aucun remplacement automatisé.** La catégorie d'un appel ne se déduit pas de la
+> permission demandée : elle dépend de ce sur quoi la route agit. Chaque site est requalifié
+> individuellement, en lisant la route.
+
+## Prérequis
+
+- [x] Branche créée : `fix/isolation-permissions-inter-eglises`
+- [x] Migration Prisma : **aucune** (pas de changement de schéma)
+
+## Tâches
+
+### 1. Données & migration
+
+*Aucune tâche — le défaut est entièrement dans la couche d'autorisation.*
+
+### 2. Logique métier (gardes d'autorisation)
+
+- [ ] **T1** — Ajouter les trois gardes explicites, sans encore rien supprimer, pour que les
+      appelants aient une cible avant la migration : *(fichier : `src/lib/auth.ts`)*
+  - `requireCurrentChurchPermission(permission)` → résout le contexte d'église courant puis
+    délègue à `requireChurchPermission` ; retourne `{ session, churchId }`. Ne doit **jamais**
+    retourner un `churchId` sur lequel la permission n'a pas été vérifiée.
+  - `requireSuperAdmin()` → administration plateforme.
+  - `requirePlatformPermission(permission)` → domaine transverse, avec liste blanche des
+    permissions autorisées (module emploi uniquement).
+- [ ] **T2** — Supprimer `requirePermission` et documenter dans le commentaire de
+      `getCurrentChurchId` qu'il retourne un **contexte d'affichage, jamais une
+      autorisation**. *(fichier : `src/lib/auth.ts`)*
+
+### 3. API (route handlers) — requalification des 23 appels
+
+- [ ] **T3** [P] — **Accueil** (7 appels) → `requireCurrentChurchPermission("events:manage")`.
+      *(fichiers : `src/app/api/welcome-duty/{suggestions,available-families,families,families/[id],assignments,assignments/[id]}/route.ts`, `src/app/(auth)/admin/welcome-duty/page.tsx`)*
+- [ ] **T4** [P] — **Comptabilité** (6 appels) → contexte courant ; pour les routes agissant
+      sur un objet identifié, résoudre l'église **depuis l'objet**.
+      *(fichiers : `src/app/api/accounting/{attachments,requests,series,series/[id]}/route.ts`)*
+- [ ] **T5** [P] — **Réservations de salles** (4 appels) → `mrbs:manage` sur l'église courante.
+      *(fichiers : `src/app/api/admin/mrbs-links/route.ts`, `src/app/(auth)/admin/mrbs-links/page.tsx`)*
+- [ ] **T6** [P] — **Audio (paramètres)** (3 appels) → `audio:manage` sur l'église courante.
+      *(fichiers : `src/app/api/audio/settings/route.ts`, `src/app/api/audio/settings/cover/sign/route.ts`)*
+- [ ] **T7** [P] — **Administration plateforme** (4 appels `church:manage`) → `requireSuperAdmin()`.
+      *(fichiers : `src/app/(auth)/admin/churches/page.tsx`, `src/app/(auth)/admin/churches/[churchId]/page.tsx`, `src/app/(auth)/admin/churches/onboard/page.tsx`, `src/app/(auth)/admin/audit-logs/page.tsx`)*
+- [ ] **T8** [P] — **Module emploi** (4 appels) → `requirePlatformPermission(...)`. Ne pas
+      rattacher à une église : ces modèles n'ont pas de `churchId`, la portée transverse est
+      voulue. *(fichiers : `src/app/api/jobs/route.ts`, `src/app/api/jobs/seekers/route.ts`, `src/app/api/jobs/freelance/{missions,profiles}/route.ts`)*
+- [ ] **T9** — Vérifier que `npm run typecheck` repasse au **vert** : plus aucun appelant
+      orphelin, donc migration exhaustive prouvée par le compilateur.
+
+### 4. UI
+
+- [ ] **T10** — Restreindre le calcul des droits d'affichage aux rôles détenus **dans
+      l'église courante** (aujourd'hui `churchRoles.map(...)` agrège toutes les églises, ce
+      qui affiche les liens d'administration de A dans le contexte de B). Conserver l'accès
+      global du Super Admin et les permissions de lecture pastorale.
+      *(fichier : `src/app/(auth)/layout.tsx`)*
+
+### 5. Tests
+
+- [ ] **T11** — Socle de session factice **deux églises** : rôle privilégié dans A, rôle
+      moindre dans B. Réutilisé par les cas suivants.
+      *(fichier : `src/lib/__tests__/auth-multitenant.test.ts`)*
+- [ ] **T12** — **Isolation (cœur)** : refus dans B avec une permission détenue seulement
+      dans A ; succès dans A. En **lecture** comme en **écriture**. *(même fichier)*
+- [ ] **T13** [P] — **Non-régression mono-église** : une session à une seule église conserve
+      exactement ses accès. *(même fichier)*
+- [ ] **T14** [P] — **Super Admin** : accès conservé sur A comme sur B. *(même fichier)*
+- [ ] **T15** — **Supervision pastorale** : lecture autorisée sur l'église supervisée ;
+      **écriture refusée**, y compris avec un rôle privilégié dans une autre église.
+      ⚠️ Ce test doit **échouer sur le code actuel** — le vérifier avant T2 vaut preuve du
+      défaut. *(même fichier)*
+- [ ] **T16** [P] — **Contexte manipulé** : un contexte d'église sans rattachement ne devient
+      jamais le périmètre de l'action. *(même fichier)*
+- [ ] **T17** [P] — **Absence de fuite** : le refus dans B est indiscernable de celui opposé à
+      une session sans aucun droit (même erreur, même message). *(même fichier)*
+- [ ] **T18** — **Portées globales énumérables** : test comparant les appels aux gardes
+      globales (`requireSuperAdmin`, `requirePlatformPermission`) à une liste blanche
+      commitée ; tout nouvel usage fait échouer la suite tant qu'il n'est pas justifié.
+      *(fichier : `src/lib/__tests__/auth-global-scopes.test.ts`)*
+
+### 6. Documentation
+
+- [ ] **T19** [P] — Mettre à jour la section « Helpers d'authentification » de `CLAUDE.md` et
+      `docs/auth.md` : `requirePermission` n'existe plus, les trois gardes le remplacent, et
+      le critère de choix entre elles. *(fichiers : `CLAUDE.md`, `docs/auth.md`)*
+
+## Vérification finale
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run lint:boundaries`
+- [ ] `npm run test`
+- [ ] Tous les critères d'acceptation de `spec.md` satisfaits
+- [ ] **Avant déploiement** : signaler aux utilisateurs concernés que les profils pastoraux
+      repassent en lecture seule stricte sur les églises supervisées (un usage réel s'appuie
+      peut-être sur le défaut actuel — cf. risques du plan)
+- [ ] PR ouverte vers `main`
+
+## Couverture des critères d'acceptation
+
+| Critère de `spec.md` | Tâche(s) |
+|---|---|
+| Aucune action dans B excédant les droits dans B | T1, T3–T8, T12 |
+| Vaut en lecture comme en écriture | T12 |
+| Refus indiscernable (pas de fuite) | T17 |
+| Contrôle sans église impossible à exprimer | T2, T9 |
+| Portées globales énumérables | T7, T8, T18 |
+| Contexte navigateur sans rattachement sans effet | T16 |
+| L'église de l'objet fait autorité | T4 |
+| Mono-église : aucun changement | T13 |
+| Super Admin : accès global conservé | T7, T14 |
+| Tests deux églises / deux rôles | T11, T12 |
+| Pastoral : aucune écriture sur église supervisée | T15 |
+| Modules touchés tous couverts | T3–T8 |
+| Actions non autorisées non proposées | T10 |

--- a/src/app/(auth)/admin/audit-logs/page.tsx
+++ b/src/app/(auth)/admin/audit-logs/page.tsx
@@ -1,8 +1,8 @@
-import { requirePermission } from "@/lib/auth";
+import { requireSuperAdmin } from "@/lib/auth";
 import AuditLogsClient from "./AuditLogsClient";
 
 export default async function AuditLogsPage() {
-  await requirePermission("church:manage");
+  await requireSuperAdmin();
 
   return (
     <div>

--- a/src/app/(auth)/admin/churches/[churchId]/page.tsx
+++ b/src/app/(auth)/admin/churches/[churchId]/page.tsx
@@ -1,4 +1,4 @@
-import { requirePermission } from "@/lib/auth";
+import { requireSuperAdmin } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import ChurchEditClient from "./ChurchEditClient";
@@ -8,7 +8,7 @@ export default async function ChurchDetailPage({
 }: {
   params: Promise<{ churchId: string }>;
 }) {
-  await requirePermission("church:manage");
+  await requireSuperAdmin();
   const { churchId } = await params;
 
   const church = await prisma.church.findUnique({

--- a/src/app/(auth)/admin/churches/onboard/page.tsx
+++ b/src/app/(auth)/admin/churches/onboard/page.tsx
@@ -1,8 +1,8 @@
-import { requirePermission } from "@/lib/auth";
+import { requireSuperAdmin } from "@/lib/auth";
 import OnboardClient from "./OnboardClient";
 
 export default async function OnboardPage() {
-  await requirePermission("church:manage");
+  await requireSuperAdmin();
 
   return (
     <div>

--- a/src/app/(auth)/admin/churches/page.tsx
+++ b/src/app/(auth)/admin/churches/page.tsx
@@ -1,9 +1,9 @@
-import { requirePermission } from "@/lib/auth";
+import { requireSuperAdmin } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import ChurchesClient from "./ChurchesClient";
 
 export default async function ChurchesPage() {
-  await requirePermission("church:manage");
+  await requireSuperAdmin();
 
   const churches = await prisma.church.findMany({
     include: {

--- a/src/app/(auth)/admin/mrbs-links/page.tsx
+++ b/src/app/(auth)/admin/mrbs-links/page.tsx
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireAuth, requireChurchPermission, getCurrentChurchId } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { registry } from "@/lib/registry";
 import { notFound } from "next/navigation";
@@ -38,9 +38,10 @@ async function fetchMrbsUsers(): Promise<MrbsUser[]> {
 export default async function MrbsLinksPage() {
   if (!registry.has("mrbs")) notFound();
 
-  const session = await requirePermission("mrbs:manage");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
+  await requireChurchPermission("mrbs:manage", churchId);
 
   const [mrbsUsers, links, koinoniaUsers] = await Promise.all([
     fetchMrbsUsers(),

--- a/src/app/(auth)/admin/welcome-duty/page.tsx
+++ b/src/app/(auth)/admin/welcome-duty/page.tsx
@@ -1,11 +1,12 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireAuth, requireChurchPermission, getCurrentChurchId } from "@/lib/auth";
 import Link from "next/link";
 import WelcomeDutyShell from "./WelcomeDutyShell";
 
 export default async function WelcomeDutyPage() {
-  const session = await requirePermission("events:manage");
+  const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p className="text-sm text-gray-500">Aucune église sélectionnée.</p>;
+  await requireChurchPermission("events:manage", churchId);
 
   return (
     <div>

--- a/src/app/(auth)/audio/ecouter/[id]/page.tsx
+++ b/src/app/(auth)/audio/ecouter/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { requireAuth, requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireAuth, requireChurchPermission, getCurrentChurchId } from "@/lib/auth";
 import { getPublishedServiceForMember } from "@/modules/audio";
 import MemberAudioPlayer from "./MemberAudioPlayer";
 
@@ -12,7 +12,7 @@ export default async function AudioListenPage({
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
-  await requirePermission("audio:listen", churchId);
+  await requireChurchPermission("audio:listen", churchId);
 
   const service = await getPublishedServiceForMember(id, churchId);
   if (!service) notFound();

--- a/src/app/(auth)/audio/ecouter/page.tsx
+++ b/src/app/(auth)/audio/ecouter/page.tsx
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import Link from "next/link";
-import { requireAuth, requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireAuth, requireChurchPermission, getCurrentChurchId } from "@/lib/auth";
 import { listPublishedServices, listSpeakers, listSeries } from "@/modules/audio";
 import { EVENT_TYPE_OPTIONS, getEventTypeLabel } from "@/lib/event-types";
 import LibraryFiltersClient from "./LibraryFiltersClient";
@@ -32,7 +32,7 @@ export default async function AudioLibraryPage({
   const session = await requireAuth();
   const churchId = await getCurrentChurchId(session);
   if (!churchId) return <p>Aucune église sélectionnée.</p>;
-  await requirePermission("audio:listen", churchId);
+  await requireChurchPermission("audio:listen", churchId);
 
   const rawParams = await searchParams;
   // Une URL bricolée retombe sur les valeurs par défaut plutôt que de casser la page (plan.md).

--- a/src/app/(auth)/audio/tabs.ts
+++ b/src/app/(auth)/audio/tabs.ts
@@ -1,4 +1,4 @@
-import { requireAudioAccess, requirePermission } from "@/lib/auth";
+import { requireAudioAccess, requireChurchPermission } from "@/lib/auth";
 
 export interface AudioTab {
   href: string;
@@ -11,7 +11,7 @@ export interface AudioTab {
  * onglet accessible).
  */
 export async function getAccessibleAudioTabs(churchId: string): Promise<AudioTab[]> {
-  const canListen = await hasAccess(() => requirePermission("audio:listen", churchId));
+  const canListen = await hasAccess(() => requireChurchPermission("audio:listen", churchId));
   const canProduce = await hasAccess(() => requireAudioAccess("audio:view", churchId));
   const canManage = await hasAccess(() => requireAudioAccess("audio:manage", churchId));
 

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -118,7 +118,13 @@ export default async function AuthLayout({
   }
 
   // Compute visible config links
-  const userRoles = churchRoles.map((r) => r.role);
+  // Uniquement les rôles détenus dans l'église COURANTE : agréger toutes les églises ici
+  // afficherait les liens d'administration d'une église où l'utilisateur n'est qu'Admin
+  // ailleurs et simple STAR dans celle-ci (isolation inter-églises, spec 024). Le masquage
+  // reste un confort d'affichage — la protection réelle est côté serveur (requireChurchPermission).
+  const userRoles = churchRoles
+    .filter((r) => r.churchId === currentChurchId)
+    .map((r) => r.role);
   const userPermissions = new Set(userRoles.flatMap((r) => rolePermissions[r] ?? []));
   // Super admins have all permissions regardless of church roles
   if (session.user.isSuperAdmin) {

--- a/src/app/api/accounting/attachments/route.ts
+++ b/src/app/api/accounting/attachments/route.ts
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { storeFile } from "@/lib/file-storage";
@@ -8,9 +8,7 @@ const ALLOWED_TYPES = ["image/jpeg", "image/png", "application/pdf"];
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("accounting:submit");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { session, churchId } = await requireCurrentChurchPermission("accounting:submit");
 
     const formData = await request.formData();
     const file = formData.get("file") as File | null;

--- a/src/app/api/accounting/requests/route.ts
+++ b/src/app/api/accounting/requests/route.ts
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { rolePermissions } from "@/lib/registry";
@@ -16,9 +16,7 @@ const createSchema = z.object({
 
 export async function GET(request: Request) {
   try {
-    const session = await requirePermission("accounting:view");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { session, churchId } = await requireCurrentChurchPermission("accounting:view");
 
     const { searchParams } = new URL(request.url);
     const status     = searchParams.get("status") ?? undefined;
@@ -86,9 +84,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("accounting:submit");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { session, churchId } = await requireCurrentChurchPermission("accounting:submit");
 
     const body = createSchema.parse(await request.json());
 

--- a/src/app/api/accounting/series/[id]/route.ts
+++ b/src/app/api/accounting/series/[id]/route.ts
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
@@ -12,13 +12,15 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await requirePermission("accounting:submit");
     const { id } = await params;
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
 
+    // L'église de l'objet fait autorité, pas le contexte affiché : on résout d'abord la
+    // série puis on vérifie la permission dans SON église, pour qu'un contexte manipulé
+    // ne puisse jamais déplacer l'action vers une autre église.
     const series = await prisma.financialSeries.findUnique({ where: { id } });
-    if (!series || series.churchId !== churchId) throw new ApiError(404, "Série introuvable");
+    if (!series) throw new ApiError(404, "Série introuvable");
+
+    const session = await requireChurchPermission("accounting:submit", series.churchId);
     if (series.submittedById !== session.user.id!) throw new ApiError(403, "Accès refusé");
 
     const { status } = patchSchema.parse(await request.json());

--- a/src/app/api/accounting/series/route.ts
+++ b/src/app/api/accounting/series/route.ts
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
@@ -15,9 +15,7 @@ const createSchema = z.object({
 
 export async function GET(request: Request) {
   try {
-    const session = await requirePermission("accounting:view");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("accounting:view");
 
     const { searchParams } = new URL(request.url);
     const status = searchParams.get("status") ?? undefined;
@@ -43,9 +41,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("accounting:submit");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { session, churchId } = await requireCurrentChurchPermission("accounting:submit");
 
     const body = createSchema.parse(await request.json());
 

--- a/src/app/api/admin/mrbs-links/route.ts
+++ b/src/app/api/admin/mrbs-links/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
 
@@ -10,9 +10,7 @@ const createSchema = z.object({
 
 export async function GET(_request: Request) {
   try {
-    const session = await requirePermission("mrbs:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("mrbs:manage");
 
     const links = await prisma.mrbsUserLink.findMany({
       where: { churchId },
@@ -31,9 +29,7 @@ export async function GET(_request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("mrbs:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { session, churchId } = await requireCurrentChurchPermission("mrbs:manage");
 
     const data = createSchema.parse(await request.json());
 
@@ -60,9 +56,7 @@ export async function POST(request: Request) {
 
 export async function DELETE(request: Request) {
   try {
-    const session = await requirePermission("mrbs:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("mrbs:manage");
 
     const mrbsUsername = new URL(request.url).searchParams.get("mrbsUsername");
     if (!mrbsUsername) throw new ApiError(400, "Paramètre mrbsUsername requis");

--- a/src/app/api/audio/services/[id]/play/route.ts
+++ b/src/app/api/audio/services/[id]/play/route.ts
@@ -4,7 +4,7 @@
  * la diffusion d'un lien de partage, une sémantique distincte).
  */
 import { z } from "zod";
-import { requirePermission } from "@/lib/auth";
+import { requireChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 
@@ -21,7 +21,7 @@ export async function POST(
     const service = await prisma.audioService.findUnique({ where: { id }, select: { churchId: true, status: true } });
     if (!service) throw new ApiError(404, "Culte audio introuvable");
 
-    await requirePermission("audio:listen", service.churchId);
+    await requireChurchPermission("audio:listen", service.churchId);
 
     if (service.status !== "PUBLISHED") throw new ApiError(410, "Ce culte n'est plus disponible.");
 

--- a/src/app/api/audio/services/[id]/share/route.ts
+++ b/src/app/api/audio/services/[id]/share/route.ts
@@ -4,7 +4,7 @@
  * non révoqué avant d'en créer un — repartager la même séquence ne multiplie pas les liens.
  */
 import { z } from "zod";
-import { requirePermission } from "@/lib/auth";
+import { requireChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { getOrCreatePrimaryShareToken, getOrCreateSegmentShareToken, buildPublicAudioUrl } from "@/modules/audio";
@@ -22,7 +22,7 @@ export async function POST(
     const service = await prisma.audioService.findUnique({ where: { id }, select: { churchId: true, status: true } });
     if (!service) throw new ApiError(404, "Culte audio introuvable");
 
-    await requirePermission("audio:listen", service.churchId);
+    await requireChurchPermission("audio:listen", service.churchId);
 
     if (service.status !== "PUBLISHED") throw new ApiError(410, "Ce culte n'est plus disponible.");
 

--- a/src/app/api/audio/services/[id]/stream/[segmentId]/route.ts
+++ b/src/app/api/audio/services/[id]/stream/[segmentId]/route.ts
@@ -3,7 +3,7 @@
  * Streaming interne (bibliothèque d'écoute, spec 021) — distinct de la route publique par
  * token : ici l'accès passe par une session authentifiée et `audio:listen`.
  */
-import { requirePermission } from "@/lib/auth";
+import { requireChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { errorResponse, ApiError } from "@/lib/api-utils";
 import { buildRenditionResponse } from "@/modules/audio";
@@ -18,7 +18,7 @@ export async function GET(
     const service = await prisma.audioService.findUnique({ where: { id }, select: { churchId: true, status: true } });
     if (!service) throw new ApiError(404, "Culte audio introuvable");
 
-    await requirePermission("audio:listen", service.churchId);
+    await requireChurchPermission("audio:listen", service.churchId);
 
     if (service.status !== "PUBLISHED") throw new ApiError(410, "Ce culte n'est plus disponible.");
 

--- a/src/app/api/audio/settings/cover/sign/route.ts
+++ b/src/app/api/audio/settings/cover/sign/route.ts
@@ -3,8 +3,8 @@
  * navigateur → S3 la couverture par défaut du module audio.
  */
 import { z } from "zod";
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
-import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { requireCurrentChurchPermission } from "@/lib/auth";
+import { successResponse, errorResponse } from "@/lib/api-utils";
 import { validateCoverFile, getCoverExtensionFromMimeType, getDefaultCoverKey } from "@/modules/audio";
 import { getSignedPutUrl, getSignedStreamUrl } from "@/modules/storage";
 
@@ -16,9 +16,7 @@ const signSchema = z.object({
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("audio:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("audio:manage");
 
     const body = signSchema.parse(await request.json());
     validateCoverFile(body.mimeType, body.size);

--- a/src/app/api/audio/settings/route.ts
+++ b/src/app/api/audio/settings/route.ts
@@ -4,9 +4,9 @@
  * fonctions de département (`Department.function = "CAPTATION_AUDIO"`, spec 021).
  */
 import { z } from "zod";
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { successResponse, errorResponse } from "@/lib/api-utils";
 
 const schema = z.object({
   defaultCoverKey: z.string().nullable().optional(),
@@ -15,9 +15,7 @@ const schema = z.object({
 
 export async function GET() {
   try {
-    const session = await requirePermission("audio:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("audio:manage");
 
     const settings = await prisma.audioSettings.findUnique({ where: { churchId } });
     return successResponse(settings);
@@ -28,9 +26,7 @@ export async function GET() {
 
 export async function PUT(request: Request) {
   try {
-    const session = await requirePermission("audio:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("audio:manage");
 
     const body = schema.parse(await request.json());
 

--- a/src/app/api/jobs/__tests__/freelance.test.ts
+++ b/src/app/api/jobs/__tests__/freelance.test.ts
@@ -3,11 +3,11 @@ import { prismaMock } from "@/__mocks__/prisma";
 import { createAdminSession, createSession } from "@/__mocks__/auth";
 
 const mockRequireAuth       = vi.fn();
-const mockRequirePermission = vi.fn();
+const mockRequirePlatformPermission = vi.fn();
 
 vi.mock("@/lib/auth", () => ({
   requireAuth:       (...args: unknown[]) => mockRequireAuth(...args),
-  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+  requirePlatformPermission: (...args: unknown[]) => mockRequirePlatformPermission(...args),
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
 
@@ -88,7 +88,7 @@ describe("GET /api/jobs/freelance/missions", () => {
 describe("POST /api/jobs/freelance/missions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(userSession);
+    mockRequirePlatformPermission.mockResolvedValue(userSession);
     prismaMock.jobNotificationSubscription.findMany.mockResolvedValue([]);
   });
 
@@ -122,7 +122,7 @@ describe("POST /api/jobs/freelance/missions", () => {
   });
 
   it("returns 401 when unauthenticated", async () => {
-    mockRequirePermission.mockRejectedValue(new Error("UNAUTHORIZED"));
+    mockRequirePlatformPermission.mockRejectedValue(new Error("UNAUTHORIZED"));
     const req = new Request("http://localhost/api/jobs/freelance/missions", {
       method: "POST",
       body: JSON.stringify({ title: "t", domain: "d", description: "desc" }),
@@ -217,12 +217,12 @@ describe("DELETE /api/jobs/freelance/missions/[id]", () => {
 describe("POST /api/jobs/freelance/profiles", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(userSession);
+    mockRequirePlatformPermission.mockResolvedValue(userSession);
     prismaMock.jobNotificationSubscription.findMany.mockResolvedValue([]);
   });
 
   it("returns 401 when unauthenticated", async () => {
-    mockRequirePermission.mockRejectedValue(new Error("UNAUTHORIZED"));
+    mockRequirePlatformPermission.mockRejectedValue(new Error("UNAUTHORIZED"));
     const req = new Request("http://localhost/api/jobs/freelance/profiles", {
       method: "POST",
       body: JSON.stringify({ title: "t", domain: "d", description: "desc" }),

--- a/src/app/api/jobs/__tests__/jobs.test.ts
+++ b/src/app/api/jobs/__tests__/jobs.test.ts
@@ -3,11 +3,11 @@ import { prismaMock } from "@/__mocks__/prisma";
 import { createAdminSession } from "@/__mocks__/auth";
 
 const mockRequireAuth       = vi.fn();
-const mockRequirePermission = vi.fn();
+const mockRequirePlatformPermission = vi.fn();
 
 vi.mock("@/lib/auth", () => ({
   requireAuth:       (...args: unknown[]) => mockRequireAuth(...args),
-  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+  requirePlatformPermission: (...args: unknown[]) => mockRequirePlatformPermission(...args),
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
 vi.mock("@/lib/email",  () => ({
@@ -47,7 +47,7 @@ describe("GET /api/jobs", () => {
 describe("POST /api/jobs", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequirePlatformPermission.mockResolvedValue(createAdminSession());
     prismaMock.jobNotificationSubscription.findMany.mockResolvedValue([]);
   });
 
@@ -79,7 +79,7 @@ describe("POST /api/jobs", () => {
   });
 
   it("returns 403 when permission denied", async () => {
-    mockRequirePermission.mockRejectedValue(new Error("FORBIDDEN"));
+    mockRequirePlatformPermission.mockRejectedValue(new Error("FORBIDDEN"));
     const req = new Request("http://localhost/api/jobs", {
       method: "POST",
       body: JSON.stringify({ title: "Dev", type: "EMPLOI", company: "Corp", description: "Desc" }),

--- a/src/app/api/jobs/__tests__/seekers.test.ts
+++ b/src/app/api/jobs/__tests__/seekers.test.ts
@@ -3,11 +3,11 @@ import { prismaMock } from "@/__mocks__/prisma";
 import { createAdminSession } from "@/__mocks__/auth";
 
 const mockRequireAuth       = vi.fn();
-const mockRequirePermission = vi.fn();
+const mockRequirePlatformPermission = vi.fn();
 
 vi.mock("@/lib/auth", () => ({
   requireAuth:       (...args: unknown[]) => mockRequireAuth(...args),
-  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+  requirePlatformPermission: (...args: unknown[]) => mockRequirePlatformPermission(...args),
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
 
@@ -64,7 +64,7 @@ describe("GET /api/jobs/seekers", () => {
 describe("POST /api/jobs/seekers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequirePlatformPermission.mockResolvedValue(createAdminSession());
     prismaMock.jobNotificationSubscription.findMany.mockResolvedValue([]);
   });
 
@@ -101,7 +101,7 @@ describe("POST /api/jobs/seekers", () => {
   });
 
   it("returns 401 when unauthenticated", async () => {
-    mockRequirePermission.mockRejectedValue(new Error("UNAUTHORIZED"));
+    mockRequirePlatformPermission.mockRejectedValue(new Error("UNAUTHORIZED"));
     const req = new Request("http://localhost/api/jobs/seekers", {
       method: "POST",
       body: JSON.stringify({ title: "Dev", wantEmploi: true, description: "Desc" }),

--- a/src/app/api/jobs/freelance/missions/route.ts
+++ b/src/app/api/jobs/freelance/missions/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireAuth, requirePermission } from "@/lib/auth";
+import { requireAuth, requirePlatformPermission } from "@/lib/auth";
 import { successResponse, errorResponse } from "@/lib/api-utils";
 import { z } from "zod";
 
@@ -38,7 +38,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("jobs:freelance");
+    const session = await requirePlatformPermission("jobs:freelance");
     const data = createMissionSchema.parse(await request.json());
 
     const mission = await prisma.freelanceMission.create({

--- a/src/app/api/jobs/freelance/profiles/route.ts
+++ b/src/app/api/jobs/freelance/profiles/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireAuth, requirePermission } from "@/lib/auth";
+import { requireAuth, requirePlatformPermission } from "@/lib/auth";
 import { successResponse, errorResponse } from "@/lib/api-utils";
 import { z } from "zod";
 
@@ -38,7 +38,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("jobs:freelance");
+    const session = await requirePlatformPermission("jobs:freelance");
     const data = createProfileSchema.parse(await request.json());
 
     const profile = await prisma.freelanceProfile.create({

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireAuth, requirePermission } from "@/lib/auth";
+import { requireAuth, requirePlatformPermission } from "@/lib/auth";
 import { successResponse, errorResponse } from "@/lib/api-utils";
 import { sendEmail, buildJobOfferEmail } from "@/lib/email";
 import { z } from "zod";
@@ -46,7 +46,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("jobs:post");
+    const session = await requirePlatformPermission("jobs:post");
     const body = await request.json();
     const data = jobSchema.parse(body);
 

--- a/src/app/api/jobs/seekers/route.ts
+++ b/src/app/api/jobs/seekers/route.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { requireAuth, requirePermission } from "@/lib/auth";
+import { requireAuth, requirePlatformPermission } from "@/lib/auth";
 import { successResponse, errorResponse } from "@/lib/api-utils";
 import { z } from "zod";
 
@@ -56,7 +56,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("jobs:seek");
+    const session = await requirePlatformPermission("jobs:seek");
     const body = await request.json();
     const data = createSeekerSchema.parse(body);
 

--- a/src/app/api/welcome-duty/__tests__/welcome-duty.test.ts
+++ b/src/app/api/welcome-duty/__tests__/welcome-duty.test.ts
@@ -2,11 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { prismaMock } from "@/__mocks__/prisma";
 import { createAdminSession } from "@/__mocks__/auth";
 
-const mockRequirePermission = vi.fn();
-const mockGetCurrentChurchId = vi.fn().mockResolvedValue("church-1");
+const mockRequireCurrentChurchPermission = vi.fn();
 vi.mock("@/lib/auth", () => ({
-  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
-  getCurrentChurchId: (...args: unknown[]) => mockGetCurrentChurchId(...args),
+  requireCurrentChurchPermission: (...args: unknown[]) =>
+    mockRequireCurrentChurchPermission(...args),
 }));
 vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
 
@@ -18,7 +17,10 @@ const { PATCH: patchFamily, DELETE: deleteFamily } = await import("../families/[
 describe("GET /api/welcome-duty/families", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequireCurrentChurchPermission.mockResolvedValue({
+      session: createAdminSession(),
+      churchId: "church-1",
+    });
   });
 
   it("returns pool families", async () => {
@@ -34,7 +36,7 @@ describe("GET /api/welcome-duty/families", () => {
   });
 
   it("returns 401 when unauthenticated", async () => {
-    mockRequirePermission.mockRejectedValue(new Error("UNAUTHORIZED"));
+    mockRequireCurrentChurchPermission.mockRejectedValue(new Error("UNAUTHORIZED"));
     const res = await getFamilies(new Request("http://localhost/api/welcome-duty/families"));
     expect(res.status).toBe(401);
   });
@@ -43,7 +45,10 @@ describe("GET /api/welcome-duty/families", () => {
 describe("POST /api/welcome-duty/families", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequireCurrentChurchPermission.mockResolvedValue({
+      session: createAdminSession(),
+      churchId: "church-1",
+    });
   });
 
   it("creates a new family in pool", async () => {
@@ -97,7 +102,10 @@ describe("POST /api/welcome-duty/families", () => {
 describe("PATCH /api/welcome-duty/families/[id]", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequireCurrentChurchPermission.mockResolvedValue({
+      session: createAdminSession(),
+      churchId: "church-1",
+    });
   });
 
   it("toggles active status", async () => {
@@ -132,7 +140,10 @@ describe("PATCH /api/welcome-duty/families/[id]", () => {
 describe("DELETE /api/welcome-duty/families/[id]", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequireCurrentChurchPermission.mockResolvedValue({
+      session: createAdminSession(),
+      churchId: "church-1",
+    });
   });
 
   it("deletes a family from pool", async () => {
@@ -156,7 +167,10 @@ const { DELETE: deleteAssignment } = await import("../assignments/[id]/route");
 describe("GET /api/welcome-duty/assignments", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequireCurrentChurchPermission.mockResolvedValue({
+      session: createAdminSession(),
+      churchId: "church-1",
+    });
   });
 
   it("returns assignments for an event", async () => {
@@ -179,7 +193,10 @@ describe("GET /api/welcome-duty/assignments", () => {
 describe("POST /api/welcome-duty/assignments", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequireCurrentChurchPermission.mockResolvedValue({
+      session: createAdminSession(),
+      churchId: "church-1",
+    });
   });
 
   it("creates an assignment", async () => {
@@ -212,7 +229,10 @@ describe("POST /api/welcome-duty/assignments", () => {
 describe("DELETE /api/welcome-duty/assignments/[id]", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequireCurrentChurchPermission.mockResolvedValue({
+      session: createAdminSession(),
+      churchId: "church-1",
+    });
   });
 
   it("deletes an assignment", async () => {
@@ -237,7 +257,10 @@ const { GET: getSuggestions } = await import("../suggestions/route");
 describe("GET /api/welcome-duty/suggestions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequirePermission.mockResolvedValue(createAdminSession());
+    mockRequireCurrentChurchPermission.mockResolvedValue({
+      session: createAdminSession(),
+      churchId: "church-1",
+    });
   });
 
   it("returns suggestions sorted by last served", async () => {

--- a/src/app/api/welcome-duty/assignments/[id]/route.ts
+++ b/src/app/api/welcome-duty/assignments/[id]/route.ts
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 
@@ -7,9 +7,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await requirePermission("events:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("events:manage");
 
     const { id } = await params;
     const assignment = await prisma.welcomeDutyAssignment.findFirst({ where: { id, churchId } });

--- a/src/app/api/welcome-duty/assignments/route.ts
+++ b/src/app/api/welcome-duty/assignments/route.ts
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
@@ -11,9 +11,7 @@ const createSchema = z.object({
 
 export async function GET(request: Request) {
   try {
-    const session = await requirePermission("events:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("events:manage");
 
     const { searchParams } = new URL(request.url);
     const eventId = searchParams.get("eventId");
@@ -47,9 +45,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("events:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("events:manage");
 
     const body = createSchema.parse(await request.json());
 

--- a/src/app/api/welcome-duty/available-families/route.ts
+++ b/src/app/api/welcome-duty/available-families/route.ts
@@ -1,4 +1,4 @@
-import { requirePermission } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 
 const FAMILLES_URL =
@@ -6,7 +6,7 @@ const FAMILLES_URL =
 
 export async function GET(_request: Request) {
   try {
-    await requirePermission("events:manage");
+    await requireCurrentChurchPermission("events:manage");
 
     const res = await fetch(`${FAMILLES_URL}/api/geojson`, {
       next: { revalidate: 3600 },

--- a/src/app/api/welcome-duty/families/[id]/route.ts
+++ b/src/app/api/welcome-duty/families/[id]/route.ts
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 
@@ -7,9 +7,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await requirePermission("events:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("events:manage");
 
     const { id } = await params;
     const family = await prisma.welcomeDutyFamily.findFirst({ where: { id, churchId } });
@@ -35,9 +33,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await requirePermission("events:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("events:manage");
 
     const { id } = await params;
     const family = await prisma.welcomeDutyFamily.findFirst({ where: { id, churchId } });

--- a/src/app/api/welcome-duty/families/route.ts
+++ b/src/app/api/welcome-duty/families/route.ts
@@ -1,4 +1,4 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { z } from "zod";
@@ -10,9 +10,7 @@ const createSchema = z.object({
 
 export async function GET(request: Request) {
   try {
-    const session = await requirePermission("events:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("events:manage");
 
     const { searchParams } = new URL(request.url);
     const activeOnly = searchParams.get("active") !== "false";
@@ -37,9 +35,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const session = await requirePermission("events:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("events:manage");
 
     const body = createSchema.parse(await request.json());
 

--- a/src/app/api/welcome-duty/suggestions/route.ts
+++ b/src/app/api/welcome-duty/suggestions/route.ts
@@ -1,12 +1,10 @@
-import { requirePermission, getCurrentChurchId } from "@/lib/auth";
+import { requireCurrentChurchPermission } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
+import { successResponse, errorResponse } from "@/lib/api-utils";
 
 export async function GET(request: Request) {
   try {
-    const session = await requirePermission("events:manage");
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+    const { churchId } = await requireCurrentChurchPermission("events:manage");
 
     const { searchParams } = new URL(request.url);
     const eventId = searchParams.get("eventId");

--- a/src/lib/__tests__/auth-global-scopes.test.ts
+++ b/src/lib/__tests__/auth-global-scopes.test.ts
@@ -1,0 +1,67 @@
+// Spec 024 — critère « les portées globales sont énumérables ». Un contrôle d'autorisation
+// sans église cible (Super Admin ou domaine transverse) doit rester un acte délibéré et
+// visible en revue, pas une omission qui repasse inaperçue. Ce test compare l'usage réel de
+// `requireSuperAdmin` et `requirePlatformPermission` (importés depuis @/lib/auth) à une
+// liste blanche commitée : tout nouvel appel fait échouer la suite tant qu'il n'y est pas
+// ajouté explicitement.
+//
+// Ne couvre PAS les gardes globales locales pré-existantes et indépendantes de ce refactor
+// (ex. les fonctions `requireSuperAdmin` dupliquées localement dans certaines routes admin/
+// backups et churches) : elles n'ont jamais dépendu de l'ancien `requirePermission` sans
+// église et ne présentaient donc pas le défaut H-01.
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const APP_ROOT = join(__dirname, "../../app");
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) out.push(...listSourceFiles(full));
+    else if (/\.(ts|tsx)$/.test(entry) && !entry.includes(".test.")) out.push(full);
+  }
+  return out;
+}
+
+function findGlobalScopeUsages(guardName: string): string[] {
+  const hits: string[] = [];
+  for (const file of listSourceFiles(APP_ROOT)) {
+    const content = readFileSync(file, "utf-8");
+    const importsGuard = new RegExp(
+      `import\\s*{[^}]*\\b${guardName}\\b[^}]*}\\s*from\\s*["']@/lib/auth["']`
+    ).test(content);
+    if (importsGuard && content.includes(`${guardName}(`)) {
+      hits.push(relative(APP_ROOT, file));
+    }
+  }
+  return hits.sort();
+}
+
+const EXPECTED_SUPER_ADMIN_FILES = [
+  "(auth)/admin/audit-logs/page.tsx",
+  "(auth)/admin/churches/[churchId]/page.tsx",
+  "(auth)/admin/churches/onboard/page.tsx",
+  "(auth)/admin/churches/page.tsx",
+].sort();
+
+const EXPECTED_PLATFORM_PERMISSION_FILES = [
+  "api/jobs/freelance/missions/route.ts",
+  "api/jobs/freelance/profiles/route.ts",
+  "api/jobs/route.ts",
+  "api/jobs/seekers/route.ts",
+].sort();
+
+describe("portées globales énumérables (T18)", () => {
+  it("requireSuperAdmin n'est appelé que depuis la liste blanche commitée", () => {
+    expect(findGlobalScopeUsages("requireSuperAdmin")).toEqual(EXPECTED_SUPER_ADMIN_FILES);
+  });
+
+  it("requirePlatformPermission n'est appelé que depuis la liste blanche commitée (module emploi)", () => {
+    expect(findGlobalScopeUsages("requirePlatformPermission")).toEqual(
+      EXPECTED_PLATFORM_PERMISSION_FILES
+    );
+  });
+});

--- a/src/lib/__tests__/auth-multitenant.test.ts
+++ b/src/lib/__tests__/auth-multitenant.test.ts
@@ -1,0 +1,198 @@
+// Spec 024 — Isolation inter-églises des contrôles de permission (audit H-01).
+//
+// Ces tests couvrent spécifiquement `requireCurrentChurchPermission`, le remplaçant de
+// l'ancien `requirePermission(permission)` sans église : il résout le contexte d'église
+// courant (cookie `current-church`, potentiellement manipulé par le client) PUIS vérifie
+// la permission dans CETTE église — jamais l'inverse.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createSession, createSuperAdminSession } from "@/__mocks__/auth";
+
+const mockAuth = vi.fn();
+const mockCookieGet = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: mockAuth, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/auth")>();
+  return { ...original, auth: () => mockAuth() };
+});
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: (name: string) => mockCookieGet(name) }),
+}));
+
+const { requireCurrentChurchPermission, requireChurchPermission } =
+  await import("@/lib/auth");
+
+/** Session avec un rôle privilégié dans A et un rôle moindre dans B. */
+function multiChurchSession() {
+  return createSession({
+    churchRoles: [
+      {
+        id: "role-a",
+        churchId: "church-A",
+        role: "ADMIN",
+        ministryId: null,
+        church: { id: "church-A", name: "Église A", slug: "eglise-a" },
+        departments: [],
+      },
+      {
+        id: "role-b",
+        churchId: "church-B",
+        role: "STAR",
+        ministryId: null,
+        church: { id: "church-B", name: "Église B", slug: "eglise-b" },
+        departments: [],
+      },
+    ],
+  });
+}
+
+function setCurrentChurchCookie(churchId: string | undefined) {
+  mockCookieGet.mockImplementation((name: string) =>
+    name === "current-church" && churchId ? { value: churchId } : undefined
+  );
+}
+
+describe("requireCurrentChurchPermission — isolation inter-églises (T12)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refuse dans B une permission détenue seulement dans A (écriture)", async () => {
+    mockAuth.mockResolvedValue(multiChurchSession());
+    setCurrentChurchCookie("church-B");
+
+    await expect(
+      requireCurrentChurchPermission("members:manage")
+    ).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("refuse dans B une permission détenue seulement dans A (lecture)", async () => {
+    mockAuth.mockResolvedValue(multiChurchSession());
+    setCurrentChurchCookie("church-B");
+
+    // members:view est accordé à ADMIN mais pas à STAR.
+    await expect(
+      requireCurrentChurchPermission("members:view")
+    ).rejects.toThrow("FORBIDDEN");
+  });
+
+  it("autorise la même permission une fois le contexte basculé sur A", async () => {
+    mockAuth.mockResolvedValue(multiChurchSession());
+    setCurrentChurchCookie("church-A");
+
+    const { churchId } = await requireCurrentChurchPermission("members:manage");
+    expect(churchId).toBe("church-A");
+  });
+});
+
+describe("requireCurrentChurchPermission — non-régression mono-église (T13)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("conserve exactement ses accès pour une session à une seule église", async () => {
+    mockAuth.mockResolvedValue(createSession()); // ADMIN de church-1 uniquement
+    setCurrentChurchCookie(undefined); // aucun cookie : retombe sur l'unique église
+
+    const { churchId } = await requireCurrentChurchPermission("members:manage");
+    expect(churchId).toBe("church-1");
+  });
+});
+
+describe("requireCurrentChurchPermission — Super Admin (T14)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("conserve l'accès global quel que soit le contexte d'église", async () => {
+    mockAuth.mockResolvedValue(createSuperAdminSession());
+    setCurrentChurchCookie("church-999");
+
+    await expect(
+      requireCurrentChurchPermission("church:manage")
+    ).resolves.toBeDefined();
+  });
+});
+
+describe("requireChurchPermission — supervision pastorale en lecture seule (T15)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("autorise la lecture sur l'église supervisée", async () => {
+    mockAuth.mockResolvedValue(
+      createSession({ churchRoles: [], pastoralChurchIds: ["church-B"] })
+    );
+
+    await expect(
+      requireChurchPermission("members:view", "church-B")
+    ).resolves.toBeDefined();
+  });
+
+  it("refuse l'écriture sur l'église supervisée, même avec un rôle privilégié ailleurs", async () => {
+    // Le cas le plus exposé (cf. plan.md « Risques ») : un profil pastoral supervisant B,
+    // par ailleurs ADMIN de A. La supervision ne doit JAMAIS ouvrir l'écriture sur B.
+    mockAuth.mockResolvedValue(
+      createSession({
+        pastoralChurchIds: ["church-B"],
+        churchRoles: [
+          {
+            id: "role-a",
+            churchId: "church-A",
+            role: "ADMIN",
+            ministryId: null,
+            church: { id: "church-A", name: "Église A", slug: "eglise-a" },
+            departments: [],
+          },
+        ],
+      })
+    );
+
+    await expect(
+      requireChurchPermission("members:manage", "church-B")
+    ).rejects.toThrow("FORBIDDEN");
+  });
+});
+
+describe("requireCurrentChurchPermission — contexte manipulé (T16)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ignore un cookie d'église sans rattachement : ne devient jamais le périmètre de l'action", async () => {
+    mockAuth.mockResolvedValue(createSession()); // rôle uniquement dans church-1
+    setCurrentChurchCookie("church-sans-rattachement");
+
+    const { churchId } = await requireCurrentChurchPermission("members:manage");
+    // getCurrentChurchId ignore la valeur manipulée et retombe sur la seule église
+    // où la session a un rattachement légitime.
+    expect(churchId).toBe("church-1");
+    expect(churchId).not.toBe("church-sans-rattachement");
+  });
+});
+
+describe("requireChurchPermission — absence de fuite d'information (T17)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("le refus dans B est indiscernable du refus opposé à une session sans aucun droit", async () => {
+    const noRightsAnywhere = createSession({ churchRoles: [] });
+    const rightsOnlyInA = multiChurchSession();
+
+    let errorNoRights: unknown;
+    let errorWrongChurch: unknown;
+
+    mockAuth.mockResolvedValue(noRightsAnywhere);
+    try {
+      await requireChurchPermission("members:manage", "church-B");
+    } catch (e) {
+      errorNoRights = e;
+    }
+
+    mockAuth.mockResolvedValue(rightsOnlyInA);
+    try {
+      await requireChurchPermission("members:manage", "church-B");
+    } catch (e) {
+      errorWrongChurch = e;
+    }
+
+    expect(errorNoRights).toBeInstanceOf(Error);
+    expect(errorWrongChurch).toBeInstanceOf(Error);
+    expect((errorNoRights as Error).message).toBe((errorWrongChurch as Error).message);
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -277,28 +277,6 @@ export async function requireAuth() {
   return session;
 }
 
-export async function requirePermission(permission: string, churchId?: string) {
-  const session = await requireAuth();
-
-  // Global super admin bypasses all permissions
-  if (session.user.isSuperAdmin) return session;
-
-  const roles = session.user.churchRoles.filter(
-    (r) => !churchId || r.churchId === churchId
-  );
-
-  const { rolePermissions } = await import("./registry");
-  const userPermissions = new Set(
-    roles.flatMap((r) => rolePermissions[r.role] ?? [])
-  );
-
-  if (!userPermissions.has(permission)) {
-    throw new Error("FORBIDDEN");
-  }
-
-  return session;
-}
-
 type DepartmentScope =
   | { scoped: false }
   | { scoped: true; departmentIds: string[] };
@@ -360,7 +338,8 @@ export function getUserDepartmentScope(session: Session, churchId: string): Depa
 
 /**
  * Vérifie qu'un utilisateur possède une permission donnée **dans une église précise**.
- * Contrairement à requirePermission, le churchId est obligatoire.
+ * Le churchId est obligatoire — voir requireCurrentChurchPermission pour le résoudre
+ * depuis le contexte courant.
  */
 // Permissions accordées aux utilisateurs ayant un profil pastoral dans une église
 // (lire mais pas écrire)
@@ -712,6 +691,11 @@ export async function requireAudioUnpublishAccess(churchId: string) {
   throw new Error("FORBIDDEN");
 }
 
+// Contexte d'AFFICHAGE, jamais une autorisation : la valeur peut provenir d'un cookie
+// posé par le client. Elle ne fait que sélectionner, parmi les églises où la session a
+// un rattachement (rôle ou supervision pastorale), laquelle regarder — elle ne confère
+// aucun droit par elle-même. Toute décision d'autorisation doit vérifier la permission
+// DANS l'église ainsi désignée (cf. requireCurrentChurchPermission), jamais s'y fier seule.
 export async function getCurrentChurchId(
   session: Session
 ): Promise<string | undefined> {
@@ -728,4 +712,65 @@ export async function getCurrentChurchId(
   }
 
   return session.user.churchRoles[0]?.churchId ?? pastoralChurchIds[0];
+}
+
+/**
+ * Vérifie une permission dans l'église courante (cf. getCurrentChurchId) et la retourne.
+ * Remplaçant de l'ancien `requirePermission(permission)` sans église : résout le contexte
+ * PUIS vérifie la permission dans ce contexte — jamais l'inverse — pour qu'un `churchId`
+ * ne puisse être retourné sans que la permission y ait été vérifiée.
+ */
+export async function requireCurrentChurchPermission(permission: string) {
+  const session = await requireAuth();
+  const { ApiError } = await import("./api-utils");
+  const churchId = await getCurrentChurchId(session);
+  if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
+  await requireChurchPermission(permission, churchId);
+  return { session, churchId };
+}
+
+/**
+ * Réserve une action à l'administration de la plateforme (permissions globales telles que
+ * `church:manage`) : jamais évaluée dans une église, toujours globale — le Super Admin
+ * uniquement aujourd'hui, cf. `src/modules/core/index.ts`.
+ */
+export async function requireSuperAdmin() {
+  const session = await requireAuth();
+  if (!session.user.isSuperAdmin) {
+    throw new Error("FORBIDDEN");
+  }
+  return session;
+}
+
+/**
+ * Permissions volontairement transverses, non rattachées à une église : les modèles
+ * concernés (module emploi) n'ont pas de `churchId` par conception. Liste blanche
+ * explicite pour que toute portée globale reste énumérable et justifiée en revue —
+ * ne pas y ajouter une permission qui devrait être vérifiée par église.
+ */
+const PLATFORM_PERMISSIONS = new Set([
+  "jobs:seek",
+  "jobs:post",
+  "jobs:freelance",
+]);
+
+export async function requirePlatformPermission(permission: string) {
+  if (!PLATFORM_PERMISSIONS.has(permission)) {
+    throw new Error(
+      `Permission "${permission}" non déclarée comme transverse — vérifier par église via requireCurrentChurchPermission.`
+    );
+  }
+  const session = await requireAuth();
+
+  if (session.user.isSuperAdmin) return session;
+
+  const { rolePermissions } = await import("./registry");
+  const userPermissions = new Set(
+    session.user.churchRoles.flatMap((r) => rolePermissions[r.role] ?? [])
+  );
+  if (!userPermissions.has(permission)) {
+    throw new Error("FORBIDDEN");
+  }
+
+  return session;
 }


### PR DESCRIPTION
## Résumé

`requirePermission(permission, churchId?)` agrégeait les rôles de **toutes** les
églises de l'utilisateur quand `churchId` était omis (31 appels sur 37). Les
routes résolvaient ensuite l'église cible via `getCurrentChurchId()`, qui lit
le cookie `current-church` — sous le contrôle du client. Un Admin de l'église A
et simple STAR de l'église B pouvait ainsi poser ce cookie sur B et agir avec
les droits détenus dans A (H-01 de l'audit sécurité du 2026-08-29).

## Changement

`requirePermission` est **supprimé** et remplacé par trois gardes explicites qui
rendent l'erreur non-représentable :

- `requireCurrentChurchPermission(permission)` — résout l'église courante puis
  vérifie la permission **dans cette même église**
- `requireSuperAdmin()` — actions réservées à l'administration de la plateforme
- `requirePlatformPermission(permission)` — permissions volontairement
  transverses aux églises (module emploi), liste blanche testée

Les 31 appels non scopés sont migrés module par module (accueil, comptabilité,
réservations de salles, audio/paramètres, administration plateforme, emploi).
Corrige aussi `(auth)/layout.tsx`, qui calculait les liens de navigation admin
en agrégeant les rôles de toutes les églises au lieu de la seule église
courante.

## Tests

- `src/lib/__tests__/auth-multitenant.test.ts` (9 tests) : isolation
  lecture/écriture entre deux églises, non-régression mono-église, Super
  Admin, supervision pastorale en lecture seule, contexte manipulé sans effet,
  absence de fuite d'information sur le message de refus
- `src/lib/__tests__/auth-global-scopes.test.ts` (2 tests) : les portées
  globales (`requireSuperAdmin`, `requirePlatformPermission`) sont
  énumérables et limitées à une liste blanche

## Vérification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries`
- [x] `npm run test` (868 tests)
- [x] Critères d'acceptation de la spec relus et satisfaits

Spec complète : `specs/024-isolation-permissions-inter-eglises/`

## ⚠️ À faire avant déploiement

Les profils pastoraux repassent en lecture seule **stricte** sur les églises
supervisées (le défaut précédent leur laissait potentiellement de l'écriture
via l'agrégation de rôles). Signaler ce changement aux utilisateurs concernés
avant la mise en production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)