### PR TITLE
feat(securite): preuve d'humanité sur le formulaire public d'intégration (spec 030)

### DIFF
--- a/specs/030-captcha-formulaire-integration/plan.md
+++ b/specs/030-captcha-formulaire-integration/plan.md
@@ -1,0 +1,167 @@
+# Plan technique — Preuve d'humanité sur le formulaire public « Rejoindre une famille »
+
+- **Spec associée** : `./spec.md`
+- **Statut** : Validé
+- **Mis à jour le** : 2026-08-29
+
+> Ce plan traduit la spec en **approche technique** conforme à `../constitution.md`.
+
+## Vérification de conformité (constitution)
+
+- [x] **Frontières modules** : aucun import cross-module ajouté ; la vérification vit dans
+      `src/lib/` (utilitaire transverse, comme `rate-limit.ts`), consommé par deux routes
+- [x] **Sécurité** : la route reste volontairement publique (formulaire sans compte, c'est sa
+      raison d'être) ; elle gagne le contrôle anti-robot qui lui manquait, appliqué **avant** tout
+      effet de bord. `churchId` continue d'être résolu et vérifié comme aujourd'hui
+- [x] **Permissions** via `rolePermissions` — sans objet, endpoint public non authentifié
+- [x] **Validation** Zod : le jeton entre dans le schéma existant de la mutation, comme sur le
+      formulaire de rendez-vous
+- [x] **Migration** Prisma : **aucune** — pas de changement de schéma
+- [x] **Enums** depuis `@/generated/prisma/client` — inchangé
+- [x] **UI** : aucun composant `src/components/ui/` à créer ; le widget est un `<div>` monté par
+      le script Cloudflare, exactement comme sur le formulaire de rendez-vous
+
+## Approche générale
+
+Réplication à l'identique du mécanisme déjà éprouvé sur `/agenda-public/[churchSlug]`, avec une
+seule différence : la fonction de vérification serveur, aujourd'hui définie **en local** dans la
+route agenda, est extraite dans `src/lib/turnstile.ts` puisqu'elle acquiert un second
+consommateur. La route agenda est modifiée pour l'importer, sans aucun changement de comportement.
+
+Ordre d'exécution dans la route d'intégration — c'est lui qui porte le critère « aucun effet de
+bord sur refus » : `requireRateLimit` → `schema.parse` → **vérification du jeton** → recherche de
+l'église → contrôle du membre → géocodage → créations → email. Placer la vérification juste après
+le `parse` garantit qu'un refus n'atteint ni le service de géolocalisation, ni la base, ni l'envoi
+d'email.
+
+## Modèle de données
+
+`[Aucun changement]`.
+
+## API
+
+| Endpoint | Méthode | Permission | Entrée | Sortie |
+|---|---|---|---|---|
+| `/api/integration/requests` | POST | aucune (public, inchangé) | schéma existant **+** `turnstileToken: z.string().min(1, "Vérification CAPTCHA manquante")` | inchangée (`{ id, suggestedFamilyName }`, 201) |
+| `/api/agenda/requests/public` | POST | aucune (public, inchangé) | inchangée | inchangée — seule l'origine de `verifyTurnstile` change (import au lieu de définition locale) |
+
+Refus : `ApiError(400, "Vérification CAPTCHA échouée. Veuillez réessayer.")` — message et code
+repris **mot pour mot** de la route agenda, conformément à la contrainte de la spec. Un jeton
+absent est intercepté en amont par Zod, avec le message « Vérification CAPTCHA manquante ».
+
+## Services / logique métier
+
+- **`src/lib/turnstile.ts`** (nouveau) — accueille la fonction déplacée depuis la route agenda,
+  à l'identique :
+  ```ts
+  export async function verifyTurnstile(token: string, ip: string): Promise<boolean>
+  ```
+  Comportement conservé tel quel, y compris le **fail-closed** : `TURNSTILE_SECRET_KEY` absent →
+  `false`, donc soumission refusée. Ce choix est celui de la spec (§ cas limites) et n'est pas
+  modifié ici ; il est simplement documenté dans le fichier pour qu'un futur lecteur ne le prenne
+  pas pour un oubli.
+
+- **`src/app/api/agenda/requests/public/route.ts`** — suppression de la définition locale de
+  `verifyTurnstile` (lignes 29-39) au profit d'un import depuis `@/lib/turnstile`. Aucun autre
+  changement : même appel, mêmes arguments, même traitement du résultat.
+
+- **`src/app/api/integration/requests/route.ts`** — ajout de `turnstileToken` au schéma Zod de la
+  mutation, puis, immédiatement après `schema.parse` :
+  ```ts
+  const valid = await verifyTurnstile(data.turnstileToken, getClientIp(request));
+  if (!valid) throw new ApiError(400, "Vérification CAPTCHA échouée. Veuillez réessayer.");
+  ```
+  `getClientIp` est déjà importé dans cette route pour la clé de rate-limit — pas de nouvelle
+  dépendance. Aucune autre ligne de la route n'est touchée.
+
+## UI / composants
+
+- **`src/app/rejoindre/[churchSlug]/page.tsx`** — lit `process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY`
+  (avec repli `""`, comme la page agenda) et le passe en prop `turnstileSiteKey` à `JoinForm`.
+- **`src/app/rejoindre/[churchSlug]/JoinForm.tsx`** — transposition du bloc déjà présent dans
+  `PublicRequestForm.tsx` :
+  - nouvelle prop `turnstileSiteKey: string` ;
+  - état `turnstileToken` + `widgetRef`/`widgetId`, et le `useEffect` de montage du widget
+    (chargement du script `challenges.cloudflare.com/turnstile/v0/api.js` s'il n'est pas déjà
+    présent, puis `turnstile.render` avec les callbacks `callback` / `expired-callback` /
+    `error-callback` — ces deux derniers remettant le jeton à `null`, ce qui satisfait le critère
+    « refaire la vérification si elle expire ») ;
+  - garde en tête de `handleSubmit` :
+    `if (!turnstileToken) { setGlobalError("Veuillez compléter la vérification CAPTCHA."); return; }` ;
+  - `turnstileToken` ajouté au corps de la requête ;
+  - rendu : `<div ref={widgetRef} />` + la mention « Vérification anti-spam requise. » tant
+    qu'aucun jeton n'est obtenu, placés au-dessus du bouton d'envoi ;
+  - bouton d'envoi : `disabled={submitting || (!!turnstileSiteKey && !turnstileToken)}`.
+
+  Le formulaire conserve son état de saisie lors d'un refus (la garde retourne sans réinitialiser
+  `form`), ce qui satisfait le critère « sans perdre les informations déjà saisies ».
+
+## Décisions & alternatives écartées
+
+- **Choix : extraire `verifyTurnstile` dans `src/lib/` plutôt que la dupliquer** — *Pourquoi* :
+  une seconde copie signifierait deux endroits à corriger le jour où le fournisseur, l'URL de
+  vérification ou le traitement du fail-closed change — sur un contrôle de sécurité, c'est
+  précisément le genre de divergence qui finit par laisser une route en arrière. `src/lib/` est le
+  bon niveau : la fonction ne dépend d'aucun module métier et sert des routes de deux domaines
+  différents (agenda et intégration).
+- **Choix : vérifier juste après `schema.parse`, avant la recherche d'église** — *Pourquoi* : le
+  critère d'acceptation exige qu'un refus ne déclenche ni géocodage, ni création, ni email. Placer
+  le contrôle plus bas (par exemple après la résolution de l'église) le satisferait encore, mais
+  ferait payer une requête base à chaque soumission robotisée sans bénéfice.
+- **Écarté : rendre le contrôle optionnel quand `TURNSTILE_SECRET_KEY` est absent
+  (fail-open)** — *Raison* : ce serait un interrupteur silencieux désactivant une protection de
+  sécurité selon la configuration — exactement le genre de comportement qui passe inaperçu en
+  production. La spec tranche explicitement pour le refus, et c'est déjà le comportement du
+  formulaire de rendez-vous : diverger ici créerait deux règles pour un même mécanisme.
+- **Écarté : protéger aussi `GET /api/integration/families/suggest`** — *Raison* : hors périmètre
+  acté par la spec. Cet endpoint est appelé au fil de la frappe pour suggérer une famille ; y
+  exiger un défi le rendrait inutilisable. Il ne crée rien et n'envoie pas d'email ; sa limite de
+  débit (20/min par IP) reste sa seule protection, inchangée.
+- **Écarté : introduire un composant UI partagé « widget Turnstile »** — *Raison* : deux
+  occurrences d'un bloc dont le montage dépend d'un script tiers et de refs impératives ; un
+  composant partagé serait défendable, mais la constitution demande de ne pas sur-ingénierer et
+  les deux formulaires publics sont les seuls consommateurs prévisibles. La **vérification
+  serveur** est mutualisée parce que c'est elle qui porte la sécurité ; le montage du widget reste
+  local à chaque formulaire.
+
+## Risques & points d'attention
+
+- **Prérequis de déploiement (bloquant)** : `NEXT_PUBLIC_TURNSTILE_SITE_KEY` et
+  `TURNSTILE_SECRET_KEY` doivent être renseignées sur l'environnement cible **avant** la mise en
+  ligne, sinon le formulaire d'intégration refusera toute soumission. Ces variables existent déjà
+  pour le formulaire de rendez-vous et sont documentées dans `.env.example` — à confirmer
+  explicitement sur recette puis sur production (tâche de vérification dédiée).
+- **Environnement de développement local sans clés** : le formulaire d'intégration deviendra
+  inutilisable en local tant que les clés ne sont pas renseignées, là où il fonctionnait
+  jusqu'ici. Cohérent avec le formulaire agenda (même contrainte aujourd'hui), à signaler dans la
+  PR pour ne pas surprendre.
+- **Non-régression de la route agenda** : l'extraction de `verifyTurnstile` touche une route de
+  production qui fonctionne. Le déplacement doit être strictement iso-comportement — aucune
+  reformulation « au passage », vérifiée par les tests.
+- **Faiblesse résiduelle assumée** : l'IP transmise à Cloudflare (`remoteip`) provient de
+  `X-Forwarded-For`. Si le proxy ne réécrit pas cet en-tête, cette valeur est falsifiable. Cela
+  n'affaiblit pas la vérification du jeton lui-même (le jeton reste vérifié par Cloudflare) ;
+  c'est une limite connue, documentée en tête de `src/lib/rate-limit.ts` et hors périmètre.
+
+## Stratégie de tests
+
+- **`src/lib/__tests__/turnstile.test.ts`** (nouveau) — `fetch` global mocké :
+  - `TURNSTILE_SECRET_KEY` absent → `false` **sans appel réseau** (verrouille le fail-closed, qui
+    est la décision de sécurité la plus facile à casser par inadvertance) ;
+  - réponse `{ success: true }` → `true` ;
+  - réponse `{ success: false }` → `false` ;
+  - le corps envoyé contient bien le secret, le jeton et l'IP.
+- **`src/app/api/integration/requests/__tests__/captcha.test.ts`** (nouveau) — `@/lib/turnstile`
+  et `@/lib/prisma` mockés, `geocodeAddress` et `sendEmail` mockés pour pouvoir affirmer qu'ils ne
+  sont **pas** appelés :
+  - corps sans `turnstileToken` → 400, aucune écriture Prisma, aucun géocodage, aucun email
+    (le refus vient de Zod) ;
+  - `verifyTurnstile` renvoyant `false` → 400 avec le message attendu, et les mêmes assertions
+    d'absence d'effet de bord — c'est le test qui porte le critère central de la spec ;
+  - `verifyTurnstile` renvoyant `true` → 201, création effectuée, parcours nominal préservé.
+- **Non-régression agenda** : la route `/api/agenda/requests/public` n'a pas de test dédié
+  aujourd'hui (les fichiers `__tests__` existants du domaine agenda couvrent `profiles`,
+  `requests` et `entries` côté authentifié). L'extraction étant un pur déplacement, la garantie
+  principale reste `npm run typecheck` plus la suite complète ; un test minimal de la route
+  publique agenda (jeton invalide → 400) est ajouté **avec** cette spec pour que la mutualisation
+  ne repose pas uniquement sur la relecture.

--- a/specs/030-captcha-formulaire-integration/spec.md
+++ b/specs/030-captcha-formulaire-integration/spec.md
@@ -1,0 +1,127 @@
+# Spec — Preuve d'humanité sur le formulaire public « Rejoindre une famille »
+
+- **Numéro** : 030
+- **Statut** : Implémentée
+- **Créée le** : 2026-08-29
+- **Branche suggérée** : `feat/captcha-formulaire-integration`
+
+> ⚠️ Cette spec décrit **QUOI** et **POURQUOI** — jamais **COMMENT**.
+> Aucun nom de table, de librairie, d'endpoint ou de composant ici. Le technique va dans `plan.md`.
+
+## Contexte & problème
+
+Koinonia expose un formulaire public « Rejoindre une famille », accessible sans compte à toute
+personne disposant du lien d'une église. Il est conçu pour être partagé largement — c'est sa
+raison d'être.
+
+Chaque soumission déclenche pourtant une chaîne d'effets coûteux et visibles, **sans qu'aucune
+preuve d'humanité ne soit demandée** :
+
+- une interrogation d'un service de géolocalisation externe sur l'adresse saisie ;
+- la création d'une demande d'intégration, visible par les responsables de l'église ;
+- la création d'un dossier de suivi de parcours pour la personne ;
+- s'il y a demande de soin pastoral, la création d'une demande de rendez-vous supplémentaire ;
+- **l'envoi d'un email de confirmation à l'adresse saisie dans le formulaire**.
+
+Ce dernier point est le plus sensible : l'adresse email destinataire est choisie par celui qui
+remplit le formulaire. Un script automatisé peut donc faire envoyer des emails, depuis le domaine
+de l'église, à des adresses qu'il choisit — un usage qui abîme la réputation d'expéditeur du
+domaine en plus de noyer les responsables sous de fausses demandes.
+
+La seule protection actuelle est une limite du nombre de soumissions par minute et par adresse
+réseau. Elle ralentit un script naïf, mais ne l'arrête pas : il suffit de faire tourner les
+adresses réseau. Elle ne distingue jamais un humain d'un programme.
+
+Un autre formulaire public de Koinonia — la demande de rendez-vous — exige déjà, lui, une preuve
+d'humanité avant toute soumission. Les deux formulaires ont le même profil de risque ; seul l'un
+des deux est protégé.
+
+**Précision par rapport au constat d'audit** : le rapport présente aussi la limite par adresse
+réseau comme mal conçue (« clé de rate limit contournable »). Vérification faite dans le code,
+ce point a déjà été corrigé lors d'un correctif antérieur : la limite est bien appliquée par
+adresse réseau et bornée. Ce qui reste réellement ouvert, c'est **l'absence de preuve
+d'humanité** — objet de cette spec — ainsi que le fait que l'adresse réseau du visiteur est lue
+depuis une information transmise par le proxy, ce qui suppose que celui-ci soit configuré pour
+la réécrire. Ce second point relève de la configuration d'infrastructure et non du code : il est
+mentionné ici comme limite connue, il n'est pas un critère d'acceptation de cette spec.
+
+**Pourquoi maintenant** : le formulaire est en production et son lien est destiné à circuler
+publiquement. Le coût d'un abus n'est pas théorique (emails sortants, appels à un service externe
+facturable, pollution des dossiers de suivi), et le moyen de s'en protéger existe déjà dans
+l'application, éprouvé sur un autre formulaire.
+
+## Utilisateurs concernés
+
+- **Toute personne remplissant le formulaire public** (visiteur sans compte Koinonia) — devra
+  franchir une vérification anti-robot avant de pouvoir soumettre, comme c'est déjà le cas sur le
+  formulaire public de demande de rendez-vous.
+- **Admin / Secrétaire, et les responsables du suivi d'intégration** — destinataires des demandes
+  et des dossiers de parcours créés ; ce sont eux qui subissent aujourd'hui le bruit d'une
+  soumission automatisée. Leur usage de l'application n'est pas modifié.
+- **Aucun autre rôle n'est impacté** : la partie authentifiée de Koinonia ne change pas.
+
+## Comportement attendu
+
+### Scénario principal
+
+1. Une personne ouvre le formulaire public « Rejoindre une famille » d'une église.
+2. Elle remplit les informations demandées.
+3. Une vérification anti-robot lui est présentée dans le formulaire, au même titre que les autres
+   champs à renseigner.
+4. Tant que cette vérification n'est pas franchie, la soumission n'aboutit pas.
+5. Une fois la vérification franchie, elle soumet le formulaire.
+6. Le serveur contrôle **lui-même** la validité de cette preuve avant de créer quoi que ce soit
+   ou d'envoyer le moindre email.
+7. La demande est enregistrée et l'email de confirmation envoyé, exactement comme aujourd'hui.
+
+### Scénarios alternatifs / cas limites
+
+- **Si une soumission arrive sans preuve d'humanité**, elle est refusée avec un message explicite,
+  et aucune donnée n'est créée, aucun email envoyé, aucun service externe interrogé.
+- **Si la preuve fournie est invalide ou périmée**, la soumission est refusée de la même manière ;
+  la personne peut refaire la vérification et soumettre à nouveau sans perdre sa saisie.
+- **Si la vérification expire pendant que la personne remplit le formulaire** (formulaire long,
+  hésitation), elle doit pouvoir la refaire, et la soumission doit rester possible ensuite.
+- **Si le service de vérification est inaccessible ou non configuré**, la soumission est refusée
+  plutôt qu'acceptée sans contrôle — le formulaire est temporairement indisponible, mais jamais
+  ouvert aux robots. C'est un choix assumé, cohérent avec le formulaire de rendez-vous existant.
+- **Le formulaire public de demande de rendez-vous** doit continuer de fonctionner exactement
+  comme avant cette évolution.
+
+## Critères d'acceptation
+
+- [x] Une soumission du formulaire « Rejoindre une famille » sans preuve d'humanité est refusée.
+- [x] Une soumission avec une preuve invalide ou périmée est refusée.
+- [x] Une soumission refusée pour cette raison ne crée aucune demande d'intégration, aucun dossier
+      de suivi, aucune demande de rendez-vous, et ne provoque aucun envoi d'email ni aucune
+      interrogation du service de géolocalisation.
+- [x] Une soumission accompagnée d'une preuve valide aboutit exactement comme aujourd'hui.
+- [x] La vérification est contrôlée côté serveur, pas seulement affichée côté navigateur.
+- [x] La personne peut refaire la vérification si celle-ci expire, sans perdre les informations
+      déjà saisies.
+- [x] Le formulaire public de demande de rendez-vous conserve son comportement actuel, inchangé.
+
+## Hors périmètre
+
+- **La suggestion de famille pendant la saisie de l'adresse** : cette fonction est appelée au fil
+  de la frappe et ne crée aucune donnée, n'envoie aucun email. Y exiger une preuve d'humanité
+  imposerait de résoudre un défi à chaque caractère saisi, ce qui rendrait le formulaire
+  inutilisable. Elle reste protégée par sa seule limite de débit, comme aujourd'hui.
+- **La fiabilité de l'identification de l'adresse réseau du visiteur** : elle dépend de la
+  configuration du proxy placé devant l'application, pas du code. Limite connue et documentée,
+  hors périmètre.
+- **Remplacer la limite de débit par un mécanisme partagé entre plusieurs instances** : le
+  déploiement actuel est mono-instance ; cette évolution serait une refonte d'infrastructure sans
+  rapport avec le problème traité ici.
+- **Étendre la preuve d'humanité à d'autres formulaires** que celui visé : les autres points
+  d'entrée publics existants sont déjà protégés ou hors sujet.
+- **Changer le fournisseur de vérification anti-robot** ou en introduire un second : cette spec
+  réutilise celui déjà en service.
+
+## Questions ouvertes
+
+- Aucune sur le comportement attendu. **Point d'attention de déploiement**, à acter plutôt qu'à
+  trancher : si le service de vérification n'est pas configuré pour l'environnement, le formulaire
+  refusera toute soumission (comportement volontaire, voir cas limites). La configuration existe
+  déjà en production pour le formulaire de rendez-vous ; il faut confirmer qu'elle s'applique
+  bien au formulaire d'intégration avant mise en ligne.

--- a/specs/030-captcha-formulaire-integration/tasks.md
+++ b/specs/030-captcha-formulaire-integration/tasks.md
@@ -1,0 +1,90 @@
+# Tâches — Preuve d'humanité sur le formulaire public « Rejoindre une famille »
+
+- **Spec** : `./spec.md` · **Plan** : `./plan.md`
+- **Statut** : Terminé
+
+> Tâches **ordonnées** et **vérifiables**. Chacune est atomique et suit les dépendances
+> naturelles : service partagé → API → UI → tests. Les tâches `[P]` sont parallélisables.
+
+## Prérequis
+
+- [x] Branche créée : `feat/captcha-formulaire-integration`
+- [x] Migration Prisma : **sans objet** (aucun changement de schéma)
+
+## Tâches
+
+### 1. Service partagé
+
+- [x] **T1** — Créer `src/lib/turnstile.ts` exportant
+      `verifyTurnstile(token: string, ip: string): Promise<boolean>`, par **déplacement à
+      l'identique** de la fonction actuellement locale à la route agenda (lignes 29-39). Documenter
+      dans le fichier que le fail-closed (`TURNSTILE_SECRET_KEY` absent → `false`) est un choix
+      délibéré, pas un oubli. *(fichier : `src/lib/turnstile.ts`)*
+- [x] **T2** — Retirer la définition locale de `verifyTurnstile` de la route agenda et l'importer
+      depuis `@/lib/turnstile`. Aucun autre changement : même appel, mêmes arguments, même
+      traitement du résultat. *(fichier : `src/app/api/agenda/requests/public/route.ts`)*
+
+### 2. API
+
+- [x] **T3** — Ajouter `turnstileToken: z.string().min(1, "Vérification CAPTCHA manquante")` au
+      schéma Zod de la mutation, puis vérifier le jeton **immédiatement après `schema.parse`**
+      (avant la recherche d'église, donc avant tout géocodage, création ou email) :
+      `verifyTurnstile(data.turnstileToken, getClientIp(request))` → si `false`,
+      `ApiError(400, "Vérification CAPTCHA échouée. Veuillez réessayer.")`. `getClientIp` est déjà
+      importé dans cette route. Ne toucher à aucune autre ligne.
+      *(fichier : `src/app/api/integration/requests/route.ts`)*
+
+### 3. UI
+
+- [x] **T4** — Lire `process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY` (repli `""`, comme la page
+      agenda) et le passer en prop `turnstileSiteKey` à `JoinForm`.
+      *(fichier : `src/app/rejoindre/[churchSlug]/page.tsx`)*
+- [x] **T5** — Transposer le bloc widget de `PublicRequestForm.tsx` dans `JoinForm` : prop
+      `turnstileSiteKey`, états `turnstileToken`/`widgetRef`/`widgetId`, `useEffect` de montage
+      (chargement du script Cloudflare puis `turnstile.render` avec les callbacks `callback` /
+      `expired-callback` / `error-callback`, ces deux derniers remettant le jeton à `null`), garde
+      en tête de `handleSubmit`, `turnstileToken` ajouté au corps de la requête, `<div ref>` +
+      mention « Vérification anti-spam requise. » au-dessus du bouton, et
+      `disabled={submitting || (!!turnstileSiteKey && !turnstileToken)}` sur le bouton d'envoi.
+      Ne pas réinitialiser `form` en cas de refus (la saisie doit être conservée).
+      *(fichier : `src/app/rejoindre/[churchSlug]/JoinForm.tsx`)*
+
+### 4. Tests
+
+- [x] **T6** [P] — Tests de `verifyTurnstile` (`fetch` global mocké) : secret absent → `false`
+      **sans appel réseau** ; `{ success: true }` → `true` ; `{ success: false }` → `false` ; le
+      corps envoyé contient bien le secret, le jeton et l'IP.
+      *(fichier : `src/lib/__tests__/turnstile.test.ts`)*
+- [x] **T7** [P] — Tests du volet CAPTCHA de la route d'intégration (`@/lib/turnstile`,
+      `@/lib/prisma`, `geocodeAddress` et `sendEmail` mockés) : corps sans `turnstileToken` → 400
+      + aucune écriture Prisma, aucun géocodage, aucun email ; `verifyTurnstile` → `false` → 400
+      avec le message attendu + les mêmes assertions d'absence d'effet de bord ; `verifyTurnstile`
+      → `true` → 201 et parcours nominal préservé.
+      *(fichier : `src/app/api/integration/requests/__tests__/captcha.test.ts`)*
+- [x] **T8** [P] — Test minimal de non-régression de la route publique agenda après mutualisation
+      (jeton invalide → 400), pour que l'extraction ne repose pas uniquement sur la relecture.
+      *(fichier : `src/app/api/agenda/requests/__tests__/public-captcha.test.ts`)*
+
+## Traçabilité critères d'acceptation → tâches
+
+| Critère d'acceptation (spec.md) | Couvert par |
+|---|---|
+| Soumission sans preuve refusée | T3, T5, T7 |
+| Soumission avec preuve invalide ou périmée refusée | T1, T3, T7 |
+| Refus → aucune création, aucun email, aucun géocodage | T3 (ordre d'exécution), T7 |
+| Soumission avec preuve valide aboutit comme aujourd'hui | T3, T7 |
+| Vérification contrôlée côté serveur | T1, T3, T6, T7 |
+| Vérification refaisable si expirée, sans perte de saisie | T5 (callbacks + garde sans reset) |
+| Formulaire de rendez-vous inchangé | T2, T8 |
+
+## Vérification finale
+
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run lint:boundaries`
+- [x] `npm run test`
+- [x] Tous les critères d'acceptation de `spec.md` satisfaits
+- [ ] **Avant déploiement** : confirmer que `NEXT_PUBLIC_TURNSTILE_SITE_KEY` et
+      `TURNSTILE_SECRET_KEY` sont renseignées sur recette puis production — sans elles, le
+      formulaire d'intégration refusera toute soumission (fail-closed volontaire)
+- [ ] PR ouverte vers `main`

--- a/specs/030-captcha-formulaire-integration/tasks.md
+++ b/specs/030-captcha-formulaire-integration/tasks.md
@@ -87,4 +87,4 @@
 - [ ] **Avant déploiement** : confirmer que `NEXT_PUBLIC_TURNSTILE_SITE_KEY` et
       `TURNSTILE_SECRET_KEY` sont renseignées sur recette puis production — sans elles, le
       formulaire d'intégration refusera toute soumission (fail-closed volontaire)
-- [ ] PR ouverte vers `main`
+- [x] PR ouverte vers `main` — #481

--- a/src/__mocks__/prisma.ts
+++ b/src/__mocks__/prisma.ts
@@ -79,6 +79,9 @@ export const prismaMock = {
   audioServiceTemplate: createModelMock(),
   audioJob: createModelMock(),
   audioShareToken: createModelMock(),
+  // Module intégration
+  familyIntegrationRequest: createModelMock(),
+  personJourney: createModelMock(),
   // Module comptabilité
   financialSeries: createModelMock(),
   financialRequest: createModelMock(),

--- a/src/app/api/agenda/requests/__tests__/public-captcha.test.ts
+++ b/src/app/api/agenda/requests/__tests__/public-captcha.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Test de non-regression — spec 030 : la route publique agenda consomme desormais
+ * `verifyTurnstile` depuis `@/lib/turnstile` au lieu d'une copie locale. L'extraction devant
+ * etre strictement iso-comportement, on verrouille ici son point le plus sensible : un jeton
+ * refuse par Cloudflare bloque la soumission avant toute creation.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+const mockVerifyTurnstile = vi.fn();
+vi.mock("@/lib/turnstile", () => ({
+  verifyTurnstile: (...args: unknown[]) => mockVerifyTurnstile(...args),
+}));
+
+const mockSendEmail = vi.fn();
+vi.mock("@/lib/email", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+  buildAppointmentConfirmationEmail: () => ({ subject: "Confirmation", html: "<p>ok</p>" }),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  notifyUsersWithRole: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+const { POST } = await import("../public/route");
+
+const validBody = {
+  churchSlug: "icc-rennes",
+  lastName: "Dupont",
+  firstName: "Jean",
+  gender: "Homme",
+  phone: "0600000000",
+  email: "jean@example.org",
+  ageRange: "21-30 ans",
+  membershipDuration: "1 à 2 ans",
+  isStar: "Non",
+  motifs: ["Renseignements"],
+  preferredDay: "Mardi",
+  turnstileToken: "tok",
+};
+
+function post(body: unknown, ip: string) {
+  return new Request("http://localhost/api/agenda/requests/public", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/agenda/requests/public — CAPTCHA mutualisé", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendEmail.mockResolvedValue(undefined);
+    prismaMock.church.findUnique.mockResolvedValue({ id: "church-1", name: "ICC Rennes" });
+    prismaMock.appointmentRequest.create.mockResolvedValue({ id: "appt-1" });
+  });
+
+  it("refuse un jeton invalide sans rien créer", async () => {
+    mockVerifyTurnstile.mockResolvedValue(false);
+
+    const res = await POST(post(validBody, "198.51.100.1"));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Vérification CAPTCHA échouée");
+    expect(prismaMock.appointmentRequest.create).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("accepte un jeton valide comme avant la mutualisation", async () => {
+    mockVerifyTurnstile.mockResolvedValue(true);
+
+    const res = await POST(post(validBody, "198.51.100.2"));
+
+    expect(res.status).toBe(201);
+    expect(mockVerifyTurnstile).toHaveBeenCalledWith("tok", "198.51.100.2");
+    expect(prismaMock.appointmentRequest.create).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/api/agenda/requests/public/route.ts
+++ b/src/app/api/agenda/requests/public/route.ts
@@ -3,6 +3,7 @@ import { successResponse, errorResponse, ApiError } from "@/lib/api-utils";
 import { sendEmail, buildAppointmentConfirmationEmail } from "@/lib/email";
 import { notifyUsersWithRole } from "@/lib/notifications";
 import { requireRateLimit } from "@/lib/rate-limit";
+import { verifyTurnstile } from "@/lib/turnstile";
 import { z } from "zod";
 
 const AGE_RANGES = ["18-20 ans", "21-30 ans", "31-40 ans", "41-50 ans", "+50 ans"] as const;
@@ -25,18 +26,6 @@ const submitSchema = z.object({
   preferredDay: z.enum(DAYS, { errorMap: () => ({ message: "Veuillez sélectionner un jour" }) }),
   turnstileToken: z.string().min(1, "Vérification CAPTCHA manquante"),
 });
-
-async function verifyTurnstile(token: string, ip: string): Promise<boolean> {
-  const secret = process.env.TURNSTILE_SECRET_KEY;
-  if (!secret) return false;
-  const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({ secret, response: token, remoteip: ip }),
-  });
-  const data = await res.json() as { success: boolean };
-  return data.success === true;
-}
 
 export async function POST(request: Request) {
   try {

--- a/src/app/api/integration/requests/__tests__/captcha.test.ts
+++ b/src/app/api/integration/requests/__tests__/captcha.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests — spec 030 : preuve d'humanite sur POST /api/integration/requests.
+ *
+ * Le critere central de la spec n'est pas seulement « la soumission est refusee », c'est
+ * « refusee SANS effet de bord » : pas de geocodage externe, pas d'ecriture en base, pas
+ * d'email vers une adresse choisie par l'appelant. Chaque cas de refus verifie donc ces
+ * trois absences, et pas uniquement le code HTTP.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prismaMock } from "@/__mocks__/prisma";
+
+const mockVerifyTurnstile = vi.fn();
+vi.mock("@/lib/turnstile", () => ({
+  verifyTurnstile: (...args: unknown[]) => mockVerifyTurnstile(...args),
+}));
+
+const mockGeocodeAddress = vi.fn();
+const mockFindFamilyByCoords = vi.fn();
+vi.mock("@/lib/family-geo", () => ({
+  geocodeAddress: (...args: unknown[]) => mockGeocodeAddress(...args),
+  findFamilyByCoords: (...args: unknown[]) => mockFindFamilyByCoords(...args),
+}));
+
+const mockSendEmail = vi.fn();
+vi.mock("@/lib/email", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+vi.mock("@/modules/integration", () => ({
+  requireIntegrationAccess: vi.fn(),
+  buildConfirmationEmail: () => "<p>ok</p>",
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+const { POST } = await import("../route");
+
+const validBody = {
+  firstName: "Jean",
+  lastName: "Dupont",
+  email: "jean@example.org",
+  phone: "0600000000",
+  address: "1 rue de l'Église, Rennes",
+  ageRange: "ADULT",
+  churchStatus: "VISITOR",
+  pastoralCareRequested: false,
+  salvationCall: false,
+  churchId: "church-1",
+  turnstileToken: "tok-valide",
+};
+
+function post(body: unknown, ip = "203.0.113.1") {
+  return new Request("http://localhost/api/integration/requests", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify(body),
+  });
+}
+
+function expectNoSideEffect() {
+  expect(mockGeocodeAddress).not.toHaveBeenCalled();
+  expect(mockSendEmail).not.toHaveBeenCalled();
+  expect(prismaMock.familyIntegrationRequest.create).not.toHaveBeenCalled();
+  expect(prismaMock.personJourney.create).not.toHaveBeenCalled();
+  expect(prismaMock.appointmentRequest.create).not.toHaveBeenCalled();
+}
+
+describe("POST /api/integration/requests — CAPTCHA", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.church.findUnique.mockResolvedValue({ id: "church-1", name: "ICC Rennes" });
+    mockGeocodeAddress.mockResolvedValue(null);
+    mockSendEmail.mockResolvedValue(undefined);
+    prismaMock.familyIntegrationRequest.create.mockResolvedValue({ id: "fir-1" });
+    prismaMock.personJourney.create.mockResolvedValue({ id: "pj-1" });
+  });
+
+  it("refuse une soumission sans jeton, sans aucun effet de bord", async () => {
+    const { turnstileToken: _omit, ...withoutToken } = validBody;
+    const res = await POST(post(withoutToken, "203.0.113.10"));
+
+    expect(res.status).toBe(400);
+    expect(mockVerifyTurnstile).not.toHaveBeenCalled();
+    expectNoSideEffect();
+  });
+
+  it("refuse un jeton invalide avec le message attendu, sans aucun effet de bord", async () => {
+    mockVerifyTurnstile.mockResolvedValue(false);
+
+    const res = await POST(post(validBody, "203.0.113.11"));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Vérification CAPTCHA échouée");
+    expectNoSideEffect();
+  });
+
+  it("verifie le jeton avant meme de chercher l'eglise", async () => {
+    mockVerifyTurnstile.mockResolvedValue(false);
+
+    await POST(post(validBody, "203.0.113.12"));
+
+    expect(prismaMock.church.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("laisse passer le parcours nominal quand le jeton est valide", async () => {
+    mockVerifyTurnstile.mockResolvedValue(true);
+
+    const res = await POST(post(validBody, "203.0.113.13"));
+
+    expect(res.status).toBe(201);
+    expect(mockVerifyTurnstile).toHaveBeenCalledWith("tok-valide", "203.0.113.13");
+    expect(prismaMock.familyIntegrationRequest.create).toHaveBeenCalledOnce();
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/api/integration/requests/route.ts
+++ b/src/app/api/integration/requests/route.ts
@@ -4,6 +4,7 @@ import { requireIntegrationAccess, buildConfirmationEmail } from "@/modules/inte
 import { sendEmail } from "@/lib/email";
 import { geocodeAddress, findFamilyByCoords } from "@/lib/family-geo";
 import { requireRateLimit, getClientIp } from "@/lib/rate-limit";
+import { verifyTurnstile } from "@/lib/turnstile";
 import { z } from "zod";
 import type { FamilyAgeRange, FamilyChurchStatus, FamilyIntegrationStatus, Prisma } from "@/generated/prisma/client";
 
@@ -69,6 +70,7 @@ const createSchema = z.object({
   // Lien membre optionnel (si connecté)
   memberId:    z.string().optional(),
   churchId:    z.string().min(1),
+  turnstileToken: z.string().min(1, "Vérification CAPTCHA manquante"),
 });
 
 export async function POST(request: Request) {
@@ -77,6 +79,15 @@ export async function POST(request: Request) {
 
     const body = await request.json();
     const data = createSchema.parse(body);
+
+    // Preuve d'humanite verifiee AVANT tout effet de bord : chaque soumission declenche
+    // sinon un geocodage externe, plusieurs creations en base et un email vers une adresse
+    // choisie par l'appelant. Le rate-limit par IP seul ne distingue pas un script d'un
+    // humain (spec 030).
+    const humanVerified = await verifyTurnstile(data.turnstileToken, getClientIp(request));
+    if (!humanVerified) {
+      throw new ApiError(400, "Vérification CAPTCHA échouée. Veuillez réessayer.");
+    }
 
     // Vérifier que l'église existe
     const church = await prisma.church.findUnique({

--- a/src/app/rejoindre/[churchSlug]/JoinForm.tsx
+++ b/src/app/rejoindre/[churchSlug]/JoinForm.tsx
@@ -70,6 +70,7 @@ function useAddressSuggestions(query: string) {
 interface Props {
   churchId: string;
   churchName: string;
+  turnstileSiteKey: string;
 }
 
 type FieldErrors = Partial<Record<string, string>>;
@@ -145,7 +146,7 @@ interface SuccessData {
   pastoralCare: boolean;
 }
 
-export default function JoinForm({ churchId, churchName }: Props) {
+export default function JoinForm({ churchId, churchName, turnstileSiteKey }: Props) {
   const [form, setForm] = useState({
     firstName: "",
     lastName: "",
@@ -164,6 +165,30 @@ export default function JoinForm({ churchId, churchName }: Props) {
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const { suggestions: addressSuggestions, clear: clearSuggestions } = useAddressSuggestions(form.address);
   const familySuggestion = useFamilySuggestion(churchId);
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  const widgetRef = useRef<HTMLDivElement>(null);
+  const widgetId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!turnstileSiteKey) return;
+    function init() {
+      if (!widgetRef.current || widgetId.current) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      widgetId.current = (window as any).turnstile?.render(widgetRef.current, {
+        sitekey: turnstileSiteKey,
+        callback: (token: string) => setTurnstileToken(token),
+        "expired-callback": () => setTurnstileToken(null),
+        "error-callback": () => setTurnstileToken(null),
+      });
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((window as any).turnstile) { init(); } else {
+      const script = document.createElement("script");
+      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+      script.async = true; script.defer = true; script.onload = init;
+      document.head.appendChild(script);
+    }
+  }, [turnstileSiteKey]);
 
   function set(field: string, value: string | boolean) {
     setForm((f) => ({ ...f, [field]: value }));
@@ -172,6 +197,10 @@ export default function JoinForm({ churchId, churchName }: Props) {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (!turnstileToken) {
+      setGlobalError("Veuillez compléter la vérification CAPTCHA.");
+      return;
+    }
     setSubmitting(true);
     setGlobalError(null);
     setFieldErrors({});
@@ -186,6 +215,7 @@ export default function JoinForm({ churchId, churchName }: Props) {
           address: form.address || undefined,
           pastoralMessage: form.pastoralMessage || undefined,
           churchId,
+          turnstileToken,
         }),
       });
 
@@ -545,9 +575,16 @@ export default function JoinForm({ churchId, churchName }: Props) {
         </p>
       )}
 
+      <div>
+        <div ref={widgetRef} />
+        {!turnstileToken && (
+          <p className="text-xs text-gray-400 mt-1">Vérification anti-spam requise.</p>
+        )}
+      </div>
+
       <button
         type="submit"
-        disabled={submitting}
+        disabled={submitting || (!!turnstileSiteKey && !turnstileToken)}
         className="w-full bg-icc-violet text-white py-3 rounded-lg font-medium text-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-icc-violet disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
       >
         {submitting ? "Envoi en cours…" : "Envoyer ma demande"}

--- a/src/app/rejoindre/[churchSlug]/page.tsx
+++ b/src/app/rejoindre/[churchSlug]/page.tsx
@@ -16,6 +16,8 @@ export default async function RejoindrePublicPage({
 
   if (!church) return notFound();
 
+  const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "";
+
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <header className="bg-icc-violet px-4 py-6">
@@ -31,7 +33,7 @@ export default async function RejoindrePublicPage({
       </header>
 
       <main className="flex-1 max-w-xl mx-auto w-full px-4 py-8">
-        <JoinForm churchId={church.id} churchName={church.name} />
+        <JoinForm churchId={church.id} churchName={church.name} turnstileSiteKey={turnstileSiteKey} />
       </main>
 
       <footer className="text-center text-xs text-gray-400 py-5 border-t border-gray-200">

--- a/src/lib/__tests__/turnstile.test.ts
+++ b/src/lib/__tests__/turnstile.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests — spec 030 : verification Cloudflare Turnstile.
+ *
+ * Le cas le plus important est le fail-closed : sans secret configure, la fonction doit
+ * refuser SANS appeler le reseau. C'est la decision de securite la plus facile a casser par
+ * inadvertance (un repli permissif « pour que ca marche en local » desactiverait la
+ * protection en production selon la configuration).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { verifyTurnstile } from "../turnstile";
+
+const SITEVERIFY = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+const mockFetch = vi.fn();
+const originalSecret = process.env.TURNSTILE_SECRET_KEY;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (originalSecret === undefined) delete process.env.TURNSTILE_SECRET_KEY;
+  else process.env.TURNSTILE_SECRET_KEY = originalSecret;
+});
+
+describe("verifyTurnstile", () => {
+  it("fail-closed : sans TURNSTILE_SECRET_KEY, refuse sans appel réseau", async () => {
+    delete process.env.TURNSTILE_SECRET_KEY;
+
+    await expect(verifyTurnstile("tok", "203.0.113.1")).resolves.toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("accepte quand Cloudflare répond success: true", async () => {
+    process.env.TURNSTILE_SECRET_KEY = "secret-test";
+    mockFetch.mockResolvedValue({ json: async () => ({ success: true }) });
+
+    await expect(verifyTurnstile("tok", "203.0.113.1")).resolves.toBe(true);
+  });
+
+  it("refuse quand Cloudflare répond success: false", async () => {
+    process.env.TURNSTILE_SECRET_KEY = "secret-test";
+    mockFetch.mockResolvedValue({ json: async () => ({ success: false }) });
+
+    await expect(verifyTurnstile("tok", "203.0.113.1")).resolves.toBe(false);
+  });
+
+  it("transmet le secret, le jeton et l'IP à l'API siteverify", async () => {
+    process.env.TURNSTILE_SECRET_KEY = "secret-test";
+    mockFetch.mockResolvedValue({ json: async () => ({ success: true }) });
+
+    await verifyTurnstile("tok-abc", "203.0.113.9");
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(SITEVERIFY);
+    expect(init.method).toBe("POST");
+
+    const params = new URLSearchParams(init.body as string);
+    expect(params.get("secret")).toBe("secret-test");
+    expect(params.get("response")).toBe("tok-abc");
+    expect(params.get("remoteip")).toBe("203.0.113.9");
+  });
+});

--- a/src/lib/turnstile.ts
+++ b/src/lib/turnstile.ts
@@ -1,0 +1,25 @@
+/**
+ * Verification Cloudflare Turnstile — preuve d'humanite sur les formulaires publics
+ * (demande de RDV `/agenda-public`, integration `/rejoindre`).
+ *
+ * Mutualisee ici plutot que dupliquee par route : c'est un controle de securite, et deux
+ * copies finissent par diverger le jour ou le fournisseur, l'URL de verification ou le
+ * traitement d'erreur change — en laissant une route en arriere sans que personne le voie.
+ *
+ * FAIL-CLOSED VOLONTAIRE : sans `TURNSTILE_SECRET_KEY`, la fonction retourne `false`, donc
+ * toute soumission est refusee. Ce n'est pas un oubli : un repli permissif serait un
+ * interrupteur silencieux desactivant la protection selon la configuration. Consequence a
+ * connaitre — un environnement sans cette variable rend les formulaires publics
+ * inutilisables (voir specs/030-captcha-formulaire-integration/).
+ */
+export async function verifyTurnstile(token: string, ip: string): Promise<boolean> {
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+  if (!secret) return false;
+  const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ secret, response: token, remoteip: ip }),
+  });
+  const data = (await res.json()) as { success: boolean };
+  return data.success === true;
+}


### PR DESCRIPTION
## Contexte

Audit DevSecOps du 2026-08-29, finding **M-01**. Spec : `specs/030-captcha-formulaire-integration/`.

`POST /api/integration/requests` est public et déclenche, sans aucune preuve d'humanité : un géocodage externe, la création d'une `FamilyIntegrationRequest`, d'un `PersonJourney`, éventuellement d'un `AppointmentRequest`, et **l'envoi d'un email à une adresse choisie par l'appelant**. Le rate-limit par IP (5/min) ralentit un script naïf mais ne distingue jamais un humain d'un programme.

> **Nuance par rapport à l'audit** : le rapport décrit aussi la clé de rate-limit comme contournable. Vérification faite, elle est déjà composée avec l'IP et bornée (commit `d83ae2a`). Ce qui restait réellement ouvert, c'est l'absence de CAPTCHA.

## Changements

- **`src/lib/turnstile.ts`** (nouveau) — `verifyTurnstile` déplacée **à l'identique** depuis la route agenda, qui l'avait en local ; l'arrivée d'un second consommateur est le moment de mutualiser plutôt que de dupliquer un contrôle de sécurité. Le **fail-closed** (`TURNSTILE_SECRET_KEY` absent → refus) est conservé et documenté comme choix délibéré.
- **`/api/integration/requests`** — `turnstileToken` ajouté au schéma Zod, vérifié **immédiatement après `parse`**, avant la recherche d'église : un refus n'atteint ni le géocodeur, ni la base, ni l'email.
- **`/api/agenda/requests/public`** — import au lieu de définition locale. Aucun autre changement.
- **`JoinForm.tsx` / `page.tsx`** — widget Turnstile transposé du formulaire de RDV (callbacks `expired`/`error` remettant le jeton à zéro). La garde de soumission retourne **avant** `setSubmitting`, donc la saisie n'est jamais perdue.

## ⚠️ Prérequis de déploiement

`NEXT_PUBLIC_TURNSTILE_SITE_KEY` et `TURNSTILE_SECRET_KEY` doivent être renseignées sur recette **et** production avant la mise en ligne — sinon le formulaire d'intégration refusera toute soumission (fail-closed volontaire). Elles existent déjà pour le formulaire de RDV, à confirmer côté intégration. Même remarque en local.

## Tests

10 tests ajoutés : fail-closed **sans appel réseau**, corps siteverify correct, refus sans jeton / jeton invalide → 400 **avec assertion d'absence de tout effet de bord**, parcours nominal → 201, et non-régression de la route agenda après mutualisation.

`typecheck` ✅ · `lint` ✅ (warnings préexistants uniquement) · `lint:boundaries` ✅ · `test` ✅ 953/953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwEXWCWqPAgjfEnmKCMmSd