### PR TITLE
fix(migration-audio): journal transactionnel pour la migration Audiobookshelf (H-06)

### DIFF
--- a/prisma/scripts/migrate-audiobookshelf/README.md
+++ b/prisma/scripts/migrate-audiobookshelf/README.md
@@ -123,11 +123,16 @@ le même checkout** entre les relances d'une même cible, ou reporter le fichier
 ## Idempotence & reprise
 
 - Le **ledger** `.ledger.jsonl` (git-ignoré, à côté du script) contient une
-  ligne JSON par culte importé avec succès, clé = nom du dossier ABS.
-- Une relance saute ces dossiers : sûr de relancer autant de fois que
-  nécessaire.
-- Un échec en cours de culte laisse un `AudioService` partiel **non inscrit** au
-  ledger. Le nettoyer avec `--purge "<dossier>"` avant de relancer.
+  entrée `status: "started"` dès la création du `AudioService`, remplacée par
+  `status: "done"` une fois l'import terminé — clé = nom du dossier ABS.
+- Une relance saute les dossiers dont la dernière entrée est `"done"` (ou une
+  entrée historique sans `status`, écrite par une version antérieure du
+  script) : sûr de relancer autant de fois que nécessaire.
+- Un échec en cours de culte laisse une entrée `"started"` sans `"done"`
+  associée. Ces dossiers sont **exclus automatiquement** d'une nouvelle
+  tentative d'import (affichés en avertissement) — nettoyer avec
+  `--purge "<dossier>"` avant de relancer, l'outil retrouve désormais
+  systématiquement le service à supprimer, même pour une tentative inaboutie.
 
 ## Surveillance du rendu
 

--- a/prisma/scripts/migrate-audiobookshelf/index.ts
+++ b/prisma/scripts/migrate-audiobookshelf/index.ts
@@ -30,15 +30,18 @@ import {
   createAudioService,
   applySequences,
   publishAudioService,
+  unpublishAudioService,
   deleteAudioService,
   getAudioSourceKey,
 } from "@/modules/audio";
+import { ApiError } from "@/lib/errors";
 import { scanRoot } from "./scan";
 import { buildManifest } from "./parse";
 import { assertValidManifest } from "./manifest";
 import { assertFfprobe, probeDurationMs } from "./probe";
 import { putObjectWithEtag } from "./s3";
-import { readLedger, appendLedger, removeFromLedger } from "./ledger";
+import { readLedger, appendLedger, removeFromLedger, latestEntryByFolder } from "./ledger";
+import { classifyFolders } from "./resolution";
 import type { Manifest, ManifestCulte } from "./types";
 
 const CHURCH_SLUG = "icc-rennes";
@@ -127,6 +130,20 @@ async function importCulte(
     prisma
   );
 
+  const predicationMatched = culte.sequences.some((s) => s.fromPredicationsLibrary);
+
+  // Écrit avant tout effet externe supplémentaire (upload S3, publication) : si l'import
+  // échoue après ce point, `--purge` retrouve ce service via cette entrée `started`.
+  await appendLedger({
+    folder: culte.folder,
+    serviceId: service.id,
+    date: culte.date,
+    sequences: culte.sequences.length,
+    predicationMatched,
+    at: new Date().toISOString(),
+    status: "started",
+  });
+
   const sequences: { sourceId: string; order: number; title: string }[] = [];
   for (const seq of culte.sequences) {
     const ext = (path.extname(seq.filePath).slice(1) || "mp3").toLowerCase();
@@ -163,8 +180,9 @@ async function importCulte(
     serviceId: service.id,
     date: culte.date,
     sequences: sequences.length,
-    predicationMatched: culte.sequences.some((s) => s.fromPredicationsLibrary),
+    predicationMatched,
     at: new Date().toISOString(),
+    status: "done",
   });
 }
 
@@ -190,12 +208,23 @@ async function main(): Promise<void> {
     if (!publisher) throw new Error(`Utilisateur publieur introuvable (email « ${PUBLISHER_EMAIL} »)`);
 
     if (args.purge) {
-      const entry = (await readLedger()).find((e) => e.folder === args.purge);
+      const entry = latestEntryByFolder(await readLedger(), args.purge);
       if (!entry) {
         console.log(`Aucune entrée de ledger pour « ${args.purge} » — rien à purger.`);
         return;
       }
-      await deleteAudioService(entry.serviceId, church.id, prisma);
+      try {
+        await deleteAudioService(entry.serviceId, church.id, prisma);
+      } catch (err) {
+        // Fenêtre étroite : `publishAudioService` a réussi mais l'entrée `done` n'a jamais
+        // été écrite (crash entre les deux). Dépublier avant de réessayer.
+        if (err instanceof ApiError && err.statusCode === 400) {
+          await unpublishAudioService(entry.serviceId, church.id, prisma);
+          await deleteAudioService(entry.serviceId, church.id, prisma);
+        } else {
+          throw err;
+        }
+      }
       await removeFromLedger(args.purge);
       console.log(`Culte « ${args.purge} » (${entry.serviceId}) supprimé et retiré du ledger.`);
       return;
@@ -214,14 +243,27 @@ async function main(): Promise<void> {
       return;
     }
 
-    const done = new Set((await readLedger()).map((e) => e.folder));
-    let candidates = manifest.cultes.filter((c) => !done.has(c.folder));
+    const ledgerEntries = await readLedger();
+    const { toImport, alreadyDone, pendingCleanup } = classifyFolders(
+      manifest.cultes.map((c) => c.folder),
+      ledgerEntries
+    );
+
+    if (pendingCleanup.length > 0) {
+      console.log(`\n⚠ Tentatives inabouties détectées — à purger avant réimport :`);
+      for (const folder of pendingCleanup) {
+        console.log(`   --purge "${folder}"`);
+      }
+    }
+
+    let candidates = manifest.cultes.filter((c) => toImport.includes(c.folder));
     if (args.only.length > 0) candidates = candidates.filter((c) => args.only.includes(c.folder));
     if (args.limit !== null) candidates = candidates.slice(0, args.limit);
 
     console.log(
       `\n=== Import ===\n${candidates.length} culte(s) à importer` +
-        (done.size ? ` (${done.size} déjà dans le ledger)` : "")
+        (alreadyDone.length ? ` (${alreadyDone.length} déjà dans le ledger)` : "") +
+        (pendingCleanup.length ? ` (${pendingCleanup.length} en attente de purge, exclu(s))` : "")
     );
 
     const failed: string[] = [];

--- a/prisma/scripts/migrate-audiobookshelf/ledger.test.ts
+++ b/prisma/scripts/migrate-audiobookshelf/ledger.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { rm } from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  readLedger,
+  appendLedger,
+  removeFromLedger,
+  latestEntryByFolder,
+  isFolderDone,
+  type LedgerEntry,
+} from "./ledger";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const LEDGER_PATH = path.join(HERE, ".ledger.jsonl");
+
+const baseEntry = (overrides: Partial<LedgerEntry> = {}): LedgerEntry => ({
+  folder: "Culte du 01 01 2025",
+  serviceId: "svc-1",
+  date: "2025-01-01",
+  sequences: 5,
+  predicationMatched: true,
+  at: "2025-01-01T10:00:00.000Z",
+  ...overrides,
+});
+
+describe("latestEntryByFolder", () => {
+  it("retourne undefined si aucune entrée pour le dossier", () => {
+    expect(latestEntryByFolder([baseEntry({ folder: "autre" })], "Culte du 01 01 2025")).toBeUndefined();
+  });
+
+  it("retourne la dernière entrée dans l'ordre du tableau pour un dossier avec plusieurs entrées", () => {
+    const started = baseEntry({ status: "started" });
+    const done = baseEntry({ status: "done", at: "2025-01-01T10:05:00.000Z" });
+    expect(latestEntryByFolder([started, done], "Culte du 01 01 2025")).toBe(done);
+  });
+});
+
+describe("isFolderDone", () => {
+  it("true pour status: done", () => {
+    expect(isFolderDone(baseEntry({ status: "done" }))).toBe(true);
+  });
+
+  it("false pour status: started", () => {
+    expect(isFolderDone(baseEntry({ status: "started" }))).toBe(false);
+  });
+
+  it("true pour une entrée historique sans status (compat ascendante)", () => {
+    const legacy = baseEntry();
+    delete (legacy as Partial<LedgerEntry>).status;
+    expect(isFolderDone(legacy)).toBe(true);
+  });
+
+  it("false si aucune entrée", () => {
+    expect(isFolderDone(undefined)).toBe(false);
+  });
+});
+
+describe("appendLedger / readLedger / removeFromLedger", () => {
+  afterEach(async () => {
+    await rm(LEDGER_PATH, { force: true });
+  });
+
+  it("round-trip : une entrée ajoutée est relue telle quelle", async () => {
+    const entry = baseEntry({ status: "started" });
+    await appendLedger(entry);
+    expect(await readLedger()).toEqual([entry]);
+  });
+
+  it("removeFromLedger retire toutes les lignes du dossier (started + done)", async () => {
+    const started = baseEntry({ status: "started" });
+    const done = baseEntry({ status: "done", at: "2025-01-01T10:05:00.000Z" });
+    const other = baseEntry({ folder: "autre culte", status: "done" });
+    await appendLedger(started);
+    await appendLedger(done);
+    await appendLedger(other);
+
+    await removeFromLedger("Culte du 01 01 2025");
+
+    expect(await readLedger()).toEqual([other]);
+  });
+
+  it("readLedger retourne [] si le fichier n'existe pas", async () => {
+    expect(await readLedger()).toEqual([]);
+  });
+});

--- a/prisma/scripts/migrate-audiobookshelf/ledger.ts
+++ b/prisma/scripts/migrate-audiobookshelf/ledger.ts
@@ -1,7 +1,11 @@
 /**
- * Ledger d'idempotence : une ligne JSON par culte importé avec succès, dans
- * `.ledger.jsonl` (git-ignoré, à côté du script). Une relance saute les dossiers
- * déjà présents. Clé métier = nom du dossier Audiobookshelf.
+ * Ledger d'idempotence : une ou deux lignes JSON par culte, dans `.ledger.jsonl`
+ * (git-ignoré, à côté du script). `importCulte()` écrit une entrée `status: "started"`
+ * dès la création du service, puis une entrée `status: "done"` une fois l'import
+ * terminé — la dernière entrée d'un dossier fait foi (voir `latestEntryByFolder`).
+ * Une entrée sans `status` (écrite par une version antérieure du script, qui
+ * n'écrivait qu'à la fin d'un import réussi) est traitée comme `"done"`.
+ * Clé métier = nom du dossier Audiobookshelf.
  */
 
 import { readFile, appendFile, writeFile } from "fs/promises";
@@ -18,6 +22,7 @@ export interface LedgerEntry {
   sequences: number;
   predicationMatched: boolean;
   at: string; // ISO
+  status?: "started" | "done";
 }
 
 export async function readLedger(): Promise<LedgerEntry[]> {
@@ -40,4 +45,22 @@ export async function appendLedger(entry: LedgerEntry): Promise<void> {
 export async function removeFromLedger(folder: string): Promise<void> {
   const kept = (await readLedger()).filter((e) => e.folder !== folder);
   await writeFile(LEDGER_PATH, kept.map((e) => JSON.stringify(e)).join("\n") + (kept.length ? "\n" : ""), "utf8");
+}
+
+/** Dernière entrée connue pour un dossier (ordre du fichier), `undefined` si absent. */
+export function latestEntryByFolder(entries: LedgerEntry[], folder: string): LedgerEntry | undefined {
+  let latest: LedgerEntry | undefined;
+  for (const entry of entries) {
+    if (entry.folder === folder) latest = entry;
+  }
+  return latest;
+}
+
+/**
+ * `true` si la dernière entrée du dossier représente un import terminé avec succès —
+ * `status: "done"`, ou une entrée historique sans `status` (l'ancien script n'écrivait
+ * qu'à la fin d'un import réussi). `false` si absente ou `status: "started"`.
+ */
+export function isFolderDone(entry: LedgerEntry | undefined): boolean {
+  return entry !== undefined && (entry.status === "done" || entry.status === undefined);
 }

--- a/prisma/scripts/migrate-audiobookshelf/resolution.test.ts
+++ b/prisma/scripts/migrate-audiobookshelf/resolution.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { classifyFolders } from "./resolution";
+import type { LedgerEntry } from "./ledger";
+
+const entry = (overrides: Partial<LedgerEntry> = {}): LedgerEntry => ({
+  folder: "Culte du 01 01 2025",
+  serviceId: "svc-1",
+  date: "2025-01-01",
+  sequences: 5,
+  predicationMatched: true,
+  at: "2025-01-01T10:00:00.000Z",
+  ...overrides,
+});
+
+describe("classifyFolders", () => {
+  it("dossier sans entrée -> toImport", () => {
+    const result = classifyFolders(["Culte du 01 01 2025"], []);
+    expect(result).toEqual({ toImport: ["Culte du 01 01 2025"], alreadyDone: [], pendingCleanup: [] });
+  });
+
+  it("dossier avec entrée done -> alreadyDone", () => {
+    const result = classifyFolders(["Culte du 01 01 2025"], [entry({ status: "done" })]);
+    expect(result).toEqual({ toImport: [], alreadyDone: ["Culte du 01 01 2025"], pendingCleanup: [] });
+  });
+
+  it("dossier avec entrée historique sans status -> alreadyDone", () => {
+    const legacy = entry();
+    delete (legacy as Partial<LedgerEntry>).status;
+    const result = classifyFolders(["Culte du 01 01 2025"], [legacy]);
+    expect(result).toEqual({ toImport: [], alreadyDone: ["Culte du 01 01 2025"], pendingCleanup: [] });
+  });
+
+  it("dossier avec entrée started seule -> pendingCleanup, jamais toImport", () => {
+    const result = classifyFolders(["Culte du 01 01 2025"], [entry({ status: "started" })]);
+    expect(result).toEqual({ toImport: [], alreadyDone: [], pendingCleanup: ["Culte du 01 01 2025"] });
+  });
+
+  it("dossier avec started puis done -> alreadyDone (la dernière entrée fait foi)", () => {
+    const started = entry({ status: "started" });
+    const done = entry({ status: "done", at: "2025-01-01T10:05:00.000Z" });
+    const result = classifyFolders(["Culte du 01 01 2025"], [started, done]);
+    expect(result).toEqual({ toImport: [], alreadyDone: ["Culte du 01 01 2025"], pendingCleanup: [] });
+  });
+
+  it("plusieurs dossiers mélangés -> classement indépendant de chacun", () => {
+    const entries: LedgerEntry[] = [
+      entry({ folder: "neuf" }),
+      entry({ folder: "fait", status: "done" }),
+      entry({ folder: "en-panne", status: "started" }),
+    ].filter((e) => e.folder !== "neuf"); // "neuf" n'a volontairement aucune entrée
+
+    const result = classifyFolders(["neuf", "fait", "en-panne"], entries);
+    expect(result).toEqual({
+      toImport: ["neuf"],
+      alreadyDone: ["fait"],
+      pendingCleanup: ["en-panne"],
+    });
+  });
+});

--- a/prisma/scripts/migrate-audiobookshelf/resolution.ts
+++ b/prisma/scripts/migrate-audiobookshelf/resolution.ts
@@ -1,0 +1,32 @@
+/**
+ * Décide, pour un ensemble de dossiers candidats, ce qu'il faut en faire à partir de
+ * l'état du ledger — pure, sans I/O, testable indépendamment de Prisma/S3/ffprobe.
+ */
+
+import { isFolderDone, latestEntryByFolder, type LedgerEntry } from "./ledger";
+
+export interface FolderClassification {
+  /** Aucune entrée pour ce dossier : à importer. */
+  toImport: string[];
+  /** Dernière entrée `status: "done"` (ou historique sans `status`) : déjà importé. */
+  alreadyDone: string[];
+  /** Dernière entrée `status: "started"` sans `"done"` associée : tentative inaboutie, à purger avant reprise. */
+  pendingCleanup: string[];
+}
+
+export function classifyFolders(folders: string[], allEntries: LedgerEntry[]): FolderClassification {
+  const result: FolderClassification = { toImport: [], alreadyDone: [], pendingCleanup: [] };
+
+  for (const folder of folders) {
+    const entry = latestEntryByFolder(allEntries, folder);
+    if (!entry) {
+      result.toImport.push(folder);
+    } else if (isFolderDone(entry)) {
+      result.alreadyDone.push(folder);
+    } else {
+      result.pendingCleanup.push(folder);
+    }
+  }
+
+  return result;
+}

--- a/specs/028-journal-migration-audiobookshelf/plan.md
+++ b/specs/028-journal-migration-audiobookshelf/plan.md
@@ -1,0 +1,196 @@
+# Plan technique — Reprise fiable de la migration des cultes Audiobookshelf après un échec partiel
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Validé
+- **Mis à jour le** : 2026-08-29
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : aucun nouvel import cross-module ; le script continue d'utiliser
+      les seules fonctions déjà exposées par `@/modules/audio` (`createAudioService`,
+      `deleteAudioService`, `unpublishAudioService`, `publishAudioService`, `applySequences`)
+- [x] **Sécurité** : sans objet — outil hors application web, exécuté par un opérateur ayant déjà
+      un accès direct à la base de données et à l'environnement serveur ; aucune route ajoutée
+- [x] **Permissions** via `rolePermissions` : sans objet, pas de route API concernée
+- [x] **Validation** Zod : sans objet, pas de mutation exposée à un utilisateur final ; les
+      entrées du journal restent un format interne à l'outil (typé TypeScript, pas une frontière
+      de confiance)
+- [x] **Migration** Prisma : **aucune** — le journal reste un fichier local (`.ledger.jsonl`),
+      aucun changement de `schema.prisma`
+- [x] **Enums** depuis `@/generated/prisma/client` : sans objet
+- [x] **UI** : sans objet, aucun composant
+
+## Approche générale
+
+Le journal (`.ledger.jsonl`) passe d'un format "une ligne = un import réussi" à un format "une
+ligne = un événement d'étape", avec un champ `status` (`"started"` | `"done"`). `importCulte()`
+écrit une entrée `started` **immédiatement après** la création du service (avant tout effet
+externe supplémentaire), puis une entrée `done` à la toute fin, une fois la publication terminée.
+Le fichier reste strictement append-only pendant l'import (aucune réécriture en place) — la
+dernière entrée connue pour un dossier fait foi, ce qui reste un simple `Array.reduce`/boucle
+sur les lignes lues dans l'ordre.
+
+La logique de décision (« ce dossier est déjà importé / doit être nettoyé / peut être importé »)
+est extraite dans une fonction pure et testée indépendamment de Prisma/S3, plutôt que codée en
+ligne dans `main()` — c'est la seule partie de ce correctif qui a besoin de tests unitaires
+directs, le reste (`main()`, `importCulte()`) restant un script d'orchestration non testé comme
+aujourd'hui (aucun test existant ne couvre `main()`).
+
+`--purge` retrouve désormais **toute** tentative (aboutie ou non) via la dernière entrée connue du
+dossier, et gère le cas où le service a été marqué publié avant l'échec (dépublication préalable
+si nécessaire) — cas limite étroit mais réel avec l'ordre `publishAudioService()` → écriture de
+l'entrée `done`.
+
+Les entrées historiques du journal (écrites par la version actuelle du script, sans champ
+`status`) restent lisibles : leur absence de `status` est interprétée comme `"done"` (elles ne
+pouvaient être écrites que par un import déjà terminé avec succès, dans l'ancien code).
+
+## Modèle de données
+
+`[Aucun changement]` — le journal reste un fichier local, pas une table Prisma.
+
+## API
+
+`[Aucun changement]` — aucun endpoint HTTP concerné.
+
+## Services / logique métier
+
+Fichiers du script `prisma/scripts/migrate-audiobookshelf/` (hors module `@/modules/audio`,
+lui-même inchangé) :
+
+- **`ledger.ts`** :
+  - `LedgerEntry` gagne un champ `status?: "started" | "done"` (optionnel pour rester compatible
+    avec les lignes historiques déjà écrites sur des postes d'opérateurs).
+  - `readLedger()` : inchangé dans sa forme (lit toutes les lignes, dans l'ordre du fichier).
+  - `appendLedger(entry)` : inchangé, réutilisé pour écrire aussi bien une entrée `started` qu'une
+    entrée `done` (deux appels au lieu d'un par culte importé).
+  - `removeFromLedger(folder)` : inchangé dans sa forme, mais retire désormais **toutes** les
+    lignes du dossier (`started` et `done` confondues) — déjà son comportement actuel (`filter`
+    par `folder`), rien à changer ici.
+  - **Nouveau** : `latestEntryByFolder(entries: LedgerEntry[], folder: string): LedgerEntry |
+    undefined` — parcourt les entrées dans l'ordre du fichier et retient la dernière rencontrée
+    pour ce dossier (une entrée `done` postérieure à une entrée `started` la remplace comme état
+    courant). Fonction pure, testée isolément.
+  - **Nouveau** : `isFolderDone(entry: LedgerEntry | undefined): boolean` — `true` si `entry`
+    existe et que `entry.status === "done"` **ou** `entry.status === undefined` (compatibilité
+    entrées historiques). `false` sinon (absent, ou `"started"`).
+
+- **Nouveau fichier `resolution.ts`** (logique de reprise, pure, sans I/O) :
+  - `classifyFolders(folders: string[], allEntries: LedgerEntry[]): { toImport: string[];
+    alreadyDone: string[]; pendingCleanup: string[] }` — pour chaque dossier candidat, calcule sa
+    dernière entrée (`latestEntryByFolder`) et le classe :
+    - aucune entrée → `toImport`
+    - dernière entrée `done`/legacy → `alreadyDone`
+    - dernière entrée `started` (jamais complétée) → `pendingCleanup`
+  - Utilisée à la fois par `main()` (import normal) pour ne **jamais** tenter de réimporter un
+    dossier en tentative inaboutie, et testée directement avec des jeux d'entrées construits à la
+    main (pas besoin de fichier réel ni de Prisma).
+
+- **`index.ts`** :
+  - `importCulte()` : ajoute `await appendLedger({ folder, serviceId: service.id, status:
+    "started", date, sequences: culte.sequences.length, predicationMatched, at })` juste après
+    `createAudioService(...)` (avant la boucle d'upload des séquences). L'entrée finale, en fin de
+    fonction (après `publishAudioService`), passe à `status: "done"` avec un nouvel horodatage —
+    même contenu que l'entrée actuelle aujourd'hui, avec `status: "done"` en plus.
+  - `main()` :
+    - Construit `candidates` à partir de `manifest.cultes.filter(...)`, puis appelle
+      `classifyFolders(candidates.map(c => c.folder), await readLedger())`.
+    - Les dossiers `alreadyDone` sont retirés des candidats (comportement actuel, inchangé dans
+      son intention).
+    - Les dossiers `pendingCleanup` sont **retirés des candidats à importer** (jamais réimportés
+      automatiquement — conforme au scénario alternatif de la spec) et affichés clairement en
+      console avant le lancement de l'import, avec la commande de nettoyage à exécuter
+      (`--purge "<dossier>"`) avant toute reprise.
+    - Le message d'échec affiché dans le `catch` de la boucle d'import (`reprise : … --purge
+      "${culte.folder}" puis relancer`) reste tel quel dans sa forme — il devient **vrai** avec ce
+      correctif (l'entrée `started` existe désormais forcément dès que `createAudioService` a
+      réussi), alors qu'il était trompeur avant.
+  - Branche `--purge <dossier>` :
+    - Recherche désormais via `latestEntryByFolder(await readLedger(), args.purge)` (au lieu du
+      premier `.find` sur la liste brute — nécessaire puisqu'un dossier peut désormais avoir
+      jusqu'à deux lignes).
+    - Si aucune entrée → message inchangé ("Aucune entrée de ledger… rien à purger.").
+    - Sinon, tente `deleteAudioService(entry.serviceId, church.id, prisma)` ; si l'erreur est une
+      `ApiError` avec `statusCode === 400` (culte déjà publié — la fenêtre étroite où l'échec
+      serait survenu entre `publishAudioService` et l'écriture de l'entrée `done`), appelle
+      d'abord `unpublishAudioService(entry.serviceId, church.id, prisma)` puis retente
+      `deleteAudioService`. Toute autre erreur remonte telle quelle (comportement actuel).
+    - `removeFromLedger(args.purge)` en fin de purge, comme aujourd'hui (retire toutes les lignes
+      du dossier, `started` et `done`).
+
+## UI / composants
+
+`[Aucun changement]`.
+
+## Décisions & alternatives écartées
+
+- **Choix : deux lignes append-only (`started` puis `done`) plutôt qu'une réécriture en place du
+  fichier à chaque étape** — *Pourquoi* : conserve la propriété actuelle du journal (append-only,
+  robuste à une interruption brutale du process pendant l'écriture — un `writeFile` complet
+  serait, lui, à risque de corrompre le fichier entier en cas de coupure en cours d'écriture,
+  contrairement à un `appendFile` d'une ligne).
+- **Choix : extraire `classifyFolders`/`latestEntryByFolder` en fonctions pures testables plutôt
+  que de coder la logique inline dans `main()`** — *Pourquoi* : `main()` orchestre des appels
+  Prisma/S3/ffprobe réels et n'est pas testable unitairement sans lourds mocks (déjà le cas
+  aujourd'hui, aucun test ne le couvre) ; isoler la décision "importer / nettoyer / ignorer" dans
+  une fonction pure permet de la tester précisément sans dépendance externe, conformément à la
+  contrainte de la spec ("tests attendus… sur la logique de reprise/purge").
+- **Écarté : stocker le journal en base de données (table Prisma) plutôt qu'en fichier local** —
+  *Raison* : sur-ingénierie pour un script one-off exécuté par un seul opérateur à la fois, hors
+  artefact de déploiement ; introduirait une migration Prisma et un modèle permanents pour un
+  besoin strictement transitoire (le journal n'a plus de raison d'exister une fois la migration
+  terminée). Écarté aussi par la spec elle-même ("pas de sur-ingénierie type état distribué").
+- **Écarté : verrou de fichier / protection contre deux exécutions concurrentes** — *Raison*
+  explicitement hors périmètre de la spec ; l'usage reste un opérateur unique, séquentiel.
+- **Écarté : migration automatique des lignes historiques du journal vers le nouveau format lors
+  de la première lecture** — *Raison* : inutile, l'absence de `status` est interprétée comme
+  `"done"` de façon permanente et sans ambiguïté (une ligne historique ne peut représenter qu'un
+  import déjà réussi, l'ancien code n'écrivant jamais rien d'autre) — pas besoin de réécrire le
+  fichier pour le rendre compatible, `isFolderDone` gère la rétrocompatibilité directement.
+- **Écarté : rendre `--purge` d'une entrée `done` explicitement plus strict (confirmation
+  supplémentaire)** — *Raison* : hors du problème rapporté par H-06 (purge d'un import réussi
+  volontaire, pas un cas d'échec) ; `deleteAudioService` refuse déjà de supprimer un culte publié
+  sans dépublication explicite, ce garde-fou existant est conservé tel quel pour ce cas, seule la
+  fenêtre étroite "publié mais jamais marqué `done`" (un vrai résidu de l'échec ciblé par cette
+  spec) reçoit la dépublication automatique.
+
+## Risques & points d'attention
+
+- **Fenêtre étroite entre `publishAudioService()` et l'écriture de l'entrée `done`** : un crash
+  exactement à ce moment laisse un service **publié** avec une entrée `started` — géré par la
+  dépublication automatique dans la branche `--purge` (voir ci-dessus) ; à mentionner dans le
+  `README.md` du script si un opérateur constate ce cas précis (contenu déjà publiquement
+  accessible via un lien de partage entre le crash et la purge — improbable en pratique, aucune
+  publication de lien n'a lieu automatiquement lors d'une migration, mais signalé pour
+  transparence).
+- **Compatibilité ascendante du fichier `.ledger.jsonl`** : un poste d'opérateur ayant déjà un
+  journal de l'ancien format doit continuer à fonctionner sans étape manuelle — couvert par
+  `isFolderDone` traitant `status` absent comme `"done"` (voir Services / logique métier et tests).
+- **`README.md`** du script mentionne la commande `--purge` en cas d'échec — à vérifier après
+  implémentation que le texte reste cohérent avec le nouveau comportement (pas de contenu
+  contradictoire laissé après ce correctif).
+
+## Stratégie de tests
+
+- **`ledger.test.ts`** (nouveau, `prisma/scripts/migrate-audiobookshelf/`) :
+  - `latestEntryByFolder` : plusieurs entrées pour un même dossier → retourne la dernière dans
+    l'ordre du tableau ; dossier absent → `undefined`.
+  - `isFolderDone` : `status: "done"` → `true` ; `status: "started"` → `false` ; `status`
+    absent (entrée historique) → `true` ; `undefined` (aucune entrée) → `false`.
+  - `readLedger`/`appendLedger`/`removeFromLedger` : comportement déjà correct aujourd'hui, non
+    testé jusqu'ici — ajout de tests de base (round-trip append/read, suppression par dossier)
+    tant qu'on touche ce fichier, sans étendre au-delà de ce que cette spec requiert.
+- **`resolution.test.ts`** (nouveau) :
+  - Dossier sans aucune entrée → `toImport`.
+  - Dossier avec une entrée `done` → `alreadyDone`.
+  - Dossier avec une entrée historique sans `status` → `alreadyDone`.
+  - Dossier avec une entrée `started` seule (pas de `done` associée) → `pendingCleanup`, jamais
+    `toImport` — le test qui couvre directement le critère d'acceptation central de cette spec.
+  - Dossier avec `started` **puis** `done` (import complété normalement) → `alreadyDone` (la
+    dernière entrée fait foi).
+  - Plusieurs dossiers mélangés dans un seul appel → classement correct de chacun indépendamment.
+- `main()` et `importCulte()` restent non testés unitairement (inchangé par rapport à
+  aujourd'hui) — ils orchestrent Prisma/S3/ffprobe réels ; la fiabilité de la reprise est
+  entièrement couverte par les fonctions pures ci-dessus, qui portent la totalité de la décision.

--- a/specs/028-journal-migration-audiobookshelf/spec.md
+++ b/specs/028-journal-migration-audiobookshelf/spec.md
@@ -1,0 +1,116 @@
+# Spec — Reprise fiable de la migration des cultes Audiobookshelf après un échec partiel
+
+- **Numéro** : 028
+- **Statut** : Implémentée
+- **Créée le** : 2026-08-29
+- **Branche suggérée** : `feat/journal-migration-audiobookshelf`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+Lors d'une migration ponctuelle des cultes depuis l'ancien système Audiobookshelf, un opérateur
+lance un outil de migration qui traite les cultes un par un. Pour chaque culte traité avec
+succès, l'outil retient qu'il a été importé, afin qu'une éventuelle relance ne le réimporte pas
+en double.
+
+Aujourd'hui, si le traitement d'un culte échoue **après** que des données aient déjà été créées
+côté Koinonia mais **avant** que l'outil n'ait fini d'enregistrer que ce culte est traité, deux
+problèmes surviennent au moment où l'opérateur corrige le problème et relance l'outil :
+
+1. **Le culte est réimporté en double** : l'outil ne sait pas qu'une tentative précédente a déjà
+   créé des données pour ce culte, puisque rien n'a été retenu à son sujet. Le culte se retrouve
+   donc importé deux fois.
+2. **Le nettoyage de la tentative ratée est impossible via l'outil lui-même** : l'outil propose une
+   commande pour annuler l'import d'un culte, mais cette commande ne fonctionne que si l'outil a
+   gardé une trace de ce culte — ce qui n'est justement pas le cas pour une tentative qui a échoué
+   avant la fin. L'opérateur se retrouve face à des données orphelines qu'il ne peut nettoyer
+   qu'en intervenant manuellement, en dehors de l'outil prévu à cet effet.
+
+L'outil affiche lui-même, au moment de l'échec, un message suggérant d'utiliser la commande de
+nettoyage puis de relancer — un conseil qui ne fonctionne pas dans cette situation précise et
+induit l'opérateur en erreur.
+
+**Pourquoi maintenant** : cette migration est un outil ponctuel destiné à être exécuté en
+production, contre des données réelles de culte, potentiellement pour plusieurs eglises. Un échec
+partiel n'est pas hypothétique (dépendance à un service externe pendant l'upload) et sa
+conséquence — doublons en base, données orphelines non nettoyables par l'outil — nécessite
+aujourd'hui une intervention manuelle en base de données à chaque incident, sans garde-fou.
+
+## Utilisateurs concernés
+
+- **Super Admin / Admin** — seuls profils habilités à exécuter cet outil de migration (accès
+  direct à l'environnement serveur et à la base de données, hors de l'application web). Aucun
+  autre rôle n'est concerné : l'outil n'est pas exposé dans l'application, c'est un outil
+  opérationnel réservé à l'équipe technique lors d'une migration ponctuelle.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Un opérateur lance l'outil de migration sur un ensemble de cultes.
+2. Chaque culte est traité l'un après l'autre ; l'outil retient, dès le tout début du traitement
+   d'un culte (avant toute création de donnée), qu'une tentative est en cours pour ce culte.
+3. Un culte dont le traitement se termine avec succès est marqué comme définitivement importé.
+4. Un culte dont le traitement échoue à n'importe quelle étape reste marqué comme "tentative
+   inaboutie" — ni traité comme importé avec succès, ni oublié.
+5. L'opérateur corrige la cause de l'échec (ex. rétablissement d'un service externe) puis relance
+   l'outil sur le même ensemble de cultes.
+6. Les cultes déjà importés avec succès sont ignorés (pas de doublon).
+7. Pour le ou les cultes en tentative inaboutie, l'outil de nettoyage retrouve et supprime
+   correctement toutes les données déjà créées par la tentative précédente, sans intervention
+   manuelle en base.
+8. L'opérateur relance ensuite l'import normal : le culte nettoyé est traité comme neuf et importé
+   avec succès.
+
+### Scénarios alternatifs / cas limites
+
+- **Si l'échec survient avant toute création de donnée** (ex. erreur de lecture du dossier source
+  avant le moindre appel externe) alors il n'y a rien à nettoyer — le culte doit simplement être
+  retenté normalement à la prochaine exécution, sans laisser de trace inutile.
+- **Si un opérateur relance l'outil sans avoir d'abord nettoyé une tentative inaboutie**, l'outil
+  ne doit ni créer de doublon, ni échouer silencieusement — il doit signaler clairement à
+  l'opérateur qu'une tentative précédente existe pour ce culte et nécessite un nettoyage avant
+  réimport.
+- **Si l'outil a déjà été exécuté par le passé** (avant cette évolution) et a laissé une trace
+  d'anciens cultes importés avec succès, ces traces doivent continuer à être reconnues comme
+  "déjà importé" sans qu'aucune action de l'opérateur ne soit nécessaire pour les faire migrer
+  vers le nouveau comportement.
+- **Quand l'opérateur demande le nettoyage d'un culte qui n'a en réalité aucune tentative connue**
+  (ni réussie, ni inaboutie), l'outil doit l'indiquer clairement plutôt que d'échouer de façon
+  confuse.
+
+## Critères d'acceptation
+
+- [x] Un échec survenant après la création de données pour un culte, mais avant la fin de son
+      traitement, n'entraîne jamais la création d'un doublon lors d'une relance ultérieure de
+      l'import normal (avant tout nettoyage).
+- [x] Un échec de ce type produit une tentative que l'outil de nettoyage peut retrouver et
+      supprimer intégralement, sans intervention manuelle en base de données.
+- [x] Une fois une tentative inaboutie nettoyée, le culte correspondant peut être réimporté
+      normalement et aboutit à un import unique et complet.
+- [x] Les cultes importés avec succès lors d'exécutions passées de l'outil (avant cette évolution)
+      restent reconnus comme "déjà importés" sans action requise de l'opérateur.
+- [x] Un culte pour lequel aucune donnée n'a été créée avant l'échec ne laisse aucune trace
+      empêchant sa reprise normale.
+- [x] Le message affiché par l'outil en cas d'échec reflète fidèlement la procédure de reprise
+      réellement disponible (n'oriente plus l'opérateur vers une commande de nettoyage qui ne
+      fonctionne pas dans son cas).
+
+## Hors périmètre
+
+- Toute évolution de l'outil au-delà de la fiabilité de la reprise après échec (nouveaux formats
+  source, nouvelles options de filtrage, parallélisation des imports, etc.).
+- Rendre l'outil utilisable par un rôle autre que l'équipe technique / Super Admin — il reste un
+  outil opérationnel hors de l'application web, pas une fonctionnalité exposée aux utilisateurs
+  de Koinonia.
+- Garantir une reprise automatique sans intervention de l'opérateur (l'objectif est de rendre le
+  nettoyage possible et fiable via l'outil, pas de le déclencher automatiquement).
+- Tout mécanisme de verrouillage empêchant deux exécutions simultanées de l'outil — l'usage reste
+  un opérateur unique exécutant l'outil de façon séquentielle, comme aujourd'hui.
+
+## Questions ouvertes
+
+- Aucune — le comportement attendu ci-dessus couvre le cas rapporté ; pas de point bloquant
+  identifié pour la planification technique.

--- a/specs/028-journal-migration-audiobookshelf/tasks.md
+++ b/specs/028-journal-migration-audiobookshelf/tasks.md
@@ -1,0 +1,90 @@
+# Tâches — Reprise fiable de la migration des cultes Audiobookshelf après un échec partiel
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : Terminé
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : journal → logique de décision → orchestration script → tests. Les tâches `[P]`
+> sont parallélisables.
+
+## Prérequis
+
+- [x] Branche créée : `feat/journal-migration-audiobookshelf`
+- [ ] Migration Prisma : **sans objet** (aucun changement de schéma)
+
+## Tâches
+
+### 1. Journal (`ledger.ts`)
+
+- [x] **T1** — Ajouter `status?: "started" | "done"` à `LedgerEntry`.
+      *(fichier : `prisma/scripts/migrate-audiobookshelf/ledger.ts`)*
+- [x] **T2** — Ajouter `latestEntryByFolder(entries, folder)` : retourne la dernière entrée du
+      tableau correspondant au dossier, `undefined` si aucune. *(même fichier)*
+- [x] **T3** — Ajouter `isFolderDone(entry)` : `true` si `entry?.status === "done"` ou
+      `entry !== undefined && entry.status === undefined` (compat entrées historiques) ; `false`
+      sinon. *(même fichier)*
+
+### 2. Logique de décision (nouveau fichier, pur)
+
+- [x] **T4** — Créer `resolution.ts` exportant `classifyFolders(folders, allEntries)` qui, pour
+      chaque dossier, calcule sa dernière entrée via `latestEntryByFolder` et le classe dans
+      `toImport` / `alreadyDone` (via `isFolderDone`) / `pendingCleanup` (dernière entrée
+      `status: "started"`). *(fichier : `prisma/scripts/migrate-audiobookshelf/resolution.ts`)*
+
+### 3. Orchestration du script (`index.ts`)
+
+- [x] **T5** — Dans `importCulte()`, ajouter l'écriture de l'entrée `status: "started"` juste
+      après `createAudioService(...)`, avant la boucle d'upload des séquences.
+      *(fichier : `prisma/scripts/migrate-audiobookshelf/index.ts`)*
+- [x] **T6** — Faire passer l'entrée finale (déjà écrite en fin de `importCulte()`, après
+      `publishAudioService`) à `status: "done"`, avec un nouvel horodatage `at`. *(même fichier)*
+- [x] **T7** — Dans `main()` (import normal), remplacer le calcul `done`/`candidates` actuel par
+      un appel à `classifyFolders(...)` : les dossiers `alreadyDone` sont ignorés (comme
+      aujourd'hui), les dossiers `pendingCleanup` sont exclus des candidats à importer et affichés
+      clairement en console avec l'instruction `--purge "<dossier>"` à exécuter avant reprise ;
+      seuls les dossiers `toImport` sont proposés à l'import. *(même fichier)*
+- [x] **T8** — Dans la branche `--purge` de `main()`, remplacer la recherche `.find()` sur la
+      liste brute par `latestEntryByFolder(await readLedger(), args.purge)`. Si l'entrée trouvée
+      correspond à un culte publié (`deleteAudioService` échoue avec `ApiError` `statusCode ===
+      400`), appeler `unpublishAudioService(entry.serviceId, church.id, prisma)` puis retenter
+      `deleteAudioService` avant de propager toute autre erreur. Import de `unpublishAudioService`
+      depuis `@/modules/audio` à ajouter. *(même fichier)*
+- [x] **T9** — Vérifier/adapter le texte du `README.md` du script si son contenu décrit encore
+      l'ancien comportement de `--purge` en cas d'échec (ex. mentionner explicitement que
+      `--purge` retrouve désormais toute tentative inaboutie, pas seulement un import réussi).
+      *(fichier : `prisma/scripts/migrate-audiobookshelf/README.md`)*
+
+### 4. Tests
+
+- [x] **T10** [P] — `ledger.test.ts` : `latestEntryByFolder` (plusieurs entrées pour un même
+      dossier → la dernière ; dossier absent → `undefined`) ; `isFolderDone` (`"done"` → `true`,
+      `"started"` → `false`, `status` absent avec entrée présente → `true`, entrée absente →
+      `false`) ; round-trip `appendLedger`/`readLedger` ; `removeFromLedger` retire bien toutes
+      les lignes d'un dossier (y compris `started` + `done` combinées).
+      *(fichier : `prisma/scripts/migrate-audiobookshelf/ledger.test.ts`)*
+- [x] **T11** [P] — `resolution.test.ts` : dossier sans entrée → `toImport` ; dossier avec entrée
+      `done` → `alreadyDone` ; dossier avec entrée historique sans `status` → `alreadyDone` ;
+      dossier avec entrée `started` seule → `pendingCleanup` (jamais `toImport`) ; dossier avec
+      `started` puis `done` → `alreadyDone` ; plusieurs dossiers mélangés dans un seul appel →
+      classement indépendant correct de chacun.
+      *(fichier : `prisma/scripts/migrate-audiobookshelf/resolution.test.ts`)*
+
+## Traçabilité critères d'acceptation → tâches
+
+| Critère d'acceptation (spec.md) | Couvert par |
+|---|---|
+| Pas de doublon après échec post-création, avant nettoyage | T5, T7, T11 |
+| `--purge` retrouve et supprime une tentative inaboutie | T2, T4, T8, T10, T11 |
+| Culte nettoyé réimportable normalement, import unique | T7, T8, T11 |
+| Entrées historiques (avant cette évolution) reconnues comme déjà importées | T3, T10, T11 |
+| Aucune trace bloquante si l'échec précède toute création de donnée | T5 (l'entrée n'existe que si `createAudioService` a réussi — aucun changement requis en amont) |
+| Message d'échec cohérent avec la procédure de reprise réelle | T7 (aucun changement de texte nécessaire — devient vrai grâce à T5/T8) |
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits
+- [ ] PR ouverte vers `main`


### PR DESCRIPTION
## Résumé

Corrige H-06 de l'audit DevSecOps du 2026-08-29 : le script ponctuel de migration Audiobookshelf → Koinonia (`prisma/scripts/migrate-audiobookshelf/`) créait le `AudioService` et tous ses effets externes (upload S3, publication) **avant** d'inscrire le culte dans son journal d'idempotence (`.ledger.jsonl`). Un échec entre les deux laissait un service orphelin, non retrouvable par `--purge` (lui aussi dépendant du ledger) et systématiquement dupliqué à la relance.

Voir `specs/028-journal-migration-audiobookshelf/` (spec, plan, tasks).

## Changement

- Le ledger porte désormais un statut `started`/`done` par culte : l'entrée `started` est écrite dès la création du service, avant tout effet externe ; l'entrée `done` seulement à la fin d'un import réussi.
- `main()` (import normal) exclut automatiquement les dossiers en tentative inaboutie (`pendingCleanup`) plutôt que de les réimporter, et les affiche clairement avec l'instruction `--purge` à exécuter.
- `--purge` retrouve désormais systématiquement le service à nettoyer via la dernière entrée du dossier — y compris la fenêtre étroite où le culte aurait été publié juste avant l'échec de l'écriture finale (dépublication automatique avant suppression dans ce cas).
- Les entrées historiques du journal (écrites par la version précédente du script, sans champ `status`) restent reconnues comme `done` — pas de migration de fichier nécessaire.
- Logique de décision (`classifyFolders`, `latestEntryByFolder`, `isFolderDone`) extraite en fonctions pures et testées indépendamment de Prisma/S3/ffprobe.

Aucun changement de schéma, aucune route API — script hors artefact de déploiement.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 erreur (11 warnings pré-existants inchangés)
- [x] `npm run lint:boundaries` — clean
- [x] `npm run test` — 934/934 (919 + 15 nouveaux tests sur `ledger.ts`/`resolution.ts`)
- [x] Critères d'acceptation de `specs/028-journal-migration-audiobookshelf/spec.md` relus un par un

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwEXWCWqPAgjfEnmKCMmSd