### PR TITLE
fix(securite): autorisation objet des medias et pieces comptables (H-02, H-03)

### DIFF
--- a/prisma/migrations/20260829113418_add_church_to_financial_attachments/migration.sql
+++ b/prisma/migrations/20260829113418_add_church_to_financial_attachments/migration.sql
@@ -1,0 +1,38 @@
+/*
+  Warnings:
+
+  - Added the required column `churchId` to the `financial_attachments` table.
+
+  Reprise (spec 025) : l'église était jusqu'ici déduite de la demande liée — précisément le
+  rattachement qu'un appelant peut provoquer pour usurper l'accès à une pièce d'autrui. On rend
+  l'église intrinsèque à la pièce, remplie par une reprise en deux temps :
+    1. depuis la demande liée quand elle existe (source la plus fiable) ;
+    2. depuis le chemin de stockage pour les pièces orphelines, qui suit toujours le format
+       `accounting/{churchId}/{horodatage}-{aléa}.{ext}` (src/app/api/accounting/attachments/route.ts).
+  Le passage en NOT NULL échoue si une ligne reste sans église récupérable : la migration doit
+  échouer bruyamment plutôt qu'inventer un rattachement.
+*/
+
+-- AlterTable (colonne d'abord nullable, le temps de la reprise)
+ALTER TABLE `financial_attachments` ADD COLUMN `churchId` VARCHAR(191) NULL;
+
+-- Reprise 1/2 : depuis la demande liée
+UPDATE `financial_attachments` fa
+JOIN `financial_requests` fr ON fr.id = fa.requestId
+SET fa.churchId = fr.churchId
+WHERE fa.churchId IS NULL;
+
+-- Reprise 2/2 : pièces orphelines, église extraite du chemin de stockage
+UPDATE `financial_attachments`
+SET `churchId` = SUBSTRING_INDEX(SUBSTRING_INDEX(`s3Key`, '/', 2), '/', -1)
+WHERE `churchId` IS NULL
+  AND `s3Key` LIKE 'accounting/%/%';
+
+-- Bascule en NOT NULL : échoue si une ligne résiste aux deux reprises ci-dessus.
+ALTER TABLE `financial_attachments` MODIFY COLUMN `churchId` VARCHAR(191) NOT NULL;
+
+-- CreateIndex
+CREATE INDEX `financial_attachments_churchId_idx` ON `financial_attachments`(`churchId`);
+
+-- AddForeignKey
+ALTER TABLE `financial_attachments` ADD CONSTRAINT `financial_attachments_churchId_fkey` FOREIGN KEY (`churchId`) REFERENCES `churches`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,6 +91,7 @@ model Church {
   // Module comptabilité
   financialSeries           FinancialSeries[]
   financialRequests         FinancialRequest[]
+  financialAttachments      FinancialAttachment[]
   // Module service d'accueil
   welcomeDutyFamilies       WelcomeDutyFamily[]
   welcomeDutyAssignments    WelcomeDutyAssignment[]
@@ -1459,6 +1460,9 @@ model FinancialAttachment {
   id           String  @id @default(cuid())
   requestId    String?
   uploadedById String?
+  // Église de dépôt — fait autorité pour toute décision d'accès. Ne dépend jamais du
+  // rattachement à une demande, que l'appelant peut lui-même provoquer (spec 025).
+  churchId     String
   s3Key        String  @db.VarChar(512)
   filename     String  @db.VarChar(255)
   mimeType     String  @db.VarChar(100)
@@ -1466,9 +1470,11 @@ model FinancialAttachment {
 
   request    FinancialRequest? @relation(fields: [requestId], references: [id], onDelete: Cascade)
   uploadedBy User?             @relation("AccountingAttachmentsUploaded", fields: [uploadedById], references: [id])
+  church     Church            @relation(fields: [churchId], references: [id])
   uploadedAt DateTime          @default(now())
 
   @@index([requestId])
+  @@index([churchId])
   @@map("financial_attachments")
 }
 

--- a/specs/025-autorisation-objet-medias-comptabilite/plan.md
+++ b/specs/025-autorisation-objet-medias-comptabilite/plan.md
@@ -1,0 +1,220 @@
+# Plan technique — Autorisation objet des médias et des pièces comptables
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Validé
+- **Mis à jour le** : 2026-08-29
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : les routes continuent d'importer `@/modules/media` via son index ;
+      aucune nouvelle dépendance inter-modules n'est introduite
+- [x] **Sécurité** : routes session protégées par `requireCurrentChurchPermission` (spec 024) ;
+      routes à jeton bornées par le périmètre du jeton ; multi-tenant `churchId` renforcé
+- [x] **Permissions** via `rolePermissions` (`@/lib/registry`) — aucune permission nouvelle
+- [x] **Validation** Zod : schémas existants conservés, `attachmentIds` déjà validé en forme
+- [x] **Migration** Prisma prévue (`churchId` sur les pièces jointes) — jamais `db push`
+- [x] **Enums** importés depuis `@/generated/prisma/client`
+- [x] **UI** : aucun changement d'interface (correctifs serveur uniquement)
+
+## Approche générale
+
+Deux corrections indépendantes, réunies parce qu'elles relèvent du même principe : **le périmètre
+d'autorisation se déduit de l'objet, jamais d'un champ facultatif du porteur d'accès ni d'un
+rattachement que l'appelant peut lui-même provoquer.**
+
+1. **Médias** — remplacer les gardes de périmètre *conditionnelles* par des gardes
+   *inconditionnelles*, et faire porter le filtre par la requête elle-même plutôt que par un `if`
+   consécutif. Le motif correct existe déjà dans le dépôt (`validate/[token]/file/[fileId]`) : on
+   l'aligne.
+2. **Comptabilité** — donner aux pièces jointes une **église propre**, écrite au dépôt et jamais
+   dérivée du rattachement, puis valider les pièces désignées avant de les rattacher.
+
+### Constat élargi par rapport à l'audit
+
+L'audit ne signale que `validate/[token]/photo/[photoId]`. La lecture du code montre que la même
+garde conditionnelle existe dans **deux routes supplémentaires** :
+
+| Route | Garde | Atteignable ? |
+|---|---|---|
+| `validate/[token]/photo/[photoId]` (GET + PATCH) | `if (shareToken.mediaEventId && …)` | **Oui** — pas de branche projet : un jeton projet tombe directement dans le code photo |
+| `gallery/[token]/photo/[photoId]` | `if (shareToken.mediaEventId && …)` | **Oui, mais étroitement** — la branche projet intercepte les jetons projet ; reste le jeton sans aucune cible |
+| `download/[token]/photo/[photoId]` | `if (shareToken.mediaEventId && …)` | Idem gallery |
+
+Le type `CreateTokenWithTarget` (`services/tokens.ts`) autorise explicitement une troisième forme
+`{ mediaEventId?: never; mediaProjectId?: never }` — un jeton **sans aucune cible** est donc
+représentable. Pour ces deux routes, la garde conditionnelle devient alors un accès total. Les
+trois sont corrigées, la nuance d'atteignabilité étant consignée ici et non dans la spec.
+
+**Fait structurant** : `MediaPhoto.mediaEventId` est **obligatoire** (schema.prisma:892) et
+`MediaProject` n'a **aucune** relation `photos` — un projet ne contient que des fichiers. Un jeton
+délégué à un projet n'a donc légitimement **rien** à faire sur une route photo : le refus est la
+seule réponse correcte, et non une tentative de résolution alternative.
+
+## Modèle de données
+
+`FinancialAttachment` ne porte **aucun** `churchId` : son église est aujourd'hui déduite de
+`request.churchId`. C'est exactement la dérivation que l'attaquant manipule en rattachant la pièce
+à sa propre demande. On rend donc l'église **intrinsèque** à la pièce.
+
+```prisma
+model FinancialAttachment {
+  id           String  @id @default(cuid())
+  requestId    String?
+  uploadedById String?
+  // Église de dépôt — autorité pour toute décision d'accès.
+  // Ne dépend jamais du rattachement à une demande, que l'appelant peut provoquer.
+  churchId     String
+  church       Church  @relation(fields: [churchId], references: [id])
+  s3Key        String  @db.VarChar(512)
+  // … champs inchangés
+
+  @@index([requestId])
+  @@index([churchId])
+  @@map("financial_attachments")
+}
+```
+
+**Migration** (`npm run db:migrate`, nom suggéré `add_church_to_financial_attachments`) :
+
+1. Ajouter la colonne en **nullable**.
+2. Remplir l'existant. Deux sources, dans cet ordre :
+   - `request.churchId` lorsque la pièce est rattachée ;
+   - à défaut (pièces orphelines), l'église est **extractible du chemin de stockage** : les clés
+     suivent `accounting/{churchId}/{horodatage}-{aléa}.{ext}` (`attachments/route.ts`). Le
+     backfill lit ce segment.
+3. Passer la colonne en **NOT NULL**.
+
+L'étape 2 est écrite dans le fichier de migration SQL, pas dans un script à part : la reprise doit
+être atomique avec l'ajout de contrainte.
+
+> Si des lignes résiduelles ne sont récupérables par aucune des deux sources, la migration doit
+> échouer bruyamment plutôt que d'inventer une église. Le cas sera traité manuellement.
+
+## API
+
+Aucun endpoint créé ni supprimé. Modifications de comportement :
+
+| Endpoint | Méthode | Contrôle ajouté |
+|---|---|---|
+| `/api/media/validate/[token]/photo/[photoId]` | GET, PATCH | Refus si le jeton ne porte pas d'événement ; filtre par événement porté dans la requête |
+| `/api/media/gallery/[token]/photo/[photoId]` | GET | Idem |
+| `/api/media/download/[token]/photo/[photoId]` | GET | Idem |
+| `/api/accounting/requests` | POST | Les `attachmentIds` sont validés (déposant, orphelines, même église) avant rattachement, dans la transaction de création |
+| `/api/accounting/attachments/[id]` | GET | L'église fait autorité via `churchId` propre ; lire la pièce d'un tiers exige `accounting:manage` |
+| `/api/accounting/attachments/[id]` | DELETE | L'église fait autorité via `churchId` propre |
+| `/api/accounting/attachments` | POST | Écrit `churchId` au dépôt |
+
+**Permission retenue pour lire la pièce d'un tiers** : `accounting:manage`
+(`SUPER_ADMIN`, `ADMIN`, `ACCOUNTANT`) — c'est la compétence de **traitement** des demandes,
+conformément à la décision de la spec. `accounting:submit` (qui inclut `MINISTER` et
+`DEPARTMENT_HEAD`) ne suffit pas. Le déposant garde l'accès à ses propres pièces sans condition
+de permission.
+
+Aucun schéma Zod ne change : `attachmentIds` est déjà validé en forme (tableau de chaînes). Ce qui
+manquait n'est pas de la validation de forme mais de l'autorisation — elle ne peut se faire qu'en
+base et ne relève donc pas de Zod.
+
+## Services / logique métier
+
+**Média** — pas de nouveau service. Les routes appliquent le motif déjà présent dans
+`validate/[token]/file/[fileId]` :
+
+```
+1. refuser si le jeton ne porte pas le type de périmètre attendu ;
+2. charger l'objet avec un `findFirst` filtré par l'identifiant ET le périmètre du jeton ;
+3. absence de résultat → 404 unique.
+```
+
+L'étape 2 supprime la fenêtre entre lecture et vérification, et l'étape 3 satisfait le critère de
+non-divulgation : hors périmètre et inexistant rendent la **même** réponse. Le PATCH poursuit avec
+un `updateMany` filtré sur le même périmètre, pour que la mise à jour ne puisse pas viser un objet
+que la lecture n'a pas autorisé.
+
+**Comptabilité** — un service unique dans `src/modules/accounting/services/attachments.ts` porte la
+règle, afin que les trois appelants ne la réimplémentent pas :
+
+- `assertAttachmentsAssignable(attachmentIds, { userId, churchId })` — vérifie en **une** requête
+  que chaque identifiant désigne une pièce du déposant, sans `requestId`, et de l'église donnée.
+  Toute divergence de cardinalité (pièce absente, d'autrui, déjà rattachée, autre église) lève un
+  `ApiError` unique et indifférencié.
+- `canReadAttachment(attachment, session, churchId)` — déposant, ou `accounting:manage` dans
+  l'église de la pièce.
+
+L'appel à `assertAttachmentsAssignable` et la création de la demande sont enveloppés dans une
+**transaction** (`prisma.$transaction`), afin que le critère « aucun rattachement partiel » tienne
+aussi face à une suppression concurrente de la pièce entre la vérification et le `connect`.
+
+## UI / composants
+
+Aucun changement. Les corrections sont exclusivement serveur ; les parcours légitimes (déposer une
+pièce, la joindre à sa demande, valider des photos depuis un lien correctement délégué) conservent
+un comportement identique.
+
+## Décisions & alternatives écartées
+
+- **Choix** : refuser un jeton sans événement sur les routes photo, plutôt que de tenter de
+  résoudre les photos « du projet ». — *Pourquoi* : une photo appartient toujours à un événement
+  et jamais à un projet ; il n'existe aucune interprétation valide de cette combinaison. La
+  refuser est à la fois correct et non-ambigu.
+- **Choix** : filtrer dans la requête (`findFirst` / `updateMany` avec le périmètre) plutôt que de
+  charger puis comparer. — *Pourquoi* : rend le défaut non-représentable — on ne peut pas oublier
+  la comparaison si elle n'est plus une étape distincte — et supprime la divulgation d'existence.
+- **Choix** : ajouter `churchId` aux pièces jointes. — *Pourquoi* : sans lui, toute vérification
+  d'église reste dérivée d'un rattachement que l'appelant contrôle. C'est le seul correctif qui
+  ferme l'enchaînement plutôt que d'en masquer une étape.
+- **Écarté** : se contenter de vérifier la propriété des pièces au rattachement, sans `churchId`.
+  — *Raison* : corrige le chemin connu mais laisse l'église dérivée d'une relation mutable ; tout
+  futur chemin d'écriture rouvrirait le défaut.
+- **Écarté** : exiger `accounting:view` pour lire la pièce d'un tiers. — *Raison* : cette
+  permission inclut `MINISTER` et `DEPARTMENT_HEAD`, soit précisément les rôles soumetteurs que la
+  spec veut exclure de la lecture croisée.
+- **Écarté** : un `churchId` sur les pièces alimenté depuis le contexte d'église affiché à la
+  lecture. — *Raison* : réintroduirait une valeur d'origine cliente dans une décision
+  d'autorisation, ce que la spec 024 vient d'éliminer.
+- **Écarté** : corriger uniquement la route signalée par l'audit. — *Raison* : deux autres routes
+  portent la même garde conditionnelle ; les laisser reviendrait à corriger un symptôme.
+
+## Risques & points d'attention
+
+- **Migration sur données existantes** : le backfill dépend du format des clés de stockage pour les
+  pièces orphelines. Le format est stable et vérifié dans le code actuel, mais des pièces déposées
+  avant ce format seraient irrécupérables. La migration doit échouer plutôt que de deviner.
+- **Rattachements incorrects déjà en base** : la spec les place hors périmètre. Après migration,
+  l'église d'une pièce redevient celle du dépôt, donc un rattachement abusif antérieur cesse
+  d'accorder l'accès — le correctif neutralise le passé sans le nettoyer.
+- **Restriction de lecture** : des personnes qui consultaient les pièces d'autrui avec un rôle
+  `MINISTER`/`DEPARTMENT_HEAD` perdront cet accès. Ce n'était pas un usage prévu, mais il faut
+  s'attendre à un signalement.
+- **Jetons sans cible** : leur existence est autorisée par le type mais leur usage légitime n'est
+  pas clair. Le plan les traite en refus sur les routes photo ; il ne cherche pas à les supprimer.
+- **Non-régression média** : les liens correctement délégués (événement pour les photos, projet
+  pour les fichiers) doivent continuer à fonctionner à l'identique — c'est le principal risque de
+  régression fonctionnelle visible.
+
+## Stratégie de tests
+
+Tests unitaires Vitest, en miroir de ceux ajoutés par la spec 024 (mocks `prismaMock`, sessions de
+`@/__mocks__/auth`).
+
+**Médias** — `src/app/api/media/__tests__/validate-photo-scope.test.ts` :
+- jeton **projet** sur une route photo → refusé (GET et PATCH), aucune écriture émise ;
+- jeton **sans cible** → refusé sur les trois routes ;
+- jeton **événement** visant une photo d'un **autre** événement → refusé ;
+- jeton **événement** visant une photo de **son** événement → autorisé (non-régression) ;
+- refus hors périmètre et refus pour photo inexistante → **même** statut et **même** message ;
+- le PATCH refusé ne déclenche aucune transition d'état de l'événement.
+
+**Comptabilité** — `src/modules/accounting/services/__tests__/attachments.test.ts` et
+`src/app/api/accounting/__tests__/attachments-scope.test.ts` :
+- création de demande avec une pièce **d'autrui** → refus, demande non créée ;
+- avec une pièce **déjà rattachée** → refus ;
+- avec une pièce d'une **autre église** → refus ;
+- lot **mixte** (une valide, une invalide) → refus global, **aucun** rattachement (le critère
+  d'atomicité) ;
+- avec ses propres pièces orphelines → succès (non-régression) ;
+- lecture d'une pièce d'un tiers avec `accounting:submit` seul → refusée ; avec
+  `accounting:manage` → autorisée ; par le déposant → autorisée ;
+- lecture d'une pièce d'une autre église, y compris en manipulant le contexte d'église → refusée.
+
+La couverture cible les chemins d'autorisation, conformément au constat Q-01 de l'audit sur
+l'absence de tests d'autorisation objet.

--- a/specs/025-autorisation-objet-medias-comptabilite/spec.md
+++ b/specs/025-autorisation-objet-medias-comptabilite/spec.md
@@ -1,7 +1,7 @@
 # Spec — Autorisation objet des médias et des pièces comptables
 
 - **Numéro** : 025
-- **Statut** : Validée
+- **Statut** : Implémentée
 - **Créée le** : 2026-08-29
 - **Branche suggérée** : `fix/autorisation-objet-medias-comptabilite`
 

--- a/specs/025-autorisation-objet-medias-comptabilite/spec.md
+++ b/specs/025-autorisation-objet-medias-comptabilite/spec.md
@@ -1,0 +1,145 @@
+# Spec — Autorisation objet des médias et des pièces comptables
+
+- **Numéro** : 025
+- **Statut** : Validée
+- **Créée le** : 2026-08-29
+- **Branche suggérée** : `fix/autorisation-objet-medias-comptabilite`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+
+## Contexte & problème
+
+La spec 024 a corrigé les décisions d'autorisation prises **sur la mauvaise église**. Deux
+défauts de même famille subsistent, mais à l'échelle de l'**objet** : l'accès est accordé sans
+vérifier que l'objet visé appartient bien au périmètre de celui qui le demande. Les deux ont été
+vérifiés dans le code, pas seulement repris de l'audit du 2026-08-29 (constats H-02 et H-03).
+
+**1 — Un lien de validation média peut agir hors de son périmètre.**
+Koinonia permet de partager un lien de validation à une personne **sans compte** (un pasteur, un
+client, un responsable externe) pour qu'elle approuve ou écarte des photos. Ce lien est délégué
+à un périmètre précis : soit un événement média, soit un projet média.
+
+Le contrôle de périmètre n'est appliqué **que si** le lien porte un événement. Or un lien délégué
+à un **projet** ne porte, par construction, aucun événement : pour lui, aucun contrôle n'a lieu.
+Le porteur d'un tel lien peut donc désigner **n'importe quelle photo de la plateforme**, toutes
+églises confondues, pour en obtenir l'original haute définition et pour en changer le statut
+(approuvée / rejetée). Aucune vérification de rattachement à une église n'existe sur ce chemin,
+y compris lorsque le lien porte bien un événement.
+
+**2 — Une pièce justificative comptable peut être rattachée à la demande de quelqu'un d'autre.**
+Lorsqu'un utilisateur soumet une demande de dépense, il peut y joindre des pièces justificatives.
+Rien ne vérifie que les pièces qu'il désigne sont les siennes, qu'elles sont encore libres de tout
+rattachement, ni qu'elles relèvent de son église.
+
+Cela ouvre un enchaînement complet d'exfiltration : la personne crée une demande dans sa propre
+église en y désignant la pièce justificative d'un tiers ; la pièce se retrouve rattachée à une
+demande dont elle est l'auteur ; la consultation de cette pièce lui est alors accordée, puisque
+le contrôle d'accès existant déduit l'église de la pièce depuis la demande à laquelle elle est
+rattachée — rattachement que l'attaquant vient précisément de provoquer. Le justificatif d'une
+autre personne, potentiellement d'une autre église, devient lisible.
+
+À cela s'ajoute que la consultation d'une pièce justificative n'exige aujourd'hui **aucune
+compétence comptable** : toute personne disposant d'un rôle quelconque dans l'église peut lire
+la pièce attachée à la demande d'un tiers.
+
+**Pourquoi maintenant** : ces deux défauts exposent des données personnelles et financières
+(justificatifs de dépenses, photos non publiées) au-delà des frontières d'église. L'audit les
+classe en priorité immédiate, au même rang que le défaut d'isolation déjà corrigé.
+
+## Utilisateurs concernés
+
+- **Porteurs d'un lien de validation partagé** (personnes **sans compte** Koinonia) : leur pouvoir
+  doit être strictement borné au périmètre qui leur a été délégué — l'événement ou le projet
+  nommé lors de la création du lien, et rien d'autre.
+- **Toute personne soumettant une demande de dépense** (tout rôle disposant du droit de soumettre) :
+  ne doit pouvoir joindre à sa demande que des pièces qu'elle a elle-même déposées et qui ne sont
+  pas déjà rattachées ailleurs.
+- **Personnes chargées du suivi comptable** : doivent continuer à consulter les pièces des demandes
+  qu'elles traitent, sans restriction nouvelle sur leur travail légitime.
+- **Admin / Super Admin** : inchangé, sous réserve du respect de l'isolation par église.
+- **Autres rôles (STAR, Ministre, Resp. département, Secrétaire, Reporter, Faiseur de Disciples)** :
+  perdent la possibilité de consulter une pièce justificative qui ne les concerne pas — ce qui
+  n'était pas un usage prévu.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Une personne externe reçoit un lien de validation délégué au **projet** « Campagne de rentrée ».
+2. Elle ouvre le lien et voit les médias de ce projet. Elle en approuve certains : cela fonctionne.
+3. Elle tente de désigner une photo qui ne relève pas de ce projet — une photo d'une autre église,
+   dont elle a deviné ou obtenu l'identifiant.
+4. **La demande est refusée**, aussi bien pour consulter l'original que pour en changer le statut.
+   Le refus est identique à celui opposé pour une photo inexistante : rien n'indique si la photo
+   existe ailleurs sur la plateforme.
+
+### Scénarios alternatifs / cas limites
+
+- **Si** le lien de validation est délégué à un **événement**, il ne peut agir que sur les médias
+  de cet événement — comportement déjà attendu aujourd'hui, désormais garanti sans condition.
+- **Si** le lien est délégué à un **projet**, il ne peut agir que sur les médias de ce projet.
+- **Quand** un lien ne porte **aucun** périmètre exploitable, il ne doit accorder **aucune** action
+  sur un média : l'absence de périmètre vaut refus, jamais accès total.
+- **Quand** une personne soumet une demande de dépense en désignant des pièces justificatives, le
+  système n'accepte que celles qu'elle a déposées, encore rattachées à aucune demande, et relevant
+  de son église. Si une seule pièce désignée ne remplit pas ces conditions, **la demande entière
+  est refusée** — aucun rattachement partiel n'est effectué.
+- **Si** une personne consulte une pièce justificative rattachée à la demande d'un tiers, l'accès
+  n'est accordé que si elle dispose d'une compétence comptable dans l'église concernée ; sinon il
+  est refusé.
+- **Quand** une pièce n'est rattachée à aucune demande, seule la personne qui l'a déposée peut la
+  consulter ou la supprimer — comportement actuel, conservé.
+- **Si** un rattachement incorrect existe déjà en base au moment de la correction, il ne doit pas
+  devenir un moyen d'accès : l'église d'une pièce doit rester celle où elle a été déposée, et non
+  celle que le rattachement lui a donnée.
+
+## Critères d'acceptation
+
+- [ ] Un lien de validation délégué à un projet **ne peut ni consulter ni modifier** un média qui
+      ne relève pas de ce projet, quelle que soit la façon dont il le désigne.
+- [ ] Un lien de validation délégué à un événement **ne peut ni consulter ni modifier** un média
+      qui ne relève pas de cet événement.
+- [ ] Un lien ne portant aucun périmètre exploitable n'accorde **aucune** action sur un média.
+- [ ] Aucun chemin d'accès par lien partagé ne permet d'atteindre un média d'une **autre église**
+      que celle du périmètre délégué.
+- [ ] Le refus opposé à un média hors périmètre est **indiscernable** du refus opposé à un média
+      inexistant : aucune information sur l'existence de l'objet ailleurs n'est divulguée.
+- [ ] Une demande de dépense désignant une pièce justificative **déposée par quelqu'un d'autre**
+      est refusée.
+- [ ] Une demande désignant une pièce **déjà rattachée** à une autre demande est refusée.
+- [ ] Une demande désignant une pièce relevant d'une **autre église** est refusée.
+- [ ] Lorsqu'une pièce désignée est invalide, **aucune** des pièces de la demande n'est rattachée
+      et la demande n'est pas créée.
+- [ ] La consultation d'une pièce rattachée à la demande d'un tiers exige une **compétence
+      comptable** dans l'église concernée ; un rôle quelconque dans l'église ne suffit plus.
+- [ ] L'église dont relève une pièce justificative ne peut pas être **modifiée par l'appelant** :
+      elle ne dépend pas d'un rattachement que celui-ci peut provoquer.
+- [ ] Le dépôt et la consultation de ses **propres** pièces, ainsi que le travail comptable
+      légitime, restent inchangés.
+- [ ] Des tests automatisés couvrent explicitement : lien projet vs lien événement, média hors
+      périmètre, pièce d'autrui, pièce déjà rattachée, et cas inter-églises ; ils échouent si l'un
+      de ces défauts réapparaît.
+
+## Hors périmètre
+
+- La refonte du mécanisme de liens partagés (durée de vie, révocation, renouvellement) : seuls
+  leur périmètre et son application sont traités ici.
+- Les autres constats de l'audit du 2026-08-29 (cookie de session en sous-domaine, cache audio
+  immuable, reprise de migration, comptes de déploiement, gate de dépendances…).
+- L'ajout d'un antivirus ou d'une inspection de contenu sur les pièces justificatives.
+- La modification de la matrice des rôles : aucune permission nouvelle n'est créée, seules les
+  compétences existantes sont exigées là où elles manquaient.
+- Le nettoyage rétroactif d'éventuels rattachements incorrects déjà présents en base — à traiter
+  séparément si l'exploitation du défaut est avérée.
+
+## Questions ouvertes
+
+*Tranchées avec le porteur du projet avant le plan — aucune ne bloque plus.*
+
+- **Consultation d'une pièce rattachée à la demande d'un tiers** → exige la compétence de
+  **traitement comptable** (les personnes qui instruisent les demandes). La compétence de
+  simple soumission ne suffit pas : un déposant n'a pas à lire les justificatifs des autres.
+  Le déposant conserve l'accès à ses propres pièces.
+- **Journalisation des tentatives d'accès hors périmètre par lien partagé** → **hors périmètre**
+  de cette correction. On corrige le défaut sans ajouter de mécanisme de détection ; les liens
+  partagés étant non authentifiés, décider quoi identifier est un sujet à part entière.

--- a/specs/025-autorisation-objet-medias-comptabilite/tasks.md
+++ b/specs/025-autorisation-objet-medias-comptabilite/tasks.md
@@ -10,18 +10,18 @@
 ## Prérequis
 
 - [x] Branche créée : `fix/autorisation-objet-medias-comptabilite`
-- [ ] Migration Prisma générée (schéma modifié : `churchId` sur les pièces jointes)
+- [x] Migration Prisma générée (schéma modifié : `churchId` sur les pièces jointes)
 
 ## Tâches
 
 ### 1. Données & migration
 
-- [ ] **T1** — Ajouter `churchId` (obligatoire) et sa relation `church` au modèle
+- [x] **T1** — Ajouter `churchId` (obligatoire) et sa relation `church` au modèle
       `FinancialAttachment`, avec `@@index([churchId])`. Documenter en commentaire que ce champ
       fait autorité et ne dépend jamais du rattachement à une demande.
       *(fichier : `prisma/schema.prisma`)*
 
-- [ ] **T2** — Générer la migration (`npm run db:migrate`, nom `add_church_to_financial_attachments`)
+- [x] **T2** — Générer la migration (`npm run db:migrate`, nom `add_church_to_financial_attachments`)
       puis **éditer le SQL** pour que l'ajout et la reprise soient atomiques, dans cet ordre :
       colonne nullable → remplissage depuis `request.churchId` → remplissage du reliquat depuis le
       2ᵉ segment de `s3Key` (`accounting/{churchId}/…`) → passage en `NOT NULL`.
@@ -30,7 +30,7 @@
 
 ### 2. Logique métier (services)
 
-- [ ] **T3** — Créer le service d'autorisation des pièces jointes, seul porteur de la règle :
+- [x] **T3** — Créer le service d'autorisation des pièces jointes, seul porteur de la règle :
       - `assertAttachmentsAssignable(attachmentIds, { userId, churchId })` — vérifie en **une**
         requête que chaque identifiant désigne une pièce du déposant, **sans** `requestId`, et de
         l'église donnée ; toute divergence de cardinalité lève un `ApiError` **unique et
@@ -43,7 +43,7 @@
 
 ### 3. API (route handlers)
 
-- [ ] **T4** — **Médias / validation** : refuser inconditionnellement un jeton sans événement
+- [x] **T4** — **Médias / validation** : refuser inconditionnellement un jeton sans événement
       (`if (!shareToken.mediaEventId) throw new ApiError(403, …)`), puis charger la photo avec un
       `findFirst` filtré par `{ id, mediaEventId: shareToken.mediaEventId }` et répondre **404**
       si absente. Le PATCH poursuit avec un `updateMany` filtré sur le même périmètre, afin que
@@ -51,24 +51,24 @@
       transition d'état de l'événement n'est pas déclenchée sur un refus.
       *(fichier : `src/app/api/media/validate/[token]/photo/[photoId]/route.ts`)*
 
-- [ ] **T5** [P] — **Médias / galerie** : même traitement sur la branche photo (la branche projet
+- [x] **T5** [P] — **Médias / galerie** : même traitement sur la branche photo (la branche projet
       existante, correctement scopée, reste inchangée).
       *(fichier : `src/app/api/media/gallery/[token]/photo/[photoId]/route.ts`)*
 
-- [ ] **T6** [P] — **Médias / téléchargement** : même traitement sur la branche photo.
+- [x] **T6** [P] — **Médias / téléchargement** : même traitement sur la branche photo.
       *(fichier : `src/app/api/media/download/[token]/photo/[photoId]/route.ts`)*
 
-- [ ] **T7** — **Comptabilité / dépôt** : écrire `churchId` à la création de la pièce (l'église
+- [x] **T7** — **Comptabilité / dépôt** : écrire `churchId` à la création de la pièce (l'église
       vient de `requireCurrentChurchPermission`, déjà en place).
       *(fichier : `src/app/api/accounting/attachments/route.ts`)*
 
-- [ ] **T8** — **Comptabilité / création de demande** : appeler `assertAttachmentsAssignable`
+- [x] **T8** — **Comptabilité / création de demande** : appeler `assertAttachmentsAssignable`
       avant de rattacher, et envelopper vérification **et** création dans une même
       `prisma.$transaction`, pour qu'aucun rattachement partiel ne survive à une suppression
       concurrente. Un lot contenant une seule pièce invalide ne crée **aucune** demande.
       *(fichier : `src/app/api/accounting/requests/route.ts`)*
 
-- [ ] **T9** — **Comptabilité / consultation et suppression** : faire porter l'autorité à
+- [x] **T9** — **Comptabilité / consultation et suppression** : faire porter l'autorité à
       `attachment.churchId` (et non plus à `request.churchId`), et soumettre la lecture d'une
       pièce d'un tiers à `canReadAttachment` — `accounting:submit` seul ne suffit plus.
       *(fichier : `src/app/api/accounting/attachments/[id]/route.ts`)*
@@ -80,20 +80,20 @@ comportement identique.*
 
 ### 5. Tests
 
-- [ ] **T10** — **Périmètre des jetons média** : jeton **projet** sur une route photo refusé en
+- [x] **T10** — **Périmètre des jetons média** : jeton **projet** sur une route photo refusé en
       GET **et** PATCH sans écriture émise ; jeton **sans cible** refusé sur les trois routes ;
       jeton événement visant la photo d'un **autre** événement refusé ; jeton événement visant
       **sa** photo autorisé (non-régression) ; refus hors périmètre et photo inexistante rendant
       le **même** statut et le **même** message ; aucune transition d'état d'événement sur refus.
       *(fichier : `src/app/api/media/__tests__/validate-photo-scope.test.ts`)*
 
-- [ ] **T11** [P] — **Service d'autorisation comptable** : pièce d'autrui, pièce déjà rattachée,
+- [x] **T11** [P] — **Service d'autorisation comptable** : pièce d'autrui, pièce déjà rattachée,
       pièce d'une autre église, identifiant inexistant → chacun rejeté avec le **même** message ;
       pièces propres et orphelines → acceptées ; `canReadAttachment` vrai pour le déposant et pour
       `accounting:manage`, faux pour `accounting:submit` seul.
       *(fichier : `src/modules/accounting/services/__tests__/attachments.test.ts`)*
 
-- [ ] **T12** — **Bout en bout comptable** : création de demande refusée pour une pièce d'autrui,
+- [x] **T12** — **Bout en bout comptable** : création de demande refusée pour une pièce d'autrui,
       déjà rattachée, ou d'une autre église ; lot **mixte** → refus global et **aucun**
       rattachement (critère d'atomicité) ; création avec ses propres pièces orphelines → succès ;
       lecture d'une pièce d'un tiers refusée avec `accounting:submit`, autorisée avec
@@ -121,11 +121,11 @@ comportement identique.*
 
 ## Vérification finale
 
-- [ ] `npm run typecheck`
-- [ ] `npm run lint`
-- [ ] `npm run lint:boundaries`
-- [ ] `npm run test`
-- [ ] Tous les critères d'acceptation de `spec.md` satisfaits
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits
 - [ ] **Avant déploiement** : la migration T2 est irréversible en pratique (colonne `NOT NULL`
       remplie par reprise) — vérifier sur une copie des données de production qu'aucune pièce ne
       résiste au double backfill avant de l'appliquer

--- a/specs/025-autorisation-objet-medias-comptabilite/tasks.md
+++ b/specs/025-autorisation-objet-medias-comptabilite/tasks.md
@@ -1,0 +1,135 @@
+# Tâches — Autorisation objet des médias et des pièces comptables
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : À faire
+
+> Deux chantiers indépendants : **médias** (T4–T6, gardes de périmètre des jetons) et
+> **comptabilité** (T1–T3, T7–T9, église intrinsèque des pièces). Ils ne partagent aucun fichier
+> et peuvent être menés en parallèle jusqu'aux tests.
+
+## Prérequis
+
+- [x] Branche créée : `fix/autorisation-objet-medias-comptabilite`
+- [ ] Migration Prisma générée (schéma modifié : `churchId` sur les pièces jointes)
+
+## Tâches
+
+### 1. Données & migration
+
+- [ ] **T1** — Ajouter `churchId` (obligatoire) et sa relation `church` au modèle
+      `FinancialAttachment`, avec `@@index([churchId])`. Documenter en commentaire que ce champ
+      fait autorité et ne dépend jamais du rattachement à une demande.
+      *(fichier : `prisma/schema.prisma`)*
+
+- [ ] **T2** — Générer la migration (`npm run db:migrate`, nom `add_church_to_financial_attachments`)
+      puis **éditer le SQL** pour que l'ajout et la reprise soient atomiques, dans cet ordre :
+      colonne nullable → remplissage depuis `request.churchId` → remplissage du reliquat depuis le
+      2ᵉ segment de `s3Key` (`accounting/{churchId}/…`) → passage en `NOT NULL`.
+      La migration doit **échouer** s'il reste des lignes sans église, jamais en inventer une.
+      *(fichier : `prisma/migrations/…/migration.sql`)*
+
+### 2. Logique métier (services)
+
+- [ ] **T3** — Créer le service d'autorisation des pièces jointes, seul porteur de la règle :
+      - `assertAttachmentsAssignable(attachmentIds, { userId, churchId })` — vérifie en **une**
+        requête que chaque identifiant désigne une pièce du déposant, **sans** `requestId`, et de
+        l'église donnée ; toute divergence de cardinalité lève un `ApiError` **unique et
+        indifférencié** (ne jamais révéler laquelle des conditions a échoué) ;
+      - `canReadAttachment(attachment, session, churchId)` — vrai si déposant, ou si
+        `accounting:manage` dans l'église **de la pièce**.
+      Exporter les deux depuis l'index du module (les routes importent via `@/modules/accounting`,
+      jamais un chemin interne).
+      *(fichiers : `src/modules/accounting/services/attachments.ts`, `src/modules/accounting/index.ts`)*
+
+### 3. API (route handlers)
+
+- [ ] **T4** — **Médias / validation** : refuser inconditionnellement un jeton sans événement
+      (`if (!shareToken.mediaEventId) throw new ApiError(403, …)`), puis charger la photo avec un
+      `findFirst` filtré par `{ id, mediaEventId: shareToken.mediaEventId }` et répondre **404**
+      si absente. Le PATCH poursuit avec un `updateMany` filtré sur le même périmètre, afin que
+      l'écriture ne puisse viser un objet que la lecture n'a pas autorisé. Vérifier que la
+      transition d'état de l'événement n'est pas déclenchée sur un refus.
+      *(fichier : `src/app/api/media/validate/[token]/photo/[photoId]/route.ts`)*
+
+- [ ] **T5** [P] — **Médias / galerie** : même traitement sur la branche photo (la branche projet
+      existante, correctement scopée, reste inchangée).
+      *(fichier : `src/app/api/media/gallery/[token]/photo/[photoId]/route.ts`)*
+
+- [ ] **T6** [P] — **Médias / téléchargement** : même traitement sur la branche photo.
+      *(fichier : `src/app/api/media/download/[token]/photo/[photoId]/route.ts`)*
+
+- [ ] **T7** — **Comptabilité / dépôt** : écrire `churchId` à la création de la pièce (l'église
+      vient de `requireCurrentChurchPermission`, déjà en place).
+      *(fichier : `src/app/api/accounting/attachments/route.ts`)*
+
+- [ ] **T8** — **Comptabilité / création de demande** : appeler `assertAttachmentsAssignable`
+      avant de rattacher, et envelopper vérification **et** création dans une même
+      `prisma.$transaction`, pour qu'aucun rattachement partiel ne survive à une suppression
+      concurrente. Un lot contenant une seule pièce invalide ne crée **aucune** demande.
+      *(fichier : `src/app/api/accounting/requests/route.ts`)*
+
+- [ ] **T9** — **Comptabilité / consultation et suppression** : faire porter l'autorité à
+      `attachment.churchId` (et non plus à `request.churchId`), et soumettre la lecture d'une
+      pièce d'un tiers à `canReadAttachment` — `accounting:submit` seul ne suffit plus.
+      *(fichier : `src/app/api/accounting/attachments/[id]/route.ts`)*
+
+### 4. UI
+
+*Aucune tâche : les corrections sont exclusivement serveur et les parcours légitimes conservent un
+comportement identique.*
+
+### 5. Tests
+
+- [ ] **T10** — **Périmètre des jetons média** : jeton **projet** sur une route photo refusé en
+      GET **et** PATCH sans écriture émise ; jeton **sans cible** refusé sur les trois routes ;
+      jeton événement visant la photo d'un **autre** événement refusé ; jeton événement visant
+      **sa** photo autorisé (non-régression) ; refus hors périmètre et photo inexistante rendant
+      le **même** statut et le **même** message ; aucune transition d'état d'événement sur refus.
+      *(fichier : `src/app/api/media/__tests__/validate-photo-scope.test.ts`)*
+
+- [ ] **T11** [P] — **Service d'autorisation comptable** : pièce d'autrui, pièce déjà rattachée,
+      pièce d'une autre église, identifiant inexistant → chacun rejeté avec le **même** message ;
+      pièces propres et orphelines → acceptées ; `canReadAttachment` vrai pour le déposant et pour
+      `accounting:manage`, faux pour `accounting:submit` seul.
+      *(fichier : `src/modules/accounting/services/__tests__/attachments.test.ts`)*
+
+- [ ] **T12** — **Bout en bout comptable** : création de demande refusée pour une pièce d'autrui,
+      déjà rattachée, ou d'une autre église ; lot **mixte** → refus global et **aucun**
+      rattachement (critère d'atomicité) ; création avec ses propres pièces orphelines → succès ;
+      lecture d'une pièce d'un tiers refusée avec `accounting:submit`, autorisée avec
+      `accounting:manage`, autorisée pour le déposant ; lecture inter-églises refusée **même en
+      manipulant le contexte d'église** (l'autorité est `attachment.churchId`).
+      *(fichier : `src/app/api/accounting/__tests__/attachments-scope.test.ts`)*
+
+## Traçabilité des critères d'acceptation
+
+| Critère (spec) | Couvert par |
+|---|---|
+| Jeton projet ne peut ni lire ni modifier hors projet | T4, T10 |
+| Jeton événement ne peut ni lire ni modifier hors événement | T4–T6, T10 |
+| Jeton sans périmètre exploitable n'accorde aucune action | T4–T6, T10 |
+| Aucun accès à un média d'une autre église par lien partagé | T4–T6, T10 |
+| Refus hors périmètre indiscernable du refus « inexistant » | T4–T6, T10 |
+| Demande avec pièce déposée par autrui refusée | T3, T8, T11, T12 |
+| Demande avec pièce déjà rattachée refusée | T3, T8, T11, T12 |
+| Demande avec pièce d'une autre église refusée | T3, T8, T11, T12 |
+| Pièce invalide → aucun rattachement, demande non créée | T8, T12 |
+| Lecture de la pièce d'un tiers exige `accounting:manage` | T3, T9, T11, T12 |
+| L'église d'une pièce n'est pas modifiable par l'appelant | T1, T2, T7, T9, T12 |
+| Dépôt/lecture de ses propres pièces et travail comptable inchangés | T9, T11, T12 |
+| Tests couvrant jeton projet/événement, pièce d'autrui, inter-églises | T10, T11, T12 |
+
+## Vérification finale
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run lint:boundaries`
+- [ ] `npm run test`
+- [ ] Tous les critères d'acceptation de `spec.md` satisfaits
+- [ ] **Avant déploiement** : la migration T2 est irréversible en pratique (colonne `NOT NULL`
+      remplie par reprise) — vérifier sur une copie des données de production qu'aucune pièce ne
+      résiste au double backfill avant de l'appliquer
+- [ ] **Après déploiement** : signaler que la lecture des pièces justificatives d'autrui est
+      désormais réservée au traitement comptable (`ACCOUNTANT`, `ADMIN`, `SUPER_ADMIN`) — les rôles
+      `MINISTER` et `DEPARTMENT_HEAD` perdent cet accès
+- [ ] PR ouverte vers `main`

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -80,6 +80,11 @@ export const prismaMock = {
   audioServiceTemplate: createModelMock(),
   audioJob: createModelMock(),
   audioShareToken: createModelMock(),
+  // Module comptabilité
+  financialSeries: createModelMock(),
+  financialRequest: createModelMock(),
+  financialAttachment: createModelMock(),
+  financialPayment: createModelMock(),
   $queryRaw: vi.fn(),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   $transaction: vi.fn((arg: any) => (Array.isArray(arg) ? Promise.all(arg) : arg(prismaMock))),

--- a/src/app/api/accounting/__tests__/attachments-scope.test.ts
+++ b/src/app/api/accounting/__tests__/attachments-scope.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests — spec 025 (H-03) : autorisation objet des pièces justificatives comptables,
+ * bout en bout (routes de création de demande et de consultation d'une pièce).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createSession, createAdminSession } from "@/__mocks__/auth";
+
+const mockRequireCurrentChurchPermission = vi.fn();
+const mockRequireAuth = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  requireCurrentChurchPermission: (...args: unknown[]) =>
+    mockRequireCurrentChurchPermission(...args),
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/email", () => ({
+  sendEmail: vi.fn(),
+  buildAccountingNewRequestEmail: vi.fn().mockReturnValue({ subject: "s", html: "h" }),
+}));
+vi.mock("@/lib/file-storage", () => ({
+  getFileUrl: vi.fn().mockResolvedValue("https://example.com/signed-url"),
+  deleteFile: vi.fn(),
+}));
+// canReadAttachment (via @/modules/accounting) importe dynamiquement @/lib/registry, qui charge
+// la chaîne de boot jusqu'à @/lib/auth (NextAuth(...)) — mock requis hors contexte Next.js.
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: vi.fn(), handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+
+const { POST: postRequest } = await import("../requests/route");
+const { GET: getAttachment } = await import("../attachments/[id]/route");
+
+const makeParams = (id: string) => Promise.resolve({ id });
+
+const requestBody = (attachmentIds?: string[]) =>
+  new Request("http://localhost/api/accounting/requests", {
+    method: "POST",
+    body: JSON.stringify({
+      type: "EXPENSE_REPORT",
+      label: "Frais de déplacement",
+      amount: 42,
+      ...(attachmentIds ? { attachmentIds } : {}),
+    }),
+  });
+
+describe("POST /api/accounting/requests — autorisation des pièces jointes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireCurrentChurchPermission.mockResolvedValue({
+      session: createSession({ id: "user-1" }),
+      churchId: "church-1",
+    });
+  });
+
+  it("refuse une pièce déposée par quelqu'un d'autre — aucune demande créée", async () => {
+    prismaMock.financialAttachment.count.mockResolvedValue(0);
+
+    const res = await postRequest(requestBody(["att-of-someone-else"]));
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.financialRequest.create).not.toHaveBeenCalled();
+  });
+
+  it("refuse une pièce déjà rattachée à une autre demande", async () => {
+    prismaMock.financialAttachment.count.mockResolvedValue(0);
+
+    const res = await postRequest(requestBody(["att-already-linked"]));
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.financialRequest.create).not.toHaveBeenCalled();
+  });
+
+  it("refuse une pièce d'une autre église", async () => {
+    prismaMock.financialAttachment.count.mockResolvedValue(0);
+
+    const res = await postRequest(requestBody(["att-other-church"]));
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.financialRequest.create).not.toHaveBeenCalled();
+  });
+
+  it("un lot mixte (une pièce valide, une invalide) est refusé dans son ensemble", async () => {
+    // 2 ids demandés, un seul valide → count=1 ≠ 2 → rejet global, aucun rattachement partiel.
+    prismaMock.financialAttachment.count.mockResolvedValue(1);
+
+    const res = await postRequest(requestBody(["att-valid", "att-invalid"]));
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.financialRequest.create).not.toHaveBeenCalled();
+  });
+
+  it("accepte la création avec ses propres pièces orphelines (non-régression)", async () => {
+    prismaMock.financialAttachment.count.mockResolvedValue(1);
+    prismaMock.financialRequest.create.mockResolvedValue({
+      id: "req-1",
+      type: "EXPENSE_REPORT",
+      label: "Frais de déplacement",
+      amount: 42,
+      description: null,
+      department: null,
+      submittedBy: { name: "Test User", email: "test@example.com" },
+    } as never);
+    prismaMock.userChurchRole.findMany.mockResolvedValue([]);
+    prismaMock.church.findUnique.mockResolvedValue(null);
+
+    const res = await postRequest(requestBody(["att-mine"]));
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.financialRequest.create).toHaveBeenCalled();
+  });
+
+  it("accepte la création sans pièce jointe (non-régression)", async () => {
+    prismaMock.financialRequest.create.mockResolvedValue({
+      id: "req-2",
+      type: "EXPENSE_REPORT",
+      label: "Frais de déplacement",
+      amount: 42,
+      description: null,
+      department: null,
+      submittedBy: { name: "Test User", email: "test@example.com" },
+    } as never);
+    prismaMock.userChurchRole.findMany.mockResolvedValue([]);
+    prismaMock.church.findUnique.mockResolvedValue(null);
+
+    const res = await postRequest(requestBody());
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.financialAttachment.count).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/accounting/attachments/[id] — lecture de la pièce d'un tiers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refuse la lecture avec accounting:submit seul (MINISTER)", async () => {
+    mockRequireAuth.mockResolvedValue(
+      createSession({
+        id: "user-2",
+        churchRoles: [
+          {
+            id: "role-1",
+            churchId: "church-1",
+            role: "MINISTER",
+            ministryId: null,
+            church: { id: "church-1", name: "Test Church", slug: "test-church" },
+            departments: [],
+          },
+        ],
+      })
+    );
+    prismaMock.financialAttachment.findUnique.mockResolvedValue({
+      id: "att-1",
+      uploadedById: "someone-else",
+      churchId: "church-1",
+      s3Key: "accounting/church-1/x.pdf",
+      filename: "justificatif.pdf",
+      mimeType: "application/pdf",
+    } as never);
+
+    const res = await getAttachment(new Request("http://localhost"), {
+      params: makeParams("att-1"),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("autorise la lecture avec accounting:manage dans l'église de la pièce", async () => {
+    mockRequireAuth.mockResolvedValue(createAdminSession("church-1"));
+    prismaMock.financialAttachment.findUnique.mockResolvedValue({
+      id: "att-1",
+      uploadedById: "someone-else",
+      churchId: "church-1",
+      s3Key: "accounting/church-1/x.pdf",
+      filename: "justificatif.pdf",
+      mimeType: "application/pdf",
+    } as never);
+
+    const res = await getAttachment(new Request("http://localhost"), {
+      params: makeParams("att-1"),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("autorise le déposant à lire sa propre pièce", async () => {
+    mockRequireAuth.mockResolvedValue(createSession({ id: "user-3" }));
+    prismaMock.financialAttachment.findUnique.mockResolvedValue({
+      id: "att-1",
+      uploadedById: "user-3",
+      churchId: "church-1",
+      s3Key: "accounting/church-1/x.pdf",
+      filename: "justificatif.pdf",
+      mimeType: "application/pdf",
+    } as never);
+
+    const res = await getAttachment(new Request("http://localhost"), {
+      params: makeParams("att-1"),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("refuse la lecture inter-églises même avec accounting:manage dans une AUTRE église", async () => {
+    // ADMIN de l'église A, mais la pièce relève de l'église B — l'autorité est attachment.churchId,
+    // jamais un contexte affiché manipulable côté client.
+    mockRequireAuth.mockResolvedValue(createAdminSession("church-A"));
+    prismaMock.financialAttachment.findUnique.mockResolvedValue({
+      id: "att-1",
+      uploadedById: "someone-else",
+      churchId: "church-B",
+      s3Key: "accounting/church-B/x.pdf",
+      filename: "justificatif.pdf",
+      mimeType: "application/pdf",
+    } as never);
+
+    const res = await getAttachment(new Request("http://localhost"), {
+      params: makeParams("att-1"),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("retourne 404 pour une pièce inexistante", async () => {
+    mockRequireAuth.mockResolvedValue(createSession({ id: "user-1" }));
+    prismaMock.financialAttachment.findUnique.mockResolvedValue(null);
+
+    const res = await getAttachment(new Request("http://localhost"), {
+      params: makeParams("missing"),
+    });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/accounting/attachments/[id]/route.ts
+++ b/src/app/api/accounting/attachments/[id]/route.ts
@@ -1,7 +1,8 @@
-import { requireAuth, getCurrentChurchId } from "@/lib/auth";
+import { requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { getFileUrl, deleteFile } from "@/lib/file-storage";
+import { canReadAttachment } from "@/modules/accounting";
 
 export async function GET(
   _request: Request,
@@ -10,18 +11,15 @@ export async function GET(
   try {
     const { id } = await params;
     const session = await requireAuth();
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
 
-    const attachment = await prisma.financialAttachment.findUnique({
-      where: { id },
-      include: { request: { select: { churchId: true, submittedById: true } } },
-    });
+    // L'église de la pièce fait autorité — jamais le contexte d'église affiché, qui peut être
+    // manipulé côté client (spec 025, même principe que spec 024).
+    const attachment = await prisma.financialAttachment.findUnique({ where: { id } });
     if (!attachment) throw new ApiError(404, "Pièce jointe introuvable");
 
-    const attachmentChurchId = attachment.request?.churchId ?? null;
-    if (attachmentChurchId && attachmentChurchId !== churchId) throw new ApiError(403, "Accès refusé");
-    if (!attachment.request && attachment.uploadedById !== session.user.id!) throw new ApiError(403, "Accès refusé");
+    if (!(await canReadAttachment(attachment, session))) {
+      throw new ApiError(403, "Accès refusé");
+    }
 
     const url = await getFileUrl(attachment.s3Key, attachment.filename);
     return successResponse({ url, filename: attachment.filename, mimeType: attachment.mimeType });
@@ -37,12 +35,10 @@ export async function DELETE(
   try {
     const { id } = await params;
     const session = await requireAuth();
-    const churchId = await getCurrentChurchId(session);
-    if (!churchId) throw new ApiError(400, "Aucune église sélectionnée");
 
     const attachment = await prisma.financialAttachment.findUnique({
       where: { id },
-      include: { request: { select: { churchId: true, submittedById: true, status: true } } },
+      include: { request: { select: { submittedById: true, status: true } } },
     });
     if (!attachment) throw new ApiError(404, "Pièce jointe introuvable");
 

--- a/src/app/api/accounting/attachments/route.ts
+++ b/src/app/api/accounting/attachments/route.ts
@@ -35,6 +35,7 @@ export async function POST(request: Request) {
       data: {
         requestId:    requestId ?? undefined,
         uploadedById: session.user.id!,
+        churchId,
         s3Key,
         filename: file.name,
         mimeType: file.type,

--- a/src/app/api/accounting/requests/route.ts
+++ b/src/app/api/accounting/requests/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { rolePermissions } from "@/lib/registry";
 import { sendEmail, buildAccountingNewRequestEmail } from "@/lib/email";
+import { assertAttachmentsAssignable } from "@/modules/accounting";
 import { z } from "zod";
 
 const createSchema = z.object({
@@ -96,26 +97,36 @@ export async function POST(request: Request) {
       if (!dept) throw new ApiError(404, "Département introuvable");
     }
 
-    const req = await prisma.financialRequest.create({
-      data: {
-        churchId,
-        departmentId: body.departmentId ?? undefined,
-        submittedById: session.user.id!,
-        type:        body.type,
-        label:       body.label,
-        description: body.description,
-        amount:      body.amount,
-        status:      "SUBMITTED",
-        ...(body.attachmentIds?.length
-          ? { attachments: { connect: body.attachmentIds.map((id) => ({ id })) } }
-          : {}),
-      },
-      include: {
-        department:  { select: { id: true, name: true } },
-        submittedBy: { select: { id: true, name: true, email: true } },
-        attachments: true,
-        payments:    true,
-      },
+    const req = await prisma.$transaction(async (tx) => {
+      if (body.attachmentIds?.length) {
+        await assertAttachmentsAssignable(
+          body.attachmentIds,
+          { userId: session.user.id!, churchId },
+          tx
+        );
+      }
+
+      return tx.financialRequest.create({
+        data: {
+          churchId,
+          departmentId: body.departmentId ?? undefined,
+          submittedById: session.user.id!,
+          type:        body.type,
+          label:       body.label,
+          description: body.description,
+          amount:      body.amount,
+          status:      "SUBMITTED",
+          ...(body.attachmentIds?.length
+            ? { attachments: { connect: body.attachmentIds.map((id) => ({ id })) } }
+            : {}),
+        },
+        include: {
+          department:  { select: { id: true, name: true } },
+          submittedBy: { select: { id: true, name: true, email: true } },
+          attachments: true,
+          payments:    true,
+        },
+      });
     });
 
     // Notification email compta + in-app (best-effort)

--- a/src/app/api/media/__tests__/validate-photo-scope.test.ts
+++ b/src/app/api/media/__tests__/validate-photo-scope.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests — spec 025 (H-02) : périmètre des jetons de partage sur les routes photo.
+ *
+ * Une photo n'appartient jamais à un projet (MediaPhoto.mediaEventId est obligatoire).
+ * Un jeton délégué à un projet, ou sans cible du tout, ne doit donc jamais accéder à une photo.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+const mockValidateMediaShareToken = vi.fn();
+
+vi.mock("@/modules/media", () => ({
+  validateMediaShareToken: (...args: unknown[]) => mockValidateMediaShareToken(...args),
+  getSignedOriginalUrl: vi.fn().mockResolvedValue("https://example.com/original.jpg"),
+  getSignedDownloadUrl: vi.fn().mockResolvedValue("https://example.com/download.jpg"),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+const { GET: validateGet, PATCH: validatePatch } = await import(
+  "../validate/[token]/photo/[photoId]/route"
+);
+const { GET: galleryGet } = await import("../gallery/[token]/photo/[photoId]/route");
+const { GET: downloadGet } = await import("../download/[token]/photo/[photoId]/route");
+
+const makeParams = (token: string, photoId: string) => Promise.resolve({ token, photoId });
+
+const eventToken = { id: "tok-1", type: "VALIDATOR" as const, mediaEventId: "evt-1" };
+const projectToken = { id: "tok-2", type: "VALIDATOR" as const, mediaProjectId: "proj-1" };
+const noTargetToken = { id: "tok-3", type: "VALIDATOR" as const };
+
+const galleryEventToken = { id: "tok-4", type: "GALLERY" as const, mediaEventId: "evt-1", config: null };
+const galleryProjectToken = { id: "tok-5", type: "GALLERY" as const, mediaProjectId: "proj-1", config: null };
+const galleryNoTargetToken = { id: "tok-6", type: "GALLERY" as const, config: null };
+
+const downloadEventToken = { id: "tok-7", type: "MEDIA" as const, mediaEventId: "evt-1" };
+const downloadProjectToken = { id: "tok-8", type: "MEDIA" as const, mediaProjectId: "proj-1" };
+const downloadNoTargetToken = { id: "tok-9", type: "MEDIA" as const };
+
+describe("H-02 : périmètre des jetons sur les routes photo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("validate/[token]/photo/[photoId]", () => {
+    it("jeton projet refusé en GET (aucune requête photo émise)", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(projectToken);
+
+      const res = await validateGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-of-another-church"),
+      });
+
+      expect(res.status).toBe(404);
+      expect(prismaMock.mediaPhoto.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("jeton projet refusé en PATCH (aucune écriture émise)", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(projectToken);
+
+      const request = new Request("http://localhost", {
+        method: "PATCH",
+        body: JSON.stringify({ status: "APPROVED" }),
+      });
+      const res = await validatePatch(request, {
+        params: makeParams("tok", "photo-of-another-church"),
+      });
+
+      expect(res.status).toBe(404);
+      expect(prismaMock.mediaPhoto.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("jeton sans aucune cible refusé en GET et PATCH", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(noTargetToken);
+
+      const resGet = await validateGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-1"),
+      });
+      expect(resGet.status).toBe(404);
+
+      const resPatch = await validatePatch(
+        new Request("http://localhost", {
+          method: "PATCH",
+          body: JSON.stringify({ status: "APPROVED" }),
+        }),
+        { params: makeParams("tok", "photo-1") }
+      );
+      expect(resPatch.status).toBe(404);
+    });
+
+    it("jeton événement filtre la requête par son propre événement (photo d'un autre événement refusée)", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(eventToken);
+      prismaMock.mediaPhoto.findFirst.mockResolvedValue(null);
+
+      const res = await validateGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-other-event"),
+      });
+
+      expect(res.status).toBe(404);
+      expect(prismaMock.mediaPhoto.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "photo-other-event", mediaEventId: "evt-1" },
+        })
+      );
+    });
+
+    it("jeton événement autorise une photo de son propre événement (non-régression)", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(eventToken);
+      prismaMock.mediaPhoto.findFirst.mockResolvedValue({
+        id: "photo-1",
+        originalKey: "key.jpg",
+        filename: "photo.jpg",
+      } as never);
+
+      const res = await validateGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-1"),
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it("refus hors périmètre et refus pour photo inexistante rendent le même statut et le même message", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(eventToken);
+      prismaMock.mediaPhoto.findFirst.mockResolvedValue(null);
+      const outOfScope = await validateGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-other-event"),
+      });
+
+      mockValidateMediaShareToken.mockResolvedValue(noTargetToken);
+      const noTarget = await validateGet(new Request("http://localhost"), {
+        params: makeParams("tok", "any-photo"),
+      });
+
+      expect(outOfScope.status).toBe(noTarget.status);
+      expect(await outOfScope.json()).toEqual(await noTarget.json());
+    });
+
+    it("un refus PATCH ne déclenche aucune transition d'état de l'événement", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(eventToken);
+      prismaMock.mediaPhoto.updateMany.mockResolvedValue({ count: 0 } as never);
+
+      await validatePatch(
+        new Request("http://localhost", {
+          method: "PATCH",
+          body: JSON.stringify({ status: "APPROVED" }),
+        }),
+        { params: makeParams("tok", "missing") }
+      );
+
+      expect(prismaMock.mediaEvent.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("gallery/[token]/photo/[photoId]", () => {
+    it("jeton sans aucune cible refusé", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(galleryNoTargetToken);
+
+      const res = await galleryGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-1"),
+      });
+
+      expect(res.status).toBe(404);
+      expect(prismaMock.mediaPhoto.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("jeton projet passe par la branche fichier, jamais par la branche photo", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(galleryProjectToken);
+      prismaMock.mediaFile.findUnique.mockResolvedValue(null);
+
+      const res = await galleryGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-1"),
+      });
+
+      expect(res.status).toBe(404);
+      expect(prismaMock.mediaPhoto.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("jeton événement autorise sa propre photo (non-régression)", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(galleryEventToken);
+      prismaMock.mediaPhoto.findFirst.mockResolvedValue({
+        id: "photo-1",
+        filename: "photo.jpg",
+        originalKey: "key.jpg",
+        status: "APPROVED",
+      } as never);
+
+      const res = await galleryGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-1"),
+      });
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("download/[token]/photo/[photoId]", () => {
+    it("jeton sans aucune cible refusé", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(downloadNoTargetToken);
+
+      const res = await downloadGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-1"),
+      });
+
+      expect(res.status).toBe(404);
+      expect(prismaMock.mediaPhoto.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("jeton projet passe par la branche fichier, jamais par la branche photo", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(downloadProjectToken);
+      prismaMock.mediaFile.findUnique.mockResolvedValue(null);
+
+      const res = await downloadGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-1"),
+      });
+
+      expect(res.status).toBe(404);
+      expect(prismaMock.mediaPhoto.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("jeton événement autorise sa propre photo approuvée (non-régression)", async () => {
+      mockValidateMediaShareToken.mockResolvedValue(downloadEventToken);
+      prismaMock.mediaPhoto.findFirst.mockResolvedValue({
+        id: "photo-1",
+        filename: "photo.jpg",
+        originalKey: "key.jpg",
+        status: "APPROVED",
+      } as never);
+
+      const res = await downloadGet(new Request("http://localhost"), {
+        params: makeParams("tok", "photo-1"),
+      });
+
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/src/app/api/media/download/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/download/[token]/photo/[photoId]/route.ts
@@ -51,15 +51,17 @@ export async function GET(
     }
 
     // ── Événement : photo ───────────────────────────────────────────────────────
-    const photo = await prisma.mediaPhoto.findUnique({
-      where: { id: photoId },
-      select: { id: true, filename: true, mediaEventId: true, originalKey: true, status: true },
+    // Une photo n'appartient jamais à un projet : un jeton sans événement (ou délégué à un
+    // projet, déjà traité ci-dessus) n'a rien de légitime à faire ici — refus inconditionnel
+    // (spec 025).
+    if (!shareToken.mediaEventId) throw new ApiError(404, "Photo introuvable");
+
+    const photo = await prisma.mediaPhoto.findFirst({
+      where: { id: photoId, mediaEventId: shareToken.mediaEventId },
+      select: { id: true, filename: true, originalKey: true, status: true },
     });
 
     if (!photo) throw new ApiError(404, "Photo introuvable");
-    if (shareToken.mediaEventId && photo.mediaEventId !== shareToken.mediaEventId) {
-      throw new ApiError(403, "Photo hors périmètre");
-    }
     if (shareToken.type === "MEDIA" && photo.status !== "APPROVED") {
       throw new ApiError(403, "Photo non approuvée");
     }

--- a/src/app/api/media/gallery/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/gallery/[token]/photo/[photoId]/route.ts
@@ -48,15 +48,17 @@ export async function GET(
       return successResponse({ id: file.id, filename: file.filename, downloadUrl });
     }
 
-    const photo = await prisma.mediaPhoto.findUnique({
-      where: { id: photoId },
-      select: { id: true, filename: true, mediaEventId: true, originalKey: true, status: true },
+    // Une photo n'appartient jamais à un projet : un jeton sans événement (ou délégué à un
+    // projet, déjà traité ci-dessus) n'a rien de légitime à faire ici — refus inconditionnel
+    // (spec 025).
+    if (!shareToken.mediaEventId) throw new ApiError(404, "Photo introuvable");
+
+    const photo = await prisma.mediaPhoto.findFirst({
+      where: { id: photoId, mediaEventId: shareToken.mediaEventId },
+      select: { id: true, filename: true, originalKey: true, status: true },
     });
 
     if (!photo) throw new ApiError(404, "Photo introuvable");
-    if (shareToken.mediaEventId && photo.mediaEventId !== shareToken.mediaEventId) {
-      throw new ApiError(403, "Photo hors périmètre");
-    }
 
     if (onlyApproved && photo.status !== "APPROVED") {
       throw new ApiError(403, "Cette photo n'est pas approuvée");

--- a/src/app/api/media/validate/[token]/photo/[photoId]/__tests__/route.test.ts
+++ b/src/app/api/media/validate/[token]/photo/[photoId]/__tests__/route.test.ts
@@ -41,17 +41,7 @@ describe("HIGH-2 : PATCH photo/[photoId] — machine d'état", () => {
   it("VALIDATOR peut corriger APPROVED → REJECTED (correction d'erreur)", async () => {
     mockValidateMediaShareToken.mockResolvedValue(baseValidatorToken);
 
-    prismaMock.mediaPhoto.findUnique.mockResolvedValue({
-      id: "photo-1",
-      mediaEventId: "evt-1",
-      status: "APPROVED",
-    } as never);
-
-    prismaMock.mediaPhoto.update.mockResolvedValue({
-      id: "photo-1",
-      status: "REJECTED",
-      validatedAt: new Date(),
-    } as never);
+    prismaMock.mediaPhoto.updateMany.mockResolvedValue({ count: 1 } as never);
 
     prismaMock.mediaPhoto.count.mockResolvedValue(0);
     prismaMock.mediaEvent.updateMany.mockResolvedValue({ count: 0 } as never);
@@ -70,17 +60,7 @@ describe("HIGH-2 : PATCH photo/[photoId] — machine d'état", () => {
   it("VALIDATOR peut corriger REJECTED → APPROVED (correction d'erreur)", async () => {
     mockValidateMediaShareToken.mockResolvedValue(baseValidatorToken);
 
-    prismaMock.mediaPhoto.findUnique.mockResolvedValue({
-      id: "photo-1",
-      mediaEventId: "evt-1",
-      status: "REJECTED",
-    } as never);
-
-    prismaMock.mediaPhoto.update.mockResolvedValue({
-      id: "photo-1",
-      status: "APPROVED",
-      validatedAt: new Date(),
-    } as never);
+    prismaMock.mediaPhoto.updateMany.mockResolvedValue({ count: 1 } as never);
 
     prismaMock.mediaPhoto.count.mockResolvedValue(0);
     prismaMock.mediaEvent.updateMany.mockResolvedValue({ count: 1 } as never);
@@ -99,17 +79,7 @@ describe("HIGH-2 : PATCH photo/[photoId] — machine d'état", () => {
   it("PREVALIDATOR peut transitionner PENDING → PREVALIDATED", async () => {
     mockValidateMediaShareToken.mockResolvedValue(basePrevalidatorToken);
 
-    prismaMock.mediaPhoto.findUnique.mockResolvedValue({
-      id: "photo-1",
-      mediaEventId: "evt-1",
-      status: "PENDING",
-    } as never);
-
-    prismaMock.mediaPhoto.update.mockResolvedValue({
-      id: "photo-1",
-      status: "PREVALIDATED",
-      validatedAt: new Date(),
-    } as never);
+    prismaMock.mediaPhoto.updateMany.mockResolvedValue({ count: 1 } as never);
 
     const request = new Request("http://localhost/api/media/validate/tok/photo/photo-1", {
       method: "PATCH",
@@ -125,12 +95,6 @@ describe("HIGH-2 : PATCH photo/[photoId] — machine d'état", () => {
   it("PREVALIDATOR ne peut pas mettre APPROVED", async () => {
     mockValidateMediaShareToken.mockResolvedValue(basePrevalidatorToken);
 
-    prismaMock.mediaPhoto.findUnique.mockResolvedValue({
-      id: "photo-1",
-      mediaEventId: "evt-1",
-      status: "PENDING",
-    } as never);
-
     const request = new Request("http://localhost/api/media/validate/tok/photo/photo-1", {
       method: "PATCH",
       body: JSON.stringify({ status: "APPROVED" }),
@@ -143,17 +107,7 @@ describe("HIGH-2 : PATCH photo/[photoId] — machine d'état", () => {
   it("VALIDATOR peut transitionner PREVALIDATED → APPROVED", async () => {
     mockValidateMediaShareToken.mockResolvedValue(baseValidatorToken);
 
-    prismaMock.mediaPhoto.findUnique.mockResolvedValue({
-      id: "photo-1",
-      mediaEventId: "evt-1",
-      status: "PREVALIDATED",
-    } as never);
-
-    prismaMock.mediaPhoto.update.mockResolvedValue({
-      id: "photo-1",
-      status: "APPROVED",
-      validatedAt: new Date(),
-    } as never);
+    prismaMock.mediaPhoto.updateMany.mockResolvedValue({ count: 1 } as never);
 
     prismaMock.mediaPhoto.count.mockResolvedValue(0);
     prismaMock.mediaEvent.updateMany.mockResolvedValue({ count: 1 } as never);
@@ -172,7 +126,7 @@ describe("HIGH-2 : PATCH photo/[photoId] — machine d'état", () => {
   it("retourne 404 si la photo est introuvable", async () => {
     mockValidateMediaShareToken.mockResolvedValue(baseValidatorToken);
 
-    prismaMock.mediaPhoto.findUnique.mockResolvedValue(null);
+    prismaMock.mediaPhoto.updateMany.mockResolvedValue({ count: 0 } as never);
 
     const request = new Request("http://localhost/api/media/validate/tok/photo/missing", {
       method: "PATCH",

--- a/src/app/api/media/validate/[token]/photo/[photoId]/route.ts
+++ b/src/app/api/media/validate/[token]/photo/[photoId]/route.ts
@@ -19,15 +19,16 @@ export async function GET(
     const { token, photoId } = await params;
     const shareToken = await validateMediaShareToken(token, ["VALIDATOR", "PREVALIDATOR"]);
 
-    const photo = await prisma.mediaPhoto.findUnique({
-      where: { id: photoId },
-      select: { id: true, originalKey: true, filename: true, mediaEventId: true },
+    // Une photo n'appartient jamais à un projet : un jeton sans événement (ou délégué à un
+    // projet) n'a rien de légitime à faire ici — refus inconditionnel (spec 025).
+    if (!shareToken.mediaEventId) throw new ApiError(404, "Photo introuvable");
+
+    const photo = await prisma.mediaPhoto.findFirst({
+      where: { id: photoId, mediaEventId: shareToken.mediaEventId },
+      select: { id: true, originalKey: true, filename: true },
     });
 
     if (!photo) throw new ApiError(404, "Photo introuvable");
-    if (shareToken.mediaEventId && photo.mediaEventId !== shareToken.mediaEventId) {
-      throw new ApiError(403, "Photo hors périmètre");
-    }
 
     const originalUrl = await getSignedOriginalUrl(photo.originalKey);
     return successResponse({ id: photo.id, originalUrl, filename: photo.filename });
@@ -57,20 +58,16 @@ export async function PATCH(
       throw new ApiError(403, "Le validateur ne peut qu'approuver ou rejeter");
     }
 
-    const photo = await prisma.mediaPhoto.findUnique({
-      where: { id: photoId },
-      select: { id: true, mediaEventId: true, status: true },
-    });
+    // Une photo n'appartient jamais à un projet : un jeton sans événement (ou délégué à un
+    // projet) n'a rien de légitime à faire ici — refus inconditionnel (spec 025).
+    if (!shareToken.mediaEventId) throw new ApiError(404, "Photo introuvable");
 
-    if (!photo) throw new ApiError(404, "Photo introuvable");
-    if (shareToken.mediaEventId && photo.mediaEventId !== shareToken.mediaEventId) {
-      throw new ApiError(403, "Photo hors périmètre");
-    }
-
-    const updated = await prisma.mediaPhoto.update({
-      where: { id: photoId },
+    const result = await prisma.mediaPhoto.updateMany({
+      where: { id: photoId, mediaEventId: shareToken.mediaEventId },
       data: { status, validatedAt: new Date() },
     });
+
+    if (result.count === 0) throw new ApiError(404, "Photo introuvable");
 
     // Auto-transition de l'événement → REVIEWED si plus aucune photo en attente
     if (shareToken.type === "VALIDATOR" && shareToken.mediaEventId) {
@@ -91,7 +88,7 @@ export async function PATCH(
       }
     }
 
-    return successResponse(updated);
+    return successResponse({ id: photoId, status });
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/modules/accounting/index.ts
+++ b/src/modules/accounting/index.ts
@@ -1,5 +1,7 @@
 import { defineModule } from "@/core/module-registry";
 
+export { assertAttachmentsAssignable, canReadAttachment } from "./services/attachments";
+
 export const accountingModule = defineModule({
   name: "accounting",
   version: "1.0.0",

--- a/src/modules/accounting/services/__tests__/attachments.test.ts
+++ b/src/modules/accounting/services/__tests__/attachments.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests — spec 025 (H-03) : autorisation objet des pièces justificatives comptables.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createSession, createAdminSession } from "@/__mocks__/auth";
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+// canReadAttachment importe dynamiquement @/lib/registry, qui charge la chaîne de boot des
+// modules jusqu'à @/lib/auth (NextAuth(...)) — sans ce mock, l'import réel de "next-auth"
+// échoue hors contexte Next.js (cf. src/lib/__tests__/auth-multitenant.test.ts).
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: vi.fn(), handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+
+const { assertAttachmentsAssignable, canReadAttachment } = await import("../attachments");
+
+describe("assertAttachmentsAssignable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepte quand toutes les pièces sont du déposant, orphelines et de son église", async () => {
+    prismaMock.financialAttachment.count.mockResolvedValue(2);
+
+    await expect(
+      assertAttachmentsAssignable(["att-1", "att-2"], { userId: "user-1", churchId: "church-1" })
+    ).resolves.toBeUndefined();
+
+    expect(prismaMock.financialAttachment.count).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["att-1", "att-2"] },
+        uploadedById: "user-1",
+        requestId: null,
+        churchId: "church-1",
+      },
+    });
+  });
+
+  it("rejette une pièce déposée par quelqu'un d'autre", async () => {
+    prismaMock.financialAttachment.count.mockResolvedValue(0);
+
+    await expect(
+      assertAttachmentsAssignable(["att-of-someone-else"], { userId: "user-1", churchId: "church-1" })
+    ).rejects.toThrow();
+  });
+
+  it("rejette une pièce déjà rattachée à une autre demande", async () => {
+    // La pièce existe mais requestId n'est plus null → hors du filtre → count divergent.
+    prismaMock.financialAttachment.count.mockResolvedValue(0);
+
+    await expect(
+      assertAttachmentsAssignable(["att-already-linked"], { userId: "user-1", churchId: "church-1" })
+    ).rejects.toThrow();
+  });
+
+  it("rejette une pièce d'une autre église", async () => {
+    prismaMock.financialAttachment.count.mockResolvedValue(0);
+
+    await expect(
+      assertAttachmentsAssignable(["att-other-church"], { userId: "user-1", churchId: "church-1" })
+    ).rejects.toThrow();
+  });
+
+  it("rejette un identifiant inexistant", async () => {
+    prismaMock.financialAttachment.count.mockResolvedValue(0);
+
+    await expect(
+      assertAttachmentsAssignable(["nonexistent"], { userId: "user-1", churchId: "church-1" })
+    ).rejects.toThrow();
+  });
+
+  it("un lot mixte (une valide, une invalide) est rejeté dans son ensemble", async () => {
+    // 2 ids demandés, un seul remplit les conditions → count=1 ≠ 2 → rejet global.
+    prismaMock.financialAttachment.count.mockResolvedValue(1);
+
+    await expect(
+      assertAttachmentsAssignable(["att-valid", "att-invalid"], {
+        userId: "user-1",
+        churchId: "church-1",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("dédoublonne les identifiants avant de comparer la cardinalité", async () => {
+    prismaMock.financialAttachment.count.mockResolvedValue(1);
+
+    await expect(
+      assertAttachmentsAssignable(["att-1", "att-1"], { userId: "user-1", churchId: "church-1" })
+    ).resolves.toBeUndefined();
+  });
+
+  it("ne fait aucune requête pour une liste vide", async () => {
+    await assertAttachmentsAssignable([], { userId: "user-1", churchId: "church-1" });
+    expect(prismaMock.financialAttachment.count).not.toHaveBeenCalled();
+  });
+
+  it("accepte un client de transaction explicite plutôt que le singleton global", async () => {
+    const txCount = vi.fn().mockResolvedValue(1);
+    const tx = { financialAttachment: { count: txCount } };
+
+    await assertAttachmentsAssignable(
+      ["att-1"],
+      { userId: "user-1", churchId: "church-1" },
+      tx as never
+    );
+
+    expect(txCount).toHaveBeenCalled();
+    expect(prismaMock.financialAttachment.count).not.toHaveBeenCalled();
+  });
+});
+
+describe("canReadAttachment", () => {
+  it("autorise le déposant à lire sa propre pièce", async () => {
+    const session = createSession({ id: "user-1" });
+    const result = await canReadAttachment(
+      { uploadedById: "user-1", churchId: "church-1" },
+      session
+    );
+    expect(result).toBe(true);
+  });
+
+  it("autorise le Super Admin sans condition d'église", async () => {
+    const session = createSession({ id: "user-2", isSuperAdmin: true });
+    const result = await canReadAttachment(
+      { uploadedById: "someone-else", churchId: "church-1" },
+      session
+    );
+    expect(result).toBe(true);
+  });
+
+  it("autorise accounting:manage dans l'église de la pièce", async () => {
+    const session = createAdminSession("church-1"); // ADMIN → accounting:manage
+    const result = await canReadAttachment(
+      { uploadedById: "someone-else", churchId: "church-1" },
+      session
+    );
+    expect(result).toBe(true);
+  });
+
+  it("refuse accounting:submit seul (MINISTER) pour la pièce d'un tiers", async () => {
+    const session = createSession({
+      id: "user-3",
+      churchRoles: [
+        {
+          id: "role-1",
+          churchId: "church-1",
+          role: "MINISTER",
+          ministryId: null,
+          church: { id: "church-1", name: "Test Church", slug: "test-church" },
+          departments: [],
+        },
+      ],
+    });
+    const result = await canReadAttachment(
+      { uploadedById: "someone-else", churchId: "church-1" },
+      session
+    );
+    expect(result).toBe(false);
+  });
+
+  it("refuse accounting:manage détenu dans une AUTRE église que celle de la pièce", async () => {
+    const session = createAdminSession("church-A"); // ADMIN dans A seulement
+    const result = await canReadAttachment(
+      { uploadedById: "someone-else", churchId: "church-B" },
+      session
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/src/modules/accounting/services/attachments.ts
+++ b/src/modules/accounting/services/attachments.ts
@@ -1,0 +1,58 @@
+import type { Session } from "next-auth";
+import type { PrismaClient } from "@/generated/prisma/client";
+import { ApiError } from "@/lib/api-utils";
+
+type PrismaClientOrTx = Pick<PrismaClient, "financialAttachment">;
+
+/**
+ * Vérifie que chaque pièce désignée peut être rattachée à une nouvelle demande : déposée par
+ * l'appelant, encore orpheline, dans son église. Toute divergence lève la même erreur — ne
+ * jamais révéler laquelle des conditions a échoué (spec 025).
+ *
+ * Accepte un client de transaction (`tx`) pour que cette vérification et le rattachement qui
+ * la suit s'exécutent atomiquement — sans quoi une suppression concurrente entre les deux
+ * pourrait laisser passer un rattachement partiel. Le client par défaut n'est importé qu'à
+ * l'appel (import différé) pour ne pas construire le client Prisma réel au simple chargement
+ * du module — voir le motif équivalent dans `src/lib/auth.ts`.
+ */
+export async function assertAttachmentsAssignable(
+  attachmentIds: string[],
+  params: { userId: string; churchId: string },
+  client?: PrismaClientOrTx
+): Promise<void> {
+  const uniqueIds = Array.from(new Set(attachmentIds));
+  if (uniqueIds.length === 0) return;
+
+  const db = client ?? (await import("@/lib/prisma")).prisma;
+  const count = await db.financialAttachment.count({
+    where: {
+      id: { in: uniqueIds },
+      uploadedById: params.userId,
+      requestId: null,
+      churchId: params.churchId,
+    },
+  });
+
+  if (count !== uniqueIds.length) {
+    throw new ApiError(403, "Pièce jointe invalide");
+  }
+}
+
+/**
+ * Autorise la lecture d'une pièce déposée par quelqu'un d'autre : réservée au traitement
+ * comptable (accounting:manage) dans l'église de la pièce — pas à la simple soumission.
+ * L'église de la pièce fait autorité, jamais un contexte affiché.
+ */
+export async function canReadAttachment(
+  attachment: { uploadedById: string | null; churchId: string },
+  session: Session
+): Promise<boolean> {
+  if (attachment.uploadedById && attachment.uploadedById === session.user.id) return true;
+  if (session.user.isSuperAdmin) return true;
+
+  const { rolePermissions } = await import("@/lib/registry");
+  const roles = session.user.churchRoles.filter((r) => r.churchId === attachment.churchId);
+  const permissions = new Set(roles.flatMap((r) => rolePermissions[r.role] ?? []));
+
+  return permissions.has("accounting:manage");
+}


### PR DESCRIPTION
## Résumé

Deux défauts d'autorisation **objet** (le pendant, à l'échelle de l'objet, du défaut d'isolation
inter-églises corrigé dans #475) : dans les deux cas, l'accès dépendait d'un champ facultatif ou
d'un rattachement que l'appelant pouvait lui-même provoquer, plutôt que d'un contrôle
inconditionnel porté par l'objet.

### H-02 — Périmètre non vérifié pour un jeton de validation média

`validate/[token]/photo/[photoId]`, `gallery/[token]/photo/[photoId]` et
`download/[token]/photo/[photoId]` ne vérifiaient le périmètre que si le jeton portait un
événement (`if (shareToken.mediaEventId && …)`). Un jeton délégué à un **projet** — ou sans cible
du tout, forme explicitement représentable par le type `CreateTokenWithTarget` — contournait
totalement le contrôle : n'importe quelle photo de la plateforme, toutes églises confondues,
devenait consultable en HD et modifiable en statut (approuvée/rejetée).

Une photo n'appartenant jamais à un projet, le refus est désormais **inconditionnel** dès
l'absence d'événement porté par le jeton. Le périmètre est porté par la requête elle-même
(`findFirst`/`updateMany` filtrés par `mediaEventId`) plutôt que vérifié après coup : le refus
hors périmètre devient indiscernable du 404 « introuvable ».

*Constat élargi par rapport à l'audit* : celui-ci ne signalait que la route `validate`. La lecture
du code a montré la même garde conditionnelle dans `gallery` et `download` — corrigées aussi.

### H-03 — Pièces comptables associables sans contrôle de propriété

`FinancialAttachment` n'avait pas d'église propre : elle était déduite de la demande liée — le
rattachement qu'un appelant pouvait précisément provoquer pour s'approprier l'accès à la pièce
d'un tiers (créer une demande dans sa propre église en y connectant la pièce d'autrui la rendait
ensuite lisible).

- `FinancialAttachment.churchId` est désormais **intrinsèque** à la pièce (migration avec reprise
  en deux temps : depuis la demande liée, puis depuis le chemin de stockage pour les pièces
  orphelines — échoue si une pièce résiste aux deux).
- La création d'une demande vérifie, **dans la même transaction** que le rattachement, que chaque
  pièce désignée est déposée par l'appelant, orpheline et de son église. Un lot contenant une
  seule pièce invalide ne crée **aucune** demande.
- La lecture de la pièce d'un tiers exige désormais la compétence de **traitement comptable**
  (`accounting:manage`) — la simple soumission (`accounting:submit`, qui inclut Ministre et
  Responsable de département) ne suffit plus.

## Tests

- `src/app/api/media/__tests__/validate-photo-scope.test.ts` (13 tests) : jeton projet/sans
  cible refusé sur les 3 routes, filtrage par événement, refus indiscernable du 404, aucune
  transition d'état sur refus.
- `src/modules/accounting/services/__tests__/attachments.test.ts` (14 tests) : pièce d'autrui,
  déjà rattachée, autre église, lot mixte, dédoublonnage, `canReadAttachment` par rôle/église.
- `src/app/api/accounting/__tests__/attachments-scope.test.ts` (11 tests) : bout en bout création
  de demande + lecture inter-églises, y compris avec `accounting:manage` détenu dans une **autre**
  église que celle de la pièce.
- Test existant `validate/[token]/photo/[photoId]/__tests__/route.test.ts` adapté au nouveau
  filtrage par requête (`findFirst`/`updateMany`).

## Vérification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries`
- [x] `npm run test` (906 tests)
- [x] Critères d'acceptation de la spec relus et satisfaits

Spec complète : `specs/025-autorisation-objet-medias-comptabilite/`

## ⚠️ À faire

- **Avant déploiement** : la migration (`add_church_to_financial_attachments`) passe `churchId`
  en `NOT NULL` après reprise — vérifier sur une copie des données de production qu'aucune pièce
  ne résiste au double backfill (demande liée, puis chemin de stockage) avant de l'appliquer.
- **Après déploiement** : signaler que la lecture des pièces justificatives d'un tiers est
  désormais réservée au traitement comptable (`ACCOUNTANT`, `ADMIN`, `SUPER_ADMIN`) — les rôles
  `MINISTER` et `DEPARTMENT_HEAD` perdent cet accès qu'ils avaient par défaut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)