### PR TITLE
chore(sécurité): graphe de production à zéro vulnérabilité + gate CI (M-07)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
       - run: npm run lint
       - run: npm run lint:boundaries
       - run: npm run test:coverage
+      # Bloque l'ajout d'une dependance de PRODUCTION vulnerable (haute ou critique). Limite a
+      # `--omit=dev` volontairement : une faille dans un outil de build ou de test n'est pas
+      # exposee aux utilisateurs, et faire echouer la CI dessus pousserait a desactiver le
+      # garde-fou. Le graphe de production est a zero vulnerabilite au moment de l'ajout de
+      # cette etape — le seuil est donc tenable et non un voeu pieux.
+      - run: npm audit --omit=dev --audit-level=high
 
   build:
     needs: lint-test

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -422,7 +422,30 @@ Quatre types de tokens controlent les acces sans authentification :
 - **ESLint** : `eslint.config.mjs` (`eslint-config-next` + `eslint-plugin-react-hooks`)
 - **dependency-cruiser** : frontieres modules enforces en CI (`npm run lint:boundaries`)
 - **Tests** : Vitest, `npm run test`
-- **CI** : typecheck + lint + lint:boundaries + tests sur chaque PR
+- **CI** : typecheck + lint + lint:boundaries + tests + `npm audit --omit=dev --audit-level=high`
+  sur chaque PR
+
+### Dependances vulnerables : le champ `overrides`
+
+`npm audit --omit=dev --audit-level=high` bloque la CI si une dependance de **production**
+presente une faille haute ou critique. Le perimetre s'arrete volontairement a la production :
+une faille dans un outil de build ou de test n'est pas exposee aux utilisateurs, et faire
+echouer la CI dessus finirait par pousser a desactiver le garde-fou.
+
+Quand la correction depend d'un paquet intermediaire qui n'a pas encore relache la version
+saine, le champ `overrides` de `package.json` force la version corrigee dans tout l'arbre.
+Chaque entree existe pour une faille precise et doit **disparaitre** des que le paquet parent
+publie une version qui embarque deja le correctif :
+
+| Override | Pourquoi | A retirer quand |
+|---|---|---|
+| `@prisma/adapter-mariadb > mariadb: ^3.5.3` | L'adaptateur epingle `mariadb@3.4.5`, qui fuit le mot de passe en clair face a un MitM malgre `ssl: true` | L'adaptateur epingle une version >= 3.5.3 |
+| `nodemailer: ^9.0.6` | Injections de commandes SMTP (CRLF) sur `<= 9.0.0` ; `next-auth` et `@auth/core` declarent encore `^7 \|\| ^8`, ce qui reintroduisait une copie vulnerable | `next-auth` accepte `^9` |
+| `deepmerge-ts: ^8.0.0` | Epuisement de pile dans `@prisma/config` (chargement de configuration, hors chemin de requete) | `@prisma/config` depend de `>= 8` |
+| `uuid: ^11.1.1` | Borne de buffer manquante, tiree par `exceljs` | `exceljs` depend de `>= 11.1.1` |
+
+Un override est un contournement, pas une solution : verifier a chaque montee de version si le
+paquet parent a rattrape son retard, et retirer la ligne devenue inutile.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "mariadb": "^3.5.3",
         "next": "^16.3.3",
         "next-auth": "5.0.0-beta.32",
-        "nodemailer": "^7.0.13",
+        "nodemailer": "^9.0.6",
         "pino": "^10.3.1",
         "prisma": "^7.10.0",
         "react": "^19.2.8",
@@ -61,7 +61,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@auth/core": {
+    "node_modules/@auth/prisma-adapter": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.3.tgz",
+      "integrity": "sha512-jZbpVAO6PTc9zNtdTWc0RLWG8qap4iMc54/3oWaWbuKdj92wHxzPrs3HivWB2mB9975GPW0l3YM/wFUWiUlTlg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.3"
+      },
+      "peerDependencies": {
+        "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
+      }
+    },
+    "node_modules/@auth/prisma-adapter/node_modules/@auth/core": {
       "version": "0.41.3",
       "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.3.tgz",
       "integrity": "sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==",
@@ -88,18 +100,6 @@
         "nodemailer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@auth/prisma-adapter": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.3.tgz",
-      "integrity": "sha512-jZbpVAO6PTc9zNtdTWc0RLWG8qap4iMc54/3oWaWbuKdj92wHxzPrs3HivWB2mB9975GPW0l3YM/wFUWiUlTlg==",
-      "license": "ISC",
-      "dependencies": {
-        "@auth/core": "0.41.3"
-      },
-      "peerDependencies": {
-        "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
       }
     },
     "node_modules/@aws-sdk/checksums": {
@@ -2129,9 +2129,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2147,9 +2144,6 @@
       "integrity": "sha512-W7viwCk9JY/cAkdz/A273rd5bb3RgT/IHwR7Upv90tunjBWNtAAhGhoecHh+teRNRSinuAFmE+l7fwZ4YKkrXg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2167,9 +2161,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2185,9 +2176,6 @@
       "integrity": "sha512-H4mBso8ZTMBPtdT0PN0pBx2ayTvQuTuvS6qT13d77yVFJXAPCxkyIhLTmdMaGTJs0krQYI/qpzdHijCeihXhbg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2322,49 +2310,6 @@
         "@prisma/driver-adapter-utils": "7.10.0",
         "mariadb": "3.4.5"
       }
-    },
-    "node_modules/@prisma/adapter-mariadb/node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@prisma/adapter-mariadb/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@prisma/adapter-mariadb/node_modules/mariadb": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/mariadb/-/mariadb-3.4.5.tgz",
-      "integrity": "sha512-gThTYkhIS5rRqkVr+Y0cIdzr+GRqJ9sA2Q34e0yzmyhMCwyApf3OKAC1jnF23aSlIOqJuyaUFUcj7O1qZslmmQ==",
-      "license": "LGPL-2.1-or-later",
-      "dependencies": {
-        "@types/geojson": "^7946.0.16",
-        "@types/node": "^24.0.13",
-        "denque": "^2.1.0",
-        "iconv-lite": "^0.6.3",
-        "lru-cache": "^10.4.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@prisma/adapter-mariadb/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT"
     },
     "node_modules/@prisma/client": {
       "version": "7.10.0",
@@ -4735,9 +4680,9 @@
       }
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5315,9 +5260,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6035,12 +5980,22 @@
       "license": "MIT"
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz",
+      "integrity": "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/define-data-property": {
@@ -6180,9 +6135,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -8733,9 +8688,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -9725,6 +9680,35 @@
         }
       }
     },
+    "node_modules/next-auth/node_modules/@auth/core": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.3.tgz",
+      "integrity": "sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7 || ^8.0.5"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -9762,9 +9746,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
-      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.6.tgz",
+      "integrity": "sha512-IQUGFdhdGwI9+AWX+FpUt4DLmvFaOjTMEoneTIWX/RXxuy1TdenPwWrvFMSfLkPKl+HQEXWuSAxEMMbPYXtBmg==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -9780,9 +9764,9 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
-      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.7.tgz",
+      "integrity": "sha512-4RxcKxXjuItDFZ20RRPf4YTw3kpeXJyCgJFxVzJ068A7PNJ18st2Dg90tlC1LkSDS0GecroagCLHYEIVUhCAkw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -10535,9 +10519,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -11786,9 +11770,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -12220,12 +12204,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/valibot": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mariadb": "^3.5.3",
     "next": "^16.3.3",
     "next-auth": "5.0.0-beta.32",
-    "nodemailer": "^7.0.13",
+    "nodemailer": "^9.0.6",
     "pino": "^10.3.1",
     "prisma": "^7.10.0",
     "react": "^19.2.8",
@@ -64,5 +64,13 @@
     "tsx": "^4.23.12",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
+  },
+  "overrides": {
+    "@prisma/adapter-mariadb": {
+      "mariadb": "^3.5.3"
+    },
+    "nodemailer": "^9.0.6",
+    "deepmerge-ts": "^8.0.0",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## Contexte

Audit DevSecOps du 2026-08-29, finding **M-07**. Contrairement à M-06 et M-09, le constat était **exact** : `npm audit --omit=dev` remontait bien 11 vulnérabilités dont 7 hautes.

La PR Dependabot #474 (minor/patch, encore d'actualité) a été mergée en préalable — elle ne corrigeait aucune des 11.

## Résultat

`npm audit --omit=dev` : **11 vulnérabilités (7 hautes) → 0**, sans aucun downgrade ni changement de comportement applicatif.

| Lot | Traitement |
|---|---|
| `brace-expansion`, `dompurify`, `tmp` | `npm audit fix` — transitifs, non cassants |
| `nodemailer` (6 avis hauts) | 7 → 9 : injections de commandes SMTP via CRLF sur `<= 9.0.0` |
| `mariadb` | override `^3.5.3` sous `@prisma/adapter-mariadb` |
| `deepmerge-ts`, `uuid` | overrides `^8` / `^11.1.1` |

### Pourquoi des overrides

Pour ces trois derniers, le correctif proposé par npm était un **downgrade majeur** — `prisma@6.12.0` et `exceljs@3.4.0` — incompatible avec la stack (Prisma 7 ESM-only + driver adapter). Les versions saines existent en amont, ce sont les paquets intermédiaires qui n'ont pas rattrapé.

Deux points méritent attention :

- **`mariadb`** est le plus sérieux du lot : `@prisma/adapter-mariadb` épingle `3.4.5`, dont le connecteur **fuit le mot de passe en clair face à un MitM malgré `ssl: true`**. C'est le driver de la base en production.
- **`nodemailer`** a nécessité un override *global* : bumper la seule dépendance directe faisait apparaître une copie imbriquée `8.0.11` sous `@auth/core` — le compte de vulnérabilités montait de 6 à 9. `next-auth` déclare encore `^7 || ^8` ; sa plage est donc en retard, mais son provider Email n'est pas configuré ici (OAuth Google uniquement).

Chaque override est documenté dans `docs/architecture.md` avec **la condition de son retrait** — c'est un contournement daté, pas un acquis.

## Gate CI

`npm audit --omit=dev --audit-level=high` rejoint le job `lint-test`. Le périmètre s'arrête volontairement à la production : une faille dans un outil de build ou de test n'est pas exposée aux utilisateurs, et faire échouer la CI dessus finirait par pousser quelqu'un à désactiver le garde-fou. Le seuil est tenable puisque le graphe est à zéro au moment où l'étape est ajoutée.

## Vérifications

Réinstallation propre depuis le lockfile (`rm -rf node_modules && npm ci`), puis `typecheck` ✅ · `lint` ✅ (warnings préexistants) · `lint:boundaries` ✅ · `test` ✅ 955/955 · `build` ✅ (Next + bundle worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwEXWCWqPAgjfEnmKCMmSd