### PR TITLE
fix(audio): adresser les renditions par contenu pour que les corrections soient servies

### DIFF
--- a/docs/adr/0008-cache-disque-renditions-audio.md
+++ b/docs/adr/0008-cache-disque-renditions-audio.md
@@ -104,6 +104,30 @@ l'est aussi, alors que la redirection déportait cette charge sur le stockage ob
 prix assumé de la décision, et la raison pour laquelle le CDN reste la porte de sortie si
 l'audience change d'ordre de grandeur.
 
+## Mise à jour — 2026-08-29 (spec 026)
+
+La section « Décision » affirmait : « la clé de cache est celle de la rendition dans le stockage
+objet, qui change quand le rendu change — il n'y a donc pas d'invalidation à orchestrer. » Cette
+prémisse n'était pas tenue par le code : `getRenditionKey(serviceId, segmentId)` ne dépendait que
+de ces deux identifiants, jamais du contenu. Un nouveau rendu (ex. correction d'un culte déjà
+publié) écrasait silencieusement le même objet à la même clé — donc la même URL de streaming — et
+un navigateur ayant déjà mis l'ancienne version en cache (`immutable`, jusqu'à un an) continuait
+à la servir indéfiniment. Le cache disque serveur, nommé par hash de cette même clé, portait le
+même défaut.
+
+**Correction (spec 026)** : la clé intègre désormais une empreinte du `sourceHash` du rendu — la
+prémisse énoncée ci-dessus est maintenant vraie. Un nouveau rendu produit une clé différente,
+donc un fichier de cache disque différent et une URL de streaming différente (l'empreinte est
+propagée jusqu'au lecteur en paramètre de requête, purement indicatif côté serveur). L'ancien
+objet S3 est supprimé après bascule. Aucun changement des en-têtes `Cache-Control` ni de la
+décision elle-même : voir
+[Plan de la spec 026](../../specs/026-cache-corrections-audio/plan.md) pour le détail.
+
+Reste hors périmètre, alors et maintenant : un appareil ayant déjà mis un fichier en cache
+localement continue de le servir après une dépublication ou une révocation de lien, quel que
+soit le schéma de clé — limite inhérente à tout cache privé, non résolue par cette mise à jour
+(suivi dédié à ouvrir séparément, spec 026 § Questions ouvertes).
+
 ## Références
 
 - [Spec 021 — Bibliothèque d'écoute des cultes](../../specs/021-audio-bibliotheque-ecoute/spec.md) — la

--- a/specs/026-cache-corrections-audio/plan.md
+++ b/specs/026-cache-corrections-audio/plan.md
@@ -1,0 +1,185 @@
+# Plan technique — Prise en compte immédiate des corrections audio malgré le cache navigateur
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Brouillon
+- **Mis à jour le** : 2026-08-29
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : les imports `src/app/` → module passent par l'index (`@/modules/X`)
+      — aucun nouvel import interne ; on étend des symboles déjà exportés par `@/modules/audio`
+- [x] **Sécurité** : toutes les routes protégées par `requireAuth`/`requirePermission` ;
+      multi-tenant `churchId` respecté — **aucune route de streaming n'est touchée côté
+      autorisation** (les gardes existantes restent telles quelles)
+- [x] **Permissions** via `rolePermissions` (`@/lib/registry`) — inchangées
+- [x] **Validation** Zod sur toutes les mutations — aucune mutation ajoutée
+- [x] **Migration** Prisma prévue si le schéma change (pas de `db push`) — **aucun changement de
+      schéma** (voir § Modèle de données)
+- [x] **Enums** importés depuis `@/generated/prisma/client`
+- [x] **UI** : composants `src/components/ui/` réutilisés avant création — aucun composant créé
+
+## Approche générale
+
+Le fil directeur : **restaurer l'invariant que l'ADR-0008 énonce déjà mais que le code ne tient
+pas**.
+
+ADR-0008 justifie le cache long et `immutable` par cette affirmation :
+
+> « La clé de cache est celle de la rendition dans le stockage objet, **qui change quand le rendu
+> change** — il n'y a donc pas d'invalidation à orchestrer. »
+
+Or `getRenditionKey(serviceId, segmentId)` (`src/modules/audio/worker/handlers/render.ts:31`)
+produit `audio-services/{serviceId}/renditions/{segmentId}.mp3` — une clé **indépendante du
+contenu**. Un nouveau rendu écrase le même objet à la même clé. La prémisse de l'ADR est fausse
+en pratique, et c'est la racine du constat H-07 : puisque la clé ne change pas, rien ne change en
+aval — ni le nom du fichier de cache disque (`sha1(s3Key)`), ni l'URL vue par le navigateur.
+
+On corrige donc à deux niveaux, l'un rétablissant la prémisse, l'autre la propageant jusqu'au
+navigateur :
+
+1. **Clé de rendition adressée par contenu** — `getRenditionKey` intègre le `sourceHash` du rendu.
+   Un nouveau rendu écrit une nouvelle clé, donc un nouveau fichier de cache disque : le cache
+   serveur cesse structurellement de pouvoir servir un contenu périmé, sur n'importe quelle
+   machine. L'ancien objet S3 est supprimé après bascule.
+2. **URL de streaming versionnée** — l'identifiant de version du rendu est exposé jusqu'au
+   lecteur, qui l'ajoute à l'URL `<audio src>`. L'URL change quand le contenu change : le
+   navigateur, qui n'indexe son cache que par URL, refait une requête. Une piste non retouchée
+   garde son URL et reste servie depuis le cache local de l'auditeur.
+
+Aucune modification des en-têtes `Cache-Control` : ils restent longs et `immutable`, ce qui
+redevient **correct** une fois l'URL réellement immuable par contenu — c'est exactement le
+contrat que `immutable` suppose.
+
+## Modèle de données
+
+`[Aucun changement]` — aucune migration Prisma.
+
+`AudioRendition.sourceHash` existe déjà (idempotence du rendu, D10) et sert de jeton de version.
+`AudioRendition.s3Key` est déjà **stocké** en base et lu par les routes de streaming : les
+renditions existantes en production conservent leur clé historique sans hash et restent
+lisibles — elles adoptent la nouvelle forme au premier re-rendu. Aucune reprise de données, donc
+aucun risque de régression sur l'existant.
+
+## API
+
+| Endpoint | Méthode | Permission | Entrée | Sortie |
+|---|---|---|---|---|
+| `/api/audio/services/[id]/stream/[segmentId]` | GET | `audio:listen` (église du culte) | inchangée + paramètre de requête `v` **ignoré** | inchangée |
+| `/api/audio/public/[token]/stream/[segmentId]` | GET | jeton de partage | idem | inchangée |
+
+Le paramètre `v` est un pur **casse-cache côté navigateur** : il n'est jamais lu côté serveur et
+ne participe à aucune décision. La clé faisant autorité reste `segment.rendition.s3Key`, résolue
+en base après les contrôles d'accès existants. Aucun schéma Zod n'est requis pour un paramètre
+non lu — l'ajouter donnerait la fausse impression qu'il influence la réponse.
+
+Conséquence voulue : un appelant qui forge un `v` arbitraire n'obtient rien d'autre que le
+contenu courant auquel il a déjà droit.
+
+## Services / logique métier
+
+**`src/modules/audio/worker/handlers/render.ts`**
+- `getRenditionKey(serviceId, segmentId, sourceHash)` → `audio-services/{serviceId}/renditions/{segmentId}-{sourceHash tronqué}.mp3`.
+- Avant l'`upsert` de `AudioRendition`, mémoriser la clé du rendu précédent (`findUnique` sur
+  `segmentId`, déjà unique). Après un `upsert` réussi et si l'ancienne clé diffère de la nouvelle,
+  supprimer l'ancien objet (`deleteMediaFile`, déjà utilisé par le module audio) en
+  **best-effort non bloquant** : un objet orphelin n'empêche aucune écoute, alors qu'un échec de
+  nettoyage qui ferait échouer le rendu, si.
+- Le pré-chauffage `primeRenditionCache(key, outputPath)` suit naturellement la nouvelle clé.
+  Les fichiers de cache disque périmés portent une autre empreinte et partiront par éviction LRU,
+  déjà en place — pas de nettoyage à écrire.
+
+**`src/modules/audio/services/public.ts`**
+- `PublicAudioSegment` gagne un champ `version: string` (le `sourceHash` du rendu, tronqué de la
+  même façon que dans la clé).
+- `mapPublishedSegments` le renseigne. C'est **le seul point de mapping** — il alimente déjà à la
+  fois `resolvePublicAudioService` (lien public) et `getPublishedServiceForMember`
+  (`services/library.ts`, bibliothèque membre), donc les deux chemins d'écoute reçoivent la
+  version sans duplication de logique, conformément à la contrainte de la spec.
+
+Aucun événement du bus concerné.
+
+## UI / composants
+
+**`src/components/audio/AudioPlayer.tsx`**
+- `AudioPlayerSegment` gagne `version: string`.
+- La prop `streamUrl` passe de `(segmentId: string) => string` à
+  `(segment: AudioPlayerSegment) => string`. Passer le segment entier plutôt qu'un couple
+  `(id, version)` évite d'avoir à retoucher cette signature au prochain besoin, et le seul appel
+  (`<audio src={streamUrl(current)}>`) devient trivialement correct.
+
+**`src/app/(auth)/audio/ecouter/[id]/MemberAudioPlayer.tsx`** et
+**`src/app/ecouter/[token]/PublicAudioPlayer.tsx`**
+- Chacun construit son URL en y ajoutant `?v=${segment.version}`. Les deux pages serveur qui les
+  alimentent transmettent déjà les segments issus de `mapPublishedSegments` : le champ arrive
+  sans autre changement de plomberie.
+
+Aucun composant `src/components/ui/` créé ni modifié.
+
+## Décisions & alternatives écartées
+
+- **Choix : adresser la clé S3 par le contenu, en plus de versionner l'URL** — *Pourquoi* : le
+  seul versionnement d'URL corrigerait le navigateur mais laisserait un défaut plus grave en
+  place. Le cache disque est nommé `sha1(s3Key)` ; à clé constante, un fichier périmé y reste
+  valide. Il n'est rafraîchi que par `primeRenditionCache`, appelé par le **worker**, qui est un
+  process distinct (ADR-0007) : s'il ne partage pas le disque du process web, le cache web sert
+  l'ancien contenu **même à un auditeur qui n'a jamais rien mis en cache** — un cas que la spec
+  exige explicitement de servir correctement. Adresser la clé par le contenu supprime la
+  question au lieu d'ajouter une invalidation à orchestrer.
+- **Écarté : ne changer que le `Cache-Control` (raccourcir `max-age`, retirer `immutable`)** —
+  *Raison* : on paierait une revalidation sur chaque écoute de chaque auditeur pour un événement
+  rare (une correction), c'est-à-dire annuler l'essentiel du bénéfice d'ADR-0008 (l'egress et la
+  latence) pour ne traiter que le symptôme. Et cela ne corrigerait pas le cache disque serveur.
+- **Écarté : versionner par un `updatedAt` ajouté à `AudioRendition`** — *Raison* : imposerait
+  une migration, et un horodatage change même quand le contenu est identique (re-rendu à
+  l'identique) — le cache serait invalidé pour rien. `sourceHash` est déjà là, déjà tenu à jour
+  par le rendu, et ne change **que** si le contenu source change : c'est la sémantique voulue.
+- **Écarté : segment de chemin (`/stream/{segmentId}/{version}`) plutôt qu'un paramètre `v`** —
+  *Raison* : imposerait un nouveau segment de route et un `await params` supplémentaire pour une
+  valeur que le serveur n'utilise pas. Un paramètre de requête exprime mieux ce qu'il est : une
+  donnée de cache, pas une donnée d'adressage.
+- **Écarté : conserver les anciens objets S3 après re-rendu** — *Raison* : ils ne sont plus
+  jamais référencés (la base ne porte qu'une clé par segment) et s'accumuleraient sans limite,
+  facturés. La suppression best-effort les élimine sans jamais mettre un rendu en échec.
+- **Choix : mettre à jour ADR-0008 plutôt que d'ouvrir un nouvel ADR** — *Pourquoi* : la décision
+  d'architecture (servir depuis un cache disque local, avec en-têtes longs) n'est pas remise en
+  cause — c'est une de ses prémisses énoncées qui n'était pas tenue par le code. Un ADR
+  supplémentaire laisserait l'affirmation fausse en place dans le document de référence.
+
+## Risques & points d'attention
+
+- **Renditions historiques sans hash** : elles gardent leur clé (stockée en base) et restent
+  servies. Leur URL portera un `v` valant leur `sourceHash` existant — le champ est déjà
+  renseigné pour tout rendu, y compris ancien. Aucun cas de `version` absente pour une rendition
+  existante ; à vérifier tout de même sur les données de production avant déploiement.
+- **Le premier re-rendu d'un culte ancien** crée une clé neuve et supprime l'ancienne : les
+  auditeurs en cours d'écoute au moment exact de la bascule verront leur requête de plage
+  suivante échouer et le lecteur rechargera. Impact jugé négligeable (fenêtre de quelques
+  secondes, sur une action manuelle rare).
+- **Signature de `streamUrl` modifiée** : changement rompant pour tout futur appelant du lecteur.
+  Il n'y en a que deux aujourd'hui, tous deux dans ce dépôt et mis à jour ici ; `typecheck` le
+  garantit.
+- **Limite assumée** : un appareil ayant déjà mis un fichier en cache continuera de le lire après
+  dépublication ou révocation d'un lien. Hors périmètre par décision de la spec, avec suivi dédié
+  à ouvrir.
+
+## Stratégie de tests
+
+Vitest, ciblant le comportement observable plutôt que l'implémentation :
+
+- **`getRenditionKey` / handler de rendu** : deux `sourceHash` différents produisent deux clés
+  différentes pour le même segment ; un même `sourceHash` produit la même clé (idempotence
+  préservée, D10). Un re-rendu supprime l'ancien objet S3 ; un rendu identique n'en supprime
+  aucun. Un échec de suppression ne fait pas échouer le rendu.
+- **`mapPublishedSegments`** : le segment exposé porte une `version` dérivée du `sourceHash` du
+  rendu ; deux renditions de `sourceHash` différents donnent deux `version` différentes ; un
+  segment sans rendition reste exclu (non-régression).
+- **Chaîne membre et publique** : `getPublishedServiceForMember` et `resolvePublicAudioService`
+  exposent tous deux la `version` — la garantie « les deux vues ne divergent pas » est ce que la
+  spec exige des deux chemins d'écoute.
+- **Construction d'URL** : l'URL produite pour un segment change quand sa `version` change, et
+  reste identique à version constante (critère « pas de retéléchargement inutile »).
+
+Les routes de streaming ne sont pas retestées : elles ne changent pas, et leurs contrôles
+d'accès sont déjà couverts.

--- a/specs/026-cache-corrections-audio/spec.md
+++ b/specs/026-cache-corrections-audio/spec.md
@@ -1,0 +1,95 @@
+# Spec — Prise en compte immédiate des corrections audio malgré le cache navigateur
+
+- **Numéro** : 026
+- **Statut** : Implémentée
+- **Créée le** : 2026-08-29
+- **Branche suggérée** : `feat/cache-corrections-audio`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+L'écoute des cultes audio met en cache le fichier de chaque piste sur l'appareil de l'auditeur
+pendant une durée très longue, pour éviter de retélécharger le même contenu à chaque lecture.
+
+Quand une équipe de captation corrige un culte déjà publié (montage refait, coupure d'un
+passage, réparation d'un problème de son…), les auditeurs qui avaient déjà écouté ce culte
+avant la correction continuent d'entendre l'ancienne version, sans aucun moyen de s'en rendre
+compte — leur appareil ne redemande jamais le fichier au serveur tant que le cache n'a pas
+expiré. Une correction publiée n'atteint donc pas réellement ces auditeurs, ce qui compromet la
+raison d'être même de la correction (retirer un contenu erroné ou sensible, améliorer la
+qualité).
+
+Ce problème n'existe pas pour un auditeur qui n'a encore jamais ouvert ce culte : il obtient
+d'emblée la version corrigée.
+
+## Utilisateurs concernés
+
+- **STAR / tout membre** (droit `audio:listen`, accordé à tous les rôles) : écoute les cultes
+  publiés depuis l'espace Audio de l'application.
+- **Destinataire d'un lien de partage public** (non authentifié, aucun rôle Koinonia) : écoute
+  un culte via un lien partagé, potentiellement sur un appareil déjà utilisé pour une écoute
+  précédente du même culte.
+- **Resp. département de captation / Ministre / Admin / Secrétaire** (`audio:manage` ou membre
+  du département de captation) : produit les corrections — concerné indirectement, car l'objectif
+  de la feature est que son travail de correction soit effectivement reçu par les auditeurs.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Un auditeur écoute une piste d'un culte publié ; son appareil conserve une copie locale du
+   fichier.
+2. L'équipe de captation corrige ce même culte (nouveau montage d'une ou plusieurs pistes) et
+   republie le résultat.
+3. L'auditeur revient plus tard sur la page d'écoute de ce culte (espace Audio ou lien de
+   partage) et relance la lecture d'une piste corrigée.
+4. Il entend la version corrigée, sans avoir eu à vider manuellement le cache de son appareil ou
+   de son navigateur.
+
+### Scénarios alternatifs / cas limites
+
+- **Si** une piste n'a pas été retouchée par la correction, **alors** l'auditeur qui la réécoute
+  peut continuer à bénéficier d'une copie déjà en cache (pas de retéléchargement inutile).
+- **Si** un auditeur n'a jamais écouté ce culte auparavant, **alors** il reçoit directement la
+  version corrigée, comme aujourd'hui.
+- **Quand** une piste est corrigée plusieurs fois de suite (corrections successives), chaque
+  nouvelle version doit être servie à la prochaine lecture, sans accumulation de versions
+  obsolètes en cache indéfiniment.
+
+## Critères d'acceptation
+
+- [ ] Après republication d'une correction sur une piste, un auditeur qui rouvre la page
+      d'écoute (espace Audio, authentifié) et relance cette piste entend le contenu corrigé,
+      même si son navigateur avait déjà mis en cache l'ancienne version.
+- [ ] Le même comportement est vérifié pour un auditeur accédant via un lien de partage public
+      (non authentifié).
+- [ ] Une piste non retouchée par une correction reste éligible à une réutilisation depuis le
+      cache de l'auditeur (pas de retéléchargement systématique de tout le culte à chaque
+      republication).
+- [ ] Un auditeur qui écoute un culte pour la première fois reçoit directement la dernière
+      version disponible.
+- [ ] Des corrections successives sur une même piste sont toutes prises en compte à la lecture
+      suivante, dans l'ordre (la dernière correction publiée est celle qui est entendue).
+
+## Hors périmètre
+
+- La **révocation d'accès** (dépublication d'un culte, révocation d'un lien de partage) reste
+  hors périmètre de cette feature : un appareil ayant déjà mis un fichier en cache localement
+  peut continuer à le lire après une dépublication ou une révocation côté serveur — cette
+  limite est inhérente à toute mise en cache côté appareil et n'est pas résolue ici. Décision :
+  cette limite fait l'objet d'un **suivi dédié**, à traiter dans une spec ultérieure (voir
+  Questions ouvertes) — elle n'est ni traitée ni acceptée définitivement ici.
+- Aucun changement du comportement de production/rendu des pistes audio (montage, encodage,
+  déclenchement d'un nouveau rendu) — cette feature ne concerne que ce qui est servi à la
+  lecture après qu'une correction a déjà été produite et publiée.
+- Aucune notification aux auditeurs qu'une correction a eu lieu.
+
+## Questions ouvertes
+
+- **Tranchée** : la révocation d'accès malgré un cache appareil déjà chaud (dépublication d'un
+  culte, révocation d'un lien de partage) ne relève pas de cette spec mais d'un **suivi dédié**
+  à ouvrir séparément. Elle appelle des arbitrages qui lui sont propres (durée de conservation
+  côté appareil, compromis entre confidentialité et consommation de données, comportement hors
+  ligne) et qu'il serait faux de trancher au détour d'un correctif sur les corrections.

--- a/specs/026-cache-corrections-audio/tasks.md
+++ b/specs/026-cache-corrections-audio/tasks.md
@@ -1,0 +1,114 @@
+# Tâches — Prise en compte immédiate des corrections audio malgré le cache navigateur
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : Terminé
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : migration → services → API → UI → tests. Les tâches `[P]` sont parallélisables.
+
+## Prérequis
+
+- [x] Branche créée : `fix/cache-corrections-audio`
+- [ ] Migration Prisma générée (si schéma modifié) — **sans objet** : aucun changement de schéma
+      (`sourceHash` et `s3Key` existent déjà sur `AudioRendition`)
+
+## Tâches
+
+### 1. Données & migration
+
+*Aucune tâche — voir Prérequis.*
+
+### 2. Logique métier (services)
+
+- [x] **T1** — Adresser la clé de rendition par le contenu : `getRenditionKey(serviceId,
+      segmentId, sourceHash)` produit `audio-services/{serviceId}/renditions/{segmentId}-{hash
+      tronqué}.mp3`. Extraire la troncature dans une fonction unique réutilisable (même valeur
+      pour la clé et pour la version exposée en T3), afin que les deux ne puissent pas diverger.
+      *(fichier : `src/modules/audio/worker/handlers/render.ts`)*
+
+- [x] **T2** — Nettoyer l'ancien objet S3 après re-rendu : lire la rendition existante du segment
+      avant l'`upsert`, puis, après un `upsert` réussi et **uniquement si la clé a changé**,
+      supprimer l'ancienne via `deleteMediaFile`, en best-effort non bloquant (un échec de
+      nettoyage ne doit jamais faire échouer le rendu).
+      *(fichier : `src/modules/audio/worker/handlers/render.ts`)*
+
+- [x] **T3** — Exposer la version du rendu aux vues d'écoute : ajouter `version: string` à
+      `PublicAudioSegment` et le renseigner dans `mapPublishedSegments` à partir du `sourceHash`
+      de la rendition, en réutilisant la troncature de T1. Point de mapping unique : alimente à
+      la fois `resolvePublicAudioService` et `getPublishedServiceForMember`.
+      *(fichier : `src/modules/audio/services/public.ts`)*
+
+### 3. API (route handlers)
+
+*Aucune tâche — les deux routes de streaming sont inchangées. Le paramètre `v` est un casse-cache
+navigateur, jamais lu côté serveur (plan § API).*
+
+### 4. UI
+
+- [x] **T4** — Faire porter la version au lecteur : ajouter `version: string` à
+      `AudioPlayerSegment` et changer la prop `streamUrl` de `(segmentId: string) => string` en
+      `(segment: AudioPlayerSegment) => string` ; adapter l'unique usage `<audio src={…}>`.
+      *(fichier : `src/components/audio/AudioPlayer.tsx`)*
+
+- [x] **T5** [P] — Construire l'URL versionnée côté membre : `?v=${segment.version}`.
+      *(fichier : `src/app/(auth)/audio/ecouter/[id]/MemberAudioPlayer.tsx`)*
+
+- [x] **T6** [P] — Construire l'URL versionnée côté lien public : `?v=${segment.version}`.
+      *(fichier : `src/app/ecouter/[token]/PublicAudioPlayer.tsx`)*
+
+### 5. Tests
+
+- [x] **T7** — Clé de rendition et nettoyage : deux `sourceHash` différents donnent deux clés
+      différentes pour le même segment ; un `sourceHash` identique donne la même clé (idempotence
+      D10 préservée) ; un re-rendu supprime l'ancien objet S3 ; un rendu à clé inchangée n'en
+      supprime aucun ; un échec de `deleteMediaFile` ne fait pas échouer le rendu.
+      **Attention** : le mock de `@/modules/storage` de ce fichier n'expose aujourd'hui que
+      `downloadFile`/`uploadFile` — y ajouter `deleteMediaFile`.
+      *(fichier : `src/modules/audio/worker/handlers/__tests__/render.test.ts`)*
+
+- [x] **T8** [P] — Mapping des segments : `mapPublishedSegments` expose une `version` dérivée du
+      `sourceHash` ; deux renditions de `sourceHash` différents donnent deux `version`
+      différentes ; un segment sans rendition reste exclu (non-régression).
+      *(fichier : `src/modules/audio/services/__tests__/public.test.ts` — à créer)*
+
+- [x] **T9** [P] — Parité des deux chemins d'écoute : `getPublishedServiceForMember` (bibliothèque
+      membre) et `resolvePublicAudioService` (lien public) exposent tous deux la `version` pour un
+      même culte — les deux vues ne divergent pas.
+      *(fichiers : `src/modules/audio/services/__tests__/library.test.ts`,
+      `src/modules/audio/services/__tests__/public.test.ts`)*
+
+- [x] **T10** — Construction d'URL côté lecteur : l'URL produite pour un segment change quand sa
+      `version` change, et reste identique à version constante (critère « pas de retéléchargement
+      inutile »). Couvre les deux constructeurs (membre et public).
+      *(fichier : `src/components/audio/__tests__/stream-url.test.ts` — à créer, ou tests
+      colocalisés aux deux lecteurs selon ce que permet leur découpage)*
+
+### 6. Documentation
+
+- [x] **T11** — Amender ADR-0008 : sa section « Décision » affirme que la clé de rendition change
+      quand le rendu change, ce qui n'était pas tenu par le code. Ajouter une mise à jour datée
+      qui constate l'écart, le corrige (clé adressée par contenu) et renvoie à cette spec.
+      *(fichier : `docs/adr/0008-cache-disque-renditions-audio.md`)*
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test` — **suite complète**, pas seulement les fichiers ajoutés (919/919)
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits
+- [ ] Vérifier sur les données de production qu'aucune rendition existante n'a de `sourceHash`
+      vide (risque noté au plan § Risques)
+- [ ] Ouvrir le **suivi dédié** sur la révocation malgré cache appareil (décision de la spec,
+      § Questions ouvertes)
+- [ ] PR ouverte vers `main`
+
+## Traçabilité — critères d'acceptation → tâches
+
+| Critère d'acceptation (`spec.md`) | Tâches |
+|---|---|
+| Correction entendue par un auditeur au cache chaud — espace Audio authentifié | T1, T3, T4, T5, T7, T8, T10 |
+| Idem via un lien de partage public | T1, T3, T4, T6, T7, T8, T10 |
+| Piste non retouchée toujours servie depuis le cache (pas de retéléchargement) | T1, T10 |
+| Première écoute : dernière version servie directement | T1, T2, T7 |
+| Corrections successives toutes prises en compte, dans l'ordre | T1, T3, T7, T8 |

--- a/src/app/(auth)/audio/ecouter/[id]/MemberAudioPlayer.tsx
+++ b/src/app/(auth)/audio/ecouter/[id]/MemberAudioPlayer.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import AudioPlayer, { type AudioPlayerService } from "@/components/audio/AudioPlayer";
+import { buildStreamUrl } from "./stream-url";
 
 interface Props {
   serviceId: string;
@@ -51,7 +52,7 @@ export default function MemberAudioPlayer({ serviceId, service }: Props) {
       )}
       <AudioPlayer
         service={service}
-        streamUrl={(segmentId) => `/api/audio/services/${serviceId}/stream/${segmentId}`}
+        streamUrl={(segment) => buildStreamUrl(serviceId, segment)}
         onPlay={(segmentId) => {
           fetch(`/api/audio/services/${serviceId}/play`, {
             method: "POST",

--- a/src/app/(auth)/audio/ecouter/[id]/__tests__/stream-url.test.ts
+++ b/src/app/(auth)/audio/ecouter/[id]/__tests__/stream-url.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { buildStreamUrl } from "../stream-url";
+import type { AudioPlayerSegment } from "@/components/audio/AudioPlayer";
+
+function segment(overrides: Partial<AudioPlayerSegment> = {}): AudioPlayerSegment {
+  return { id: "seg-1", title: "Louange", order: 0, durationMs: 60000, version: "v1", ...overrides };
+}
+
+describe("buildStreamUrl (espace Audio membre)", () => {
+  it("change quand la version change (spec 026 : correction visible sans vider le cache)", () => {
+    const before = buildStreamUrl("service-1", segment({ version: "v1" }));
+    const after = buildStreamUrl("service-1", segment({ version: "v2" }));
+
+    expect(before).not.toBe(after);
+  });
+
+  it("reste identique à version constante (pas de retéléchargement inutile)", () => {
+    const a = buildStreamUrl("service-1", segment({ version: "v1" }));
+    const b = buildStreamUrl("service-1", segment({ version: "v1" }));
+
+    expect(a).toBe(b);
+  });
+
+  it("porte le segmentId et la version en paramètre de requête", () => {
+    expect(buildStreamUrl("service-1", segment({ id: "seg-9", version: "abc123" }))).toBe(
+      "/api/audio/services/service-1/stream/seg-9?v=abc123"
+    );
+  });
+});

--- a/src/app/(auth)/audio/ecouter/[id]/stream-url.ts
+++ b/src/app/(auth)/audio/ecouter/[id]/stream-url.ts
@@ -1,0 +1,10 @@
+import type { AudioPlayerSegment } from "@/components/audio/AudioPlayer";
+
+/**
+ * URL de streaming versionnée par le contenu du rendu (spec 026) — le paramètre `v` est un
+ * casse-cache navigateur, jamais lu côté serveur. Module séparé du lecteur pour rester testable
+ * sans importer la chaîne de dépendances du composant client (react-h5-audio-player).
+ */
+export function buildStreamUrl(serviceId: string, segment: AudioPlayerSegment): string {
+  return `/api/audio/services/${serviceId}/stream/${segment.id}?v=${segment.version}`;
+}

--- a/src/app/ecouter/[token]/PublicAudioPlayer.tsx
+++ b/src/app/ecouter/[token]/PublicAudioPlayer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import AudioPlayer, { type AudioPlayerService } from "@/components/audio/AudioPlayer";
+import { buildStreamUrl } from "./stream-url";
 
 interface Props {
   token: string;
@@ -17,7 +18,7 @@ export default function PublicAudioPlayer({ token, backHref, service }: Props) {
   return (
     <AudioPlayer
       service={service}
-      streamUrl={(segmentId) => `/api/audio/public/${token}/stream/${segmentId}`}
+      streamUrl={(segment) => buildStreamUrl(token, segment)}
       onPlay={(segmentId) => {
         fetch(`/api/audio/public/${token}/play`, {
           method: "POST",

--- a/src/app/ecouter/[token]/__tests__/stream-url.test.ts
+++ b/src/app/ecouter/[token]/__tests__/stream-url.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { buildStreamUrl } from "../stream-url";
+import type { AudioPlayerSegment } from "@/components/audio/AudioPlayer";
+
+function segment(overrides: Partial<AudioPlayerSegment> = {}): AudioPlayerSegment {
+  return { id: "seg-1", title: "Louange", order: 0, durationMs: 60000, version: "v1", ...overrides };
+}
+
+describe("buildStreamUrl (lien de partage public)", () => {
+  it("change quand la version change (spec 026 : correction visible sans vider le cache)", () => {
+    const before = buildStreamUrl("token-1", segment({ version: "v1" }));
+    const after = buildStreamUrl("token-1", segment({ version: "v2" }));
+
+    expect(before).not.toBe(after);
+  });
+
+  it("reste identique à version constante (pas de retéléchargement inutile)", () => {
+    const a = buildStreamUrl("token-1", segment({ version: "v1" }));
+    const b = buildStreamUrl("token-1", segment({ version: "v1" }));
+
+    expect(a).toBe(b);
+  });
+
+  it("porte le segmentId et la version en paramètre de requête", () => {
+    expect(buildStreamUrl("token-1", segment({ id: "seg-9", version: "abc123" }))).toBe(
+      "/api/audio/public/token-1/stream/seg-9?v=abc123"
+    );
+  });
+});

--- a/src/app/ecouter/[token]/stream-url.ts
+++ b/src/app/ecouter/[token]/stream-url.ts
@@ -1,0 +1,10 @@
+import type { AudioPlayerSegment } from "@/components/audio/AudioPlayer";
+
+/**
+ * URL de streaming versionnée par le contenu du rendu (spec 026) — le paramètre `v` est un
+ * casse-cache navigateur, jamais lu côté serveur. Module séparé du lecteur pour rester testable
+ * sans importer la chaîne de dépendances du composant client (react-h5-audio-player).
+ */
+export function buildStreamUrl(token: string, segment: AudioPlayerSegment): string {
+  return `/api/audio/public/${token}/stream/${segment.id}?v=${segment.version}`;
+}

--- a/src/components/audio/AudioPlayer.tsx
+++ b/src/components/audio/AudioPlayer.tsx
@@ -16,6 +16,8 @@ export interface AudioPlayerSegment {
   title: string;
   order: number;
   durationMs: number;
+  /** Empreinte du rendu — change quand le contenu change (spec 026), sert de casse-cache navigateur. */
+  version: string;
 }
 
 export interface AudioPlayerService {
@@ -28,7 +30,7 @@ export interface AudioPlayerService {
 
 interface Props {
   service: AudioPlayerService;
-  streamUrl: (segmentId: string) => string;
+  streamUrl: (segment: AudioPlayerSegment) => string;
   onPlay?: (segmentId: string) => void;
   onShare?: (segmentId: string | null) => void;
   backHref?: string | null;
@@ -250,7 +252,7 @@ export default function AudioPlayer({ service, streamUrl, onPlay, onShare, backH
             <H5AudioPlayer
               ref={playerRef}
               key={current.id}
-              src={streamUrl(current.id)}
+              src={streamUrl(current)}
               autoPlayAfterSrcChange={false}
               showJumpControls
               progressJumpSteps={{ backward: 15000, forward: 30000 }}

--- a/src/modules/audio/services/__tests__/library.test.ts
+++ b/src/modules/audio/services/__tests__/library.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { prismaMock } from "@/__mocks__/prisma";
+import { renditionVersion } from "../rendition-cache";
 
 vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
 vi.mock("@/modules/storage", () => ({
@@ -27,7 +28,7 @@ function service(overrides: Record<string, unknown> = {}) {
         kind: "SEQUENCE",
         order: 0,
         title: "Louange",
-        rendition: { durationMs: 60000 },
+        rendition: { durationMs: 60000, sourceHash: "hash-1" },
       },
     ],
     ...overrides,
@@ -161,5 +162,7 @@ describe("getPublishedServiceForMember", () => {
     expect(result).not.toBeNull();
     expect(result?.title).toBe("Culte du dimanche");
     expect(result?.segments).toHaveLength(1);
+    // Version dérivée du sourceHash (spec 026) — même mapping que la page publique.
+    expect(result?.segments[0].version).toBe(renditionVersion("hash-1"));
   });
 });

--- a/src/modules/audio/services/__tests__/public.test.ts
+++ b/src/modules/audio/services/__tests__/public.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { renditionVersion } from "../rendition-cache";
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+vi.mock("@/modules/storage", () => ({
+  getSignedStreamUrl: vi.fn(async (key: string) => `https://signed/${key}`),
+}));
+
+const { mapPublishedSegments, resolvePublicAudioService } = await import("../public");
+
+describe("mapPublishedSegments", () => {
+  it("expose une version dérivée du sourceHash de la rendition (spec 026)", () => {
+    const [result] = mapPublishedSegments([
+      {
+        id: "seg-1",
+        title: "Louange",
+        order: 0,
+        rendition: { durationMs: 60000, sourceHash: "hash-a" },
+      } as never,
+    ]);
+
+    expect(result.version).toBe(renditionVersion("hash-a"));
+  });
+
+  it("deux renditions de sourceHash différents donnent deux versions différentes", () => {
+    const [a, b] = mapPublishedSegments([
+      { id: "seg-1", title: "A", order: 0, rendition: { durationMs: 1000, sourceHash: "hash-a" } } as never,
+      { id: "seg-2", title: "B", order: 1, rendition: { durationMs: 1000, sourceHash: "hash-b" } } as never,
+    ]);
+
+    expect(a.version).not.toBe(b.version);
+  });
+
+  it("exclut un segment sans rendition (non-régression)", () => {
+    const result = mapPublishedSegments([
+      { id: "seg-1", title: "A", order: 0, rendition: null } as never,
+    ]);
+
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("resolvePublicAudioService — parité avec la bibliothèque membre", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("expose la version du rendu dans les segments retournés", async () => {
+    prismaMock.audioShareToken.findUnique.mockResolvedValue({
+      token: "tok-1",
+      serviceId: "service-1",
+      segmentId: null,
+      revokedAt: null,
+    } as never);
+    prismaMock.audioService.findUnique.mockResolvedValue({
+      id: "service-1",
+      churchId: "church-1",
+      title: "Culte du dimanche",
+      serviceDate: new Date("2026-01-04"),
+      speaker: "Pasteur Jean",
+      coverKey: null,
+      planningEventId: null,
+      status: "PUBLISHED",
+      segments: [
+        {
+          id: "seg-1",
+          title: "Louange",
+          order: 0,
+          rendition: { durationMs: 60000, sourceHash: "hash-a" },
+        },
+      ],
+    } as never);
+
+    const result = await resolvePublicAudioService("tok-1");
+
+    expect(result.status).toBe("OK");
+    if (result.status === "OK") {
+      expect(result.data.segments[0].version).toBe(renditionVersion("hash-a"));
+    }
+  });
+});

--- a/src/modules/audio/services/public.ts
+++ b/src/modules/audio/services/public.ts
@@ -1,5 +1,6 @@
 import type { AudioSegment, AudioRendition, Prisma } from "@/generated/prisma/client";
 import { getSignedStreamUrl } from "@/modules/storage";
+import { renditionVersion } from "./rendition-cache";
 
 type DbClient = Prisma.TransactionClient;
 
@@ -13,6 +14,8 @@ export interface PublicAudioSegment {
   title: string;
   order: number;
   durationMs: number;
+  /** Empreinte du rendu — change quand le contenu change (spec 026), sert de casse-cache navigateur. */
+  version: string;
 }
 
 export interface PublicAudioService {
@@ -40,7 +43,13 @@ export function mapPublishedSegments(
 ): PublicAudioSegment[] {
   return segments
     .filter((s) => s.rendition)
-    .map((s) => ({ id: s.id, title: s.title, order: s.order, durationMs: s.rendition!.durationMs }));
+    .map((s) => ({
+      id: s.id,
+      title: s.title,
+      order: s.order,
+      durationMs: s.rendition!.durationMs,
+      version: renditionVersion(s.rendition!.sourceHash),
+    }));
 }
 
 /**

--- a/src/modules/audio/services/rendition-cache.ts
+++ b/src/modules/audio/services/rendition-cache.ts
@@ -25,6 +25,16 @@ function cacheFileName(s3Key: string): string {
   return createHash("sha1").update(s3Key).digest("hex") + ".mp3";
 }
 
+/**
+ * Empreinte courte d'un `sourceHash` de rendition — utilisée à la fois dans la clé S3 (pour que
+ * la clé change quand le contenu change, spec 026) et dans l'URL de streaming exposée au lecteur
+ * (casse-cache navigateur). Les deux usages doivent produire la même valeur pour un même
+ * `sourceHash`, d'où ce point unique.
+ */
+export function renditionVersion(sourceHash: string): string {
+  return createHash("sha1").update(sourceHash).digest("hex").slice(0, 12);
+}
+
 function cachePath(s3Key: string): string {
   return path.join(CACHE_DIR, cacheFileName(s3Key));
 }

--- a/src/modules/audio/worker/handlers/__tests__/render.test.ts
+++ b/src/modules/audio/worker/handlers/__tests__/render.test.ts
@@ -10,6 +10,7 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
 import { prismaMock } from "@/__mocks__/prisma";
+import { renditionVersion } from "../../../services/rendition-cache";
 
 const execFileAsync = promisify(execFile);
 
@@ -17,12 +18,14 @@ vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
 
 let uploadedBuffer: Buffer | undefined;
 let uploadedKey: string | undefined;
+const mockDeleteMediaFile = vi.fn(async (_key: string) => {});
 vi.mock("@/modules/storage", () => ({
   downloadFile: vi.fn(async () => sourceBuffer),
   uploadFile: vi.fn(async (key: string, body: Buffer) => {
     uploadedKey = key;
     uploadedBuffer = body;
   }),
+  deleteMediaFile: (...args: [string]) => mockDeleteMediaFile(...args),
 }));
 
 // Renvoie la forme réelle de PublicationCompletion : le handler journalise `published` /
@@ -66,13 +69,7 @@ describe("renderHandler", () => {
     uploadedKey = undefined;
   });
 
-  it("rejette un job RENDER sans segmentId dans le payload", async () => {
-    await expect(
-      renderHandler({ id: "job-1", serviceId: "service-1", type: "RENDER", payload: {} } as never)
-    ).rejects.toThrow(/sans segmentId/);
-  });
-
-  it("réencode en MP3 à -16 LUFS, pose les tags ID3 et écrit l'AudioRendition", async () => {
+  function mockSegment(overrides: { rendition?: { s3Key: string } | null } = {}) {
     prismaMock.audioSegment.findUnique.mockResolvedValue({
       id: "seg-1",
       serviceId: "service-1",
@@ -80,7 +77,18 @@ describe("renderHandler", () => {
       order: 1,
       source: { s3Key: "audio-services/service-1/sources/src-1.wav", durationMs: 2000 },
       service: { title: "Culte du dimanche", speaker: "Pasteur Jean", serviceDate: new Date("2026-08-23") },
+      rendition: overrides.rendition ?? null,
     } as never);
+  }
+
+  it("rejette un job RENDER sans segmentId dans le payload", async () => {
+    await expect(
+      renderHandler({ id: "job-1", serviceId: "service-1", type: "RENDER", payload: {} } as never)
+    ).rejects.toThrow(/sans segmentId/);
+  });
+
+  it("réencode en MP3 à -16 LUFS, pose les tags ID3 et écrit l'AudioRendition", async () => {
+    mockSegment();
     prismaMock.audioRendition.upsert.mockResolvedValue({} as never);
 
     await renderHandler({
@@ -102,7 +110,8 @@ describe("renderHandler", () => {
 
     // Vérifie le fichier réellement produit par ffmpeg (pas de mock du binaire) : format MP3
     // et tags ID3 (titre/album/date/artiste/piste) posés depuis le segment/service.
-    expect(uploadedKey).toBe("audio-services/service-1/renditions/seg-1.mp3");
+    // Clé adressée par contenu (spec 026) : dépend du sourceHash, pas seulement des identifiants.
+    expect(uploadedKey).toBe(`audio-services/service-1/renditions/seg-1-${renditionVersion("hash-abc")}.mp3`);
     expect(uploadedBuffer).toBeInstanceOf(Buffer);
 
     const outputPath = path.join(tmpDir, "output-check.mp3");
@@ -121,5 +130,53 @@ describe("renderHandler", () => {
     expect(probed.format.tags?.album).toBe("Culte du dimanche");
     expect(probed.format.tags?.artist).toBe("Pasteur Jean");
     expect(probed.format.tags?.date).toBe("2026-08-23");
+  }, 20_000);
+
+  it("un re-rendu à sourceHash différent produit une clé différente et supprime l'ancien objet S3 (spec 026)", async () => {
+    const previousKey = "audio-services/service-1/renditions/seg-1-old.mp3";
+    mockSegment({ rendition: { s3Key: previousKey } });
+    prismaMock.audioRendition.upsert.mockResolvedValue({} as never);
+
+    await renderHandler({
+      id: "job-1",
+      serviceId: "service-1",
+      type: "RENDER",
+      payload: { segmentId: "seg-1", sourceHash: "hash-new" },
+    } as never);
+
+    expect(uploadedKey).toBe(`audio-services/service-1/renditions/seg-1-${renditionVersion("hash-new")}.mp3`);
+    expect(uploadedKey).not.toBe(previousKey);
+    expect(mockDeleteMediaFile).toHaveBeenCalledWith(previousKey);
+  }, 20_000);
+
+  it("un re-rendu à sourceHash identique (idempotence D10) ne supprime rien", async () => {
+    const sameKey = `audio-services/service-1/renditions/seg-1-${renditionVersion("hash-same")}.mp3`;
+    mockSegment({ rendition: { s3Key: sameKey } });
+    prismaMock.audioRendition.upsert.mockResolvedValue({} as never);
+
+    await renderHandler({
+      id: "job-1",
+      serviceId: "service-1",
+      type: "RENDER",
+      payload: { segmentId: "seg-1", sourceHash: "hash-same" },
+    } as never);
+
+    expect(uploadedKey).toBe(sameKey);
+    expect(mockDeleteMediaFile).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it("un échec de suppression de l'ancien objet S3 ne fait pas échouer le rendu", async () => {
+    mockDeleteMediaFile.mockRejectedValueOnce(new Error("S3 indisponible"));
+    mockSegment({ rendition: { s3Key: "audio-services/service-1/renditions/seg-1-old.mp3" } });
+    prismaMock.audioRendition.upsert.mockResolvedValue({} as never);
+
+    await expect(
+      renderHandler({
+        id: "job-1",
+        serviceId: "service-1",
+        type: "RENDER",
+        payload: { segmentId: "seg-1", sourceHash: "hash-new" },
+      } as never)
+    ).resolves.not.toThrow();
   }, 20_000);
 });

--- a/src/modules/audio/worker/handlers/render.ts
+++ b/src/modules/audio/worker/handlers/render.ts
@@ -5,9 +5,9 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import type { AudioJob } from "@/generated/prisma/client";
 import { prisma } from "@/lib/prisma";
-import { downloadFile, uploadFile } from "@/modules/storage";
+import { downloadFile, uploadFile, deleteMediaFile } from "@/modules/storage";
 import { maybeCompletePublication } from "../../services/publish";
-import { primeRenditionCache } from "../../services/rendition-cache";
+import { primeRenditionCache, renditionVersion } from "../../services/rendition-cache";
 import { log, since, formatBytes } from "../log";
 
 const execFileAsync = promisify(execFile);
@@ -28,8 +28,14 @@ interface LoudnormMeasured {
   target_offset: string;
 }
 
-function getRenditionKey(serviceId: string, segmentId: string): string {
-  return `audio-services/${serviceId}/renditions/${segmentId}.mp3`;
+/**
+ * Clé S3 adressée par contenu (spec 026) : intègre le `sourceHash` du rendu, pour qu'un
+ * re-rendu (ex. correction) produise une clé différente au lieu d'écraser silencieusement
+ * l'objet précédent — c'est ce que suppose le cache long et `immutable` servi en aval
+ * (ADR-0008), qui ne tenait pas tant que la clé ne dépendait que de `segmentId`.
+ */
+function getRenditionKey(serviceId: string, segmentId: string, sourceHash: string): string {
+  return `audio-services/${serviceId}/renditions/${segmentId}-${renditionVersion(sourceHash)}.mp3`;
 }
 
 /** Passe de mesure `loudnorm` (dry-run vers /dev/null) — ffmpeg écrit le JSON sur stderr. */
@@ -63,7 +69,7 @@ export async function renderHandler(job: AudioJob): Promise<void> {
 
   const segment = await prisma.audioSegment.findUnique({
     where: { id: payload.segmentId },
-    include: { source: true, service: true },
+    include: { source: true, service: true, rendition: true },
   });
   if (!segment || !segment.source) {
     throw new Error(`Segment ${payload.segmentId} introuvable ou sans source associée`);
@@ -116,7 +122,8 @@ export async function renderHandler(job: AudioJob): Promise<void> {
     );
 
     stepAt = Date.now();
-    const key = getRenditionKey(segment.serviceId, segment.id);
+    const previousKey = segment.rendition?.s3Key ?? null;
+    const key = getRenditionKey(segment.serviceId, segment.id, payload.sourceHash);
     await uploadFile(key, outputBuffer, "audio/mpeg");
     log(`rendu ${segment.id} : rendu envoyé vers ${key} en ${since(stepAt)}`);
 
@@ -144,6 +151,13 @@ export async function renderHandler(job: AudioJob): Promise<void> {
         sourceHash: payload.sourceHash,
       },
     });
+
+    // Nettoyage de l'ancien objet S3 après bascule (spec 026) : la clé n'est plus référencée
+    // par personne dès que l'upsert ci-dessus a réussi. Best-effort — un objet orphelin
+    // n'empêche aucune écoute, alors qu'un échec de nettoyage qui ferait échouer le rendu, si.
+    if (previousKey && previousKey !== key) {
+      await deleteMediaFile(previousKey).catch(() => {});
+    }
 
     const completion = await maybeCompletePublication(segment.serviceId);
     log(


### PR DESCRIPTION
## Résumé

Corrige H-07 de l'audit sécurité du 2026-08-29 : le cache navigateur immuable (jusqu'à 1 an,
ADR-0008) empêchait une correction audio republiée d'atteindre les auditeurs qui avaient déjà
écouté la piste, car la clé S3 de la rendition ne dépendait que de `serviceId`/`segmentId`,
jamais du contenu — un re-rendu écrasait silencieusement le même objet à la même URL.

- La clé de rendition intègre désormais une empreinte du `sourceHash` du rendu : un nouveau
  rendu produit une clé différente (worker `render.ts`), donc un fichier de cache disque
  différent — le défaut touchait aussi le cache serveur, pas seulement le navigateur.
- Cette empreinte (`version`) est exposée jusqu'aux lecteurs (espace Audio membre et lien de
  partage public) via le mapping partagé `mapPublishedSegments`, et ajoutée en paramètre de
  requête (`?v=…`) à l'URL `<audio src>` — un pur casse-cache navigateur, jamais lu côté
  serveur. Aucun changement des en-têtes `Cache-Control` ni des contrôles d'accès.
- L'ancien objet S3 est supprimé après bascule, en best-effort (jamais bloquant pour le rendu).
- ADR-0008 amendé : sa section « Décision » affirmait déjà que la clé change avec le contenu —
  ce n'était pas tenu par le code, c'est maintenant corrigé.

Spec complète : `specs/026-cache-corrections-audio/`.

**Hors périmètre** (décision actée dans la spec) : la révocation d'accès (dépublication, lien
révoqué) malgré un cache navigateur déjà chaud reste un point ouvert, à traiter dans un suivi
dédié séparé — limite inhérente à tout cache privé, non résolue par ce fix.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 erreur, 11 warnings préexistants non liés)
- [x] `npm run lint:boundaries`
- [x] `npm run test` — 919/919 (+13 tests : clé/nettoyage du rendu, mapping des segments, parité
      membre/public, construction d'URL versionnée)
- [x] Critères d'acceptation de la spec relus un par un

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwEXWCWqPAgjfEnmKCMmSd