### PR TITLE
fix(audio): garantir la présence en cache avant de déléguer à nginx (M-05)

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -220,6 +220,11 @@ location /protected/audio/ {
 Ne definir `AUDIO_XACCEL_LOCATION` que si ce nginx existe reellement devant Koinonia — sinon les
 requetes audio echoueront (le fichier ne sera jamais servi par personne).
 
+Le service ne delegue a nginx qu'apres s'etre assure que la rendition est presente dans
+`AUDIO_CACHE_DIR` (telechargement depuis S3 au besoin) : nginx sert le fichier tel quel et ne
+sait pas le recuperer. Si le cache est indisponible, la delegation est ignoree et le flux est
+servi directement par Node — l'ecoute reste possible.
+
 ## Rollback
 
 Pour revenir a une release precedente :

--- a/src/modules/audio/services/__tests__/stream.test.ts
+++ b/src/modules/audio/services/__tests__/stream.test.ts
@@ -80,15 +80,36 @@ describe("buildRenditionResponse", () => {
     expect(getS3ObjectStream).toHaveBeenCalledWith("segments/a.mp3");
   });
 
-  it("avec AUDIO_XACCEL_LOCATION défini : corps vide + X-Accel-Redirect sur le bon fichier, mtime rafraîchi", async () => {
+  it("avec AUDIO_XACCEL_LOCATION défini : corps vide + X-Accel-Redirect sur le bon fichier", async () => {
     process.env.AUDIO_XACCEL_LOCATION = "/protected/audio";
 
     const res = await buildRenditionResponse("segments/a.mp3", "bytes=2-5");
 
     expect(res.status).toBe(200);
     expect(res.headers.get("X-Accel-Redirect")).toBe(`/protected/audio/${getCacheFileName("segments/a.mp3")}`);
-    expect(touchRenditionAccess).toHaveBeenCalledWith("segments/a.mp3");
-    expect(getCachedRenditionPath).not.toHaveBeenCalled(); // délégué à nginx, pas de lecture locale ici
-    expect(await readBody(res)).toBe("");
+    expect(await readBody(res)).toBe(""); // octets livrés par nginx, pas par Node
+  });
+
+  it("délègue seulement après avoir garanti la présence du fichier en cache", async () => {
+    // nginx sert le fichier tel quel : deleguer sans remplir le cache produirait un 404.
+    process.env.AUDIO_XACCEL_LOCATION = "/protected/audio";
+
+    await buildRenditionResponse("segments/a.mp3", null);
+
+    expect(getCachedRenditionPath).toHaveBeenCalledWith("segments/a.mp3");
+  });
+
+  it("ne délègue pas quand le cache est indisponible : repli sur le flux S3", async () => {
+    process.env.AUDIO_XACCEL_LOCATION = "/protected/audio";
+    getCachedRenditionPath.mockResolvedValue(null);
+    const { Readable } = await import("stream");
+    getS3ObjectStream.mockResolvedValue(Readable.from([Buffer.from(CONTENT)]));
+
+    const res = await buildRenditionResponse("segments/a.mp3", null);
+
+    expect(res.headers.get("X-Accel-Redirect")).toBeNull();
+    expect(res.status).toBe(200);
+    expect(getS3ObjectStream).toHaveBeenCalledWith("segments/a.mp3");
+    expect(await readBody(res)).toBe(CONTENT);
   });
 });

--- a/src/modules/audio/services/stream.ts
+++ b/src/modules/audio/services/stream.ts
@@ -8,11 +8,12 @@
  *  - **Délégué (point de sortie, désactivé par défaut)** : si `AUDIO_XACCEL_LOCATION` est
  *    défini, la route répond un corps vide portant `X-Accel-Redirect`, et un nginx placé devant
  *    le process sert le fichier en `sendfile`. Activer ce mode suppose d'insérer nginx dans la
- *    chaîne — non fait aujourd'hui (plan.md § Services / logique métier).
+ *    chaîne — non fait aujourd'hui (plan.md § Services / logique métier). La délégation n'a lieu
+ *    que si la rendition est effectivement en cache : nginx ne sait pas la télécharger.
  */
 import { createReadStream, statSync } from "fs";
 import { Readable } from "stream";
-import { getCachedRenditionPath, getCacheFileName, touchRenditionAccess } from "./rendition-cache";
+import { getCachedRenditionPath, getCacheFileName } from "./rendition-cache";
 import { getS3ObjectStream } from "@/modules/storage";
 
 const CACHE_HEADERS = {
@@ -47,8 +48,14 @@ function parseRange(rangeHeader: string | null, size: number): { start: number; 
  */
 export async function buildRenditionResponse(s3Key: string, rangeHeader: string | null): Promise<Response> {
   const xAccelLocation = process.env.AUDIO_XACCEL_LOCATION;
-  if (xAccelLocation) {
-    await touchRenditionAccess(s3Key);
+  const cachedPath = await getCachedRenditionPath(s3Key);
+
+  if (xAccelLocation && cachedPath) {
+    // Le remplissage du cache doit précéder la délégation : nginx sert le fichier tel quel et
+    // répondrait 404 s'il était absent. Ni le pré-chauffage du worker (best-effort) ni la
+    // présence passée du fichier ne le garantissent — l'éviction LRU peut l'avoir retiré. Quand
+    // le cache est indisponible, on ne délègue pas : la suite sert le flux S3 direct, fidèle au
+    // principe d'ADR-0008 selon lequel le cache accélère l'écoute sans jamais la conditionner.
     return new Response(null, {
       status: 200,
       headers: {
@@ -59,7 +66,6 @@ export async function buildRenditionResponse(s3Key: string, rangeHeader: string 
     });
   }
 
-  const cachedPath = await getCachedRenditionPath(s3Key);
   if (cachedPath) {
     return streamLocalFile(cachedPath, rangeHeader);
   }


### PR DESCRIPTION
## Contexte

Audit DevSecOps du 2026-08-29, finding **M-05**. Correctif direct sans spec : branche morte en production, aucun changement de comportement observable, quelques lignes dans une seule fonction.

## Le défaut

`buildRenditionResponse` (`src/modules/audio/services/stream.ts`) répondait, en mode délégué, un `X-Accel-Redirect` vers `<location>/<sha1(s3Key)>.mp3` **sans jamais appeler `getCachedRenditionPath`** — la seule fonction qui télécharge la rendition depuis S3. Elle n'appelait que `touchRenditionAccess`, qui avale silencieusement l'erreur si le fichier est absent. Nginx servait donc un fichier dont rien ne garantissait l'existence → 404.

Ce n'est pas rattrapé par le pré-chauffage : `primeRenditionCache` est best-effort (il avale ses erreurs), et le cache applique une **éviction LRU** sur un budget de 5 Go. Toute rendition évincée devenait définitivement inservable en mode délégué, là où le mode autonome la re-télécharge. Le mode délégué avait perdu le principe central d'ADR-0008 — *le cache accélère l'écoute, il ne la conditionne jamais*.

## Correctif

La délégation est conditionnée au remplissage effectif du cache ; si celui-ci est indisponible, on ne délègue pas et le flux S3 direct prend le relais (repli déjà en place). `touchRenditionAccess` disparaît de l'appelant : `getCachedRenditionPath` s'en charge déjà.

## Portée réelle

**Dormant.** `AUDIO_XACCEL_LOCATION` est vide dans `.env.example`, absent des workflows de déploiement, et `docs/production.md` documente le mode comme « annexe optionnelle, non activée » (Traefik attaque Node directement, ADR-0008). Aucun impact en production aujourd'hui — c'est le piège qui se serait déclenché le jour où quelqu'un insère nginx en suivant la doc. `docs/production.md` précise désormais la précondition.

## Tests

Le test de délégation existant est conservé, débarrassé de son assertion devenue fausse (`getCachedRenditionPath` n'est plus « non appelé » — c'est précisément le bug). Deux tests ajoutés : la délégation garantit d'abord la présence du fichier ; cache indisponible + variable définie → aucun `X-Accel-Redirect`, repli sur le flux S3 avec le contenu attendu.

`typecheck` ✅ · `lint` ✅ (warnings préexistants) · `lint:boundaries` ✅ · `test` ✅ 955/955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwEXWCWqPAgjfEnmKCMmSd