### PR TITLE
fix(audio,media): appliquer réellement les bornes de dépôt et le statut publié (M-02/M-03/M-04)

### DIFF
--- a/prisma/migrations/20260829164139_audio_job_render_unicite/migration.sql
+++ b/prisma/migrations/20260829164139_audio_job_render_unicite/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE `audio_jobs` ADD COLUMN `segmentId` VARCHAR(191) NULL,
+    ADD COLUMN `sourceHash` VARCHAR(191) NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `audio_jobs_segmentId_sourceHash_key` ON `audio_jobs`(`segmentId`, `sourceHash`);
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1975,11 +1975,21 @@ model AudioJob {
   payload     Json?
   error       String?        @db.Text
 
+  /// Doublent `payload` pour porter la contrainte d'unicite ci-dessous (spec 029) :
+  /// renseignes uniquement pour les jobs RENDER, NULL sinon. MariaDB autorisant
+  /// plusieurs NULL dans un index unique, les autres types de job ne se contraignent pas
+  /// entre eux. La contrainte porte sur TOUS les jobs, y compris termines : recreer un
+  /// job pour un couple deja traite (ex. rendu supprime manuellement a regenerer) suppose
+  /// de supprimer d'abord l'ancienne ligne.
+  segmentId  String?
+  sourceHash String?
+
   service AudioService @relation(fields: [serviceId], references: [id])
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@unique([segmentId, sourceHash])
   @@index([status, leasedUntil])
   @@map("audio_jobs")
 }

--- a/specs/029-integrite-objets-audio-media/plan.md
+++ b/specs/029-integrite-objets-audio-media/plan.md
@@ -1,0 +1,207 @@
+# Plan technique — Garanties réellement appliquées sur les dépôts et les publications audio/média
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Validé
+- **Mis à jour le** : 2026-08-29
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : aucun nouvel import cross-module ; `src/app/` continue de passer
+      par `@/modules/audio` et `@/modules/media` via leur index
+- [x] **Sécurité** : les routes touchées conservent leurs guards existants
+      (`requireMediaUploadAccess`, `requireAudioAccess`) ; la route publique de comptage reste
+      volontairement non authentifiée (jeton de partage), mais gagne le contrôle de statut publié
+      qui lui manquait — multi-tenant `churchId` inchangé partout
+- [x] **Permissions** via `rolePermissions` (`@/lib/registry`) — aucune permission ajoutée
+- [x] **Validation** Zod sur toutes les mutations — schémas existants conservés, aucun nouveau
+      champ accepté du client (la taille réelle est **constatée**, jamais reçue)
+- [x] **Migration** Prisma prévue (colonnes + contrainte d'unicité sur `AudioJob`) — pas de
+      `db push`
+- [x] **Enums** importés depuis `@/generated/prisma/client` — inchangé
+- [x] **UI** : aucun composant créé ; le parcours de dépôt côté client n'est pas modifié
+
+## Approche générale
+
+Trois corrections indépendantes, réunies parce qu'elles relèvent du même défaut (une garantie
+annoncée mais non appliquée) et de la même chaîne fonctionnelle. Chacune remplace une
+vérification **déclarative ou non atomique** par une contrainte que le serveur ou la base fait
+respecter :
+
+1. **M-02** — la taille réelle de l'objet déposé est constatée sur S3 (`HeadObject`) au moment de
+   la confirmation d'upload, avant d'accepter le fichier. Hors quota → refus, suppression de
+   l'objet, aucune version créée. La taille en base est corrigée avec la valeur réelle.
+2. **M-03** — une contrainte d'unicité en base sur `(segmentId, sourceHash)` de `AudioJob`, plus
+   un `createMany({ skipDuplicates: true })`, rendent la création des jobs RENDER idempotente
+   quelle que soit la concurrence — sans verrou applicatif.
+3. **M-04** — l'incrément du compteur devient un `updateMany` unique dont le `where` inclut le
+   statut publié du service : une seule instruction SQL, donc pas de fenêtre entre le contrôle et
+   l'écriture. Zéro ligne touchée → 410, exactement comme le streaming.
+
+## Modèle de données
+
+```prisma
+model AudioJob {
+  // … champs existants inchangés (payload conservé) …
+  segmentId  String?   // renseigné pour les jobs RENDER uniquement
+  sourceHash String?   // idem — NULL pour les autres types de job
+
+  @@unique([segmentId, sourceHash])
+  @@index([status, leasedUntil])
+  @@map("audio_jobs")
+}
+```
+
+Migration Prisma dédiée (`npm run db:migrate`) : ajout des deux colonnes nullables et de l'index
+unique. **MariaDB autorise plusieurs lignes NULL dans un index unique** — les jobs non-RENDER
+(et toutes les lignes historiques, laissées à NULL) ne sont donc pas contraints entre eux.
+
+**Pas de backfill des lignes existantes** depuis `payload` : toutes les lignes antérieures sont
+terminales (`DONE`/`FAILED`) et `publishAudioService` les ignore déjà — elle ne recrée un job que
+si le `sourceHash` du rendu courant diffère. Les laisser à NULL est sans conséquence et évite une
+migration de données sur du JSON.
+
+`payload` reste écrit comme aujourd'hui (`{ segmentId, sourceHash }`) : c'est ce que lit le
+worker (`handlers/render.ts`), non modifié par cette spec. Les nouvelles colonnes le doublent
+pour porter la contrainte, elles ne le remplacent pas.
+
+## API
+
+| Endpoint | Méthode | Permission | Changement |
+|---|---|---|---|
+| `/api/media/files/[id]` | PATCH | `requireMediaUploadAccess` (inchangé) | Sur `confirmUpload: true`, constate la taille réelle sur S3 avant de créer la version ; refuse (`400`) si hors quota (objet supprimé) ou (`404`) si l'objet est absent ; met `MediaFile.size` à la valeur réelle |
+| `/api/audio/public/[token]/play` | POST | aucune (jeton de partage, inchangé) | L'incrément devient conditionnel au statut `PUBLISHED` du culte ; `410` sinon |
+| `/api/audio/services/[id]/publish` | POST | `requireAudioAccess("audio:review", …)` (inchangé) | Aucun changement de contrat — la robustesse est gagnée dans le service sous-jacent |
+
+Aucun schéma Zod modifié : le client n'envoie aucun champ nouveau. La taille réelle n'est jamais
+une entrée, toujours une constatation serveur — c'est précisément l'objet du correctif.
+
+## Services / logique métier
+
+- **`src/lib/s3.ts`** — nouvelle fonction `getMediaObjectSize(key: string): Promise<number | null>`
+  (`HeadObjectCommand` sur `s3Media`/`MEDIA_BUCKET`), retournant `null` si l'objet n'existe pas
+  (`NotFound` / `404`) et propageant toute autre erreur. Placée à côté de `deleteMediaFiles`, qui
+  est réutilisée telle quelle pour le nettoyage de l'objet hors quota.
+
+- **`src/app/api/media/files/[id]/route.ts`** — dans le bloc `if (data.confirmUpload)`, avant la
+  création de `MediaFileVersion` :
+  - dériver la clé côté serveur comme aujourd'hui (`getFileOriginalKey`, logique inchangée) ;
+  - `getMediaObjectSize(derivedKey)` → `null` : `ApiError(404, "Fichier déposé introuvable …")`
+    (rien créé, rien supprimé — il n'y a pas d'objet) ;
+  - taille `> MAX_FILE_SIZE` : `deleteMediaFiles([derivedKey])` puis
+    `ApiError(400, "Fichier trop lourd (max …)")` — aucune version créée, le `MediaFile` reste en
+    `DRAFT` (il pourra être supprimé par la route `DELETE` existante) ;
+  - sinon : création de la version comme aujourd'hui **et** `MediaFile.size` mis à la taille
+    réelle dans le même `update` que le passage en `IN_REVIEW`.
+  - `MAX_FILE_SIZE` est aujourd'hui une constante privée de la route de signature ; elle est
+    extraite dans `src/modules/media/` (exportée par l'index du module) pour être partagée par
+    les deux routes sans duplication de valeur.
+
+- **`src/modules/audio/services/publish.ts`** — `publishAudioService()` :
+  - les entrées de `jobsToCreate` portent désormais aussi `segmentId` et `sourceHash` en colonnes
+    (en plus du `payload` inchangé) ;
+  - `db.audioJob.createMany({ data: jobsToCreate })` devient
+    `db.audioJob.createMany({ data: jobsToCreate, skipDuplicates: true })` — sur publication
+    concurrente, la seconde insertion est ignorée silencieusement au lieu de créer un doublon ou
+    de lever une erreur d'unicité que l'utilisateur n'aurait pas à voir.
+  - Le reste de la fonction (contrôles de dépôt incomplet, `nowReady`, transition
+    `READY`/`PUBLISHED`) est **inchangé** — le critère « republication sans changement ne
+    déclenche rien » repose sur la comparaison de `sourceHash` déjà en place.
+
+- **`src/app/api/audio/public/[token]/play/route.ts`** — remplacement du couple
+  `findUnique` + `update` par un `updateMany` unique :
+  ```ts
+  const { count } = await prisma.audioSegment.updateMany({
+    where: { id: segmentId, serviceId: shareToken.serviceId, service: { status: "PUBLISHED" } },
+    data: { playCount: { increment: 1 } },
+  });
+  if (count === 0) throw new ApiError(410, "Ce culte n'est plus disponible.");
+  ```
+  Le contrôle d'appartenance du segment au service du jeton (aujourd'hui fait par un `findUnique`
+  puis une comparaison) entre dans le même `where` : une seule instruction, plus de fenêtre entre
+  la vérification et l'écriture. Le message et le code `410` reprennent **mot pour mot** ceux de
+  la route de streaming, conformément à la contrainte de la spec.
+
+## UI / composants
+
+Aucun changement. Le parcours de dépôt côté client (`MediaProjectDetail.tsx`) est inchangé : il
+appelle déjà la confirmation après l'upload, et affichera simplement l'erreur renvoyée par
+l'API en cas de dépassement, via son traitement d'erreur existant.
+
+## Décisions & alternatives écartées
+
+- **Choix : vérifier la taille à la confirmation (`HeadObject`) plutôt qu'à l'upload** —
+  *Pourquoi* : c'est la seule option qui n'oblige pas à changer le mécanisme de transfert côté
+  client, explicitement hors périmètre dans la spec. L'étape de confirmation existe déjà
+  (`confirmUpload`) et est le point où le fichier entre réellement dans le circuit de revue :
+  refuser là garantit qu'aucun fichier hors quota n'est jamais exploitable.
+- **Écarté : POST policy S3 avec `content-length-range`** — *Raison* : c'est la contrainte la plus
+  forte (S3 refuse le dépôt lui-même, l'octet n'est jamais écrit), mais elle impose de passer d'un
+  `PUT` présigné à un `POST` multipart form et donc de réécrire l'upload client. La spec exclut
+  ce changement de parcours. À reconsidérer si le volume de dépôts abusifs le justifiait un jour.
+- **Écarté : faire confiance à la taille déclarée et se contenter de la corriger a posteriori** —
+  *Raison* : corrigerait l'affichage sans jamais empêcher la consommation de stockage, qui est
+  l'essentiel du constat.
+- **Choix : contrainte d'unicité en base + `skipDuplicates` plutôt qu'un verrou applicatif** —
+  *Pourquoi* : `DbClient` est typé `Prisma.TransactionClient`, qui n'expose pas `$transaction` —
+  ouvrir une transaction interactive avec `SELECT … FOR UPDATE` depuis `publishAudioService`
+  imposerait de changer sa signature et de gérer le cas où elle est déjà appelée dans une
+  transaction (c'est le cas depuis le script de migration). La contrainte de base fait respecter
+  l'invariant quel que soit l'appelant, sans coordination applicative — et la spec exclut
+  explicitement tout verrou distribué.
+- **Écarté : déduire la contrainte du champ `payload` JSON** — *Raison* : MariaDB ne permet pas
+  d'index unique directement sur une extraction JSON via Prisma ; deux colonnes scalaires
+  nullables sont la traduction simple et lisible de la même règle.
+- **Choix : `updateMany` conditionnel plutôt qu'un `findUnique` suivi d'un `update`** —
+  *Pourquoi* : le constat M-04 porte autant sur le contrôle manquant que sur sa non-atomicité.
+  Une seule instruction SQL ferme les deux d'un coup et supprime une requête.
+
+## Risques & points d'attention
+
+- **Contrainte d'unicité et re-rendu légitime** : `(segmentId, sourceHash)` étant unique sur
+  **tous** les jobs, y compris terminés, il devient impossible de recréer un job RENDER pour un
+  couple déjà traité. En usage normal c'est sans effet (`publishAudioService` ne recrée un job que
+  si le hash a changé, donc jamais le même couple). Le cas résiduel — rendu supprimé manuellement
+  qu'on voudrait régénérer — nécessiterait de supprimer d'abord l'ancienne ligne de job. À
+  documenter dans le commentaire du modèle plutôt que de complexifier la contrainte.
+- **Objets déjà déposés hors quota** : la spec exclut explicitement l'assainissement rétroactif.
+  Cette correction empêche les nouveaux cas, elle ne nettoie pas l'existant.
+- **Un `HeadObject` supplémentaire par confirmation de dépôt** : un aller-retour S3 de plus sur
+  une action déjà peu fréquente et non critique en latence — coût négligeable, mentionné pour
+  transparence.
+- **`MediaFile.size` corrigé à la confirmation** : les fichiers déjà confirmés gardent leur taille
+  déclarée (potentiellement fausse). Cohérent avec le hors-périmètre « pas de nettoyage
+  rétroactif ».
+- **Dépôt audio non traité** : la même faiblesse déclarative existe sur `AUDIO_UPLOAD_MAX_SIZE`
+  (`src/modules/audio/services/upload.ts`), volontairement hors périmètre (spec). Le nombre de
+  parts signées y étant dérivé de la taille annoncée, le dépassement est bien plus contraint —
+  mais la garantie n'est pas absolue pour autant, et le point reste ouvert.
+
+## Stratégie de tests
+
+- **`src/app/api/media/files/__tests__/`** (nouveau fichier de test pour la route `[id]`, ou
+  extension de l'existant) — `getMediaObjectSize` mockée :
+  - objet plus gros que la limite → réponse 400, `deleteMediaFiles` appelée avec la clé dérivée,
+    **aucune** `mediaFileVersion.create`, statut non passé à `IN_REVIEW` ;
+  - objet absent (`null`) → réponse 404, aucune création, aucune suppression ;
+  - objet dans les clous mais plus petit que la taille déclarée → version créée, `MediaFile.size`
+    mis à jour avec la taille **réelle**, passage en `IN_REVIEW` ;
+  - `confirmUpload` sur un fichier ayant déjà une version → comportement actuel préservé (aucun
+    appel S3, aucune création — garde `existingVersions === 0`).
+- **`src/modules/audio/services/__tests__/publish.test.ts`** (existant, à étendre) :
+  - les entrées passées à `createMany` portent bien `segmentId` et `sourceHash` en colonnes, en
+    plus du `payload` ;
+  - `createMany` est appelé avec `skipDuplicates: true` — le test qui verrouille l'idempotence au
+    niveau de l'appel, la garantie réelle étant portée par la contrainte de base (non simulable
+    avec le mock Prisma, et documentée comme telle) ;
+  - les cas existants (aucun job si aucun hash n'a changé, publication immédiate en `PUBLISHED`,
+    refus si dépôt incomplet) doivent continuer de passer sans modification — c'est le filet
+    anti-régression du critère « republication sans changement ».
+- **`src/app/api/audio/public/[token]/play/__tests__/`** (nouveau) :
+  - culte publié, jeton valide → `updateMany` appelé avec le `where` incluant
+    `service: { status: "PUBLISHED" }`, réponse 200 ;
+  - `count === 0` (culte dépublié) → réponse 410 avec le message aligné sur le streaming, aucune
+    autre écriture ;
+  - jeton révoqué ou segment hors périmètre du jeton → comportements actuels (404 / 403)
+    préservés.

--- a/specs/029-integrite-objets-audio-media/spec.md
+++ b/specs/029-integrite-objets-audio-media/spec.md
@@ -1,0 +1,152 @@
+# Spec — Garanties réellement appliquées sur les dépôts et les publications audio/média
+
+- **Numéro** : 029
+- **Statut** : Implémentée
+- **Créée le** : 2026-08-29
+- **Branche suggérée** : `feat/integrite-objets-audio-media`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+Trois règles que Koinonia annonce appliquer ne sont aujourd'hui garanties par rien de solide :
+elles reposent soit sur une **déclaration du client** que le serveur ne vérifie jamais, soit sur
+une **vérification faite avant l'écriture** sans garantie que rien n'a changé entre les deux.
+Elles sont regroupées ici parce qu'elles partagent ce même défaut de fond, sur la même chaîne
+dépôt → publication → écoute.
+
+**1. La limite de taille des fichiers média n'est jamais appliquée.**
+Quand un membre de la Production Média dépose un visuel ou une vidéo, l'application annonce une
+limite de taille et refuse un fichier annoncé au-delà. Mais cette vérification porte uniquement
+sur la taille **annoncée** par le navigateur : rien n'empêche ensuite de déposer un fichier
+beaucoup plus volumineux, qui sera accepté et conservé. La taille enregistrée dans Koinonia est
+celle qui avait été annoncée — elle peut donc n'avoir aucun rapport avec le fichier réellement
+stocké. Conséquences : l'espace de stockage consommé n'est pas maîtrisé, la limite affichée aux
+utilisateurs est fictive, et les tailles affichées dans l'interface peuvent être fausses.
+
+**2. Publier deux fois le même culte en même temps déclenche deux fois le même travail.**
+Quand un culte audio est publié, Koinonia prépare les fichiers d'écoute pour chaque séquence, en
+ne refaisant que ce qui a changé. Mais si deux personnes publient le même culte au même moment
+(ou si quelqu'un double-clique), les deux publications peuvent chacune constater que le travail
+reste à faire et le lancer en double. Le résultat produit est identique — les auditeurs entendent
+le bon contenu — mais la machine refait deux fois le même calcul et la file de traitement se
+remplit de travaux redondants. C'est un défaut de robustesse, pas un problème de contenu servi.
+
+**3. Les écoutes continuent d'être comptées sur un culte dépublié.**
+Quand un culte est dépublié, l'écoute est bien refusée à quiconque tente d'ouvrir un ancien lien
+de partage. En revanche, le compteur d'écoutes de ce culte, lui, continue d'accepter d'être
+incrémenté par le détenteur d'un ancien lien. Les statistiques d'un culte retiré de la
+bibliothèque continuent donc de monter alors que plus personne ne peut réellement l'écouter, ce
+qui fausse les chiffres sur lesquels s'appuient les responsables.
+
+**Pourquoi maintenant** : les trois points sont issus de l'audit du 2026-08-29 et touchent des
+fonctionnalités déjà en production. Aucun n'expose de données à une personne non autorisée, mais
+tous les trois font que Koinonia se comporte différemment de ce qu'il annonce — sur la
+consommation de stockage, sur la charge machine, et sur des statistiques utilisées pour décider.
+
+## Utilisateurs concernés
+
+- **Admin / Secrétaire / Super Admin, et tout membre habilité au dépôt média** — déposent des
+  visuels et vidéos ; c'est leur limite de taille qui doit être réellement appliquée, et les
+  tailles affichées dans l'interface qui doivent être exactes.
+- **Admin / Secrétaire / Super Admin habilités à publier un culte audio** — publient les cultes ;
+  ce sont leurs publications simultanées ou répétées qui ne doivent plus produire de travail en
+  double.
+- **Responsables consultant les statistiques d'écoute** (Super Admin, Admin, Secrétaire,
+  Ministre, Responsable de département) — s'appuient sur des compteurs qui doivent refléter des
+  écoutes réellement possibles.
+- **Auditeurs disposant d'un lien de partage public** (y compris hors Koinonia) — leur expérience
+  ne change pas : ils sont déjà correctement empêchés d'écouter un culte dépublié.
+
+## Comportement attendu
+
+### Scénario principal
+
+**Dépôt d'un fichier média**
+
+1. Un membre de la Production Média sélectionne un fichier et lance son dépôt.
+2. Le fichier est transmis, puis Koinonia constate la taille **réellement** déposée avant de
+   l'accepter.
+3. Si cette taille respecte la limite, le fichier est accepté et entre normalement dans le
+   circuit de revue ; la taille enregistrée et affichée est celle du fichier réel.
+4. Si cette taille dépasse la limite, le dépôt est refusé avec un message explicite, et le
+   fichier déposé ne reste pas stocké.
+
+**Publication d'un culte audio**
+
+5. Deux personnes publient le même culte au même moment (ou une personne clique deux fois).
+6. La préparation des fichiers d'écoute n'est déclenchée qu'une seule fois par séquence
+   concernée ; la seconde publication ne relance pas le même travail.
+7. Le culte devient écoutable exactement comme aujourd'hui — le comportement observable par les
+   auditeurs est inchangé.
+
+**Comptage des écoutes**
+
+8. Un culte est dépublié par un responsable.
+9. Une personne détenant encore un ancien lien de partage tente de l'écouter : l'écoute est
+   refusée (comportement actuel, inchangé).
+10. Le compteur d'écoutes de ce culte n'est pas incrémenté par cette tentative.
+
+### Scénarios alternatifs / cas limites
+
+- **Si un fichier déposé dépasse la limite**, il doit être refusé **et** ne pas laisser de fichier
+  résiduel occupant de l'espace de stockage — un refus qui conserverait le fichier ne résoudrait
+  pas le problème.
+- **Si la taille réellement déposée est inférieure à celle annoncée** (compression, fichier
+  tronqué), le dépôt reste accepté tant que la limite est respectée, mais c'est la taille réelle
+  qui est enregistrée et affichée.
+- **Si le fichier attendu est introuvable au moment de la vérification** (dépôt jamais abouti,
+  interrompu), la confirmation doit être refusée clairement plutôt que d'enregistrer un fichier
+  qui n'existe pas.
+- **Quand un culte est republié sans qu'aucune séquence n'ait changé**, aucun travail de
+  préparation ne doit être déclenché — comportement actuel à préserver, la correction ne doit pas
+  le remettre en cause.
+- **Quand un culte est dépublié puis republié**, le comptage des écoutes redevient possible
+  normalement : la règle suit le statut courant du culte, elle n'est pas définitive.
+- **Si un lien de partage est révoqué** alors que le culte reste publié, le comportement actuel
+  s'applique déjà et reste inchangé (écoute et comptage refusés).
+
+## Critères d'acceptation
+
+- [x] Un fichier média réellement déposé au-delà de la limite de taille est refusé à la
+      confirmation, quelle que soit la taille annoncée au départ.
+- [x] Un fichier refusé pour dépassement de taille ne reste pas stocké.
+- [x] La taille enregistrée et affichée pour un fichier média accepté correspond à la taille du
+      fichier réellement déposé, pas à celle annoncée.
+- [x] Une confirmation de dépôt portant sur un fichier absent est refusée avec un message
+      explicite.
+- [x] Deux publications simultanées du même culte ne produisent pas deux préparations de fichier
+      d'écoute pour une même séquence.
+- [x] Une republication d'un culte dont aucune séquence n'a changé ne déclenche toujours aucune
+      préparation (comportement actuel préservé).
+- [x] Le compteur d'écoutes d'un culte dépublié n'est plus incrémentable, y compris via un lien
+      de partage non révoqué.
+- [x] Le compteur d'écoutes redevient incrémentable si le culte est republié.
+- [x] L'écoute d'un culte publié via un lien valide, et son comptage, fonctionnent exactement
+      comme aujourd'hui (aucune régression).
+
+## Hors périmètre
+
+- **La limite de taille des dépôts audio** : elle présente la même faiblesse déclarative, mais
+  le mécanisme de dépôt y est différent et la contraint bien davantage en pratique. L'audit ne la
+  vise pas ; à traiter séparément si le besoin s'en confirme.
+- **Changer la façon dont les fichiers média sont transmis** depuis le navigateur : la correction
+  doit s'appuyer sur les étapes déjà existantes du dépôt, sans imposer aux utilisateurs un
+  nouveau parcours ni une nouvelle attente.
+- **Revoir les valeurs des limites de taille** elles-mêmes : cette spec fait appliquer la limite
+  existante, elle ne la rediscute pas.
+- **Toute forme de coordination entre plusieurs instances de l'application** (verrouillage
+  distribué) : la robustesse visée ici est celle de publications simultanées sur le déploiement
+  actuel, pas une refonte de l'architecture d'exécution.
+- **Le nettoyage rétroactif** des fichiers déjà déposés hors limite ou des tailles déjà
+  incorrectes en base : cette spec empêche le problème de se reproduire ; un éventuel
+  assainissement de l'existant est un travail distinct.
+- **Les statistiques d'écoute elles-mêmes** (affichage, agrégation, correction rétroactive des
+  compteurs déjà gonflés) : hors périmètre, seule la règle d'incrémentation change.
+
+## Questions ouvertes
+
+- Aucune — les trois comportements attendus sont entièrement déterminés par le comportement déjà
+  en place ailleurs dans l'application (limite annoncée à l'utilisateur, idempotence déjà visée à
+  la publication, refus déjà appliqué à l'écoute d'un culte dépublié).

--- a/specs/029-integrite-objets-audio-media/tasks.md
+++ b/specs/029-integrite-objets-audio-media/tasks.md
@@ -1,0 +1,100 @@
+# Tâches — Garanties réellement appliquées sur les dépôts et les publications audio/média
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : Terminé
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : migration → services → API → tests. Les tâches `[P]` sont parallélisables.
+> Les trois volets (M-02 média, M-03 publication, M-04 comptage) sont indépendants entre eux.
+
+## Prérequis
+
+- [x] Branche créée : `feat/integrite-objets-audio-media`
+- [x] Migration Prisma générée (T1)
+
+## Tâches
+
+### 1. Données & migration (volet M-03)
+
+- [x] **T1** — Ajouter `segmentId String?` et `sourceHash String?` sur `AudioJob`, plus
+      `@@unique([segmentId, sourceHash])`. Commenter dans le modèle que la contrainte porte sur
+      tous les jobs (y compris terminés) et qu'un re-rendu d'un couple déjà traité suppose de
+      supprimer l'ancienne ligne. Générer la migration avec `npm run db:migrate` (jamais
+      `db push`). *(fichiers : `prisma/schema.prisma`, `prisma/migrations/…`)*
+
+### 2. Services / helpers
+
+- [x] **T2** [P] — Ajouter `getMediaObjectSize(key: string): Promise<number | null>` dans
+      `src/lib/s3.ts` (`HeadObjectCommand` sur `s3Media`/`MEDIA_BUCKET`) : retourne la taille,
+      `null` si l'objet n'existe pas (`NotFound`/404), propage toute autre erreur.
+      *(fichier : `src/lib/s3.ts`)*
+- [x] **T3** [P] — Extraire `MAX_FILE_SIZE` (500 Mo) de la route de signature vers
+      `src/modules/media/`, l'exporter depuis l'index du module, et faire consommer cette
+      constante par la route de signature à la place de sa copie locale.
+      *(fichiers : `src/modules/media/…`, `src/modules/media/index.ts`,
+      `src/app/api/media/files/upload/sign/route.ts`)*
+- [x] **T4** — Dans `publishAudioService()`, renseigner `segmentId` et `sourceHash` en colonnes
+      sur chaque entrée de `jobsToCreate` (le `payload` reste écrit à l'identique), et passer
+      `skipDuplicates: true` à `createMany`. Ne rien changer d'autre (contrôles de dépôt
+      incomplet, `nowReady`, transition `READY`/`PUBLISHED`).
+      *(fichier : `src/modules/audio/services/publish.ts`)*
+
+### 3. API (route handlers)
+
+- [x] **T5** — Dans le bloc `confirmUpload` de `PATCH /api/media/files/[id]`, avant la création de
+      la version : constater la taille réelle via `getMediaObjectSize(derivedKey)` ; `null` →
+      `ApiError(404, …)` ; taille > `MAX_FILE_SIZE` → `deleteMediaFiles([derivedKey])` puis
+      `ApiError(400, …)` sans créer de version ni changer le statut ; sinon créer la version comme
+      aujourd'hui et mettre `MediaFile.size` à la taille **réelle** dans le même `update` que le
+      passage en `IN_REVIEW`. Préserver la garde `existingVersions === 0`.
+      *(fichier : `src/app/api/media/files/[id]/route.ts`)*
+- [x] **T6** — Dans `POST /api/audio/public/[token]/play`, remplacer le couple
+      `findUnique` + `update` par un `updateMany` unique dont le `where` inclut `id`,
+      `serviceId: shareToken.serviceId` et `service: { status: "PUBLISHED" }` ; `count === 0` →
+      `ApiError(410, "Ce culte n'est plus disponible.")` (message et code repris mot pour mot de
+      la route de streaming). Conserver les contrôles de jeton révoqué (404) et de segment hors
+      périmètre (403) tels quels.
+      *(fichier : `src/app/api/audio/public/[token]/play/route.ts`)*
+
+### 4. Tests
+
+- [x] **T7** [P] — Tests de la confirmation de dépôt média (`getMediaObjectSize` mockée) : objet
+      hors quota → 400 + `deleteMediaFiles` appelée avec la clé dérivée + aucune version créée +
+      statut inchangé ; objet absent → 404, aucune création ni suppression ; objet plus petit que
+      déclaré mais dans les clous → version créée + `size` mis à la taille réelle + `IN_REVIEW` ;
+      `confirmUpload` sur un fichier ayant déjà une version → aucun appel S3, aucune création.
+      *(fichier : `src/app/api/media/files/[id]/__tests__/confirm-upload.test.ts`)*
+- [x] **T8** [P] — Étendre `publish.test.ts` : vérifier que les entrées passées à `createMany`
+      portent `segmentId` et `sourceHash` en colonnes en plus du `payload`, et que `createMany`
+      est appelé avec `skipDuplicates: true`. Confirmer que les cas existants (aucun job si aucun
+      hash n'a changé, publication immédiate en `PUBLISHED`, refus si dépôt incomplet) passent
+      toujours sans modification.
+      *(fichier : `src/modules/audio/services/__tests__/publish.test.ts`)*
+- [x] **T9** [P] — Tests du comptage de lecture publique : culte publié + jeton valide →
+      `updateMany` appelé avec `service: { status: "PUBLISHED" }` dans le `where`, réponse 200 ;
+      `count === 0` (culte dépublié) → 410 avec le message aligné sur le streaming, aucune autre
+      écriture ; jeton révoqué → 404 ; segment hors périmètre du jeton → 403.
+      *(fichier : `src/app/api/audio/public/[token]/play/__tests__/…test.ts`)*
+
+## Traçabilité critères d'acceptation → tâches
+
+| Critère d'acceptation (spec.md) | Couvert par |
+|---|---|
+| Fichier réellement déposé hors limite refusé à la confirmation | T2, T5, T7 |
+| Fichier refusé ne reste pas stocké | T5, T7 |
+| Taille enregistrée/affichée = taille réelle | T5, T7 |
+| Confirmation sur fichier absent refusée explicitement | T2, T5, T7 |
+| Deux publications simultanées → pas de préparation en double | T1, T4, T8 |
+| Republication sans changement ne déclenche toujours rien | T4, T8 (non-régression) |
+| Compteur d'un culte dépublié non incrémentable | T6, T9 |
+| Compteur redevient incrémentable après republication | T6, T9 (le `where` suit le statut courant) |
+| Écoute et comptage d'un culte publié inchangés | T6, T9 (non-régression) |
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits
+- [ ] PR ouverte vers `main`

--- a/src/app/api/audio/public/[token]/play/__tests__/play.test.ts
+++ b/src/app/api/audio/public/[token]/play/__tests__/play.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests — spec 029 (M-04) : le comptage de lecture suit la meme regle de disponibilite que
+ * l'ecoute elle-meme.
+ *
+ * Le streaming refuse deja un culte depublie (410) ; le compteur, lui, restait incrementable
+ * par tout detenteur d'un ancien lien non revoque. L'increment est desormais conditionne au
+ * statut publie DANS la meme instruction, ce qui ferme aussi la fenetre entre controle et
+ * ecriture.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+vi.mock("@/lib/rate-limit", () => ({
+  requireRateLimit: vi.fn(),
+  getClientIp: vi.fn().mockReturnValue("203.0.113.1"),
+  RATE_LIMIT_MUTATION: { windowMs: 60_000, max: 30 },
+}));
+
+const { POST } = await import("../route");
+
+const params = Promise.resolve({ token: "tok-1" });
+
+function playRequest(segmentId = "seg-1"): Request {
+  return new Request("http://localhost/api/audio/public/tok-1/play", {
+    method: "POST",
+    body: JSON.stringify({ segmentId }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prismaMock.audioShareToken.findUnique.mockResolvedValue({
+    token: "tok-1",
+    serviceId: "svc-1",
+    segmentId: null,
+    revokedAt: null,
+  } as never);
+});
+
+describe("POST /api/audio/public/[token]/play", () => {
+  it("culte publié — incrémente en une seule instruction conditionnée au statut PUBLISHED", async () => {
+    prismaMock.audioSegment.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const res = await POST(playRequest(), { params });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.audioSegment.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "seg-1",
+        serviceId: "svc-1",
+        service: { status: "PUBLISHED" },
+      },
+      data: { playCount: { increment: 1 } },
+    });
+  });
+
+  it("culte dépublié — aucune ligne touchée, réponse 410 alignée sur le streaming", async () => {
+    prismaMock.audioSegment.updateMany.mockResolvedValue({ count: 0 } as never);
+
+    const res = await POST(playRequest(), { params });
+
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.error).toBe("Ce culte n'est plus disponible.");
+  });
+
+  it("jeton révoqué — 404, aucun comptage tenté", async () => {
+    prismaMock.audioShareToken.findUnique.mockResolvedValue({
+      token: "tok-1",
+      serviceId: "svc-1",
+      segmentId: null,
+      revokedAt: new Date(),
+    } as never);
+
+    const res = await POST(playRequest(), { params });
+
+    expect(res.status).toBe(404);
+    expect(prismaMock.audioSegment.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("segment hors périmètre d'un lien ciblé — 403, aucun comptage tenté", async () => {
+    prismaMock.audioShareToken.findUnique.mockResolvedValue({
+      token: "tok-1",
+      serviceId: "svc-1",
+      segmentId: "seg-autorise",
+      revokedAt: null,
+    } as never);
+
+    const res = await POST(playRequest("seg-1"), { params });
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.audioSegment.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/audio/public/[token]/play/route.ts
+++ b/src/app/api/audio/public/[token]/play/route.ts
@@ -31,18 +31,21 @@ export async function POST(
       throw new ApiError(403, "Segment hors périmètre de ce lien");
     }
 
-    const segment = await prisma.audioSegment.findUnique({
-      where: { id: segmentId },
-      select: { id: true, serviceId: true },
-    });
-    if (!segment || segment.serviceId !== shareToken.serviceId) {
-      throw new ApiError(404, "Segment introuvable");
-    }
-
-    await prisma.audioSegment.update({
-      where: { id: segmentId },
+    // Increment conditionnel en une seule instruction : le statut publie entre dans le
+    // `where` plutot que d'etre verifie avant l'ecriture, ce qui supprime la fenetre entre
+    // les deux. Sans ce controle, un ancien lien non revoque continuait de gonfler le
+    // compteur d'un culte depublie, que le streaming refuse pourtant deja (spec 029).
+    const { count } = await prisma.audioSegment.updateMany({
+      where: {
+        id: segmentId,
+        serviceId: shareToken.serviceId,
+        service: { status: "PUBLISHED" },
+      },
       data: { playCount: { increment: 1 } },
     });
+    if (count === 0) {
+      throw new ApiError(410, "Ce culte n'est plus disponible.");
+    }
 
     return successResponse({ ok: true });
   } catch (error) {

--- a/src/app/api/media/files/[id]/__tests__/confirm-upload.test.ts
+++ b/src/app/api/media/files/[id]/__tests__/confirm-upload.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests — spec 029 (M-02) : la borne de taille est constatee sur l'objet reellement depose.
+ *
+ * La borne validee a la signature ne porte que sur la taille ANNONCEE par le client ; une URL
+ * presignee PutObject n'impose aucune limite a S3. La confirmation de depot est donc le point
+ * ou le serveur constate la taille reelle avant d'accepter le fichier dans le circuit de revue.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+import { createAdminSession } from "@/__mocks__/auth";
+
+const MAX_FILE_SIZE = 500 * 1024 * 1024;
+
+const mockGetMediaObjectSize = vi.fn();
+const mockDeleteMediaFiles = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/lib/auth", () => ({
+  requireMediaAccess: vi.fn(),
+  requireMediaUploadAccess: vi.fn(async () => createAdminSession()),
+  requireMediaManageAccess: vi.fn(),
+  requireMediaReviewAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+vi.mock("@/lib/s3", () => ({
+  deleteMediaFiles: (...args: unknown[]) => mockDeleteMediaFiles(...args),
+  getMediaObjectSize: (...args: unknown[]) => mockGetMediaObjectSize(...args),
+}));
+
+vi.mock("@/modules/media", () => ({
+  getFileOriginalKey: vi.fn().mockReturnValue("media-projects/mp-1/file-1/v1/visuel.png"),
+  MAX_FILE_SIZE,
+}));
+
+vi.mock("@/lib/notifications", () => ({ createNotification: vi.fn() }));
+
+const { PATCH } = await import("../route");
+
+const params = Promise.resolve({ id: "file-1" });
+
+function patchRequest(body: unknown): Request {
+  return new Request("http://localhost/api/media/files/file-1", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  prismaMock.mediaFile.findUnique.mockResolvedValue({
+    id: "file-1",
+    filename: "visuel.png",
+    mediaEventId: null,
+    mediaProjectId: "mp-1",
+    mediaEvent: null,
+    mediaProject: { churchId: "church-1", createdById: "user-1" },
+  });
+  prismaMock.mediaFile.update.mockResolvedValue({ id: "file-1" });
+  prismaMock.mediaFileVersion.count.mockResolvedValue(0);
+  prismaMock.mediaFileVersion.create.mockResolvedValue({ id: "v-1" });
+});
+
+describe("PATCH /api/media/files/[id] — confirmUpload, borne de taille reelle", () => {
+  it("refuse (400) un objet plus gros que la limite, le supprime et ne cree aucune version", async () => {
+    mockGetMediaObjectSize.mockResolvedValue(MAX_FILE_SIZE + 1);
+
+    const res = await PATCH(patchRequest({ confirmUpload: true }), { params });
+
+    expect(res.status).toBe(400);
+    expect(mockDeleteMediaFiles).toHaveBeenCalledWith(["media-projects/mp-1/file-1/v1/visuel.png"]);
+    expect(prismaMock.mediaFileVersion.create).not.toHaveBeenCalled();
+    // Aucun passage en IN_REVIEW : le fichier reste en DRAFT
+    expect(prismaMock.mediaFile.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: "IN_REVIEW" }) })
+    );
+  });
+
+  it("refuse (404) une confirmation portant sur un objet absent, sans rien creer ni supprimer", async () => {
+    mockGetMediaObjectSize.mockResolvedValue(null);
+
+    const res = await PATCH(patchRequest({ confirmUpload: true }), { params });
+
+    expect(res.status).toBe(404);
+    expect(mockDeleteMediaFiles).not.toHaveBeenCalled();
+    expect(prismaMock.mediaFileVersion.create).not.toHaveBeenCalled();
+  });
+
+  it("accepte un objet dans les clous et enregistre la taille REELLE, pas celle annoncee", async () => {
+    const realSize = 1234;
+    mockGetMediaObjectSize.mockResolvedValue(realSize);
+
+    const res = await PATCH(patchRequest({ confirmUpload: true }), { params });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.mediaFileVersion.create).toHaveBeenCalledOnce();
+    expect(prismaMock.mediaFile.update).toHaveBeenCalledWith({
+      where: { id: "file-1" },
+      data: { status: "IN_REVIEW", size: realSize },
+    });
+    expect(mockDeleteMediaFiles).not.toHaveBeenCalled();
+  });
+
+  it("ne verifie rien et ne cree rien si une version existe deja (garde existante preservee)", async () => {
+    prismaMock.mediaFileVersion.count.mockResolvedValue(1);
+
+    const res = await PATCH(patchRequest({ confirmUpload: true }), { params });
+
+    expect(res.status).toBe(200);
+    expect(mockGetMediaObjectSize).not.toHaveBeenCalled();
+    expect(prismaMock.mediaFileVersion.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/media/files/[id]/__tests__/route.test.ts
+++ b/src/app/api/media/files/[id]/__tests__/route.test.ts
@@ -17,6 +17,9 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
 vi.mock("@/lib/s3", () => ({
   deleteMediaFiles: vi.fn().mockResolvedValue(undefined),
+  // Taille reelle constatee a la confirmation de depot (spec 029) : valeur dans les clous,
+  // ce fichier de test porte sur la derivation des cles, pas sur la borne de taille.
+  getMediaObjectSize: vi.fn().mockResolvedValue(1024),
 }));
 
 // Mock getFileOriginalKey pour vérifier qu'elle est appelée server-side
@@ -24,6 +27,7 @@ const mockGetFileOriginalKey = vi.fn().mockReturnValue("media-events/evt-1/files
 
 vi.mock("@/modules/media", () => ({
   getFileOriginalKey: (...args: unknown[]) => mockGetFileOriginalKey(...args),
+  MAX_FILE_SIZE: 500 * 1024 * 1024,
 }));
 
 const { PATCH } = await import("../route");

--- a/src/app/api/media/files/[id]/route.ts
+++ b/src/app/api/media/files/[id]/route.ts
@@ -5,8 +5,8 @@
 import { prisma } from "@/lib/prisma";
 import { requireMediaAccess, requireMediaUploadAccess, requireMediaManageAccess, requireMediaReviewAccess } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
-import { deleteMediaFiles } from "@/lib/s3";
-import { getFileOriginalKey } from "@/modules/media";
+import { deleteMediaFiles, getMediaObjectSize } from "@/lib/s3";
+import { getFileOriginalKey, MAX_FILE_SIZE } from "@/modules/media";
 import { createNotification } from "@/lib/notifications";
 import { z } from "zod";
 
@@ -111,6 +111,19 @@ export async function PATCH(
         const containerId = (mediaFile.mediaEventId ?? mediaFile.mediaProjectId)!;
         const derivedKey = getFileOriginalKey(container, containerId, id, 1, ext);
 
+        // La borne de taille validee a la signature ne portait que sur la taille ANNONCEE :
+        // une URL presignee PutObject n'impose aucune limite, le fichier reellement depose
+        // peut donc etre bien plus gros. On constate ici sa taille reelle avant de l'accepter
+        // dans le circuit de revue (spec 029).
+        const actualSize = await getMediaObjectSize(derivedKey);
+        if (actualSize === null) {
+          throw new ApiError(404, "Fichier déposé introuvable — le dépôt n'a pas abouti.");
+        }
+        if (actualSize > MAX_FILE_SIZE) {
+          await deleteMediaFiles([derivedKey]);
+          throw new ApiError(400, `Fichier trop lourd (max ${MAX_FILE_SIZE / 1024 / 1024}MB)`);
+        }
+
         await prisma.mediaFileVersion.create({
           data: {
             mediaFileId: id,
@@ -120,7 +133,10 @@ export async function PATCH(
             createdById: session.user.id,
           },
         });
-        await prisma.mediaFile.update({ where: { id }, data: { status: "IN_REVIEW" } });
+        await prisma.mediaFile.update({
+          where: { id },
+          data: { status: "IN_REVIEW", size: actualSize },
+        });
       }
     }
 

--- a/src/app/api/media/files/upload/__tests__/sign.test.ts
+++ b/src/app/api/media/files/upload/__tests__/sign.test.ts
@@ -25,6 +25,7 @@ vi.mock("@/lib/prisma", () => ({
 
 vi.mock("@/modules/media", () => ({
   getFileOriginalKey: vi.fn().mockReturnValue("media-events/me-1/file-1/v1/file.mp4"),
+  MAX_FILE_SIZE: 500 * 1024 * 1024,
 }));
 
 vi.mock("@/lib/rate-limit", () => ({

--- a/src/app/api/media/files/upload/sign/route.ts
+++ b/src/app/api/media/files/upload/sign/route.ts
@@ -7,14 +7,13 @@ import { prisma } from "@/lib/prisma";
 import { requireMediaUploadAccess, resolveChurchId } from "@/lib/auth";
 import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { requireRateLimit, RATE_LIMIT_MUTATION } from "@/lib/rate-limit";
-import { getFileOriginalKey } from "@/modules/media";
+import { getFileOriginalKey, MAX_FILE_SIZE } from "@/modules/media";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { s3Media, MEDIA_BUCKET } from "@/lib/s3";
 import { z } from "zod";
 
 const PRESIGNED_EXPIRY = 3600; // 1h
-const MAX_FILE_SIZE = 500 * 1024 * 1024; // 500 MB
 
 const ALLOWED_MIME_TYPES = [
   // Images / visuels

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -1,4 +1,4 @@
-import { S3Client, DeleteObjectsCommand } from "@aws-sdk/client-s3";
+import { S3Client, DeleteObjectsCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
 
 const globalForS3 = globalThis as unknown as {
   s3: S3Client | undefined;
@@ -78,5 +78,24 @@ export async function deleteMediaFiles(keys: string[]): Promise<void> {
         Delete: { Objects: batch.map((Key) => ({ Key })) },
       })
     );
+  }
+}
+
+/**
+ * Taille reelle d'un objet du bucket media, telle que S3 la constate — `null` si l'objet
+ * n'existe pas. Sert a faire respecter la borne de taille cote serveur : une URL presignee
+ * `PutObject` ne porte aucune contrainte de taille, la valeur annoncee par le client a la
+ * signature ne garantit donc rien (spec 029).
+ */
+export async function getMediaObjectSize(key: string): Promise<number | null> {
+  if (!MEDIA_BUCKET) throw new Error("MEDIA_S3_BUCKET non configuré — variables MEDIA_S3_* requises");
+
+  try {
+    const head = await s3Media.send(new HeadObjectCommand({ Bucket: MEDIA_BUCKET, Key: key }));
+    return head.ContentLength ?? null;
+  } catch (err) {
+    const e = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+    if (e.name === "NotFound" || e.$metadata?.httpStatusCode === 404) return null;
+    throw err;
   }
 }

--- a/src/modules/audio/services/__tests__/publish.test.ts
+++ b/src/modules/audio/services/__tests__/publish.test.ts
@@ -66,15 +66,40 @@ describe("publishAudioService", () => {
     const result = await publishAudioService(serviceId, churchId, "user-1");
 
     expect(prismaMock.audioJob.createMany).toHaveBeenCalledWith({
+      skipDuplicates: true,
       data: [
-        { serviceId, type: "RENDER", status: "PENDING", payload: { segmentId: "seg-1", sourceHash: hashOf("etag-1") } },
-        { serviceId, type: "RENDER", status: "PENDING", payload: { segmentId: "seg-2", sourceHash: hashOf("etag-2") } },
+        { serviceId, type: "RENDER", status: "PENDING", payload: { segmentId: "seg-1", sourceHash: hashOf("etag-1") }, segmentId: "seg-1", sourceHash: hashOf("etag-1") },
+        { serviceId, type: "RENDER", status: "PENDING", payload: { segmentId: "seg-2", sourceHash: hashOf("etag-2") }, segmentId: "seg-2", sourceHash: hashOf("etag-2") },
       ],
     });
     expect(prismaMock.audioService.update).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ status: "READY" }) })
     );
     expect(result.status).toBe("READY");
+  });
+
+  it("robustesse concurrence (spec 029) — chaque job porte (segmentId, sourceHash) en colonnes et l'insertion ignore les doublons", async () => {
+    // La garantie reelle est portee par la contrainte d'unicite (segmentId, sourceHash) en base,
+    // que le mock Prisma ne peut pas simuler : ce test verrouille les deux conditions cote code
+    // sans lesquelles elle ne s'appliquerait pas — colonnes renseignees, et insertion tolerante
+    // au doublon pour qu'une publication concurrente n'echoue pas bruyamment.
+    prismaMock.audioService.findUnique.mockResolvedValue({
+      id: serviceId,
+      churchId,
+      publishedAt: null,
+      segments: [{ id: "seg-1", source: { etag: "etag-1", uploadStatus: "DONE" }, rendition: null }],
+    } as never);
+    prismaMock.audioService.findUniqueOrThrow.mockResolvedValue({ id: serviceId, status: "READY" } as never);
+
+    await publishAudioService(serviceId, churchId, "user-1");
+
+    const call = prismaMock.audioJob.createMany.mock.calls[0][0] as {
+      skipDuplicates: boolean;
+      data: { segmentId: string; sourceHash: string }[];
+    };
+    expect(call.skipDuplicates).toBe(true);
+    expect(call.data[0].segmentId).toBe("seg-1");
+    expect(call.data[0].sourceHash).toBe(hashOf("etag-1"));
   });
 
   it("idempotence — republier sans redéposer ne recrée aucun job, passe direct à PUBLISHED", async () => {
@@ -114,8 +139,9 @@ describe("publishAudioService", () => {
     await publishAudioService(serviceId, churchId, "user-1");
 
     expect(prismaMock.audioJob.createMany).toHaveBeenCalledWith({
+      skipDuplicates: true,
       data: [
-        { serviceId, type: "RENDER", status: "PENDING", payload: { segmentId: "seg-1", sourceHash: hashOf("etag-1-new") } },
+        { serviceId, type: "RENDER", status: "PENDING", payload: { segmentId: "seg-1", sourceHash: hashOf("etag-1-new") }, segmentId: "seg-1", sourceHash: hashOf("etag-1-new") },
       ],
     });
   });

--- a/src/modules/audio/services/publish.ts
+++ b/src/modules/audio/services/publish.ts
@@ -73,13 +73,22 @@ export async function publishAudioService(
       type: "RENDER",
       status: "PENDING",
       payload: { segmentId: segment.id, sourceHash: hash },
+      // Doublent le payload en colonnes pour porter la contrainte d'unicite
+      // (segmentId, sourceHash) : c'est elle qui empeche deux publications
+      // concurrentes de creer chacune le meme job RENDER (spec 029).
+      segmentId: segment.id,
+      sourceHash: hash,
     });
   }
 
   const nowReady = jobsToCreate.length === 0; // rien à re-rendre : publication immédiate
 
   await db.$transaction([
-    ...(jobsToCreate.length > 0 ? [db.audioJob.createMany({ data: jobsToCreate })] : []),
+    // `skipDuplicates` : sur publication concurrente, la seconde insertion est ignoree
+    // silencieusement plutot que de lever une erreur d'unicite sans interet pour l'utilisateur.
+    ...(jobsToCreate.length > 0
+      ? [db.audioJob.createMany({ data: jobsToCreate, skipDuplicates: true })]
+      : []),
     db.audioService.update({
       where: { id: serviceId },
       data: {

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -3,6 +3,7 @@ import { defineModule } from "@/core/module-registry";
 export { createMediaShareToken, validateMediaShareToken, getTokenUrlPath, isTokenExpired, generateToken, collectionPhotoWhere, resolveDownloadData, resolveGalleryData, resolveCollectionData, resolveValidatorData } from "./services/tokens";
 export type { CollectionConfig, ResolvedMediaData, ResolvedGalleryData, ResolvedMediaEntry, ResolvedCollectionData, ResolvedValidatorEventData, ResolvedValidatorProjectData } from "./services/tokens";
 export { processImage, validatePhotoFile, getExtensionFromMimeType, ALLOWED_PHOTO_MIME_TYPES, MAX_PHOTO_SIZE } from "./services/image";
+export { MAX_FILE_SIZE } from "./services/files";
 export {
   uploadFile as uploadMediaFile,
   deleteMediaFile,

--- a/src/modules/media/services/files.ts
+++ b/src/modules/media/services/files.ts
@@ -1,0 +1,9 @@
+/**
+ * Bornes des depots de fichiers media (visuels, videos) — hors photos, qui ont leurs
+ * propres bornes dans `image.ts` (`MAX_PHOTO_SIZE`).
+ *
+ * Partagee par la route de signature (borne annoncee, refus precoce) et par la
+ * confirmation de depot (borne reellement constatee sur l'objet depose, spec 029) :
+ * une seule valeur, deux points d'application.
+ */
+export const MAX_FILE_SIZE = 500 * 1024 * 1024; // 500 MB


### PR DESCRIPTION
## Résumé

Corrige M-02, M-03 et M-04 de l'audit DevSecOps du 2026-08-29. Les trois partagent le même défaut : une règle que le serveur croit appliquer n'est garantie ni par une contrainte serveur, ni par une opération atomique.

Voir `specs/029-integrite-objets-audio-media/` (spec, plan, tasks).

## Changements

**M-02 — borne de taille média seulement déclarative**
La limite de 500 Mo n'était vérifiée que sur la taille *annoncée* à la signature ; une URL présignée `PutObject` n'impose aucune contrainte à S3. La taille réelle est désormais constatée (`HeadObject`) à la confirmation de dépôt, point d'accroche qui existait déjà :
- hors quota → 400, objet supprimé, aucune version créée, fichier laissé en `DRAFT` ;
- objet absent → 404 explicite ;
- sinon → `MediaFile.size` prend la valeur réelle, pas la valeur annoncée.

Le parcours d'upload côté client est inchangé (pas de bascule vers une POST policy, qui aurait imposé de le réécrire).

**M-03 — jobs de rendu dupliqués en concurrence**
`publishAudioService()` lisait les rendus existants puis écrivait dans une transaction séparée. Ajout d'une contrainte d'unicité `(segmentId, sourceHash)` sur `AudioJob` (colonnes doublant le `payload`, qui reste écrit à l'identique pour le worker) et de `skipDuplicates: true`. Pas de verrou applicatif : `DbClient` est typé `Prisma.TransactionClient` et n'expose pas `$transaction`.

**M-04 — comptage possible après dépublication**
Le compteur de lecture ne vérifiait pas le statut publié, contrairement au streaming voisin qui renvoie 410. L'incrément devient un `updateMany` unique dont le `where` inclut `service: { status: "PUBLISHED" }` — ce qui ferme d'un coup le contrôle manquant *et* la fenêtre entre vérification et écriture. Message et code repris mot pour mot du streaming.

## Constats vérifiés et écartés

La vérification contre le code réel a montré que **M-06 et M-09 sont déjà corrigés** (clé de rate-limit déjà composée avec token + IP depuis `d83ae2a` ; `.dockerignore` présent et complet) et que **M-01 ne l'est que partiellement** (clé de rate-limit déjà par IP à 5/min, mais pas de CAPTCHA — gap réel, hors périmètre de cette PR).

## Déploiement

Migration `20260829164139_audio_job_render_unicite` : ajout de deux colonnes nullables et d'un index unique sur `audio_jobs`. Pas de backfill des lignes existantes (toutes terminales, laissées à NULL — MariaDB autorise plusieurs NULL dans un index unique).

⚠️ Limite assumée et documentée dans le modèle : la contrainte portant sur tous les jobs y compris terminés, recréer un job pour un couple `(segmentId, sourceHash)` déjà traité — cas d'un rendu supprimé manuellement à régénérer — suppose de supprimer d'abord l'ancienne ligne. Sans effet en usage normal.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 erreur (11 warnings pré-existants inchangés)
- [x] `npm run lint:boundaries` — clean
- [x] `npm run test` — 943/943 (934 + 9 nouveaux ; 2 fichiers de tests existants ont vu leurs mocks complétés)
- [x] Critères d'acceptation de `specs/029-integrite-objets-audio-media/spec.md` relus un par un

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwEXWCWqPAgjfEnmKCMmSd